### PR TITLE
fix: docs formatting and nav contrast accessibility

### DIFF
--- a/docs/_sass/color_schemes/rust.scss
+++ b/docs/_sass/color_schemes/rust.scss
@@ -28,3 +28,46 @@ $nav-child-link-color: #c0c0c0;
 
 // Footer
 $footer-background-color: #171717;
+
+// ── Accessibility & contrast overrides ──
+
+// Active nav item: subtle background, high-contrast white text (no orange bleed)
+.site-nav .nav-list-item {
+  .nav-list-link.active {
+    background: rgba(232, 125, 47, 0.12);
+    color: #ffffff;
+    font-weight: 600;
+    background-image: none; // kill the default gradient
+    border-left: 3px solid #e87d2f;
+    padding-left: 9px; // compensate for border
+  }
+
+  .nav-list-link:hover {
+    background: rgba(232, 125, 47, 0.08);
+    color: #ffffff;
+    background-image: none;
+  }
+}
+
+// Ensure sidebar text stays readable
+.site-nav {
+  .nav-list-link {
+    color: #d0d0d0;
+  }
+}
+
+// Site title/header link contrast
+.site-title {
+  color: #f0f0f0 !important;
+}
+
+// Search input contrast
+.search-input {
+  color: #e0e0e0;
+  border-color: #3d3d3d;
+
+  &:focus {
+    border-color: #e87d2f;
+    box-shadow: 0 0 0 2px rgba(232, 125, 47, 0.25);
+  }
+}

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -122,7 +122,7 @@ Track reverse dependencies under `## Dependencies`. SpecSync validates that refe
 
 ## Full Example
 
-<details>
+<details markdown="block">
 <summary>Complete spec file</summary>
 
 ```markdown


### PR DESCRIPTION
## Summary
- Fix full spec example in spec-format.md rendering as a text blob (missing `markdown="block"` on `<details>` tag)
- Override active nav item styling so orange accent doesn't bleed into text — uses subtle background tint with high-contrast white text and a left border accent
- Add hover, search input focus, and site title contrast improvements

## Test plan
- [ ] Check spec-format.md "Full Example" renders as a proper code block
- [ ] Verify nav items are readable with good contrast on hover and active states
- [ ] Confirm search input has visible focus ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)