### PR TITLE
chore: prepare v2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.1] - 2026-03-25
+## [2.3.0] - 2026-03-28
+
+### Added
+
+- **`--format markdown` output** — `check` and `diff` commands now accept `--format markdown` to produce clean, human-readable Markdown tables instead of plain text or JSON. Useful for pasting into PRs, docs, or chat.
+- **SHA256 release checksums** — release workflow now generates and publishes SHA256 checksums for all release binaries, improving supply chain verification.
+
+### Changed
+
+- Rolled up all v2.2.1 changes (manifest-aware modules, export granularity, language templates, robustness fixes) into this release.
+
+## [2.2.1] - 2026-03-25 (unreleased — rolled into 2.3.0)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2024"
 description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 2.2.1 → 2.3.0
- Update CHANGELOG with new features: `--format markdown` output and SHA256 release checksums
- Rolls up unreleased v2.2.1 changes (manifest-aware modules, export granularity, language templates)

## Release notes (v2.3.0)
- **`--format markdown`** — `check` and `diff` commands produce clean Markdown tables
- **SHA256 checksums** — release workflow publishes checksums for all binaries

Once merged, tag `v2.3.0` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)