### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-03-25
+
+### Fixed
+
+- **Rust export extractor** — strip raw strings, char literals with `"`, and multi-line string literals before scanning for `pub` declarations. Fixes false positives from test data inside `r#"..."#` blocks, and false negatives where `'"'` char literals confused the string regex into consuming subsequent source code.
+- **CLI spec** — added spec coverage for `main.rs` (CLI entry point).
+- **Exports spec** — expanded to 100% file coverage across all language extractors.
+
 ## [2.1.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 2.1.1
- Update CHANGELOG with bug fixes from #44 (Rust export extractor string/char literal stripping)

## Changes in this release
- **Fix**: Strip raw strings, char literals with `"`, and multi-line string literals before scanning for Rust `pub` declarations
- **Docs**: Added CLI spec for `main.rs`, expanded exports spec to 100% file coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)