### PR TITLE
chore: prepare v2.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2026-03-28
+
+### Fixed
+
+- **`action.yml` YAML parse fix** — quoted `${{ github.token }}` default value to prevent YAML stream parse errors when external repos use the action (#56).
+- **`spec:check` in CI** — added spec validation to the CI pipeline so spec drift is caught automatically (#54).
+
+### Added
+
+- **`manifest.spec.md`** — spec for the manifest module, achieving **100% file coverage** across all 23 source files (#55).
+- **Config spec update** — added `manifest` to config's `depends_on` for accurate cross-module references.
+
 ## [2.3.1] - 2026-03-28
 
 ### Added
@@ -203,6 +215,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phantom documentation for non-existent exports (errors).
 - Dependency spec cross-referencing and Consumed By section validation.
 
+[2.3.2]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.3.2
+[2.3.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.3.1
+[2.3.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.3.0
+[2.2.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.2.1
 [2.2.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.2.0
 [2.1.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.1.1
 [2.1.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2024"
 description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 2.3.2 in Cargo.toml
- Add CHANGELOG entry for v2.3.2 covering #54, #55, #56
- Add missing link references for 2.3.x versions in CHANGELOG

## Changes in v2.3.2
- **Fix**: `action.yml` YAML parse error — quoted `${{ github.token }}` default (#56)
- **Fix**: `spec:check` added to CI pipeline (#54)
- **Added**: `manifest.spec.md` — 100% file coverage across all 23 source files (#55)

Tag `v2.3.2` already pushed. Merge this to complete the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)