### PR TITLE
docs: add GitHub Pages documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,38 +1,58 @@
+<div align="center">
+
 # SpecSync
 
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-SpecSync-blue?logo=github)](https://github.com/marketplace/actions/spec-sync)
 
-Bidirectional spec-to-code validation. Keep your module specs and source code in sync with CI-enforced contract checking.
+**Bidirectional spec-to-code validation — keep your docs honest.**
 
-**Written in Rust. Language-agnostic. Blazing fast.**
+Written in Rust. Language-agnostic. Blazing fast.
 
-> **Now available on the [GitHub Marketplace](https://github.com/marketplace/actions/spec-sync)** — add spec validation to any repo in one step.
+[![CI](https://github.com/CorvidLabs/spec-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/CorvidLabs/spec-sync/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/specsync.svg)](https://crates.io/crates/specsync)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-## What it does
+[Quick Start](#quick-start) &bull; [Spec Format](#spec-format) &bull; [CLI Reference](#cli-reference) &bull; [GitHub Action](#github-action) &bull; [Configuration](#configuration) &bull; [Documentation Site](https://corvidlabs.github.io/spec-sync)
 
-SpecSync validates that your markdown module specifications match your actual source code — in both directions:
+</div>
 
-- **Code exports something not in the spec?** Warning: undocumented export
-- **Spec documents something that doesn't exist?** Error: stale spec entry
-- **Source file referenced in spec was deleted?** Error: missing file
-- **DB table in spec doesn't exist in schema?** Error: phantom table
-- **Required section missing from spec?** Error: incomplete spec
+---
+
+## The Problem
+
+Documentation drifts. Engineers add new exports but forget to update the spec. Specs reference functions that were renamed months ago. Nobody notices until a new team member reads the docs and gets confused.
+
+**SpecSync catches this automatically.**
+
+## What It Does
+
+SpecSync validates your markdown module specs against actual source code — in both directions:
+
+| Situation | Severity | Message |
+|-----------|----------|---------|
+| Code exports something not in the spec | Warning | Undocumented export |
+| Spec documents something that doesn't exist | **Error** | Stale/phantom spec entry |
+| Source file referenced in spec was deleted | **Error** | Missing file |
+| DB table in spec doesn't exist in schema | **Error** | Phantom table |
+| Required section missing from spec | **Error** | Incomplete spec |
 
 ## Supported Languages
 
-| Language | Export Detection | Test File Exclusion |
-|----------|----------------|---------------------|
-| TypeScript/JavaScript | `export function`, `export class`, `export type`, `export const`, `export enum`, re-exports | `.test.ts`, `.spec.ts`, `.d.ts` |
-| Rust | `pub fn`, `pub struct`, `pub enum`, `pub trait`, `pub type`, `pub const`, `pub static`, `pub mod` | (inline tests, no file exclusion) |
-| Swift | `public`/`open` func, class, struct, enum, protocol, typealias, actor, init | `*Tests.swift`, `*Test.swift` |
-| Kotlin | Top-level declarations (public by default), excludes `private`/`internal`/`protected` | `*Test.kt`, `*Spec.kt` |
-| Java | `public` class, interface, enum, record, methods, fields | `*Test.java`, `*Tests.java` |
-| Go | Uppercase identifiers: `func Name`, `type Name`, `var Name`, `const Name`, methods | `_test.go` |
-| Python | `__all__` list, or top-level `def`/`class` (excluding `_` prefixed) | `test_*.py`, `*_test.py` |
-| C# | `public` class, struct, interface, enum, record, delegate, methods | `*Test.cs`, `*Tests.cs` |
-| Dart | Top-level declarations (public = no `_` prefix), class, mixin, enum, typedef | `*_test.dart` |
+SpecSync auto-detects the language from file extensions. The same spec format works for all of them.
 
-Language is auto-detected from file extensions. The same spec format works for any language.
+| Language | What Gets Detected | Test Files Excluded |
+|----------|--------------------|---------------------|
+| **TypeScript / JavaScript** | `export function`, `export class`, `export type`, `export const`, `export enum`, re-exports | `.test.ts`, `.spec.ts`, `.d.ts` |
+| **Rust** | `pub fn`, `pub struct`, `pub enum`, `pub trait`, `pub type`, `pub const`, `pub static`, `pub mod` | Inline `#[cfg(test)]` modules |
+| **Go** | Uppercase identifiers: `func`, `type`, `var`, `const`, methods | `_test.go` |
+| **Python** | `__all__` list, or top-level `def`/`class` (excluding `_`-prefixed) | `test_*.py`, `*_test.py` |
+| **Swift** | `public`/`open` func, class, struct, enum, protocol, typealias, actor, init | `*Tests.swift`, `*Test.swift` |
+| **Kotlin** | Top-level declarations (public by default), excludes `private`/`internal`/`protected` | `*Test.kt`, `*Spec.kt` |
+| **Java** | `public` class, interface, enum, record, methods, fields | `*Test.java`, `*Tests.java` |
+| **C#** | `public` class, struct, interface, enum, record, delegate, methods | `*Test.cs`, `*Tests.cs` |
+| **Dart** | Top-level declarations (no `_` prefix), class, mixin, enum, typedef | `*_test.dart` |
+
+---
 
 ## Install
 
@@ -51,7 +71,7 @@ No binary download or Rust toolchain needed — the action handles everything.
 
 ### Pre-built binaries
 
-Download the latest binary from [GitHub Releases](https://github.com/CorvidLabs/spec-sync/releases):
+Download from [GitHub Releases](https://github.com/CorvidLabs/spec-sync/releases):
 
 ```bash
 # macOS (Apple Silicon)
@@ -71,7 +91,7 @@ curl -sL https://github.com/CorvidLabs/spec-sync/releases/latest/download/specsy
 sudo mv specsync-linux-aarch64 /usr/local/bin/specsync
 ```
 
-Windows: download `specsync-windows-x86_64.exe.zip` from the releases page.
+**Windows:** download `specsync-windows-x86_64.exe.zip` from the [releases page](https://github.com/CorvidLabs/spec-sync/releases).
 
 ### From source
 
@@ -80,29 +100,100 @@ cargo install --git https://github.com/CorvidLabs/spec-sync
 
 # Or clone and build
 git clone https://github.com/CorvidLabs/spec-sync.git
-cd spec-sync
-cargo install --path .
+cd spec-sync && cargo install --path .
 ```
 
-## Quick start
+### Crates.io
 
 ```bash
-# Create a config file
-specsync init
-
-# Validate all specs
-specsync check
-
-# See coverage report
-specsync coverage
-
-# Generate specs for unspecced modules
-specsync generate
+cargo install specsync
 ```
 
-## Spec format
+---
 
-Specs are markdown files with YAML frontmatter:
+## Quick Start
+
+```bash
+# 1. Initialize config in your project root
+specsync init
+
+# 2. Validate all specs
+specsync check
+
+# 3. See what's covered and what's missing
+specsync coverage
+
+# 4. Auto-generate specs for unspecced modules
+specsync generate
+
+# 5. Watch mode — re-validates on every file change
+specsync watch
+```
+
+---
+
+## Spec Format
+
+Specs are markdown files (`*.spec.md`) with YAML frontmatter. Place them in your specs directory (default: `specs/`).
+
+### Frontmatter
+
+```yaml
+---
+module: auth              # Module name (required)
+version: 3                # Spec version (required)
+status: stable            # draft | review | stable | deprecated (required)
+files:                    # Source files this spec covers (required, non-empty)
+  - src/auth/service.ts
+  - src/auth/middleware.ts
+db_tables:                # DB tables used (optional, validated against schema)
+  - users
+  - sessions
+depends_on:               # Other specs this module depends on (optional)
+  - specs/database/database.spec.md
+---
+```
+
+### Required Sections
+
+By default, every spec must include these markdown sections (configurable):
+
+| Section | Purpose |
+|---------|---------|
+| `## Purpose` | What this module does and why it exists |
+| `## Public API` | Tables listing exported symbols — this is what gets validated against code |
+| `## Invariants` | Rules that must always hold true |
+| `## Behavioral Examples` | Given/When/Then scenarios |
+| `## Error Cases` | How the module handles failures |
+| `## Dependencies` | What this module consumes from other modules |
+| `## Change Log` | History of spec changes |
+
+### Public API Tables
+
+The Public API section uses markdown tables with backtick-quoted symbol names. SpecSync extracts these and cross-references them against actual code exports.
+
+```markdown
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `authenticate` | `(token: string)` | `User \| null` | Validates a bearer token |
+| `refreshSession` | `(sessionId: string)` | `Session` | Extends session TTL |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `User` | Authenticated user object |
+| `Session` | Active session record |
+```
+
+### Full Example
+
+<details>
+<summary>Click to expand a complete spec file</summary>
 
 ```markdown
 ---
@@ -123,7 +214,8 @@ depends_on:
 
 ## Purpose
 
-Handles authentication and session management.
+Handles authentication and session management. Validates bearer tokens,
+manages session lifecycle, and provides middleware for route protection.
 
 ## Public API
 
@@ -132,17 +224,20 @@ Handles authentication and session management.
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `authenticate` | `(token: string)` | `User \| null` | Validates a token |
+| `refreshSession` | `(sessionId: string)` | `Session` | Extends session TTL |
 
 ### Exported Types
 
 | Type | Description |
 |------|-------------|
 | `User` | Authenticated user object |
+| `Session` | Active session record |
 
 ## Invariants
 
 1. Sessions expire after 24 hours
-2. Failed auth attempts are rate-limited
+2. Failed auth attempts are rate-limited to 5/minute
+3. Tokens are validated cryptographically, never by string comparison
 
 ## Behavioral Examples
 
@@ -150,7 +245,13 @@ Handles authentication and session management.
 
 - **Given** a valid JWT token
 - **When** `authenticate()` is called
-- **Then** returns the corresponding User
+- **Then** returns the corresponding User object
+
+### Scenario: Expired token
+
+- **Given** an expired JWT token
+- **When** `authenticate()` is called
+- **Then** returns null and logs a warning
 
 ## Error Cases
 
@@ -158,6 +259,7 @@ Handles authentication and session management.
 |-----------|----------|
 | Expired token | Returns null, logs warning |
 | Malformed token | Returns null |
+| DB unavailable | Throws `ServiceUnavailableError` |
 
 ## Dependencies
 
@@ -166,6 +268,7 @@ Handles authentication and session management.
 | Module | What is used |
 |--------|-------------|
 | database | `query()` for user lookups |
+| crypto | `verifyJwt()` for token validation |
 
 ## Change Log
 
@@ -174,45 +277,15 @@ Handles authentication and session management.
 | 2026-03-18 | team | Initial spec |
 ```
 
-## Configuration
+</details>
 
-Create a `specsync.json` in your project root:
+---
 
-```json
-{
-  "specsDir": "specs",
-  "sourceDirs": ["src"],
-  "schemaDir": "db/migrations",
-  "requiredSections": [
-    "Purpose",
-    "Public API",
-    "Invariants",
-    "Behavioral Examples",
-    "Error Cases",
-    "Dependencies",
-    "Change Log"
-  ],
-  "excludeDirs": ["__tests__"],
-  "excludePatterns": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"],
-  "sourceExtensions": []
-}
-```
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `specsDir` | `"specs"` | Directory containing spec files |
-| `sourceDirs` | `["src"]` | Source directories for coverage |
-| `schemaDir` | — | SQL schema dir for `db_tables` validation |
-| `schemaPattern` | `CREATE TABLE` regex | Pattern to extract table names |
-| `requiredSections` | Standard set | Required markdown sections |
-| `excludeDirs` | `["__tests__"]` | Dirs excluded from coverage |
-| `excludePatterns` | test files | File patterns excluded from coverage |
-| `sourceExtensions` | all supported | Restrict to specific extensions (e.g., `["ts", "rs"]`) |
-
-## CLI
+## CLI Reference
 
 ```
 specsync [command] [flags]
+<<<<<<< HEAD
 
 Commands:
   check       Validate all specs against source (default)
@@ -227,11 +300,67 @@ Flags:
   --require-coverage N  Fail if file coverage < N%
   --root <path>         Project root (default: cwd)
   --json                Output results as JSON
+=======
+>>>>>>> fed5ec7 (docs: add GitHub Pages documentation site)
 ```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `check` | Validate all specs against source code **(default)** |
+| `coverage` | Show file and module coverage report |
+| `generate` | Scaffold spec files for modules that don't have one |
+| `init` | Create a default `specsync.json` config file |
+| `watch` | Live validation — re-runs on file changes (500ms debounce) |
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--strict` | Treat warnings as errors (recommended for CI) |
+| `--require-coverage N` | Fail if file coverage is below N% |
+| `--root <path>` | Set project root directory (default: current directory) |
+| `--json` | Output structured JSON instead of colored text |
+
+### Examples
+
+```bash
+# Basic validation
+specsync check
+
+# Strict mode for CI — warnings fail the build
+specsync check --strict
+
+# Enforce 100% spec coverage
+specsync check --strict --require-coverage 100
+
+# JSON output for tooling integration
+specsync check --json
+
+# Override project root
+specsync check --root ./packages/backend
+
+# Watch mode for development
+specsync watch
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed |
+| `1` | Errors found, or warnings found with `--strict`, or coverage below threshold |
+
+---
 
 ## GitHub Action
 
+<<<<<<< HEAD
 Available on the [GitHub Marketplace](https://github.com/marketplace/actions/spec-sync). Use SpecSync as a reusable GitHub Action — no manual binary download needed.
+=======
+The easiest way to run SpecSync in CI. No manual binary download needed — the action auto-detects your runner's OS and architecture.
+>>>>>>> fed5ec7 (docs: add GitHub Pages documentation site)
 
 ### Basic usage
 
@@ -242,17 +371,15 @@ Available on the [GitHub Marketplace](https://github.com/marketplace/actions/spe
     require-coverage: '100'
 ```
 
-### All options
+### Inputs
 
-```yaml
-- uses: CorvidLabs/spec-sync@v1
-  with:
-    version: 'latest'        # SpecSync version (default: latest)
-    strict: 'true'           # Treat warnings as errors (default: false)
-    require-coverage: '100'  # Minimum file coverage % (default: 0)
-    root: '.'                # Project root directory (default: .)
-    args: ''                 # Additional CLI arguments (default: '')
-```
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | SpecSync release version to use |
+| `strict` | `false` | Treat warnings as errors |
+| `require-coverage` | `0` | Minimum file coverage percentage |
+| `root` | `.` | Project root directory |
+| `args` | `''` | Additional CLI arguments |
 
 ### Full workflow example
 
@@ -287,12 +414,11 @@ jobs:
           strict: 'true'
 ```
 
-The action automatically detects the runner OS and architecture (x86_64 and aarch64 on Linux/macOS, x86_64 on Windows) and downloads the correct pre-built binary.
+### Manual CI setup
 
-## CI integration (manual)
+If you prefer not to use the action:
 
 ```yaml
-# GitHub Actions — install from release binary
 - name: Install specsync
   run: |
     curl -sL https://github.com/CorvidLabs/spec-sync/releases/latest/download/specsync-linux-x86_64.tar.gz | tar xz
@@ -302,47 +428,173 @@ The action automatically detects the runner OS and architecture (x86_64 and aarc
   run: specsync check --strict --require-coverage 100
 ```
 
-```yaml
-# Or install from source (slower but always up to date)
-- name: Install specsync
-  run: cargo install --git https://github.com/CorvidLabs/spec-sync
+---
 
-- name: Spec check
-  run: specsync check --strict --require-coverage 100
+## Configuration
+
+Create `specsync.json` in your project root (or run `specsync init`):
+
+```json
+{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "schemaDir": "db/migrations",
+  "requiredSections": [
+    "Purpose",
+    "Public API",
+    "Invariants",
+    "Behavioral Examples",
+    "Error Cases",
+    "Dependencies",
+    "Change Log"
+  ],
+  "excludeDirs": ["__tests__"],
+  "excludePatterns": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"],
+  "sourceExtensions": []
+}
 ```
 
-## How it works
+### Options
 
-1. **Discovers** all `*.spec.md` files in your specs directory
-2. **Parses** YAML frontmatter (zero-dependency regex parser, no YAML library)
-3. **Validates structure** — required fields, required sections, file existence
-4. **Validates API surface** — auto-detects language, parses exports, cross-references against spec's Public API tables
-5. **Validates dependencies** — checks that `depends_on` spec files exist
-6. **Reports coverage** — which source files and modules have specs
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `specsDir` | `string` | `"specs"` | Directory containing `*.spec.md` files |
+| `sourceDirs` | `string[]` | `["src"]` | Source directories to analyze for coverage |
+| `schemaDir` | `string?` | — | SQL schema directory for `db_tables` validation |
+| `schemaPattern` | `string?` | `CREATE TABLE` regex | Custom regex to extract table names from schema files |
+| `requiredSections` | `string[]` | See above | Markdown sections every spec must include |
+| `excludeDirs` | `string[]` | `["__tests__"]` | Directories excluded from coverage scanning |
+| `excludePatterns` | `string[]` | Common test patterns | Glob patterns for files to exclude from coverage |
+| `sourceExtensions` | `string[]` | All supported | Restrict analysis to specific file extensions (e.g., `["ts", "rs"]`) |
+
+---
+
+## How It Works
+
+```
+                    *.spec.md files
+                         |
+                    [1] Discover
+                         |
+                    [2] Parse frontmatter
+                         |
+              +----------+----------+
+              |          |          |
+         [3] Structure  [4] API   [5] Dependencies
+              |          |          |
+         - Required    - Detect   - depends_on exists?
+           fields        language  - db_tables in schema?
+         - File        - Extract  - Consumed By refs?
+           exists?       exports
+         - Required    - Compare
+           sections?     with spec
+              |          |          |
+              +----------+----------+
+                         |
+                    [6] Report
+                         |
+              +----------+----------+
+              |          |          |
+           Errors    Warnings   Coverage %
+```
+
+1. **Discover** all `*.spec.md` files in your specs directory
+2. **Parse** YAML frontmatter using a zero-dependency regex parser (no YAML library needed)
+3. **Validate structure** — required fields, required markdown sections, file existence
+4. **Validate API surface** — auto-detect language from extensions, extract exports, cross-reference against the spec's Public API tables
+5. **Validate dependencies** — check `depends_on` specs exist, `db_tables` are in schema
+6. **Report** errors, warnings, and coverage metrics
+
+---
 
 ## Architecture
 
 ```
 src/
-├── main.rs           CLI (clap) + output formatting
-├── types.rs          Core data types + config schema
-├── config.rs         specsync.json loading
-├── parser.rs         Frontmatter + spec body parsing
-├── validator.rs      Spec validation + coverage computation
-├── generator.rs      Spec scaffolding for new modules
+├── main.rs            CLI entry point (clap) + output formatting
+├── types.rs           Core data types + config schema
+├── config.rs          specsync.json loading
+├── parser.rs          YAML frontmatter + spec body parsing
+├── validator.rs       Spec validation + coverage computation
+├── generator.rs       Spec scaffolding for new modules
+├── watch.rs           File watcher (notify crate, 500ms debounce)
 └── exports/
-    ├── mod.rs        Language dispatch + file utilities
-    ├── typescript.rs TypeScript/JS export extraction
-    ├── rust_lang.rs  Rust pub item extraction
-    ├── swift.rs      Swift public/open item extraction
-    ├── kotlin.rs     Kotlin public item extraction
-    ├── java.rs       Java public item extraction
-    ├── go.rs         Go exported identifier extraction
-    ├── python.rs     Python __all__ / top-level extraction
-    ├── csharp.rs     C# public item extraction
-    └── dart.rs       Dart public item extraction
+    ├── mod.rs          Language dispatch + file utilities
+    ├── typescript.rs   TypeScript/JS export extraction
+    ├── rust_lang.rs    Rust pub item extraction
+    ├── go.rs           Go exported identifier extraction
+    ├── python.rs       Python __all__ / top-level extraction
+    ├── swift.rs        Swift public/open item extraction
+    ├── kotlin.rs       Kotlin public item extraction
+    ├── java.rs         Java public item extraction
+    ├── csharp.rs       C# public item extraction
+    └── dart.rs         Dart public item extraction
 ```
+
+### Design Principles
+
+- **Single binary** — no runtime dependencies, no package managers, just download and run
+- **Zero YAML dependencies** — frontmatter is parsed with regex, keeping the binary small
+- **Language-agnostic architecture** — adding a new language means adding one file in `exports/`
+- **Release-optimized** — LTO, symbol stripping, opt-level 3 for maximum performance
+
+---
+
+## For AI Agents
+
+SpecSync is designed to work well with AI coding agents. Here's what you need to know:
+
+- **`--json` flag** outputs structured results that are easy to parse programmatically
+- **Exit code 1** means something needs attention; exit code 0 means all clear
+- **`specsync generate`** can scaffold specs automatically — useful for bootstrapping docs on an existing codebase
+- **Spec files are plain markdown** — any LLM can read and write them
+- **The Public API table format** uses backtick-quoted names that are unambiguous to parse
+
+### JSON output shape
+
+```json
+{
+  "passed": false,
+  "errors": ["auth.spec.md: phantom export `oldFunction` not found in source"],
+  "warnings": ["auth.spec.md: undocumented export `newHelper`"],
+  "specs_checked": 12
+}
+```
+
+### Recommended AI workflow
+
+```bash
+# 1. Check current state
+specsync check --json
+
+# 2. Fix any errors (update specs or code)
+# 3. Generate specs for new modules
+specsync generate
+
+# 4. Verify everything passes
+specsync check --strict --require-coverage 100
+```
+
+---
+
+## Contributing
+
+1. Fork the repo
+2. Create a feature branch (`git checkout -b feat/my-feature`)
+3. Make your changes
+4. Run tests: `cargo test`
+5. Run lints: `cargo clippy`
+6. Open a PR
+
+### Adding a new language
+
+1. Create `src/exports/yourlang.rs` implementing export extraction
+2. Add the language variant to `Language` enum in `types.rs`
+3. Wire it up in `src/exports/mod.rs`
+4. Add tests for common export patterns
+
+---
 
 ## License
 
-MIT
+[MIT](LICENSE) &copy; [CorvidLabs](https://github.com/CorvidLabs)

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,5 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+Gemfile.lock

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "just-the-docs", "~> 0.10.0"
+gem "jekyll-remote-theme"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,43 @@
+title: SpecSync
+description: Bidirectional spec-to-code validation — keep your docs honest.
+url: "https://corvidlabs.github.io"
+baseurl: "/spec-sync"
+
+remote_theme: just-the-docs/just-the-docs@v0.10.0
+
+color_scheme: dark
+
+aux_links:
+  "GitHub":
+    - "https://github.com/CorvidLabs/spec-sync"
+  "Crates.io":
+    - "https://crates.io/crates/specsync"
+
+aux_links_new_tab: true
+
+heading_anchors: true
+
+nav_sort: order
+
+footer_content: "MIT License &copy; <a href=\"https://github.com/CorvidLabs\">CorvidLabs</a>"
+
+back_to_top: true
+back_to_top_text: "Back to top"
+
+search_enabled: true
+search:
+  heading_level: 2
+  previews: 3
+  preview_words_before: 5
+  preview_words_after: 10
+
+callouts:
+  warning:
+    title: Warning
+    color: yellow
+  note:
+    title: Note
+    color: blue
+  tip:
+    title: Tip
+    color: green

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -1,0 +1,153 @@
+---
+title: For AI Agents
+layout: default
+nav_order: 6
+---
+
+# For AI Agents
+{: .no_toc }
+
+SpecSync is designed to work well with AI coding agents and LLM-powered tooling.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Why It Works for AI
+
+- **Specs are plain markdown** — any LLM can read and write them
+- **The Public API format** uses backtick-quoted names that are unambiguous to parse
+- **`--json` flag** outputs structured results, no terminal color codes to strip
+- **Exit code 1** means something needs fixing; **0** means all clear
+- **`specsync generate`** can scaffold specs automatically for an existing codebase
+
+---
+
+## Recommended Workflow
+
+```bash
+# 1. Check the current state
+specsync check --json
+
+# 2. Fix any errors reported (update specs or source code)
+
+# 3. Generate specs for new modules that don't have one
+specsync generate
+
+# 4. Verify everything passes
+specsync check --strict --require-coverage 100
+```
+
+---
+
+## JSON Output Shapes
+
+### Check result
+
+```json
+{
+  "passed": false,
+  "errors": [
+    "auth.spec.md: Spec documents 'oldFunction' but no matching export found in source"
+  ],
+  "warnings": [
+    "auth.spec.md: Export 'newHelper' not in spec (undocumented)"
+  ],
+  "specs_checked": 12
+}
+```
+
+### Coverage result
+
+```json
+{
+  "file_coverage": 85.33,
+  "files_covered": 23,
+  "files_total": 27,
+  "modules": [
+    {
+      "name": "helpers",
+      "has_spec": false
+    }
+  ]
+}
+```
+
+---
+
+## Parsing Tips
+
+- **Errors** are things that must be fixed — the spec references something that doesn't exist
+- **Warnings** are informational — code exports something the spec doesn't mention
+- With `--strict`, warnings become errors (useful for enforcing full documentation)
+- The `specs_checked` field tells you the total number of specs processed
+- `file_coverage` is a float between 0 and 100
+
+---
+
+## Writing Specs Programmatically
+
+When generating or updating specs, follow these rules:
+
+1. **Frontmatter** must have `module`, `version`, `status`, and `files` fields
+2. **Status** must be one of: `draft`, `review`, `stable`, `deprecated`
+3. **Files** must be a non-empty list of paths relative to the project root
+4. **Public API tables** must use backtick-quoted names in the first column
+5. **Required sections** default to: Purpose, Public API, Invariants, Behavioral Examples, Error Cases, Dependencies, Change Log
+
+### Minimal valid spec
+
+```markdown
+---
+module: mymodule
+version: 1
+status: draft
+files:
+  - src/mymodule.ts
+---
+
+# MyModule
+
+## Purpose
+TODO
+
+## Public API
+
+| Export | Description |
+|--------|-------------|
+| `myFunction` | Does something |
+
+## Invariants
+TODO
+
+## Behavioral Examples
+TODO
+
+## Error Cases
+TODO
+
+## Dependencies
+None
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-03-18 | Initial spec |
+```
+
+---
+
+## Integration Ideas
+
+- **Pre-commit hook**: Run `specsync check --strict` before allowing commits
+- **PR review bot**: Run `specsync check --json` and post results as a PR comment
+- **Spec generation**: After adding new modules, run `specsync generate` to scaffold
+- **Documentation pipeline**: Use spec files as source-of-truth for API documentation
+- **AI code review**: Feed `specsync check --json` output to an LLM to suggest spec updates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,140 @@
+---
+title: Architecture
+layout: default
+nav_order: 7
+---
+
+# Architecture
+{: .no_toc }
+
+How SpecSync is built — useful if you want to contribute or add language support.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Source Layout
+
+```
+src/
+├── main.rs              CLI entry point (clap) + output formatting
+├── types.rs             Core data types + config schema
+├── config.rs            specsync.json loading
+├── parser.rs            YAML frontmatter + spec body parsing
+├── validator.rs         Spec validation + coverage computation
+├── generator.rs         Spec scaffolding for new modules
+├── watch.rs             File watcher (notify crate, 500ms debounce)
+└── exports/
+    ├── mod.rs            Language dispatch + file utilities
+    ├── typescript.rs     TypeScript/JS export extraction
+    ├── rust_lang.rs      Rust pub item extraction
+    ├── go.rs             Go exported identifier extraction
+    ├── python.rs         Python __all__ / top-level extraction
+    ├── swift.rs          Swift public/open item extraction
+    ├── kotlin.rs         Kotlin public item extraction
+    ├── java.rs           Java public item extraction
+    ├── csharp.rs         C# public item extraction
+    └── dart.rs           Dart public item extraction
+```
+
+---
+
+## Design Principles
+
+### Single binary, no runtime dependencies
+
+SpecSync ships as one static binary. No Node.js, no Python, no package managers. Download it and run it.
+
+### Zero YAML dependencies
+
+Frontmatter is parsed with a purpose-built regex parser — no YAML library in the dependency tree. This keeps the binary small and compile times fast.
+
+### Language-agnostic export extraction
+
+Each language backend lives in `src/exports/` and implements export detection via regex pattern matching. No AST parsing, no language-specific toolchains required. This trades some precision for massive portability — SpecSync works anywhere without needing compilers or language servers installed.
+
+### Release-optimized builds
+
+The release profile uses LTO (Link-Time Optimization), symbol stripping, and `opt-level = 3` for maximum performance and minimum binary size.
+
+---
+
+## Validation Pipeline
+
+Validation runs in three stages:
+
+### Stage 1: Structural Validation
+
+- Parse YAML frontmatter from the spec file
+- Check required fields: `module`, `version`, `status`, `files`
+- Verify every file in the `files` list exists on disk
+- Check that all `requiredSections` are present as `## Heading` lines
+- Validate `depends_on` spec paths exist
+- Validate `db_tables` exist in schema files (if `schemaDir` is configured)
+
+### Stage 2: API Surface Validation
+
+- Detect language from file extensions
+- Extract public exports from each source file using language-specific regex
+- Extract symbol names from Public API tables in the spec (backtick-quoted)
+- Compare the two sets:
+  - **Symbol in spec but not in code** = Error (phantom/stale documentation)
+  - **Symbol in code but not in spec** = Warning (undocumented export)
+
+### Stage 3: Dependency Validation
+
+- Check `depends_on` paths point to existing spec files
+- If a `### Consumed By` section exists, validate referenced files exist
+
+---
+
+## Adding a New Language
+
+To add support for a new language:
+
+1. **Create the extractor** — add `src/exports/yourlang.rs` with a function that takes file contents and returns a `Vec<String>` of exported symbol names
+
+2. **Add the Language variant** — in `src/types.rs`, add your language to the `Language` enum
+
+3. **Wire up dispatch** — in `src/exports/mod.rs`:
+   - Add file extension detection in the language detection function
+   - Add a match arm to call your extractor
+   - Add test file patterns for your language
+
+4. **Write tests** — cover common export patterns, edge cases, and test file exclusion
+
+### Example: What an extractor looks like
+
+Each extractor follows the same pattern:
+- Strip comments from the source code
+- Apply regex patterns to find public/exported declarations
+- Return symbol names as strings
+
+The regex approach means you don't need the language's compiler or parser installed — just pattern matching on source text.
+
+---
+
+## Dependencies
+
+| Crate | Purpose |
+|:------|:--------|
+| `clap` | CLI argument parsing with derive macros |
+| `serde` + `serde_json` | JSON serialization for config and `--json` output |
+| `regex` | Pattern matching for export extraction and frontmatter parsing |
+| `walkdir` | Recursive directory traversal |
+| `colored` | Colored terminal output |
+| `notify` + `notify-debouncer-full` | File system watching for `watch` command |
+
+### Dev dependencies
+
+| Crate | Purpose |
+|:------|:--------|
+| `tempfile` | Temporary directories for integration tests |
+| `assert_cmd` | CLI testing utilities |
+| `predicates` | Assertions for CLI output matching |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,167 @@
+---
+title: CLI Reference
+layout: default
+nav_order: 3
+---
+
+# CLI Reference
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Usage
+
+```
+specsync [command] [flags]
+```
+
+If no command is given, `check` runs by default.
+
+---
+
+## Commands
+
+### `check`
+
+Validate all specs against source code. This is the default command.
+
+```bash
+specsync check
+specsync check --strict
+specsync check --strict --require-coverage 100
+specsync check --json
+```
+
+Runs three levels of validation:
+1. **Structural** — required frontmatter fields, file existence, required markdown sections
+2. **API surface** — cross-references spec symbols against actual code exports
+3. **Dependencies** — validates `depends_on` paths and `db_tables` against schema
+
+### `coverage`
+
+Show a file and module coverage report — which modules have specs and which don't.
+
+```bash
+specsync coverage
+specsync coverage --json
+```
+
+### `generate`
+
+Scaffold spec files for modules that don't have one yet. Uses `specs/_template.spec.md` if it exists, otherwise a built-in template.
+
+```bash
+specsync generate
+```
+
+### `init`
+
+Create a default `specsync.json` configuration file in the current directory.
+
+```bash
+specsync init
+```
+
+### `watch`
+
+Live validation mode. Watches your specs and source directories for changes and re-runs validation automatically with a 500ms debounce.
+
+```bash
+specsync watch
+```
+
+Press `Ctrl+C` to exit.
+
+---
+
+## Flags
+
+| Flag | Description |
+|:-----|:------------|
+| `--strict` | Treat warnings as errors. Recommended for CI. |
+| `--require-coverage N` | Fail if file coverage is below N percent. |
+| `--root <path>` | Set project root directory (default: current directory). |
+| `--json` | Output structured JSON instead of colored terminal text. |
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|:-----|:--------|
+| `0` | All checks passed |
+| `1` | Errors found, warnings found with `--strict`, or coverage below `--require-coverage` threshold |
+
+---
+
+## JSON Output
+
+Use `--json` for machine-readable output. Useful for CI pipelines, editor integrations, and AI agents.
+
+### Check output
+
+```json
+{
+  "passed": false,
+  "errors": [
+    "auth.spec.md: Spec documents 'oldFunction' but no matching export found in source"
+  ],
+  "warnings": [
+    "auth.spec.md: Export 'newHelper' not in spec (undocumented)"
+  ],
+  "specs_checked": 12
+}
+```
+
+### Coverage output
+
+```json
+{
+  "file_coverage": 85.33,
+  "files_covered": 23,
+  "files_total": 27,
+  "modules": [
+    {
+      "name": "helpers",
+      "has_spec": false
+    }
+  ]
+}
+```
+
+---
+
+## Examples
+
+```bash
+# Basic validation
+specsync check
+
+# Strict mode — warnings fail the build
+specsync check --strict
+
+# Enforce full spec coverage
+specsync check --strict --require-coverage 100
+
+# JSON output for tooling
+specsync check --json
+
+# Override project root
+specsync check --root ./packages/backend
+
+# Watch mode during development
+specsync watch
+
+# See what needs specs
+specsync coverage
+
+# Bootstrap specs for existing code
+specsync generate
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,180 @@
+---
+title: Configuration
+layout: default
+nav_order: 4
+---
+
+# Configuration
+{: .no_toc }
+
+SpecSync is configured via a `specsync.json` file in your project root.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Getting Started
+
+Generate a default config:
+
+```bash
+specsync init
+```
+
+This creates `specsync.json` with sensible defaults. SpecSync works without a config file too — it uses the defaults listed below.
+
+---
+
+## Full Config
+
+```json
+{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "schemaDir": "db/migrations",
+  "schemaPattern": "CREATE (?:VIRTUAL )?TABLE(?:\\s+IF NOT EXISTS)?\\s+(\\w+)",
+  "requiredSections": [
+    "Purpose",
+    "Public API",
+    "Invariants",
+    "Behavioral Examples",
+    "Error Cases",
+    "Dependencies",
+    "Change Log"
+  ],
+  "excludeDirs": ["__tests__"],
+  "excludePatterns": [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ],
+  "sourceExtensions": []
+}
+```
+
+---
+
+## Options
+
+### `specsDir`
+
+| Type | Default |
+|:-----|:--------|
+| `string` | `"specs"` |
+
+Directory containing your `*.spec.md` files. Searched recursively.
+
+### `sourceDirs`
+
+| Type | Default |
+|:-----|:--------|
+| `string[]` | `["src"]` |
+
+Source directories to scan for exports and coverage. SpecSync looks for source files referenced in spec frontmatter relative to the project root, but uses `sourceDirs` to determine overall coverage.
+
+### `schemaDir`
+
+| Type | Default |
+|:-----|:--------|
+| `string?` | — |
+
+Directory containing SQL schema files. When set, SpecSync validates that `db_tables` listed in spec frontmatter actually exist as `CREATE TABLE` statements in your schema files.
+
+### `schemaPattern`
+
+| Type | Default |
+|:-----|:--------|
+| `string?` | `CREATE (?:VIRTUAL )?TABLE(?:\s+IF NOT EXISTS)?\s+(\w+)` |
+
+Custom regex to extract table names from schema files. The first capture group should match the table name. Override this if your schema uses non-standard syntax.
+
+### `requiredSections`
+
+| Type | Default |
+|:-----|:--------|
+| `string[]` | `["Purpose", "Public API", "Invariants", "Behavioral Examples", "Error Cases", "Dependencies", "Change Log"]` |
+
+Markdown sections that every spec file must include. Matched against `## Heading` lines in the spec body.
+
+### `excludeDirs`
+
+| Type | Default |
+|:-----|:--------|
+| `string[]` | `["__tests__"]` |
+
+Directory names to skip entirely when scanning for source files during coverage computation.
+
+### `excludePatterns`
+
+| Type | Default |
+|:-----|:--------|
+| `string[]` | `["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"]` |
+
+Glob patterns for files to exclude from coverage scanning. These are in addition to the language-specific test file exclusions that SpecSync applies automatically.
+
+### `sourceExtensions`
+
+| Type | Default |
+|:-----|:--------|
+| `string[]` | All supported extensions |
+
+Restrict analysis to specific file extensions. When empty (the default), SpecSync considers all supported language extensions. Set this to focus on specific languages:
+
+```json
+{
+  "sourceExtensions": ["ts", "tsx"]
+}
+```
+
+---
+
+## Example Configs
+
+### TypeScript project
+
+```json
+{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "excludePatterns": [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}
+```
+
+### Rust project
+
+```json
+{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "sourceExtensions": ["rs"]
+}
+```
+
+### Monorepo
+
+```json
+{
+  "specsDir": "docs/specs",
+  "sourceDirs": ["packages/core/src", "packages/api/src"],
+  "schemaDir": "packages/db/migrations"
+}
+```
+
+### Minimal (just the essentials)
+
+```json
+{
+  "requiredSections": ["Purpose", "Public API"]
+}
+```

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,0 +1,123 @@
+---
+title: GitHub Action
+layout: default
+nav_order: 5
+---
+
+# GitHub Action
+{: .no_toc }
+
+Run SpecSync in CI with zero setup. The action auto-detects your runner's OS and architecture, downloads the correct binary, and runs validation.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Basic Usage
+
+```yaml
+- uses: CorvidLabs/spec-sync@v1
+  with:
+    strict: 'true'
+    require-coverage: '100'
+```
+
+---
+
+## Inputs
+
+| Input | Default | Description |
+|:------|:--------|:------------|
+| `version` | `latest` | SpecSync release version to download |
+| `strict` | `false` | Treat warnings as errors |
+| `require-coverage` | `0` | Minimum file coverage percentage (0-100) |
+| `root` | `.` | Project root directory |
+| `args` | `''` | Additional CLI arguments passed to `specsync check` |
+
+---
+
+## Full Workflow
+
+```yaml
+name: Spec Check
+on: [push, pull_request]
+
+jobs:
+  specsync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CorvidLabs/spec-sync@v1
+        with:
+          strict: 'true'
+          require-coverage: '100'
+```
+
+---
+
+## Multi-Platform Matrix
+
+Test across operating systems:
+
+```yaml
+jobs:
+  specsync:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CorvidLabs/spec-sync@v1
+        with:
+          strict: 'true'
+```
+
+---
+
+## Monorepo Usage
+
+Run against a specific package:
+
+```yaml
+- uses: CorvidLabs/spec-sync@v1
+  with:
+    root: './packages/backend'
+    strict: 'true'
+```
+
+---
+
+## Manual CI Setup
+
+If you prefer not to use the action, install the binary directly:
+
+```yaml
+- name: Install specsync
+  run: |
+    curl -sL https://github.com/CorvidLabs/spec-sync/releases/latest/download/specsync-linux-x86_64.tar.gz | tar xz
+    sudo mv specsync-linux-x86_64 /usr/local/bin/specsync
+
+- name: Spec check
+  run: specsync check --strict --require-coverage 100
+```
+
+---
+
+## Platform Binaries
+
+The action and release workflow provide binaries for:
+
+| Platform | Binary |
+|:---------|:-------|
+| Linux x86_64 | `specsync-linux-x86_64` |
+| Linux aarch64 | `specsync-linux-aarch64` |
+| macOS x86_64 | `specsync-macos-x86_64` |
+| macOS aarch64 (Apple Silicon) | `specsync-macos-aarch64` |
+| Windows x86_64 | `specsync-windows-x86_64.exe` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,149 @@
+---
+title: Home
+layout: home
+nav_order: 1
+---
+
+# SpecSync
+
+**Bidirectional spec-to-code validation — keep your docs honest.**
+{: .fs-6 .fw-300 }
+
+Written in Rust. Language-agnostic. Single binary. Zero config to start.
+{: .fs-5 .fw-300 }
+
+[Get Started](#install){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/CorvidLabs/spec-sync){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## The Problem
+
+Documentation drifts. Engineers add new exports but forget to update the spec. Specs reference functions that got renamed months ago. Nobody notices until a new team member reads the docs and gets confused.
+
+**SpecSync catches this automatically** by validating your markdown specs against actual source code — in both directions:
+
+| Situation | Severity | What Happens |
+|:----------|:---------|:-------------|
+| Code exports something not in the spec | Warning | Undocumented export flagged |
+| Spec documents something that doesn't exist | **Error** | Stale/phantom entry caught |
+| Source file referenced in spec was deleted | **Error** | Missing file detected |
+| DB table in spec doesn't exist in schema | **Error** | Phantom table reported |
+| Required section missing from spec | **Error** | Incomplete spec flagged |
+
+---
+
+## How It Works
+
+```
+                    *.spec.md files
+                         |
+                    [1] Discover
+                         |
+                    [2] Parse frontmatter
+                         |
+              +----------+----------+
+              |          |          |
+         [3] Structure  [4] API   [5] Dependencies
+              |          |          |
+         - Required    - Detect   - depends_on exists?
+           fields        language  - db_tables in schema?
+         - File        - Extract  - Consumed By refs?
+           exists?       exports
+         - Required    - Compare
+           sections?     with spec
+              |          |          |
+              +----------+----------+
+                         |
+                    [6] Report
+                         |
+              +----------+----------+
+              |          |          |
+           Errors    Warnings   Coverage %
+```
+
+1. **Discover** all `*.spec.md` files in your specs directory
+2. **Parse** YAML frontmatter using a zero-dependency regex parser
+3. **Validate structure** — required fields, required sections, file existence
+4. **Validate API surface** — auto-detect language, extract exports, cross-reference against spec tables
+5. **Validate dependencies** — check `depends_on` specs and `db_tables` in schema
+6. **Report** errors, warnings, and coverage metrics
+
+---
+
+## Install
+
+### Pre-built binaries (recommended)
+
+Download from [GitHub Releases](https://github.com/CorvidLabs/spec-sync/releases):
+
+```bash
+# macOS (Apple Silicon)
+curl -sL https://github.com/CorvidLabs/spec-sync/releases/latest/download/specsync-macos-aarch64.tar.gz | tar xz
+sudo mv specsync-macos-aarch64 /usr/local/bin/specsync
+
+# macOS (Intel)
+curl -sL https://github.com/CorvidLabs/spec-sync/releases/latest/download/specsync-macos-x86_64.tar.gz | tar xz
+sudo mv specsync-macos-x86_64 /usr/local/bin/specsync
+
+# Linux (x86_64)
+curl -sL https://github.com/CorvidLabs/spec-sync/releases/latest/download/specsync-linux-x86_64.tar.gz | tar xz
+sudo mv specsync-linux-x86_64 /usr/local/bin/specsync
+
+# Linux (aarch64)
+curl -sL https://github.com/CorvidLabs/spec-sync/releases/latest/download/specsync-linux-aarch64.tar.gz | tar xz
+sudo mv specsync-linux-aarch64 /usr/local/bin/specsync
+```
+
+**Windows:** download `specsync-windows-x86_64.exe.zip` from the [releases page](https://github.com/CorvidLabs/spec-sync/releases).
+
+### From crates.io
+
+```bash
+cargo install specsync
+```
+
+### From source
+
+```bash
+cargo install --git https://github.com/CorvidLabs/spec-sync
+```
+
+---
+
+## Quick Start
+
+```bash
+# 1. Initialize config
+specsync init
+
+# 2. Validate all specs
+specsync check
+
+# 3. See coverage
+specsync coverage
+
+# 4. Auto-generate specs for unspecced modules
+specsync generate
+
+# 5. Watch mode — re-validates on file changes
+specsync watch
+```
+
+---
+
+## Supported Languages
+
+SpecSync auto-detects the language from file extensions. The same spec format works for all of them — no per-language configuration needed.
+
+| Language | What Gets Detected | Test Files Excluded |
+|:---------|:-------------------|:--------------------|
+| **TypeScript / JavaScript** | `export function`, `export class`, `export type`, `export const`, `export enum`, re-exports | `.test.ts`, `.spec.ts`, `.d.ts` |
+| **Rust** | `pub fn`, `pub struct`, `pub enum`, `pub trait`, `pub type`, `pub const`, `pub static`, `pub mod` | Inline `#[cfg(test)]` modules |
+| **Go** | Uppercase identifiers: `func`, `type`, `var`, `const`, methods | `_test.go` |
+| **Python** | `__all__` list, or top-level `def`/`class` (excluding `_`-prefixed) | `test_*.py`, `*_test.py` |
+| **Swift** | `public`/`open` func, class, struct, enum, protocol, typealias, actor, init | `*Tests.swift`, `*Test.swift` |
+| **Kotlin** | Top-level declarations (public by default), excludes `private`/`internal`/`protected` | `*Test.kt`, `*Spec.kt` |
+| **Java** | `public` class, interface, enum, record, methods, fields | `*Test.java`, `*Tests.java` |
+| **C#** | `public` class, struct, interface, enum, record, delegate, methods | `*Test.cs`, `*Tests.cs` |
+| **Dart** | Top-level declarations (no `_` prefix), class, mixin, enum, typedef | `*_test.dart` |

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -1,0 +1,229 @@
+---
+title: Spec Format
+layout: default
+nav_order: 2
+---
+
+# Spec Format
+{: .no_toc }
+
+Specs are markdown files (`*.spec.md`) with YAML frontmatter. Place them in your specs directory (default: `specs/`).
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Frontmatter
+
+Every spec file starts with YAML frontmatter between `---` delimiters:
+
+```yaml
+---
+module: auth
+version: 3
+status: stable
+files:
+  - src/auth/service.ts
+  - src/auth/middleware.ts
+db_tables:
+  - users
+  - sessions
+depends_on:
+  - specs/database/database.spec.md
+---
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `module` | `string` | Module name — used for display and identification |
+| `version` | `number` | Spec version — increment when the spec changes |
+| `status` | `enum` | One of: `draft`, `review`, `stable`, `deprecated` |
+| `files` | `string[]` | Source files this spec covers (must be non-empty) |
+
+### Optional Fields
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `db_tables` | `string[]` | Database tables used by this module — validated against your schema directory |
+| `depends_on` | `string[]` | Paths to other spec files this module depends on — validated for existence |
+
+---
+
+## Required Sections
+
+By default, every spec must include these markdown sections (configurable via `requiredSections` in `specsync.json`):
+
+| Section | Purpose |
+|:--------|:--------|
+| `## Purpose` | What this module does and why it exists |
+| `## Public API` | Tables listing exported symbols — **this is what gets validated against code** |
+| `## Invariants` | Rules that must always hold true |
+| `## Behavioral Examples` | Given/When/Then scenarios showing expected behavior |
+| `## Error Cases` | How the module handles failure conditions |
+| `## Dependencies` | What this module consumes from other modules |
+| `## Change Log` | History of spec changes |
+
+You can customize these in your config:
+
+```json
+{
+  "requiredSections": ["Purpose", "Public API", "Change Log"]
+}
+```
+
+---
+
+## Public API Tables
+
+The Public API section is the core of what SpecSync validates. Use markdown tables with **backtick-quoted symbol names** — SpecSync extracts the first backtick-quoted identifier per table row and cross-references it against actual code exports.
+
+```markdown
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `authenticate` | `(token: string)` | `User \| null` | Validates a bearer token |
+| `refreshSession` | `(sessionId: string)` | `Session` | Extends session TTL |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `User` | Authenticated user object |
+| `Session` | Active session record |
+```
+
+{: .note }
+> The table column headers don't matter — SpecSync only looks at backtick-quoted names in the first column. You can structure the table however works best for your team.
+
+---
+
+## Consumed By Section
+
+You can optionally track reverse dependencies in a `### Consumed By` subsection under Dependencies. SpecSync validates that referenced files actually exist:
+
+```markdown
+## Dependencies
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| api-gateway | Uses `authenticate()` middleware |
+```
+
+---
+
+## Full Example
+
+Here's a complete spec file showing all features:
+
+```markdown
+---
+module: auth
+version: 3
+status: stable
+files:
+  - src/auth/service.ts
+  - src/auth/middleware.ts
+db_tables:
+  - users
+  - sessions
+depends_on:
+  - specs/database/database.spec.md
+---
+
+# Auth
+
+## Purpose
+
+Handles authentication and session management. Validates bearer tokens,
+manages session lifecycle, and provides middleware for route protection.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `authenticate` | `(token: string)` | `User \| null` | Validates a token |
+| `refreshSession` | `(sessionId: string)` | `Session` | Extends session TTL |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `User` | Authenticated user object |
+| `Session` | Active session record |
+
+## Invariants
+
+1. Sessions expire after 24 hours
+2. Failed auth attempts are rate-limited to 5/minute
+3. Tokens are validated cryptographically, never by string comparison
+
+## Behavioral Examples
+
+### Scenario: Valid token
+
+- **Given** a valid JWT token
+- **When** `authenticate()` is called
+- **Then** returns the corresponding User object
+
+### Scenario: Expired token
+
+- **Given** an expired JWT token
+- **When** `authenticate()` is called
+- **Then** returns null and logs a warning
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Expired token | Returns null, logs warning |
+| Malformed token | Returns null |
+| DB unavailable | Throws `ServiceUnavailableError` |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| database | `query()` for user lookups |
+| crypto | `verifyJwt()` for token validation |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| api-gateway | Uses `authenticate()` middleware |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-18 | team | Initial spec |
+```
+
+---
+
+## Custom Templates
+
+When running `specsync generate`, you can provide a custom template at `specs/_template.spec.md`. If no template exists, SpecSync uses a built-in default with all seven required sections and TODO placeholders.
+
+The generator replaces these frontmatter fields automatically:
+- `module:` — set to the module directory name
+- `version:` — set to `1`
+- `status:` — set to `draft`
+- `files:` — populated with discovered source files


### PR DESCRIPTION
## Summary
- Adds a full GitHub Pages documentation site using Jekyll with the `just-the-docs` theme (dark mode)
- 7 pages: Home, Spec Format, CLI Reference, Configuration, GitHub Action, For AI Agents, Architecture
- GitHub Actions workflow (`docs.yml`) for auto-deploying on pushes to main that touch `docs/`
- Added badges and docs site link in README header

## Setup Required
After merging, enable GitHub Pages in repo Settings > Pages > Source: "GitHub Actions"

## Test plan
- [ ] Verify docs build locally with `cd docs && bundle install && bundle exec jekyll serve`
- [ ] After merge, enable GitHub Pages and confirm site deploys at corvidlabs.github.io/spec-sync
- [ ] Check all 7 pages render correctly with navigation and search

🤖 Generated with [Claude Code](https://claude.com/claude-code)