### PR TITLE
fix: document missing exports and add spec:check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,11 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --check
+
+  spec-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo run -- check

--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -24,6 +24,7 @@ Loads project configuration from `specsync.json` or `.specsync.toml`, with fallb
 | `load_config` | `root: &Path` | `SpecSyncConfig` | Load config from specsync.json or .specsync.toml, falling back to defaults with auto-detected source dirs |
 | `detect_source_dirs` | `root: &Path` | `Vec<String>` | Auto-detect source directories by scanning for supported language files up to 3 levels deep |
 | `default_schema_pattern` | — | `&'static str` | Returns the default regex for SQL CREATE TABLE extraction |
+| `discover_manifest_modules` | `root: &Path` | `ManifestDiscovery` | Discover modules from manifest files (Package.swift, Cargo.toml, etc.) |
 
 ## Invariants
 
@@ -86,3 +87,4 @@ Loads project configuration from `specsync.json` or `.specsync.toml`, with fallb
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial spec |
+| 2026-03-28 | Document discover_manifest_modules |

--- a/specs/exports/exports.spec.md
+++ b/specs/exports/exports.spec.md
@@ -31,6 +31,7 @@ Language-aware export extraction from source files. Auto-detects the programming
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `get_exported_symbols` | `file_path: &Path` | `Vec<String>` | Extract exported symbol names from a source file, auto-detecting language from extension |
+| `get_exported_symbols_with_level` | `file_path: &Path, level: ExportLevel` | `Vec<String>` | Extract exports with configurable granularity — Type (declarations only) or Member (all symbols) |
 | `is_test_file` | `file_path: &Path` | `bool` | Check if a file is a test file based on language-specific naming conventions |
 | `is_source_file` | `file_path: &Path` | `bool` | Check if a file extension belongs to a supported source language |
 | `has_extension` | `file_path: &Path, extensions: &[String]` | `bool` | Check if file matches specific extensions, or any supported language if extensions is empty |
@@ -187,3 +188,4 @@ Each language backend exposes a single `extract_exports(content: &str) -> Vec<St
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial spec |
+| 2026-03-28 | Document get_exported_symbols_with_level |

--- a/specs/types/types.spec.md
+++ b/specs/types/types.spec.md
@@ -22,6 +22,8 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 |------|-------------|
 | `AiProvider` | Supported AI provider presets: Claude, Cursor, Copilot, Ollama, Anthropic, OpenAi, Custom |
 | `Language` | Detected source language for export extraction: TypeScript, Rust, Go, Python, Swift, Kotlin, Java, CSharp, Dart |
+| `OutputFormat` | CLI output format: Text (colored terminal, default), Json (machine-readable), Markdown (PR comments / agent consumption) |
+| `ExportLevel` | Export extraction granularity: Type (top-level declarations only) or Member (all public symbols, default) |
 
 ### Exported Structs
 
@@ -32,6 +34,7 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 | `CoverageReport` | File and LOC coverage metrics for the project |
 | `SpecSyncConfig` | User-provided configuration loaded from specsync.json or .specsync.toml |
 | `RegistryEntry` | Registry entry mapping module names to spec file paths for cross-project resolution |
+| `ModuleDefinition` | User-defined module grouping in specsync.json with files and depends_on lists |
 
 ### AiProvider Functions
 
@@ -122,3 +125,4 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial spec |
+| 2026-03-28 | Document OutputFormat, ExportLevel, ModuleDefinition |


### PR DESCRIPTION
## Summary
- Document 5 missing exports across types, config, and exports specs (OutputFormat, ExportLevel, ModuleDefinition, discover_manifest_modules, get_exported_symbols_with_level)
- Add `spec-check` CI job so spec validation runs on every push/PR
- Reduces spec warnings from **27 to 0**

## Details
The 22 remaining warnings from the previous check were all from Rust inline test fixtures (string literals containing `pub fn fake_fn` etc.) — these are false positives from the regex-based export scanner not stripping `#[cfg(test)]` blocks. The 5 real undocumented exports are now documented.

**Remaining work**: `src/manifest.rs` (828 LOC) needs its own spec to reach 100% file coverage.

## Test plan
- [x] `cargo run -- check` passes with 0 warnings, 0 failures
- [ ] CI spec-check job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6