### PR TITLE
fix: improve binary detection accuracy using OS-level PATH search

### DIFF
--- a/specs/ai/ai.spec.md
+++ b/specs/ai/ai.spec.md
@@ -35,7 +35,7 @@ Resolves and executes AI providers for spec generation. Supports CLI-based provi
 ## Invariants
 
 1. Provider resolution order: CLI `--provider` flag > `aiCommand` config > `aiProvider` config > `SPECSYNC_AI_COMMAND` env var > auto-detect
-2. Auto-detection checks CLI providers first (by binary availability), then API providers (by env var presence)
+2. Auto-detection checks CLI providers first (by attempting to run `<binary> --version` via OS-level execvp), then API providers (by env var presence)
 3. Source code is capped at 150K characters total and 30K per file to avoid exceeding context windows
 4. AI response is post-processed: code fences are stripped, frontmatter delimiters are validated
 5. Default timeout is 120 seconds, configurable via `aiTimeout` in config

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -54,16 +54,17 @@ fn is_binary_available(name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
-    // Search PATH directly — avoids spawning a shell, which may not inherit
-    // the full PATH in IDE terminals, build systems, or macOS app launchers.
-    if let Ok(path_var) = std::env::var("PATH") {
-        for dir in path_var.split(':') {
-            if std::path::Path::new(dir).join(name).exists() {
-                return true;
-            }
-        }
-    }
-    false
+    // Attempt to launch the binary with --version. If the OS cannot find it,
+    // `status()` returns Err (ENOENT); if it launches at all, is_ok() is true
+    // regardless of exit code. This uses the OS-level execvp PATH search, which
+    // handles symlinks and execute-permission checks correctly.
+    Command::new(name)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
 }
 
 /// Build the CLI command string for a provider, optionally using a custom model.


### PR DESCRIPTION
Replace manual PATH environment variable traversal with a call to the binary's version flag. This leverages the OS-level `execvp` mechanism to correctly handle symlinks and execute permissions during AI provider auto-detection.