### PR TITLE
chore: prepare v2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-03-28
+
 ### Changed
 
-- **Export validation uses allowlist** — only `### Exported ...` subsections under `## Public API` now trigger export validation. Non-export subsections (`### API Endpoints`, `### Route Handlers`, `### Component API`, `### Configuration`, etc.) are treated as informational and skipped. This fixes false errors when specs document private route handlers, component signals, service methods, or infrastructure concepts alongside validated exports.
+- **Export validation uses allowlist** — only `### Exported ...` subsections under `## Public API` now trigger export validation. Non-export subsections (`### API Endpoints`, `### Route Handlers`, `### Component API`, `### Configuration`, etc.) are treated as informational and skipped. This fixes false errors when specs document private route handlers, component signals, service methods, or infrastructure concepts alongside validated exports (#60).
 
 ## [2.3.3] - 2026-03-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "2.3.3"
+version = "2.4.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "2.3.3"
+version = "2.4.0"
 edition = "2024"
 description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to 2.4.0 in Cargo.toml
- Update CHANGELOG with v2.4.0 release date and PR reference

Release includes:
- **Export validation allowlist** (#60) — only `### Exported ...` subsections trigger validation, fixing false errors for Rust private handlers, Angular components, service methods, etc.

## Post-merge

Tag `v2.4.0` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)