### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/CorvidLabs/spec-sync/security/code-scanning/2](https://github.com/CorvidLabs/spec-sync/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scopes needed. For this CI workflow, the jobs only need to read the repository contents to build and test, so `contents: read` is sufficient. Defining this at the workflow root applies to all jobs that don’t override permissions individually, which matches the current structure and avoids duplicating configuration.

The best fix with no functional change is to insert a workflow-level `permissions` block near the top of `.github/workflows/ci.yml`, for example immediately after the `on:` section (or after `name:`), specifying `contents: read`. This ensures both `test` and `fmt` jobs run with a read-only `GITHUB_TOKEN`. No additional imports, actions, or dependencies are required, and no existing steps need modification.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Add:

```yaml
permissions:
  contents: read
```

at the root level (aligned with `name`, `on`, and `env`), so it applies to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
