### PR TITLE
feat: switch export validation to allowlist model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Export validation uses allowlist** — only `### Exported ...` subsections under `## Public API` now trigger export validation. Non-export subsections (`### API Endpoints`, `### Route Handlers`, `### Component API`, `### Configuration`, etc.) are treated as informational and skipped. This fixes false errors when specs document private route handlers, component signals, service methods, or infrastructure concepts alongside validated exports.
+
 ## [2.3.3] - 2026-03-28
 
 ### Documentation

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -102,6 +102,39 @@ The core of what SpecSync validates. Use markdown tables with **backtick-quoted 
 {: .note }
 > Column headers don't matter. SpecSync only reads backtick-quoted names in the first column. Structure the table however suits your team.
 
+### Validated vs Informational Subsections
+
+Only `### Exported ...` subsections trigger export validation. Use other heading names to document non-export API surface without triggering validation errors:
+
+```markdown
+## Public API
+
+### Exported Functions              ← validated against code exports
+| Function | Description |
+|----------|-------------|
+| `authenticate` | Validates token |
+
+### API Endpoints                   ← informational, NOT validated
+| Endpoint | Method | Handler | Description |
+|----------|--------|---------|-------------|
+| `/login` | POST | `login` | Login route |
+
+### Component API                   ← informational, NOT validated
+| Signal | Type | Description |
+|--------|------|-------------|
+| `activeTab` | string | Current tab |
+
+### Configuration                   ← informational, NOT validated
+| Key | Type | Default |
+|-----|------|---------|
+| `timeout` | number | 30 |
+```
+
+This lets specs document the full API surface — HTTP endpoints, component signals, route handlers, config options — alongside validated exports, all in one place.
+
+{: .note }
+> Tables placed directly under `## Public API` (without a `###` subsection) are always validated.
+
 ---
 
 ## Consumed By Section

--- a/specs/parser/parser.spec.md
+++ b/specs/parser/parser.spec.md
@@ -35,7 +35,7 @@ Parses spec markdown files — extracts YAML frontmatter into structured data, e
 
 1. `parse_frontmatter` returns `None` if the content does not start with `---\n...\n---\n`
 2. `get_spec_symbols` only extracts the first backtick-quoted word per table row (`` `symbol` ``)
-3. `get_spec_symbols` skips sub-tables under `### Methods`, `### Constructor`, or `### Properties` headings
+3. `get_spec_symbols` only extracts from `### Exported ...` subsections (allowlist) and top-level tables; skips non-export subsections (e.g., `### API Endpoints`, `### Route Handlers`, `### Configuration`) and `####` method/constructor/properties sub-tables
 4. Symbols are deduplicated while preserving order
 5. `get_missing_sections` uses regex matching for `## SectionName` headings — case-sensitive
 6. Frontmatter parsing handles both scalar fields (module, version, status) and list fields (files, db_tables, depends_on)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -150,16 +150,20 @@ pub fn get_spec_symbols(body: &str) -> Vec<String> {
             .map(|l| l.trim())
             .find(|l| !l.is_empty())
             .unwrap_or("");
-        if header.ends_with("Methods")
-            || header.ends_with("Constructor")
-            || header.ends_with("Properties")
-        {
+
+        // Allowlist: only validate tables under ### headers containing "Exported"
+        // (e.g., "### Exported Functions", "### Exported Types").
+        // Tables directly under ## Public API (no ### header) are also validated.
+        // Everything else (### API Endpoints, ### Component API, ### Route Handlers,
+        // ### Configuration, ### Internal Functions, etc.) is informational only.
+        if header.starts_with("### ") && !header.contains("Exported") {
             continue;
         }
 
         let mut in_method_subsection = false;
 
         for line in sub.lines() {
+            // Skip #### sub-tables for class methods/constructors/properties
             if METHOD_HEADER_RE.is_match(line) {
                 in_method_subsection = true;
                 continue;
@@ -256,5 +260,74 @@ Something
 "#;
         let symbols = get_spec_symbols(body);
         assert_eq!(symbols, vec!["createAuth", "validateToken", "AuthConfig"]);
+    }
+
+    #[test]
+    fn test_get_spec_symbols_skips_non_exported_subsections() {
+        let body = r#"## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `authenticate` | token: string | User | Validates token |
+
+### API Endpoints
+
+| Endpoint | Method | Handler | Description |
+|----------|--------|---------|-------------|
+| `/login` | POST | `login` | Login route |
+| `/logout` | POST | `logout` | Logout route |
+
+### Component API
+
+| Signal | Type | Description |
+|--------|------|-------------|
+| `activeTab` | string | Current tab |
+
+### Route Handlers
+
+| Handler | Description |
+|---------|-------------|
+| `registration_status` | Check registration |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `AuthConfig` | Config type |
+
+### Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `timeout` | number | 30 | Request timeout |
+
+### Internal Functions
+
+| Function | Description |
+|----------|-------------|
+| `hashPassword` | Internal hashing |
+
+## Invariants
+"#;
+        let symbols = get_spec_symbols(body);
+        // Only symbols under "### Exported ..." subsections should be extracted
+        assert_eq!(symbols, vec!["authenticate", "AuthConfig"]);
+    }
+
+    #[test]
+    fn test_get_spec_symbols_top_level_table() {
+        // Tables directly under ## Public API (no ### header) should be validated
+        let body = r#"## Public API
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `helper` | input: string | string | Helps |
+
+## Invariants
+"#;
+        let symbols = get_spec_symbols(body);
+        assert_eq!(symbols, vec!["helper"]);
     }
 }


### PR DESCRIPTION
## Summary

- **Switches from blocklist to allowlist** for export validation in `## Public API` sections
- Only `### Exported ...` subsections (e.g., `### Exported Functions`, `### Exported Types`) trigger export validation
- All other subsections (`### API Endpoints`, `### Route Handlers`, `### Component API`, `### Configuration`, `### Internal Functions`, etc.) are treated as informational — no validation errors
- Tables directly under `## Public API` (no `###` header) are still validated for backwards compatibility

## Motivation

Agent feedback from a Rust project: spec-sync was throwing false errors when specs documented non-export API surface — private route handlers, Angular component signals, service methods, interface fields, and infra concepts. The old blocklist (skip Methods/Constructor/Properties) was too narrow. The allowlist approach is granular — a single spec can mix validated exports with informational docs.

## Changes

| File | Change |
|------|--------|
| `src/parser.rs` | Replaced blocklist with allowlist check (`header.contains("Exported")`) |
| `src/parser.rs` | Added 2 unit tests for new behavior |
| `specs/parser/parser.spec.md` | Updated invariant 3 to reflect allowlist model |
| `docs/spec-format.md` | Added "Validated vs Informational Subsections" section with examples |
| `CHANGELOG.md` | Added unreleased entry |

## Test plan

- [x] All 64 unit tests pass (including 2 new tests)
- [x] All 73 passing integration tests still pass (1 pre-existing flaky AI test unrelated)
- [x] `specsync check` on own repo: 14 specs, 0 errors
- [ ] Test with a Rust project that has private route handlers in specs
- [ ] Test with an Angular project that has component signals in specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)