### PR TITLE
feat: add reusable GitHub Action for specsync check

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,67 @@ Flags:
   --root <path>         Project root (default: cwd)
 ```
 
-## CI integration
+## GitHub Action
+
+Use SpecSync as a reusable GitHub Action -- no manual binary download needed.
+
+### Basic usage
+
+```yaml
+- uses: CorvidLabs/spec-sync@v1
+  with:
+    strict: 'true'
+    require-coverage: '100'
+```
+
+### All options
+
+```yaml
+- uses: CorvidLabs/spec-sync@v1
+  with:
+    version: 'latest'        # SpecSync version (default: latest)
+    strict: 'true'           # Treat warnings as errors (default: false)
+    require-coverage: '100'  # Minimum file coverage % (default: 0)
+    root: '.'                # Project root directory (default: .)
+    args: ''                 # Additional CLI arguments (default: '')
+```
+
+### Full workflow example
+
+```yaml
+name: Spec Check
+on: [push, pull_request]
+
+jobs:
+  specsync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CorvidLabs/spec-sync@v1
+        with:
+          strict: 'true'
+          require-coverage: '100'
+```
+
+### Multi-platform matrix
+
+```yaml
+jobs:
+  specsync:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CorvidLabs/spec-sync@v1
+        with:
+          strict: 'true'
+```
+
+The action automatically detects the runner OS and architecture (x86_64 and aarch64 on Linux/macOS, x86_64 on Windows) and downloads the correct pre-built binary.
+
+## CI integration (manual)
 
 ```yaml
 # GitHub Actions — install from release binary

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,117 @@
+name: 'SpecSync Check'
+description: 'Validate module specs against source code with SpecSync'
+branding:
+  icon: 'check-circle'
+  color: 'green'
+
+inputs:
+  version:
+    description: 'SpecSync version to use (e.g. "1.0.0" or "latest")'
+    required: false
+    default: 'latest'
+  strict:
+    description: 'Treat warnings as errors'
+    required: false
+    default: 'false'
+  require-coverage:
+    description: 'Minimum file coverage percentage (0-100)'
+    required: false
+    default: '0'
+  root:
+    description: 'Project root directory'
+    required: false
+    default: '.'
+  args:
+    description: 'Additional arguments to pass to specsync check'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Download SpecSync
+      shell: bash
+      env:
+        SPECSYNC_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        # Detect OS
+        case "$RUNNER_OS" in
+          Linux)   OS="linux" ;;
+          macOS)   OS="macos" ;;
+          Windows) OS="windows" ;;
+          *)
+            echo "::error::Unsupported runner OS: $RUNNER_OS"
+            exit 1
+            ;;
+        esac
+
+        # Detect architecture
+        ARCH="$(uname -m)"
+        case "$ARCH" in
+          x86_64|amd64)  ARCH="x86_64" ;;
+          aarch64|arm64) ARCH="aarch64" ;;
+          *)
+            echo "::error::Unsupported architecture: $ARCH"
+            exit 1
+            ;;
+        esac
+
+        REPO="CorvidLabs/spec-sync"
+
+        # Determine download URL
+        if [ "$SPECSYNC_VERSION" = "latest" ]; then
+          BASE_URL="https://github.com/${REPO}/releases/latest/download"
+        else
+          BASE_URL="https://github.com/${REPO}/releases/download/v${SPECSYNC_VERSION}"
+        fi
+
+        # Download and install
+        INSTALL_DIR="${RUNNER_TEMP}/specsync"
+        mkdir -p "$INSTALL_DIR"
+
+        if [ "$OS" = "windows" ]; then
+          ARCHIVE="specsync-${OS}-${ARCH}.exe.zip"
+          curl -fsSL "${BASE_URL}/${ARCHIVE}" -o "${INSTALL_DIR}/specsync.zip"
+          unzip -o "${INSTALL_DIR}/specsync.zip" -d "$INSTALL_DIR"
+          mv "${INSTALL_DIR}/specsync-${OS}-${ARCH}.exe" "${INSTALL_DIR}/specsync.exe"
+        else
+          ARCHIVE="specsync-${OS}-${ARCH}.tar.gz"
+          curl -fsSL "${BASE_URL}/${ARCHIVE}" | tar xz -C "$INSTALL_DIR"
+          mv "${INSTALL_DIR}/specsync-${OS}-${ARCH}" "${INSTALL_DIR}/specsync"
+          chmod +x "${INSTALL_DIR}/specsync"
+        fi
+
+        # Add to PATH
+        echo "${INSTALL_DIR}" >> "$GITHUB_PATH"
+        echo "::notice::SpecSync installed (${OS}/${ARCH}) from ${BASE_URL}/${ARCHIVE}"
+
+    - name: Run SpecSync
+      shell: bash
+      working-directory: ${{ inputs.root }}
+      env:
+        INPUT_STRICT: ${{ inputs.strict }}
+        INPUT_REQUIRE_COVERAGE: ${{ inputs.require-coverage }}
+        INPUT_ARGS: ${{ inputs.args }}
+      run: |
+        set -euo pipefail
+
+        CMD="specsync check"
+
+        if [ "$INPUT_STRICT" = "true" ]; then
+          CMD="$CMD --strict"
+        fi
+
+        if [ "$INPUT_REQUIRE_COVERAGE" != "0" ]; then
+          CMD="$CMD --require-coverage $INPUT_REQUIRE_COVERAGE"
+        fi
+
+        if [ -n "$INPUT_ARGS" ]; then
+          CMD="$CMD $INPUT_ARGS"
+        fi
+
+        echo "::group::SpecSync Check"
+        echo "Running: $CMD"
+        eval "$CMD"
+        echo "::endgroup::"


### PR DESCRIPTION
## Summary

- Add a composite GitHub Action (`action.yml`) that downloads the correct pre-built specsync binary and runs `specsync check`
- Auto-detects runner OS (Linux, macOS, Windows) and architecture (x86_64, aarch64) to fetch the right binary from releases
- Supports configurable inputs: `version`, `strict`, `require-coverage`, `root`, `args`
- Add GitHub Action usage documentation to README (basic usage, all options, full workflow, multi-platform matrix examples)

## Usage

```yaml
- uses: CorvidLabs/spec-sync@v1
  with:
    strict: 'true'
    require-coverage: '100'
```

## Test plan

- [ ] Verify `cargo test` unit tests still pass (26/26 pass; 2 pre-existing integration failures unrelated to this change)
- [ ] Test action on ubuntu-latest runner
- [ ] Test action on macos-latest runner
- [ ] Test action on windows-latest runner
- [ ] Verify `version: 'latest'` resolves correctly
- [ ] Verify pinned version (e.g. `version: '1.0.0'`) resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)