### PR TITLE
fix: rustfmt if-let chain formatting

### DIFF
--- a/src/exports/kotlin.rs
+++ b/src/exports/kotlin.rs
@@ -35,13 +35,14 @@ pub fn extract_exports(content: &str) -> Vec<String> {
         }
 
         if let Some(caps) = KT_DECL.captures(line)
-            && let Some(name) = caps.get(1) {
-                // Skip companion objects (they're not standalone exports)
-                if trimmed.starts_with("companion") {
-                    continue;
-                }
-                symbols.push(name.as_str().to_string());
+            && let Some(name) = caps.get(1)
+        {
+            // Skip companion objects (they're not standalone exports)
+            if trimmed.starts_with("companion") {
+                continue;
             }
+            symbols.push(name.as_str().to_string());
+        }
     }
 
     symbols

--- a/src/exports/python.rs
+++ b/src/exports/python.rs
@@ -18,15 +18,16 @@ static QUOTED: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"["'](\w+)["']"#)
 pub fn extract_exports(content: &str) -> Vec<String> {
     // Check for __all__ first
     if let Some(caps) = ALL_DECL.captures(content)
-        && let Some(list) = caps.get(1) {
-            let mut symbols = Vec::new();
-            for name_cap in QUOTED.captures_iter(list.as_str()) {
-                if let Some(name) = name_cap.get(1) {
-                    symbols.push(name.as_str().to_string());
-                }
+        && let Some(list) = caps.get(1)
+    {
+        let mut symbols = Vec::new();
+        for name_cap in QUOTED.captures_iter(list.as_str()) {
+            if let Some(name) = name_cap.get(1) {
+                symbols.push(name.as_str().to_string());
             }
-            return symbols;
         }
+        return symbols;
+    }
 
     // Fallback: top-level def/class that don't start with _
     let mut symbols = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,16 +418,17 @@ fn exit_with_status(
     }
 
     if let Some(req) = require_coverage
-        && coverage.coverage_percent < req {
-            println!(
-                "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
-                "--require-coverage".red(),
-                coverage.coverage_percent,
-                coverage.unspecced_files.len()
-            );
-            for f in &coverage.unspecced_files {
-                println!("  {} {f}", "✗".red());
-            }
-            process::exit(1);
+        && coverage.coverage_percent < req
+    {
+        println!(
+            "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
+            "--require-coverage".red(),
+            coverage.coverage_percent,
+            coverage.unspecced_files.len()
+        );
+        for f in &coverage.unspecced_files {
+            println!("  {} {f}", "✗".red());
         }
+        process::exit(1);
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,10 +26,11 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
     for line in yaml_block.lines() {
         // List item: "  - value"
         if let Some(stripped) = line.trim_start().strip_prefix("- ")
-            && current_key.is_some() {
-                current_list.push(stripped.trim().to_string());
-                continue;
-            }
+            && current_key.is_some()
+        {
+            current_list.push(stripped.trim().to_string());
+            continue;
+        }
 
         // Key-value: "key: value" or "key:"
         if let Some(colon_pos) = line.find(':') {
@@ -58,10 +59,11 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
         // Blank or comment line: flush
         let trimmed = line.trim();
         if (trimmed.is_empty() || trimmed.starts_with('#'))
-            && let Some(prev_key) = current_key.take() {
-                set_field(&mut fm, &prev_key, &current_list);
-                current_list.clear();
-            }
+            && let Some(prev_key) = current_key.take()
+        {
+            set_field(&mut fm, &prev_key, &current_list);
+            current_list.clear();
+        }
     }
 
     // Flush trailing list


### PR DESCRIPTION
## Summary
- Applies rustfmt-compatible formatting to all `if let` chain blocks across parser.rs, kotlin.rs, python.rs, and main.rs
- Previous fix only addressed generator.rs; these 4 files still had the old indentation style

## Test plan
- CI `fmt` job should pass
- All existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)