### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/CorvidLabs/spec-sync/security/code-scanning/1](https://github.com/CorvidLabs/spec-sync/security/code-scanning/1)

In general, the fix is to declare a `permissions` block that grants only the scopes needed by this workflow. Since the jobs only need to read the repository contents (for checkout) and do not interact with issues, PRs, or releases, `contents: read` at the workflow or job level is sufficient.

The best fix without changing functionality is to add a top-level `permissions` block just under the `name: CI` line in `.github/workflows/ci.yml`. This will apply to all jobs (`test` and `fmt`) and restrict the `GITHUB_TOKEN` to read-only repository contents. No other permissions (like `pull-requests: write`) are needed, since this workflow does not modify PRs or push changes. No additional imports, methods, or definitions are required; the change is purely declarative in the YAML.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block (lines 1–3 in the snippet). All existing steps remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
