### PR TITLE
release: prep v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-03-30
+
+### Added
+
+- **Schema column validation** — SpecSync now parses SQL migrations (CREATE TABLE, ALTER TABLE ADD COLUMN) and validates documented columns in spec `### Schema` sections against the actual database schema. Catches phantom columns (documented but missing from schema), undocumented columns (in schema but not in spec), and column type mismatches. Opt-in via `schema_dir` in `specsync.json`.
+- **Destructive DDL support** — migration parser correctly handles DROP TABLE, ALTER TABLE DROP COLUMN, ALTER TABLE RENAME TO, and ALTER TABLE RENAME COLUMN, ensuring the schema map accurately reflects state after all migrations replay in order.
+- **Multi-language migration files** — schema extraction now supports 16 file types (SQL, TypeScript, JavaScript, Python, Ruby, Go, Rust, PHP, Swift, Kotlin, Java, C#, Dart, and more), not just `.sql`.
+- **PHP language support** — full export extraction for PHP: classes, interfaces, traits, enums, public functions/constants, with visibility filtering and magic method exclusion.
+- **Ruby language support** — full export extraction for Ruby: classes, modules, public methods with visibility toggle tracking, `attr_accessor`/`attr_reader`/`attr_writer`, constants, and `=begin/=end` comment handling.
+- Expanded export parser test coverage for Go, Python, Java, C#, and Dart.
+- Achieved 100% spec coverage across all modules.
+
 ## [2.4.0] - 2026-03-28
 
 ### Changed
@@ -229,6 +241,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phantom documentation for non-existent exports (errors).
 - Dependency spec cross-referencing and Consumed By section validation.
 
+[2.5.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.5.0
+[2.4.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.4.0
+[2.3.3]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.3.3
 [2.3.2]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.3.2
 [2.3.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.3.1
 [2.3.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v2.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "specsync"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2024"
-description = "Bidirectional spec-to-code validation — language-agnostic, blazing fast"
+description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/CorvidLabs/spec-sync"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Downloads](https://img.shields.io/crates/d/specsync.svg)](https://crates.io/crates/specsync)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Bidirectional spec-to-code validation with cross-project references.** Written in Rust. Single binary. 9 languages.
+**Bidirectional spec-to-code validation with cross-project references.** Written in Rust. Single binary. 11 languages.
 
 [Quick Start](#quick-start) &bull; [Spec Format](#spec-format) &bull; [CLI](#cli-reference) &bull; [Cross-Project Refs](#cross-project-references) &bull; [GitHub Action](#github-action) &bull; [Config](#configuration) &bull; [Docs Site](https://corvidlabs.github.io/spec-sync)
 
@@ -26,6 +26,9 @@ SpecSync validates markdown module specs (`*.spec.md`) against your source code 
 | Spec documents something missing from code | **Error** | Stale/phantom entry |
 | Source file in spec was deleted | **Error** | Missing file |
 | DB table in spec missing from schema | **Error** | Phantom table |
+| Column in spec missing from migrations | **Error** | Phantom column |
+| Column in schema not documented in spec | Warning | Undocumented column |
+| Column type mismatch between spec and schema | Warning | Type drift |
 | Required markdown section missing | **Error** | Incomplete spec |
 
 ## Supported Languages
@@ -43,6 +46,8 @@ Auto-detected from file extensions. Same spec format for all.
 | **Java** | `public` class/interface/enum/record/methods | `*Test.java`, `*Tests.java` |
 | **C#** | `public` class/struct/interface/enum/record/delegate | `*Test.cs`, `*Tests.cs` |
 | **Dart** | Top-level (no `_` prefix), class/mixin/enum/typedef | `*_test.dart` |
+| **PHP** | `class/interface/trait/enum`, `public` function/const, skips `private/protected` and `__` magic methods | `*Test.php` |
+| **Ruby** | `class`/`module`, `public` methods with visibility tracking, `attr_accessor`/`attr_reader`/`attr_writer`, constants | `*_test.rb`, `*_spec.rb` |
 
 ---
 
@@ -579,7 +584,9 @@ src/
     ├── kotlin.rs       Kotlin top-level
     ├── java.rs         Java public items
     ├── csharp.rs       C# public items
-    └── dart.rs         Dart public items
+    ├── dart.rs         Dart public items
+    ├── php.rs          PHP public items
+    └── ruby.rs         Ruby public items
 ```
 
 **Design:** Single binary, no runtime deps. Frontmatter parsed with regex (no YAML library). Language backends use regex, not ASTs — works without compilers installed. Release builds use LTO + strip + opt-level 3.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ nav_order: 1
 # SpecSync
 {: .fs-9 }
 
-Bidirectional spec-to-code validation. Written in Rust. Single binary. 9 languages.
+Bidirectional spec-to-code validation. Written in Rust. Single binary. 11 languages.
 {: .fs-6 .fw-300 }
 
 [Get Started](#quick-start){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
@@ -54,6 +54,6 @@ specsync watch                  # re-validate on file changes
 
 Auto-detected from file extensions. No per-language configuration.
 
-TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart.
+TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby.
 
 See [Spec Format](spec-format) for how to write specs, [CLI Reference](cli) for all commands, [Cross-Project References](cross-project-refs) for multi-repo validation, and [Configuration](configuration) for `specsync.json` options.


### PR DESCRIPTION
## Summary
- Bump version to **2.5.0** in Cargo.toml
- Add v2.5.0 CHANGELOG entry (schema column validation, destructive DDL, PHP & Ruby support)
- Update README: 11 languages, new detection rows, architecture diagram
- Update docs/index.md language list
- Fix missing CHANGELOG link refs for v2.3.3 and v2.4.0

## After merge
- Tag `v2.5.0` and create GitHub release
- `cargo publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)