### PR TITLE
docs: cross-project refs page + missing CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-03-28
+
+### Added
+
+- **`specsync-registry.toml`** — published module registry for cross-project spec resolution. Other projects can now verify refs to `CorvidLabs/spec-sync@<module>` via `resolve --remote`.
+
+### Documentation
+
+- **New docs page: Cross-Project References** — dedicated guide covering `owner/repo@module` syntax, registry publishing, remote verification, and CI usage.
+- **CLI Reference** — added missing commands: `add-spec`, `init-registry`, `resolve`, `hooks`. Added `--format` flag documentation.
+- **Spec Format** — documented cross-project ref syntax in `depends_on` field.
+- **Quick Start** — added `add-spec`, `resolve`, `init-registry`, and `hooks` commands.
+
 ## [2.3.0] - 2026-03-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2024"
 description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
 license = "MIT"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,6 +86,52 @@ specsync mcp                            # start MCP server (stdio JSON-RPC)
 
 Exposes tools: `specsync_check`, `specsync_generate`, `specsync_coverage`, `specsync_score`.
 
+### `add-spec`
+
+Scaffold a single spec with companion files (`tasks.md`, `context.md`).
+
+```bash
+specsync add-spec auth                     # creates specs/auth/auth.spec.md + companions
+```
+
+Companion files sit alongside the spec and give agents structured context:
+- **`tasks.md`** — outstanding work items for the module
+- **`context.md`** — design decisions, constraints, history
+
+### `init-registry`
+
+Generate a `specsync-registry.toml` listing all modules in the project. Other projects reference your modules via this registry.
+
+```bash
+specsync init-registry                     # uses project folder name
+specsync init-registry --name myapp        # custom registry name
+```
+
+Commit the generated file to your repo's default branch so `resolve --remote` can find it.
+
+### `resolve`
+
+Verify that all `depends_on` references in your specs actually exist. By default checks local paths only (no network).
+
+```bash
+specsync resolve                           # verify local refs
+specsync resolve --remote                  # also verify cross-project refs via GitHub
+```
+
+Cross-project refs use the `owner/repo@module` syntax in `depends_on`. The `--remote` flag fetches the target repo's `specsync-registry.toml` from GitHub to confirm the module exists. See [Cross-Project References](cross-project-refs) for details.
+
+### `hooks`
+
+Install agent instruction files and git hooks so AI agents and contributors stay spec-aware.
+
+```bash
+specsync hooks install                     # install agent instructions + pre-commit hook
+specsync hooks uninstall                   # remove installed hooks
+specsync hooks status                      # check what's installed
+```
+
+Supports Claude Code (`CLAUDE.md`), Cursor (`.cursor/rules`), GitHub Copilot (`.github/copilot-instructions.md`), and pre-commit hooks.
+
 ### `init`
 
 Create a default `specsync.json` in the current directory.
@@ -112,7 +158,8 @@ specsync watch
 | `--require-coverage N` | Fail if file coverage < N%. |
 | `--root <path>` | Project root directory (default: cwd). |
 | `--provider <name>` | Enable AI-powered generation and select provider: `auto` (auto-detect), `anthropic`, `openai`, or `command`. Without this flag, `generate` uses templates only. |
-| `--json` | Structured JSON output, no color codes. |
+| `--format <fmt>` | Output format: `text` (default), `json`, or `markdown`. Markdown produces clean tables suitable for PRs and docs. |
+| `--json` | Shorthand for `--format json`. Structured output, no color codes. |
 
 ---
 

--- a/docs/cross-project-refs.md
+++ b/docs/cross-project-refs.md
@@ -1,0 +1,119 @@
+---
+title: Cross-Project References
+layout: default
+nav_order: 5
+---
+
+# Cross-Project References
+{: .no_toc }
+
+Validate spec dependencies across repositories. Zero network cost by default — remote verification is opt-in.
+{: .fs-6 .fw-300 }
+
+<details open markdown="block">
+  <summary>Table of contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Overview
+
+Specs can declare dependencies on modules in other repositories using the `owner/repo@module` syntax in `depends_on`. This lets you verify that upstream APIs you depend on are still documented and available.
+
+```yaml
+depends_on:
+  - specs/database/database.spec.md          # local ref
+  - corvid-labs/algochat@messaging           # cross-project ref
+```
+
+**Local refs** are validated by `specsync check` (file must exist). **Cross-project refs** require `specsync resolve --remote` which fetches the target repo's registry from GitHub.
+
+---
+
+## How It Works
+
+1. **You declare a cross-project dependency** in your spec's `depends_on`
+2. **`specsync resolve --remote`** parses the `owner/repo@module` syntax
+3. **Fetches `specsync-registry.toml`** from the target repo's default branch on GitHub
+4. **Checks that the module exists** in the registry
+
+No authentication required for public repos. Private repos need a `GITHUB_TOKEN` environment variable.
+
+---
+
+## Publishing Your Registry
+
+For other projects to reference your modules, commit a `specsync-registry.toml` to your repo's default branch:
+
+```bash
+specsync init-registry                     # uses project folder name
+specsync init-registry --name myapp        # custom name
+git add specsync-registry.toml
+git commit -m "chore: add spec registry for cross-project refs"
+git push
+```
+
+The registry lists all modules from your specs directory:
+
+```toml
+[registry]
+name = "spec-sync"
+generated = "2026-03-28T00:00:00Z"
+
+[[modules]]
+name = "cli"
+spec = "specs/cli/cli.spec.md"
+
+[[modules]]
+name = "parser"
+spec = "specs/parser/parser.spec.md"
+```
+
+---
+
+## Verifying References
+
+```bash
+# Local refs only (no network, runs in check too)
+specsync resolve
+
+# Local + cross-project refs (fetches registries from GitHub)
+specsync resolve --remote
+```
+
+Output:
+
+```
+Cross-project references:
+  ✓ CorvidLabs/spec-sync@cli — resolved
+  ✓ CorvidLabs/spec-sync@parser — resolved
+  ✗ CorvidLabs/spec-sync@nonexistent — module not in registry
+```
+
+---
+
+## CI Usage
+
+Add `resolve --remote` to your CI pipeline to catch broken cross-project refs:
+
+```yaml
+- name: Verify cross-project refs
+  run: specsync resolve --remote
+```
+
+{: .note }
+> `specsync check` validates local refs only and never hits the network. Use `resolve --remote` explicitly when you want cross-project verification. This keeps CI fast by default.
+
+---
+
+## Error Cases
+
+| Scenario | Output |
+|:---------|:-------|
+| Module not in registry | `✗ module not in registry` |
+| Repository not found | `! HTTP 404` + `? registry fetch failed` |
+| No registry file | `? registry fetch failed` (registry not committed) |
+| Network error | `? registry fetch failed` with details |

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,10 @@ specsync generate               # scaffold specs for unspecced modules
 specsync generate --provider auto           # AI-powered specs (auto-detect provider)
 specsync generate --provider anthropic      # use Anthropic API directly
 specsync score                  # quality-score your specs (0–100)
+specsync add-spec auth          # scaffold a single spec with companion files
+specsync resolve --remote       # verify cross-project spec references
+specsync init-registry          # publish your modules for other projects
+specsync hooks install          # install agent instructions + git hooks
 specsync mcp                    # start MCP server for AI agents
 specsync watch                  # re-validate on file changes
 ```
@@ -52,4 +56,4 @@ Auto-detected from file extensions. No per-language configuration.
 
 TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart.
 
-See [Spec Format](spec-format) for how to write specs, [CLI Reference](cli) for all commands, and [Configuration](configuration) for `specsync.json` options.
+See [Spec Format](spec-format) for how to write specs, [CLI Reference](cli) for all commands, [Cross-Project References](cross-project-refs) for multi-repo validation, and [Configuration](configuration) for `specsync.json` options.

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -51,7 +51,17 @@ depends_on:
 | Field | Type | Description |
 |:------|:-----|:------------|
 | `db_tables` | `string[]` | Validated against `CREATE TABLE` statements in your `schemaDir` |
-| `depends_on` | `string[]` | Paths to other spec files — validated for existence |
+| `depends_on` | `string[]` | Local paths or cross-project refs — validated for existence |
+
+`depends_on` supports two formats:
+
+```yaml
+depends_on:
+  - specs/database/database.spec.md          # Local path (validated by check + resolve)
+  - corvid-labs/algochat@messaging           # Cross-project ref (validated by resolve --remote)
+```
+
+Cross-project refs use the `owner/repo@module` syntax. Local refs are verified by `specsync check` and `specsync resolve`. Cross-project refs require `specsync resolve --remote` which fetches the target repo's `specsync-registry.toml` from GitHub. See [Cross-Project References](cross-project-refs) for the full workflow.
 
 ---
 


### PR DESCRIPTION
## Summary

- **New docs page: Cross-Project References** — dedicated guide covering `owner/repo@module` syntax, registry publishing, `resolve --remote`, CI usage, and error cases
- **CLI Reference** — added missing commands: `add-spec`, `init-registry`, `resolve`, `hooks`. Added `--format` flag docs
- **Spec Format** — documented cross-project ref syntax in `depends_on` field
- **Quick Start** — added `add-spec`, `resolve`, `init-registry`, and `hooks` to the command list
- **Version bump to 2.3.1** with CHANGELOG entry

## Test plan

- [ ] Verify docs site builds cleanly (`bundle exec jekyll build`)
- [ ] Check new cross-project-refs page renders correctly and nav order is correct
- [ ] Verify all internal links between docs pages resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6