### PR TITLE
fix: resolve clippy and fmt CI failures

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -123,9 +123,10 @@ pub fn load_config(root: &Path) -> SpecSyncConfig {
     let config_path = root.join("specsync.json");
 
     if !config_path.exists() {
-        let mut config = SpecSyncConfig::default();
-        config.source_dirs = detect_source_dirs(root);
-        return config;
+        return SpecSyncConfig {
+            source_dirs: detect_source_dirs(root),
+            ..Default::default()
+        };
     }
 
     let content = match fs::read_to_string(&config_path) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1586,7 +1586,9 @@ fn init_auto_detects_multiple_dirs() {
         .arg(root)
         .assert()
         .success()
-        .stdout(predicate::str::contains("Detected source directories: lib, src"));
+        .stdout(predicate::str::contains(
+            "Detected source directories: lib, src",
+        ));
 
     let config: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(root.join("specsync.json")).unwrap()).unwrap();
@@ -1605,7 +1607,11 @@ fn init_ignores_node_modules_and_hidden_dirs() {
     fs::create_dir_all(root.join("app")).unwrap();
     fs::write(root.join("app/index.ts"), "export default function() {}").unwrap();
     fs::create_dir_all(root.join("node_modules/some-pkg")).unwrap();
-    fs::write(root.join("node_modules/some-pkg/index.js"), "module.exports = {}").unwrap();
+    fs::write(
+        root.join("node_modules/some-pkg/index.js"),
+        "module.exports = {}",
+    )
+    .unwrap();
     fs::create_dir_all(root.join(".cache")).unwrap();
     fs::write(root.join(".cache/data.js"), "const x = 1;").unwrap();
 


### PR DESCRIPTION
## Summary
- Fix `clippy::field_reassign_with_default` in `src/config.rs` by using struct update syntax
- Fix `rustfmt` long-line formatting in `tests/integration.rs`

These were introduced by the PR #26 merge and cause CI to fail on main.

## Test plan
- [ ] CI passes (fmt + clippy + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)