### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-18
+
+### Added
+
+- **Reusable GitHub Action** (`CorvidLabs/spec-sync@v1`) — auto-downloads the
+  correct platform binary and runs specsync check in CI. Supports `strict`,
+  `require-coverage`, `root`, and `version` inputs.
+- **`watch` subcommand** — live spec validation that re-runs on file changes.
+- **Comprehensive integration test suite** — end-to-end tests using assert_cmd.
+
+### Changed
+
+- Updated crates.io metadata (readme, homepage fields).
+
 ## [1.0.0] - 2026-03-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "specsync"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 1.1.0 in Cargo.toml and Cargo.lock
- Update CHANGELOG with v1.1.0 entries (GitHub Action, watch mode, integration tests)

This release includes all features added since v1.0.0 and is needed to create the v1.1.0 tag which will trigger the release workflow to build platform binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)