### PR TITLE
feat: add watch subcommand for live spec validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,6 +87,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -163,7 +169,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -185,7 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -193,6 +199,26 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "float-cmp"
@@ -208,6 +234,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "getrandom"
@@ -262,6 +297,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +338,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +368,18 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -304,10 +400,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcf855483228259b2353f89e99df35fc639b2b2510d1166e4858e3f67ec1afb"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "num-traits"
@@ -329,6 +478,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "predicates"
@@ -395,6 +550,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,11 +593,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -501,6 +665,8 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "notify",
+ "notify-debouncer-full",
  "predicates",
  "regex",
  "serde",
@@ -536,7 +702,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -581,6 +747,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -628,7 +800,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -640,7 +812,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -651,12 +823,159 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -716,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ serde_json = "1"
 regex = "1"
 walkdir = "2"
 colored = "3"
+notify = "7"
+notify-debouncer-full = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/exports/kotlin.rs
+++ b/src/exports/kotlin.rs
@@ -35,13 +35,14 @@ pub fn extract_exports(content: &str) -> Vec<String> {
         }
 
         if let Some(caps) = KT_DECL.captures(line)
-            && let Some(name) = caps.get(1) {
-                // Skip companion objects (they're not standalone exports)
-                if trimmed.starts_with("companion") {
-                    continue;
-                }
-                symbols.push(name.as_str().to_string());
+            && let Some(name) = caps.get(1)
+        {
+            // Skip companion objects (they're not standalone exports)
+            if trimmed.starts_with("companion") {
+                continue;
             }
+            symbols.push(name.as_str().to_string());
+        }
     }
 
     symbols

--- a/src/exports/python.rs
+++ b/src/exports/python.rs
@@ -18,15 +18,16 @@ static QUOTED: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"["'](\w+)["']"#)
 pub fn extract_exports(content: &str) -> Vec<String> {
     // Check for __all__ first
     if let Some(caps) = ALL_DECL.captures(content)
-        && let Some(list) = caps.get(1) {
-            let mut symbols = Vec::new();
-            for name_cap in QUOTED.captures_iter(list.as_str()) {
-                if let Some(name) = name_cap.get(1) {
-                    symbols.push(name.as_str().to_string());
-                }
+        && let Some(list) = caps.get(1)
+    {
+        let mut symbols = Vec::new();
+        for name_cap in QUOTED.captures_iter(list.as_str()) {
+            if let Some(name) = name_cap.get(1) {
+                symbols.push(name.as_str().to_string());
             }
-            return symbols;
         }
+        return symbols;
+    }
 
     // Fallback: top-level def/class that don't start with _
     let mut symbols = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod generator;
 mod parser;
 mod types;
 mod validator;
+mod watch;
 
 use clap::{Parser, Subcommand};
 use colored::Colorize;
@@ -48,6 +49,8 @@ enum Command {
     Generate,
     /// Create a specsync.json config file
     Init,
+    /// Watch spec and source files, re-running check on changes
+    Watch,
 }
 
 fn main() {
@@ -64,6 +67,7 @@ fn main() {
         Command::Check => cmd_check(&root, cli.strict, cli.require_coverage),
         Command::Coverage => cmd_coverage(&root, cli.strict, cli.require_coverage),
         Command::Generate => cmd_generate(&root, cli.strict, cli.require_coverage),
+        Command::Watch => watch::run_watch(&root, cli.strict, cli.require_coverage),
     }
 }
 
@@ -418,16 +422,17 @@ fn exit_with_status(
     }
 
     if let Some(req) = require_coverage
-        && coverage.coverage_percent < req {
-            println!(
-                "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
-                "--require-coverage".red(),
-                coverage.coverage_percent,
-                coverage.unspecced_files.len()
-            );
-            for f in &coverage.unspecced_files {
-                println!("  {} {f}", "✗".red());
-            }
-            process::exit(1);
+        && coverage.coverage_percent < req
+    {
+        println!(
+            "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
+            "--require-coverage".red(),
+            coverage.coverage_percent,
+            coverage.unspecced_files.len()
+        );
+        for f in &coverage.unspecced_files {
+            println!("  {} {f}", "✗".red());
         }
+        process::exit(1);
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,10 +26,11 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
     for line in yaml_block.lines() {
         // List item: "  - value"
         if let Some(stripped) = line.trim_start().strip_prefix("- ")
-            && current_key.is_some() {
-                current_list.push(stripped.trim().to_string());
-                continue;
-            }
+            && current_key.is_some()
+        {
+            current_list.push(stripped.trim().to_string());
+            continue;
+        }
 
         // Key-value: "key: value" or "key:"
         if let Some(colon_pos) = line.find(':') {
@@ -58,10 +59,11 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
         // Blank or comment line: flush
         let trimmed = line.trim();
         if (trimmed.is_empty() || trimmed.starts_with('#'))
-            && let Some(prev_key) = current_key.take() {
-                set_field(&mut fm, &prev_key, &current_list);
-                current_list.clear();
-            }
+            && let Some(prev_key) = current_key.take()
+        {
+            set_field(&mut fm, &prev_key, &current_list);
+            current_list.clear();
+        }
     }
 
     // Flush trailing list

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,166 @@
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use colored::Colorize;
+use notify::{EventKind, RecursiveMode};
+use notify_debouncer_full::{DebouncedEvent, new_debouncer};
+
+use crate::config::load_config;
+
+/// Run the check command in watch mode, re-running on file changes.
+pub fn run_watch(root: &Path, strict: bool, require_coverage: Option<usize>) {
+    let config = load_config(root);
+    let specs_dir = root.join(&config.specs_dir);
+    let source_dirs: Vec<PathBuf> = config.source_dirs.iter().map(|d| root.join(d)).collect();
+
+    // Collect directories to watch
+    let mut watch_dirs: Vec<PathBuf> = Vec::new();
+    if specs_dir.is_dir() {
+        watch_dirs.push(specs_dir.clone());
+    }
+    for dir in &source_dirs {
+        if dir.is_dir() {
+            watch_dirs.push(dir.clone());
+        }
+    }
+
+    if watch_dirs.is_empty() {
+        eprintln!(
+            "{} No directories to watch (specs_dir={}, source_dirs={:?})",
+            "Error:".red(),
+            config.specs_dir,
+            config.source_dirs
+        );
+        std::process::exit(1);
+    }
+
+    // Initial run
+    print_separator(None);
+    run_check(root, strict, require_coverage);
+
+    // Set up debounced file watcher
+    let (tx, rx) = mpsc::channel();
+    let mut debouncer = new_debouncer(
+        Duration::from_millis(500),
+        None,
+        move |events| match events {
+            Ok(evts) => {
+                for evt in evts {
+                    let _ = tx.send(evt);
+                }
+            }
+            Err(errs) => {
+                for e in errs {
+                    eprintln!("{} watcher error: {e}", "Error:".red());
+                }
+            }
+        },
+    )
+    .expect("Failed to create file watcher");
+
+    for dir in &watch_dirs {
+        debouncer
+            .watch(dir, RecursiveMode::Recursive)
+            .unwrap_or_else(|e| {
+                eprintln!("{} Failed to watch {}: {e}", "Error:".red(), dir.display());
+            });
+    }
+
+    println!(
+        "\n{} Watching for changes in: {}",
+        ">>>".cyan(),
+        watch_dirs
+            .iter()
+            .map(|d| d.strip_prefix(root).unwrap_or(d).display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    println!("{} Press Ctrl+C to stop\n", ">>>".cyan());
+
+    // Event loop
+    let mut last_run = Instant::now();
+    while let Ok(event) = rx.recv() {
+        // Skip non-modify events
+        if !is_relevant_event(&event) {
+            continue;
+        }
+
+        // Extra debounce: don't re-run if we just ran
+        if last_run.elapsed() < Duration::from_millis(300) {
+            continue;
+        }
+
+        let changed_file: Option<String> = event
+            .paths
+            .first()
+            .and_then(|p: &PathBuf| p.strip_prefix(root).ok())
+            .map(|p: &Path| p.display().to_string());
+
+        // Drain any remaining queued events
+        while rx.try_recv().is_ok() {}
+
+        print_separator(changed_file.as_deref());
+        run_check(root, strict, require_coverage);
+        last_run = Instant::now();
+
+        println!(
+            "\n{} Watching for changes... (Ctrl+C to stop)",
+            ">>>".cyan()
+        );
+    }
+}
+
+fn is_relevant_event(event: &DebouncedEvent) -> bool {
+    matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    )
+}
+
+fn print_separator(changed_file: Option<&str>) {
+    // Clear screen
+    print!("\x1B[2J\x1B[1;1H");
+
+    println!(
+        "{}",
+        "════════════════════════════════════════════════════════════".cyan()
+    );
+    if let Some(file) = changed_file {
+        println!("{} Changed: {}", ">>>".cyan(), file.bold());
+    } else {
+        println!("{} Initial run", ">>>".cyan());
+    }
+    println!(
+        "{}",
+        "════════════════════════════════════════════════════════════".cyan()
+    );
+}
+
+fn run_check(root: &Path, strict: bool, require_coverage: Option<usize>) {
+    // Fork a child process to isolate exit calls from the check command.
+    use std::process::Command;
+
+    let mut cmd = Command::new(std::env::current_exe().expect("Cannot find current executable"));
+    cmd.arg("check");
+    cmd.arg("--root").arg(root);
+    if strict {
+        cmd.arg("--strict");
+    }
+    if let Some(cov) = require_coverage {
+        cmd.arg("--require-coverage").arg(cov.to_string());
+    }
+
+    match cmd.status() {
+        Ok(status) => {
+            if status.success() {
+                println!("\n{}", "All checks passed!".green().bold());
+            } else {
+                println!("\n{}", "Some checks failed.".red().bold());
+            }
+        }
+        Err(e) => {
+            eprintln!("{} Failed to run check: {e}", "Error:".red());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `specsync watch` subcommand that monitors spec and source directories for file changes
- Re-runs validation automatically with 500ms debounce using the `notify` crate (RecommendedWatcher via notify-debouncer-full)
- Clears screen between runs and shows which file triggered the re-run
- Accepts the same `--strict` and `--require-coverage` flags as `check`
- Runs check in a subprocess to isolate `process::exit()` calls from the watch loop

## Test plan
- [x] `cargo test` passes (26 unit tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] Manual: run `specsync watch` in a project and modify a spec file — verify re-run triggers
- [ ] Manual: verify `specsync watch --strict` passes the flag through to check

🤖 Generated with [Claude Code](https://claude.com/claude-code)