### PR TITLE
fix(scoring): distinguish placeholder TODOs from descriptive references

### DIFF
--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -251,7 +251,10 @@ fn count_placeholder_todos(body: &str) -> usize {
 
     let mut count = 0;
     for line in stripped.lines() {
-        let trimmed = line.trim().trim_start_matches("- ").trim_start_matches("* ");
+        let trimmed = line
+            .trim()
+            .trim_start_matches("- ")
+            .trim_start_matches("* ");
         if todo_line_re.is_match(trimmed) {
             count += 1;
         }


### PR DESCRIPTION
## Summary
- Replaces naive `body.matches("TODO")` counting with a `count_placeholder_todos()` function that only flags actual placeholder TODOs
- Strips fenced code blocks before scanning
- Only counts lines where TODO appears as a standalone placeholder (`TODO`, `TODO: ...`) — not compound terms (`TODO-marker`) or descriptive prose (`TODO comments in source code`)

Fixes #36

## Test plan
- [x] All 92 existing tests pass
- [ ] Verify a spec describing TODO-related features no longer gets penalized
- [ ] Verify actual placeholder TODOs (standalone `TODO` or `TODO: fill in`) are still penalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)