### PR TITLE
feat: auto-detect source directories for universal project support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,131 @@
+use crate::exports::has_extension;
 use crate::types::SpecSyncConfig;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
+use walkdir::WalkDir;
+
+/// Directories that should never be treated as source directories.
+const IGNORED_DIRS: &[&str] = &[
+    "node_modules",
+    ".git",
+    ".hg",
+    ".svn",
+    "dist",
+    "build",
+    "out",
+    "target",
+    "vendor",
+    ".next",
+    ".nuxt",
+    ".output",
+    ".cache",
+    ".turbo",
+    "coverage",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    "env",
+    ".env",
+    ".idea",
+    ".vscode",
+    ".DS_Store",
+    "specs",
+    "docs",
+    "doc",
+    ".github",
+    ".gitlab",
+    "migrations",
+    "Pods",
+    ".dart_tool",
+    ".gradle",
+    "bin",
+    "obj",
+];
+
+/// Auto-detect source directories by scanning the project root for files
+/// with supported language extensions. Returns directories relative to root.
+pub fn detect_source_dirs(root: &Path) -> Vec<String> {
+    let ignored: HashSet<&str> = IGNORED_DIRS.iter().copied().collect();
+    let mut source_dirs: Vec<String> = Vec::new();
+    let mut has_root_source_files = false;
+
+    // Check immediate children of root
+    let entries = match fs::read_dir(root) {
+        Ok(e) => e,
+        Err(_) => return vec!["src".to_string()],
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        // Skip hidden dirs and ignored dirs
+        if name.starts_with('.') || ignored.contains(name.as_str()) {
+            continue;
+        }
+
+        let path = entry.path();
+
+        if path.is_dir() {
+            // Check if this directory contains any source files (scan up to 3 levels deep)
+            if dir_contains_source_files(&path, &ignored, 3) {
+                source_dirs.push(name);
+            }
+        } else if path.is_file() && has_extension(&path, &[]) {
+            // Source file directly in root
+            has_root_source_files = true;
+        }
+    }
+
+    // If source files exist directly in root, add "." as a source dir
+    if has_root_source_files && source_dirs.is_empty() {
+        return vec![".".to_string()];
+    }
+
+    if source_dirs.is_empty() {
+        // Fallback to "src" if nothing detected
+        return vec!["src".to_string()];
+    }
+
+    source_dirs.sort();
+    source_dirs
+}
+
+/// Check if a directory contains source files, scanning up to `max_depth` levels.
+fn dir_contains_source_files(dir: &Path, ignored: &HashSet<&str>, max_depth: usize) -> bool {
+    for entry in WalkDir::new(dir)
+        .max_depth(max_depth)
+        .into_iter()
+        .filter_entry(|e| {
+            if e.file_type().is_dir() {
+                let name = e.file_name().to_str().unwrap_or("");
+                !name.starts_with('.') && !ignored.contains(name)
+            } else {
+                true
+            }
+        })
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.is_file() && has_extension(path, &[]) {
+            return true;
+        }
+    }
+    false
+}
 
 /// Load specsync.json from the project root, falling back to defaults.
+/// When no config file exists, auto-detects source directories.
 pub fn load_config(root: &Path) -> SpecSyncConfig {
     let config_path = root.join("specsync.json");
 
     if !config_path.exists() {
-        return SpecSyncConfig::default();
+        let mut config = SpecSyncConfig::default();
+        config.source_dirs = detect_source_dirs(root);
+        return config;
     }
 
     let content = match fs::read_to_string(&config_path) {
@@ -15,8 +133,18 @@ pub fn load_config(root: &Path) -> SpecSyncConfig {
         Err(_) => return SpecSyncConfig::default(),
     };
 
-    match serde_json::from_str(&content) {
-        Ok(config) => config,
+    match serde_json::from_str::<SpecSyncConfig>(&content) {
+        Ok(config) => {
+            // If sourceDirs was not explicitly set in the config file (still default ["src"]),
+            // check if we should auto-detect. We do this by checking if the raw JSON
+            // contains a "sourceDirs" key.
+            if !content.contains("\"sourceDirs\"") {
+                let mut config = config;
+                config.source_dirs = detect_source_dirs(root);
+                return config;
+            }
+            config
+        }
         Err(e) => {
             eprintln!("Warning: failed to parse specsync.json: {e}");
             SpecSyncConfig::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
 
-use config::load_config;
+use config::{detect_source_dirs, load_config};
 use generator::{generate_specs_for_unspecced_modules, generate_specs_for_unspecced_modules_paths};
 use validator::{compute_coverage, find_spec_files, get_schema_table_names, validate_spec};
 
@@ -98,9 +98,12 @@ fn cmd_init(root: &Path) {
         return;
     }
 
+    let detected_dirs = detect_source_dirs(root);
+    let dirs_display = detected_dirs.join(", ");
+
     let default = serde_json::json!({
         "specsDir": "specs",
-        "sourceDirs": ["src"],
+        "sourceDirs": detected_dirs,
         "requiredSections": [
             "Purpose",
             "Public API",
@@ -117,6 +120,7 @@ fn cmd_init(root: &Path) {
     let content = serde_json::to_string_pretty(&default).unwrap() + "\n";
     fs::write(&config_path, content).expect("Failed to write specsync.json");
     println!("{} Created specsync.json", "✓".green());
+    println!("  Detected source directories: {dirs_display}");
 }
 
 fn cmd_check(root: &Path, strict: bool, require_coverage: Option<usize>, json: bool) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1519,3 +1519,155 @@ fn unknown_provider_lists_api_options() {
         .failure()
         .stderr(predicate::str::contains("anthropic").and(predicate::str::contains("openai")));
 }
+// ─── Auto-detect source directories ─────────────────────────────────────
+
+#[test]
+fn init_auto_detects_src_dir() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Create a project with src/ containing source files
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+
+    specsync()
+        .arg("init")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Detected source directories: src"));
+
+    let config: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(root.join("specsync.json")).unwrap()).unwrap();
+    let dirs = config["sourceDirs"].as_array().unwrap();
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0], "src");
+}
+
+#[test]
+fn init_auto_detects_lib_dir() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Create a project with lib/ containing source files
+    fs::create_dir_all(root.join("lib")).unwrap();
+    fs::write(root.join("lib/utils.py"), "def hello(): pass\n").unwrap();
+
+    specsync()
+        .arg("init")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Detected source directories: lib"));
+
+    let config: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(root.join("specsync.json")).unwrap()).unwrap();
+    let dirs = config["sourceDirs"].as_array().unwrap();
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0], "lib");
+}
+
+#[test]
+fn init_auto_detects_multiple_dirs() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Create a project with both src/ and lib/
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/main.ts"), "export function main() {}").unwrap();
+    fs::create_dir_all(root.join("lib")).unwrap();
+    fs::write(root.join("lib/helpers.ts"), "export function help() {}").unwrap();
+
+    specsync()
+        .arg("init")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Detected source directories: lib, src"));
+
+    let config: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(root.join("specsync.json")).unwrap()).unwrap();
+    let dirs = config["sourceDirs"].as_array().unwrap();
+    assert_eq!(dirs.len(), 2);
+    assert_eq!(dirs[0], "lib");
+    assert_eq!(dirs[1], "src");
+}
+
+#[test]
+fn init_ignores_node_modules_and_hidden_dirs() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Create source in app/ and noise in node_modules/ and .cache/
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::write(root.join("app/index.ts"), "export default function() {}").unwrap();
+    fs::create_dir_all(root.join("node_modules/some-pkg")).unwrap();
+    fs::write(root.join("node_modules/some-pkg/index.js"), "module.exports = {}").unwrap();
+    fs::create_dir_all(root.join(".cache")).unwrap();
+    fs::write(root.join(".cache/data.js"), "const x = 1;").unwrap();
+
+    specsync()
+        .arg("init")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Detected source directories: app"));
+
+    let config: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(root.join("specsync.json")).unwrap()).unwrap();
+    let dirs = config["sourceDirs"].as_array().unwrap();
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0], "app");
+}
+
+#[test]
+fn check_works_without_config_file() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Create a project with lib/ source and specs, but no specsync.json
+    fs::create_dir_all(root.join("lib/auth")).unwrap();
+    fs::write(
+        root.join("lib/auth/service.ts"),
+        "export function login() {}\nexport function logout() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/auth")).unwrap();
+    let spec = valid_spec("auth", &["lib/auth/service.ts"]);
+    fs::write(root.join("specs/auth/auth.spec.md"), spec).unwrap();
+
+    // Should auto-detect lib/ and work without any config
+    specsync()
+        .arg("check")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success();
+}
+
+#[test]
+fn init_falls_back_to_src_when_no_source_files() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Empty project with only a README
+    fs::write(root.join("README.md"), "# My Project").unwrap();
+
+    specsync()
+        .arg("init")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Detected source directories: src"));
+
+    let config: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(root.join("specsync.json")).unwrap()).unwrap();
+    let dirs = config["sourceDirs"].as_array().unwrap();
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0], "src");
+}


### PR DESCRIPTION
## Summary

Closes #24. spec-sync now works out-of-the-box with any project layout instead of hardcoding `sourceDirs` to `["src"]`.

- **Auto-detection**: Scans the project root for directories containing files with supported extensions (`.ts`, `.rs`, `.py`, `.go`, `.swift`, `.kt`, `.java`, `.cs`, `.dart`)
- **Smart filtering**: Blacklist of 35+ non-source directories (`node_modules`, `.git`, `dist`, `target`, `vendor`, `build`, `__pycache__`, etc.)
- **`specsync init`** pre-fills `sourceDirs` with detected directories and prints what was found
- **No-config mode**: `check`/`coverage`/`generate` auto-detect when no `specsync.json` exists or when `sourceDirs` is not explicitly set
- **Backwards compatible**: Existing explicit `sourceDirs` config is always respected
- **Fallback**: Defaults to `["src"]` when no source files are detected

## Test plan

- [x] 6 new integration tests covering: single dir, multiple dirs, ignored dirs, no-config mode, empty project fallback
- [x] All 61 tests pass (26 unit + 35 integration)