### PR TITLE
feat: add comprehensive integration test suite

### DIFF
--- a/src/exports/kotlin.rs
+++ b/src/exports/kotlin.rs
@@ -35,13 +35,14 @@ pub fn extract_exports(content: &str) -> Vec<String> {
         }
 
         if let Some(caps) = KT_DECL.captures(line)
-            && let Some(name) = caps.get(1) {
-                // Skip companion objects (they're not standalone exports)
-                if trimmed.starts_with("companion") {
-                    continue;
-                }
-                symbols.push(name.as_str().to_string());
+            && let Some(name) = caps.get(1)
+        {
+            // Skip companion objects (they're not standalone exports)
+            if trimmed.starts_with("companion") {
+                continue;
             }
+            symbols.push(name.as_str().to_string());
+        }
     }
 
     symbols

--- a/src/exports/python.rs
+++ b/src/exports/python.rs
@@ -18,15 +18,16 @@ static QUOTED: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"["'](\w+)["']"#)
 pub fn extract_exports(content: &str) -> Vec<String> {
     // Check for __all__ first
     if let Some(caps) = ALL_DECL.captures(content)
-        && let Some(list) = caps.get(1) {
-            let mut symbols = Vec::new();
-            for name_cap in QUOTED.captures_iter(list.as_str()) {
-                if let Some(name) = name_cap.get(1) {
-                    symbols.push(name.as_str().to_string());
-                }
+        && let Some(list) = caps.get(1)
+    {
+        let mut symbols = Vec::new();
+        for name_cap in QUOTED.captures_iter(list.as_str()) {
+            if let Some(name) = name_cap.get(1) {
+                symbols.push(name.as_str().to_string());
             }
-            return symbols;
         }
+        return symbols;
+    }
 
     // Fallback: top-level def/class that don't start with _
     let mut symbols = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,16 +418,17 @@ fn exit_with_status(
     }
 
     if let Some(req) = require_coverage
-        && coverage.coverage_percent < req {
-            println!(
-                "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
-                "--require-coverage".red(),
-                coverage.coverage_percent,
-                coverage.unspecced_files.len()
-            );
-            for f in &coverage.unspecced_files {
-                println!("  {} {f}", "✗".red());
-            }
-            process::exit(1);
+        && coverage.coverage_percent < req
+    {
+        println!(
+            "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
+            "--require-coverage".red(),
+            coverage.coverage_percent,
+            coverage.unspecced_files.len()
+        );
+        for f in &coverage.unspecced_files {
+            println!("  {} {f}", "✗".red());
         }
+        process::exit(1);
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,10 +26,11 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
     for line in yaml_block.lines() {
         // List item: "  - value"
         if let Some(stripped) = line.trim_start().strip_prefix("- ")
-            && current_key.is_some() {
-                current_list.push(stripped.trim().to_string());
-                continue;
-            }
+            && current_key.is_some()
+        {
+            current_list.push(stripped.trim().to_string());
+            continue;
+        }
 
         // Key-value: "key: value" or "key:"
         if let Some(colon_pos) = line.find(':') {
@@ -58,10 +59,11 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
         // Blank or comment line: flush
         let trimmed = line.trim();
         if (trimmed.is_empty() || trimmed.starts_with('#'))
-            && let Some(prev_key) = current_key.take() {
-                set_field(&mut fm, &prev_key, &current_list);
-                current_list.clear();
-            }
+            && let Some(prev_key) = current_key.take()
+        {
+            set_field(&mut fm, &prev_key, &current_list);
+            current_list.clear();
+        }
     }
 
     // Flush trailing list

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -255,7 +255,9 @@ Utility functions.
         .arg(&root)
         .assert()
         .success()
-        .stdout(predicate::str::contains("Export 'undocumented' not in spec"));
+        .stdout(predicate::str::contains(
+            "Export 'undocumented' not in spec",
+        ));
 }
 
 #[test]
@@ -446,9 +448,7 @@ fn generate_no_op_when_fully_covered() {
         .arg(&root)
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "No specs to generate",
-        ));
+        .stdout(predicate::str::contains("No specs to generate"));
 }
 
 // ─── 4. specsync init ───────────────────────────────────────────────────
@@ -643,7 +643,7 @@ fn root_flag_overrides_cwd() {
         .arg("check")
         .arg("--root")
         .arg(&root)
-        .current_dir("/tmp")
+        .current_dir(std::env::temp_dir())
         .assert()
         .success()
         .stdout(predicate::str::contains("specs checked"));
@@ -1022,11 +1022,7 @@ fn require_coverage_on_coverage_subcommand() {
     let root = setup_minimal_project(&tmp);
 
     // Add uncovered file
-    fs::write(
-        root.join("src/auth/extra.ts"),
-        "export function y() {}\n",
-    )
-    .unwrap();
+    fs::write(root.join("src/auth/extra.ts"), "export function y() {}\n").unwrap();
 
     specsync()
         .arg("coverage")
@@ -1064,11 +1060,7 @@ fn generate_with_multiple_languages() {
     // Need at least one spec to avoid the "no spec files" early exit.
     // Create a dummy specced module.
     fs::create_dir_all(root.join("src/base")).unwrap();
-    fs::write(
-        root.join("src/base/base.ts"),
-        "export function base() {}\n",
-    )
-    .unwrap();
+    fs::write(root.join("src/base/base.ts"), "export function base() {}\n").unwrap();
     fs::create_dir_all(root.join("specs/base")).unwrap();
     let spec = valid_spec("base", &["src/base/base.ts"]);
     fs::write(root.join("specs/base/base.spec.md"), spec).unwrap();


### PR DESCRIPTION
## Summary

- Adds 29 integration tests in `tests/integration.rs` using `assert_cmd`, `predicates`, and `tempfile`
- Covers all four CLI subcommands: `check`, `coverage`, `generate`, `init`
- Tests all global flags: `--strict`, `--require-coverage`, `--root`
- Validates multi-language support with TypeScript, Rust, Go, and Python source files
- Tests error cases: missing source files, invalid/missing frontmatter, phantom exports, missing required sections, missing dependency specs, missing spec directory

## Test plan

- [x] All 29 integration tests pass (`cargo test --test integration`)
- [x] All 26 existing unit tests still pass
- [x] Full suite: 55 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)