### PR TITLE
chore: prepare v2.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-03-25
+
+### Added
+
+- **Manifest-aware module detection** — parses `Package.swift`, `Cargo.toml`, `build.gradle.kts`, `package.json`, `pubspec.yaml`, `go.mod`, and `pyproject.toml` to auto-discover targets and source paths instead of just scanning directories.
+- **Export granularity control** — `"exportLevel": "type"` in `specsync.json` limits exports to top-level type declarations (class/struct/enum/protocol) instead of listing every member.
+- **Configurable module definitions** — `"modules"` section in `specsync.json` lets you define module groupings with explicit file lists.
+- **Language-specific spec templates** — `generate` and `--fix` produce Swift, Rust, Kotlin/Java, Go, and Python templates with appropriate section headers and table columns.
+- **AI context boundary awareness** — generation prompt instructs the provider to only document symbols from the module's own files, not imported dependencies.
+
+### Fixed
+
+- **Test file detection** — expanded Swift patterns (Spec, Mock, Stub, Fake), added Kotlin/Java/C# patterns, and detect well-known test directories (`Tests/`, `__tests__/`, `spec/`, `mocks/`).
+- **Check command no longer hangs on empty specs** — returns clean JSON/exit 0 when `--fix` is used with no spec files.
+- **Exit code 101 panic → friendly error** — wraps main in `catch_unwind`, converts panics to actionable error messages with bug report link.
+
 ## [2.2.0] - 2026-03-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 2.2.1 in Cargo.toml
- Add v2.2.1 changelog entry covering all changes from PR #48

Ready to merge and tag for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)