### PR TITLE
fix: resolve rebase conflicts from AI generation merge

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -271,8 +271,14 @@ pub fn generate_specs_for_unspecced_modules(
             eprintln!("  Generating {rel} with AI...");
         }
 
-        let spec_content =
-            generate_module_spec(module_name, &module_files, root, &specs_dir, config, ai_command);
+        let spec_content = generate_module_spec(
+            module_name,
+            &module_files,
+            root,
+            &specs_dir,
+            config,
+            ai_command,
+        );
 
         match fs::write(&spec_file, &spec_content) {
             Ok(_) => {
@@ -280,7 +286,11 @@ pub fn generate_specs_for_unspecced_modules(
                 if ai_command.is_some() {
                     // AI generation complete
                 }
-                println!("  {} Generated {rel} ({} files)", "✓".green(), module_files.len());
+                println!(
+                    "  {} Generated {rel} ({} files)",
+                    "✓".green(),
+                    module_files.len()
+                );
                 let _ = std::io::stdout().flush();
                 generated += 1;
             }
@@ -321,8 +331,14 @@ pub fn generate_specs_for_unspecced_modules_paths(
             continue;
         }
 
-        let spec_content =
-            generate_module_spec(module_name, &module_files, root, &specs_dir, config, ai_command);
+        let spec_content = generate_module_spec(
+            module_name,
+            &module_files,
+            root,
+            &specs_dir,
+            config,
+            ai_command,
+        );
 
         if fs::write(&spec_file, &spec_content).is_ok() {
             let rel = spec_file

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,8 +212,7 @@ fn cmd_generate(root: &Path, strict: bool, require_coverage: Option<usize>, json
         println!("No existing specs found. Scanning for source modules...");
         (0, 0, 0, 0)
     } else {
-        let (te, tw, p, t, _, _) =
-            run_validation(root, &spec_files, &schema_tables, &config, json);
+        let (te, tw, p, t, _, _) = run_validation(root, &spec_files, &schema_tables, &config, json);
         (te, tw, p, t)
     };
 


### PR DESCRIPTION
## Summary
- Resolves merge conflicts from rebasing the AI generation commit (#19) onto main
- Formatting-only changes in `src/generator.rs` and `src/main.rs` (line wrapping)
- Updates `Cargo.lock` version to match v1.2.0

## Test plan
- [x] `cargo check` passes
- [x] No conflict markers remain
- [x] No functional changes — diff is purely formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)