### PR TITLE
docs: complete spec coverage for v3.3.0

### DIFF
--- a/specs/archive/archive.spec.md
+++ b/specs/archive/archive.spec.md
@@ -1,0 +1,87 @@
+---
+module: archive
+version: 1
+status: stable
+files:
+  - src/archive.rs
+db_tables: []
+depends_on:
+  - specs/validator/validator.spec.md
+---
+
+# Archive
+
+## Purpose
+
+Moves completed markdown task items (`- [x]`) from active sections of companion `tasks.md` files into an `## Archive` section at the bottom. Keeps task history accessible without cluttering the active task list.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `archive_tasks` | `root: &Path, specs_dir: &Path, dry_run: bool` | `Vec<ArchiveResult>` | Scan all spec companion tasks.md files, move completed tasks to archive section |
+| `count_completed_tasks` | `specs_dir: &Path` | `usize` | Count all completed tasks across all tasks.md files |
+
+### Exported Structs
+
+| Type | Description |
+|------|-------------|
+| `ArchiveResult` | Result of archiving tasks in a single file — contains `tasks_path: String` and `archived_count: usize` |
+
+## Invariants
+
+1. Only items matching `- [x]` or `- [X]` (case-insensitive) are archived
+2. If no `## Archive` section exists, one is created at the bottom of the file
+3. Existing archive content is preserved — new items are appended
+4. `dry_run: true` returns results without modifying files
+5. Files with no completed tasks are skipped (not included in results)
+6. Uses `find_spec_files` from validator to discover specs and their companion files
+
+## Behavioral Examples
+
+### Scenario: Archive completed tasks
+
+- **Given** a tasks.md file with 3 completed and 2 pending items
+- **When** `archive_tasks(root, specs_dir, false)` is called
+- **Then** the 3 completed items move to `## Archive`, 2 pending items remain in place
+
+### Scenario: Dry run
+
+- **Given** tasks.md files with completed items
+- **When** `archive_tasks(root, specs_dir, true)` is called
+- **Then** returns `ArchiveResult` entries but does not modify any files
+
+### Scenario: No completed tasks
+
+- **Given** all tasks.md files have only pending items
+- **When** `archive_tasks` is called
+- **Then** returns an empty vec
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| tasks.md file unreadable | Prints error in red, continues processing other files |
+| tasks.md file unwritable | Prints error in red, continues processing other files |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| validator | `find_spec_files` to locate spec files and their companions |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| main | `archive_tasks` via `cmd_archive_tasks` subcommand |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-06 | Initial spec for v3.3.0 |

--- a/specs/archive/context.md
+++ b/specs/archive/context.md
@@ -1,0 +1,5 @@
+---
+spec: archive.spec.md
+---
+
+## Key Decisions

--- a/specs/archive/requirements.md
+++ b/specs/archive/requirements.md
@@ -1,0 +1,5 @@
+---
+spec: archive.spec.md
+---
+
+## User Stories

--- a/specs/archive/tasks.md
+++ b/specs/archive/tasks.md
@@ -1,0 +1,5 @@
+---
+spec: archive.spec.md
+---
+
+## Tasks

--- a/specs/cli/cli.spec.md
+++ b/specs/cli/cli.spec.md
@@ -18,6 +18,12 @@ depends_on:
   - specs/watch/watch.spec.md
   - specs/hooks/hooks.spec.md
   - specs/types/types.spec.md
+  - specs/archive/archive.spec.md
+  - specs/compact/compact.spec.md
+  - specs/view/view.spec.md
+  - specs/github/github.spec.md
+  - specs/hash_cache/hash_cache.spec.md
+  - specs/merge/merge.spec.md
 ---
 
 # CLI
@@ -38,7 +44,7 @@ Three Clap derive structs define the CLI: Cli (root parser with global flags), C
 
 | Command | Description | Key Flags |
 |---------|-------------|-----------|
-| check | Validate all specs against source code (default when no subcommand given) | --strict, --require-coverage N, --json, --fix |
+| check | Validate all specs against source code (default when no subcommand given) | --strict, --require-coverage N, --json, --fix, --force, --create-issues |
 | coverage | Show file and module coverage report | --strict, --require-coverage N, --json |
 | generate | Scaffold spec files for unspecced modules | --provider PROVIDER (AI mode: auto/claude/anthropic/openai/ollama/copilot) |
 | init | Create a specsync.json config file with auto-detected source dirs | — |
@@ -52,6 +58,11 @@ Three Clap derive structs define the CLI: Cli (root parser with global flags), C
 | hooks install | Install agent instructions and/or git hooks | --claude, --cursor, --copilot, --precommit, --claude-code-hook |
 | hooks uninstall | Remove previously installed hooks | --claude, --cursor, --copilot, --precommit, --claude-code-hook |
 | hooks status | Show installation status of all hooks | — |
+| compact | Compact changelog tables by summarizing old entries | --keep N (default 10), --dry-run |
+| archive-tasks | Move completed task items to archive section | --dry-run |
+| view | Filter spec content by stakeholder role | --role (dev\|qa\|product\|agent), --spec PATH |
+| merge | Auto-resolve git merge conflicts in spec files | --dry-run, --all, --json |
+| issues | Verify GitHub issue references in spec frontmatter | --create (create drift issues for failures) |
 
 ### Global Flags
 
@@ -60,7 +71,9 @@ Three Clap derive structs define the CLI: Cli (root parser with global flags), C
 | --strict | bool | false | Treat warnings as errors (exit 1) |
 | --require-coverage | Option usize | None | Fail if file coverage percent is below threshold |
 | --root | Option PathBuf | cwd | Project root directory |
-| --json | bool | false | Output results as JSON instead of colored text |
+| --format | text\|json\|markdown | text | Output format: colored text, machine-readable JSON, or markdown |
+| --json | bool | false | Shorthand for `--format json` |
+| --force | bool | false | Bypass hash cache and re-validate all specs |
 
 ### Internal Functions
 
@@ -77,6 +90,11 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 - **cmd_resolve** — Resolve local and cross-project depends_on references
 - **cmd_hooks** — Dispatch to hooks install/uninstall/status
 - **cmd_diff** — Compare exports across git refs, show new/removed exports per spec
+- **cmd_compact** — Compact changelog tables in all specs
+- **cmd_archive_tasks** — Move completed tasks to archive section in companion files
+- **cmd_view** — Filter and display spec content for a specific role
+- **cmd_merge** — Auto-resolve git merge conflicts in spec files
+- **cmd_issues** — Verify GitHub issue references in spec frontmatter
 - **auto_fix_specs** — Scan source files for undocumented exports and auto-add stubs to spec Public API tables
 - **collect_hook_targets** — Convert boolean flags to Vec of HookTarget
 - **load_and_discover** — Load config and find all spec files (filtering _-prefixed templates)
@@ -224,6 +242,12 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 | watch | `run_watch` |
 | hooks | `cmd_install`, `cmd_uninstall`, `cmd_status`, `HookTarget` |
 | types | `SpecSyncConfig`, `CoverageReport` |
+| archive | `archive_tasks` |
+| compact | `compact_changelogs` |
+| view | `view_spec`, `valid_roles` |
+| github | `verify_spec_issues`, `create_drift_issue`, `resolve_repo` |
+| hash_cache | `HashCache`, `classify_all_changes`, `update_cache` |
+| merge | `merge_specs`, `print_results`, `results_to_json` |
 
 ### Consumed By
 
@@ -236,3 +260,4 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial spec |
+| 2026-04-06 | Add compact, archive-tasks, view, merge, issues subcommands; add --force, --create-issues, --format flags; add hash_cache/github/archive/compact/view/merge dependencies |

--- a/specs/compact/compact.spec.md
+++ b/specs/compact/compact.spec.md
@@ -1,0 +1,87 @@
+---
+module: compact
+version: 1
+status: stable
+files:
+  - src/compact.rs
+db_tables: []
+depends_on:
+  - specs/validator/validator.spec.md
+---
+
+# Compact
+
+## Purpose
+
+Reduces changelog table size in spec files by keeping only the last N entries and summarizing older ones into a single compacted row with a date range and entry count.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `compact_changelogs` | `root: &Path, specs_dir: &Path, keep: usize, dry_run: bool` | `Vec<CompactResult>` | Compact changelog tables in all spec files, keeping the last `keep` entries |
+
+### Exported Structs
+
+| Type | Description |
+|------|-------------|
+| `CompactResult` | Result of compacting one spec — contains `spec_path: String`, `original_entries: usize`, `compacted_entries: usize`, `removed: usize` |
+
+## Invariants
+
+1. Only specs with a `## Change Log` section containing a markdown table are processed
+2. Table header and separator rows (first two `|`-prefixed lines) are always preserved
+3. The last `keep` data rows are preserved; earlier rows are summarized
+4. Summary row contains the date range of compacted entries and their count
+5. If a changelog has fewer than `keep + 1` entries, no compaction occurs
+6. `dry_run: true` returns results without modifying files
+7. Handles both 2-column and 3+ column tables with appropriate summary format
+
+## Behavioral Examples
+
+### Scenario: Compact a long changelog
+
+- **Given** a spec with 20 changelog entries and `keep = 5`
+- **When** `compact_changelogs` is called
+- **Then** the first 15 entries are replaced with a single summary row like `| 2025-01-01 — 2026-03-15 | 15 entries compacted |`
+
+### Scenario: Short changelog (no compaction needed)
+
+- **Given** a spec with 3 changelog entries and `keep = 5`
+- **When** `compact_changelogs` is called
+- **Then** the spec is skipped (not included in results)
+
+### Scenario: Dry run
+
+- **Given** specs with long changelogs
+- **When** `compact_changelogs(root, specs_dir, 5, true)` is called
+- **Then** returns `CompactResult` entries but does not modify any files
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Spec file unreadable | Prints error in bold red, continues processing other files |
+| No changelog section found | Spec is silently skipped |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| validator | `find_spec_files` to locate all spec files |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| main | `compact_changelogs` via `cmd_compact` subcommand |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-06 | Initial spec for v3.3.0 |

--- a/specs/compact/context.md
+++ b/specs/compact/context.md
@@ -1,0 +1,5 @@
+---
+spec: compact.spec.md
+---
+
+## Key Decisions

--- a/specs/compact/requirements.md
+++ b/specs/compact/requirements.md
@@ -1,0 +1,5 @@
+---
+spec: compact.spec.md
+---
+
+## User Stories

--- a/specs/compact/tasks.md
+++ b/specs/compact/tasks.md
@@ -1,0 +1,5 @@
+---
+spec: compact.spec.md
+---
+
+## Tasks

--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -28,6 +28,22 @@ Loads project configuration from `specsync.json` or `.specsync.toml`, with fallb
 | `default_schema_pattern` | — | `&'static str` | Returns the default regex for SQL CREATE TABLE extraction |
 | `discover_manifest_modules` | `root: &Path` | `ManifestDiscovery` | Discover modules from manifest files (Package.swift, Cargo.toml, etc.) |
 
+### Config File Structure
+
+The configuration file supports the following top-level sections:
+
+| Section | Type | Description |
+|---------|------|-------------|
+| `specsDir` | `String` | Directory containing spec files (default: `"specs"`) |
+| `sourceDirs` | `Vec<String>` | Source directories to scan (auto-detected if omitted) |
+| `sourceExtensions` | `Vec<String>` | File extensions to consider as source files |
+| `excludePatterns` | `Vec<String>` | Glob patterns to exclude from coverage |
+| `requiredSections` | `Vec<String>` | Sections every spec must contain |
+| `schemaPattern` | `String` | Regex for SQL CREATE TABLE extraction |
+| `github` | `GitHubConfig` | GitHub integration settings (`repo`, `labels`, `create_on_drift`) |
+| `rules` | `ValidationRules` | Custom validation rules (`max_staleness_days`, etc.) |
+| `modules` | `Map<String, ModuleDefinition>` | User-defined module groupings |
+
 ## Invariants
 
 1. Config file search order: `specsync.json` first, then `.specsync.toml`, then defaults
@@ -90,3 +106,4 @@ Loads project configuration from `specsync.json` or `.specsync.toml`, with fallb
 |------|--------|
 | 2026-03-25 | Initial spec |
 | 2026-03-28 | Document discover_manifest_modules |
+| 2026-04-06 | Document github config section, rules section, and full config file structure |

--- a/specs/github/context.md
+++ b/specs/github/context.md
@@ -1,0 +1,5 @@
+---
+spec: github.spec.md
+---
+
+## Key Decisions

--- a/specs/github/github.spec.md
+++ b/specs/github/github.spec.md
@@ -1,0 +1,108 @@
+---
+module: github
+version: 1
+status: stable
+files:
+  - src/github.rs
+db_tables: []
+depends_on:
+  - specs/parser/parser.spec.md
+---
+
+# GitHub
+
+## Purpose
+
+Links spec files to GitHub issues for traceability. Validates `implements` and `tracks` frontmatter fields against actual GitHub issues, fetches issue metadata, and creates drift detection issues when specs fall out of sync.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `detect_repo` | `root: &Path` | `Option<String>` | Auto-detect GitHub repo (`owner/repo`) from git remote URL |
+| `resolve_repo` | `config_repo: Option<&str>, root: &Path` | `Result<String, String>` | Resolve repo from config or auto-detect; error if neither available |
+| `gh_is_available` | — | `bool` | Check if the `gh` CLI is authenticated and available |
+| `fetch_issue_gh` | `repo: &str, number: u64` | `Result<GitHubIssue, String>` | Fetch issue via `gh` CLI (`gh issue view --json`) |
+| `fetch_issue_api` | `repo: &str, number: u64` | `Result<GitHubIssue, String>` | Fetch issue via GitHub REST API with `GITHUB_TOKEN` env var |
+| `fetch_issue` | `repo: &str, number: u64` | `Result<GitHubIssue, String>` | Fetch issue — tries `gh` CLI first, falls back to REST API |
+| `verify_spec_issues` | `repo: &str, spec_path: &str, implements: &[u64], tracks: &[u64]` | `IssueVerification` | Verify all issue references from a spec's frontmatter |
+| `create_drift_issue` | `repo: &str, spec_path: &str, errors: &[String], labels: &[String]` | `Result<GitHubIssue, String>` | Create a "Spec drift detected" issue with validation errors |
+
+### Exported Structs
+
+| Type | Description |
+|------|-------------|
+| `GitHubIssue` | Issue metadata — `number: u64`, `title: String`, `state: String`, `labels: Vec<String>`, `url: String` |
+| `IssueVerification` | Verification result — `valid: Vec<GitHubIssue>`, `closed: Vec<GitHubIssue>`, `not_found: Vec<u64>`, `errors: Vec<String>` |
+
+## Invariants
+
+1. `fetch_issue` always tries `gh` CLI first, falls back to REST API only if `gh` is unavailable
+2. `fetch_issue_api` requires `GITHUB_TOKEN` environment variable; returns error if unset
+3. `fetch_issue_api` uses a 10-second HTTP timeout
+4. Issue state is normalized to lowercase (`"open"` / `"closed"`)
+5. `create_drift_issue` requires `gh` CLI — no REST API fallback for issue creation
+6. `detect_repo` handles both SSH (`git@github.com:`) and HTTPS (`https://github.com/`) remote URLs
+7. `resolve_repo` prefers explicit config over auto-detection
+8. `verify_spec_issues` classifies each issue as valid (open), closed, not_found, or error
+
+## Behavioral Examples
+
+### Scenario: Verify spec issues
+
+- **Given** a spec with `implements: [42]` and `tracks: [100]`, issue #42 is open, #100 is closed
+- **When** `verify_spec_issues` is called
+- **Then** returns `valid: [#42]`, `closed: [#100]`, `not_found: []`, `errors: []`
+
+### Scenario: Auto-detect repo from SSH remote
+
+- **Given** git remote URL is `git@github.com:CorvidLabs/spec-sync.git`
+- **When** `detect_repo(root)` is called
+- **Then** returns `Some("CorvidLabs/spec-sync")`
+
+### Scenario: Create drift issue
+
+- **Given** a spec has validation errors
+- **When** `create_drift_issue(repo, path, errors, labels)` is called
+- **Then** creates a GitHub issue titled "Spec drift detected: {path}" with error list in body
+
+### Scenario: gh CLI unavailable, API fallback
+
+- **Given** `gh auth status` fails but `GITHUB_TOKEN` is set
+- **When** `fetch_issue(repo, 42)` is called
+- **Then** falls back to REST API and returns the issue
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| No git remote configured | `detect_repo` returns `None` |
+| Neither config repo nor git remote | `resolve_repo` returns `Err` |
+| `gh` unavailable and no `GITHUB_TOKEN` | `fetch_issue` returns `Err` |
+| Issue does not exist (404) | `fetch_issue_api` returns `Err("Issue not found")` |
+| Network timeout | `fetch_issue_api` returns `Err` after 10 seconds |
+| `gh` CLI not authenticated | `gh_is_available` returns `false` |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| (external) | `gh` CLI for authenticated GitHub operations |
+| (external) | `ureq` crate for HTTP REST API calls |
+| (external) | `serde_json` for parsing JSON responses |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| main | `verify_spec_issues`, `create_drift_issue`, `resolve_repo` via `cmd_check` and `cmd_issues` |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-06 | Initial spec for v3.3.0 |

--- a/specs/github/requirements.md
+++ b/specs/github/requirements.md
@@ -1,0 +1,5 @@
+---
+spec: github.spec.md
+---
+
+## User Stories

--- a/specs/github/tasks.md
+++ b/specs/github/tasks.md
@@ -1,0 +1,5 @@
+---
+spec: github.spec.md
+---
+
+## Tasks

--- a/specs/hash_cache/context.md
+++ b/specs/hash_cache/context.md
@@ -1,0 +1,5 @@
+---
+spec: hash_cache.spec.md
+---
+
+## Key Decisions

--- a/specs/hash_cache/hash_cache.spec.md
+++ b/specs/hash_cache/hash_cache.spec.md
@@ -1,0 +1,110 @@
+---
+module: hash_cache
+version: 1
+status: stable
+files:
+  - src/hash_cache.rs
+db_tables: []
+depends_on:
+  - specs/parser/parser.spec.md
+---
+
+# Hash Cache
+
+## Purpose
+
+Uses SHA-256 content hashing to track which spec files, companion files, and source files have changed since the last validation run. Enables incremental validation — only specs with detected changes are re-validated, significantly improving performance on large projects.
+
+## Public API
+
+### Exported Structs
+
+| Type | Description |
+|------|-------------|
+| `HashCache` | Persistent file hash storage — maps relative paths to hex SHA-256 digests. Stored in `.specsync/hashes.json` |
+| `ChangeKind` | Enum classifying what changed: `Spec`, `Requirements`, `Companion`, `Source` |
+| `ChangeClassification` | Result for one spec — contains `spec_path: PathBuf` and `changes: Vec<ChangeKind>` |
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `load` | `root: &Path` | `Self` | HashCache: load from `.specsync/hashes.json`; returns empty cache if missing |
+| `save` | `&self, root: &Path` | `io::Result<()>` | HashCache: write to `.specsync/hashes.json` with pretty JSON |
+| `hash_file` | `path: &Path` | `Option<String>` | HashCache: compute SHA-256 of file in 8KB chunks; returns hex string |
+| `is_changed` | `&self, root: &Path, rel_path: &str` | `bool` | HashCache: true if file is new or hash differs from cached value |
+| `update` | `&mut self, root: &Path, rel_path: &str` | `()` | HashCache: recompute and store hash for a file |
+| `prune` | `&mut self, root: &Path` | `()` | HashCache: remove entries for files that no longer exist on disk |
+| `has` | `&self, kind: ChangeKind` | `bool` | ChangeClassification: true if a specific change kind is present |
+| `classify_changes` | `root: &Path, spec_path: &Path, cache: &HashCache` | `ChangeClassification` | Check spec, companions, and source files for changes |
+| `classify_all_changes` | `root: &Path, spec_files: &[PathBuf], cache: &HashCache` | `Vec<ChangeClassification>` | Classify all specs, returns only those with changes |
+| `filter_unchanged` | `root: &Path, spec_files: &[PathBuf], cache: &HashCache` | `Vec<PathBuf>` | Return only specs with detected changes |
+| `update_cache` | `root: &Path, spec_files: &[PathBuf], cache: &mut HashCache` | `()` | Post-validation: update hashes for all specs, companions, and source files; prune deleted entries |
+| `extract_frontmatter_files` | `content: &str` | `Vec<String>` | Quick extraction of `files:` list from YAML frontmatter without full parser |
+
+## Invariants
+
+1. Cache is stored at `{root}/.specsync/hashes.json`; the `.specsync/` directory is created automatically
+2. Missing or unparseable cache file is treated as empty cache (all files considered changed)
+3. Unreadable files are treated as "changed" (conservative — triggers re-validation)
+4. SHA-256 is computed in 8KB chunks for memory efficiency on large files
+5. Path keys are normalized for cross-platform consistency (forward slashes)
+6. Companion file detection covers both naming conventions: plain (`requirements.md`) and prefixed (`{module}.req.md`)
+7. `update_cache` prunes entries for deleted files to prevent unbounded cache growth
+8. `extract_frontmatter_files` uses quick string matching — does not invoke the full YAML parser
+
+## Behavioral Examples
+
+### Scenario: Incremental validation
+
+- **Given** 50 specs, only 3 have changed since last run
+- **When** `classify_all_changes` is called
+- **Then** returns 3 `ChangeClassification` entries; 47 specs are skipped
+
+### Scenario: Source file change triggers re-validation
+
+- **Given** a spec lists `src/auth.rs` in frontmatter `files:`; that file has been modified
+- **When** `classify_changes` is called for the spec
+- **Then** returns `ChangeClassification` with `ChangeKind::Source` in changes
+
+### Scenario: First run (no cache)
+
+- **Given** `.specsync/hashes.json` does not exist
+- **When** `HashCache::load` is called
+- **Then** returns empty cache; all files will be classified as changed
+
+### Scenario: Requirements change triggers staleness
+
+- **Given** `requirements.md` companion has been updated
+- **When** `classify_changes` is called for the parent spec
+- **Then** returns `ChangeClassification` with `ChangeKind::Requirements`
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Cache file missing | Returns empty cache (all files treated as changed) |
+| Cache file has invalid JSON | Returns empty cache silently |
+| File unreadable during hashing | `hash_file` returns `None`; file treated as changed |
+| Cannot create `.specsync/` directory | `save` returns `io::Error` |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| (external) | `sha2::Sha256` for content hashing |
+| (external) | `serde` / `serde_json` for cache serialization |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| main | `HashCache`, `classify_all_changes`, `update_cache` in `cmd_check` for incremental validation |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-06 | Initial spec for v3.3.0 |

--- a/specs/hash_cache/requirements.md
+++ b/specs/hash_cache/requirements.md
@@ -1,0 +1,5 @@
+---
+spec: hash_cache.spec.md
+---
+
+## User Stories

--- a/specs/hash_cache/tasks.md
+++ b/specs/hash_cache/tasks.md
@@ -1,0 +1,5 @@
+---
+spec: hash_cache.spec.md
+---
+
+## Tasks

--- a/specs/merge/context.md
+++ b/specs/merge/context.md
@@ -1,0 +1,5 @@
+---
+spec: merge.spec.md
+---
+
+## Key Decisions

--- a/specs/merge/merge.spec.md
+++ b/specs/merge/merge.spec.md
@@ -1,0 +1,111 @@
+---
+module: merge
+version: 1
+status: stable
+files:
+  - src/merge.rs
+db_tables: []
+depends_on:
+  - specs/parser/parser.spec.md
+  - specs/validator/validator.spec.md
+---
+
+# Merge
+
+## Purpose
+
+Detects and auto-resolves git merge conflicts in spec files using context-aware strategies. Different resolution algorithms are applied based on the section type — YAML frontmatter fields are unioned, changelog tables are merged chronologically, and generic tables are deduplicated by first cell.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `merge_specs` | `root: &Path, specs_dir: &Path, dry_run: bool, all_files: bool` | `Vec<MergeResult>` | Scan for conflicted specs and attempt auto-resolution |
+| `has_conflict_markers` | `content: &str` | `bool` | Check if content contains `<<<<<<< ` conflict markers |
+| `print_results` | `results: &[MergeResult], dry_run: bool` | `()` | Print human-readable resolution summary with colored output |
+| `results_to_json` | `results: &[MergeResult]` | `String` | Format results as JSON with path, status, and details |
+
+### Exported Structs/Enums
+
+| Type | Description |
+|------|-------------|
+| `MergeResult` | Outcome for one spec — `spec_path: String`, `status: MergeStatus`, `details: Vec<String>` |
+| `MergeStatus` | Enum: `Resolved` (auto-resolved), `Manual` (needs human), `Clean` (no conflicts) |
+
+### Resolution Strategies
+
+| Context | Strategy |
+|---------|----------|
+| Frontmatter (YAML) | Lists (`files`, `db_tables`, `depends_on`) are unioned and sorted; scalars use theirs (latest) |
+| `## Change Log` table | Rows merged chronologically by date cell; deduplicated by full row content |
+| Generic markdown table | Rows merged by first cell (symbol name); theirs wins on conflicts; deduplicated |
+| Prose / section body | No auto-resolution — conflict markers preserved for manual intervention |
+
+## Invariants
+
+1. `all_files: false` uses `git diff --diff-filter=U` to find only git-conflicted files
+2. `all_files: true` scans all spec files for conflict markers regardless of git state
+3. Frontmatter list fields are unioned (not replaced) and sorted alphabetically
+4. Frontmatter scalar fields use "theirs wins" strategy (latest change takes precedence)
+5. Changelog rows are sorted by first cell (ISO date) — lexicographic sorting works correctly
+6. Prose conflicts are never auto-resolved — always marked as `Manual`
+7. Post-resolution, frontmatter is re-validated; warnings printed if invalid
+8. `dry_run: true` returns results without writing resolved content to disk
+9. Custom YAML parser handles simple key-value and list fields without external YAML library
+
+## Behavioral Examples
+
+### Scenario: Auto-resolve frontmatter list conflict
+
+- **Given** ours has `files: [a.rs, b.rs]` and theirs has `files: [b.rs, c.rs]`
+- **When** `merge_specs` resolves the conflict
+- **Then** result is `files: [a.rs, b.rs, c.rs]` (union, sorted)
+
+### Scenario: Auto-resolve changelog conflict
+
+- **Given** ours added a `2026-03-20` entry, theirs added a `2026-03-25` entry
+- **When** `merge_specs` resolves the conflict
+- **Then** both entries appear in chronological order, status is `Resolved`
+
+### Scenario: Prose conflict requires manual resolution
+
+- **Given** both sides modified the `## Purpose` section text
+- **When** `merge_specs` encounters the conflict
+- **Then** conflict markers are preserved, status is `Manual`
+
+### Scenario: Dry run
+
+- **Given** conflicted spec files exist
+- **When** `merge_specs(root, specs_dir, true, false)` is called
+- **Then** returns `MergeResult` entries with resolution details but does not modify files
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Spec file unreadable | Marked as `Manual` with read error in details |
+| `git diff` command fails | Falls back to scanning all files for conflict markers |
+| Post-resolution frontmatter invalid | Warning printed; file is still written with resolved content |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| parser | `parse_frontmatter` for post-resolution validation |
+| validator | `find_spec_files` to locate all spec files when `all_files: true` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| main | `merge_specs`, `print_results`, `results_to_json` via `cmd_merge` subcommand |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-06 | Initial spec for v3.3.0 |

--- a/specs/merge/requirements.md
+++ b/specs/merge/requirements.md
@@ -1,0 +1,5 @@
+---
+spec: merge.spec.md
+---
+
+## User Stories

--- a/specs/merge/tasks.md
+++ b/specs/merge/tasks.md
@@ -1,0 +1,5 @@
+---
+spec: merge.spec.md
+---
+
+## Tasks

--- a/specs/types/types.spec.md
+++ b/specs/types/types.spec.md
@@ -24,17 +24,20 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 | `Language` | Detected source language for export extraction: TypeScript, Rust, Go, Python, Swift, Kotlin, Java, CSharp, Dart, Php, Ruby |
 | `OutputFormat` | CLI output format: Text (colored terminal, default), Json (machine-readable), Markdown (PR comments / agent consumption) |
 | `ExportLevel` | Export extraction granularity: Type (top-level declarations only) or Member (all public symbols, default) |
+| `SpecStatus` | Spec lifecycle status: draft, stable, deprecated. Parsed from frontmatter `status` field |
 
 ### Exported Structs
 
 | Type | Description |
 |------|-------------|
-| `Frontmatter` | YAML frontmatter parsed from a spec file (module, version, status, files, db_tables, depends_on) |
+| `Frontmatter` | YAML frontmatter parsed from a spec file (module, version, status, files, db_tables, depends_on, implements, tracks, agent_policy) |
 | `ValidationResult` | Result of validating a single spec — errors, warnings, fixes, and export summary |
 | `CoverageReport` | File and LOC coverage metrics for the project |
 | `SpecSyncConfig` | User-provided configuration loaded from specsync.json or .specsync.toml |
 | `RegistryEntry` | Registry entry mapping module names to spec file paths for cross-project resolution |
 | `ModuleDefinition` | User-defined module grouping in specsync.json with files and depends_on lists |
+| `ValidationRules` | Custom validation rules configured in specsync.json (required_sections, max_staleness_days, etc.) |
+| `GitHubConfig` | GitHub integration config — `repo: Option<String>`, `labels: Vec<String>`, `create_on_drift: bool` |
 
 ### Exported AiProvider Functions
 
@@ -53,6 +56,13 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `new` | `spec_path: String` | `Self` | Create a new empty validation result |
+
+### Exported SpecStatus Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `as_str` | `&self` | `&str` | String representation of the status |
+| `parsed_status` | `s: &str` | `Option<Self>` | Parse status string into SpecStatus enum |
 
 ### Exported Language Functions
 
@@ -125,6 +135,10 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 | exports | `Language` |
 | mcp | `SpecSyncConfig` |
 | registry | `RegistryEntry` |
+| main | `SpecSyncConfig`, `Frontmatter` |
+| github | `GitHubConfig` |
+| hash_cache | `Frontmatter` |
+| view | `Frontmatter` |
 
 ## Change Log
 
@@ -132,3 +146,4 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 |------|--------|
 | 2026-03-25 | Initial spec |
 | 2026-03-28 | Document OutputFormat, ExportLevel, ModuleDefinition |
+| 2026-04-06 | Add Frontmatter implements/tracks/agent_policy fields, ValidationRules, GitHubConfig structs |

--- a/specs/validator/validator.spec.md
+++ b/specs/validator/validator.spec.md
@@ -97,9 +97,13 @@ Core validation engine for spec-sync. Validates individual spec files against so
 |--------|-------------|
 | main | `validate_spec`, `find_spec_files`, `compute_coverage`, `get_schema_table_names` |
 | mcp | `validate_spec`, `find_spec_files`, `compute_coverage`, `get_schema_table_names` |
+| archive | `find_spec_files` to locate spec companion files |
+| compact | `find_spec_files` to locate all spec files |
+| merge | `find_spec_files` to locate all spec files when `--all` is used |
 
 ## Change Log
 
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial spec |
+| 2026-04-06 | Document archive, compact, merge as consumers of find_spec_files; note hash_cache integration for incremental validation |

--- a/specs/view/context.md
+++ b/specs/view/context.md
@@ -1,0 +1,5 @@
+---
+spec: view.spec.md
+---
+
+## Key Decisions

--- a/specs/view/requirements.md
+++ b/specs/view/requirements.md
@@ -1,0 +1,5 @@
+---
+spec: view.spec.md
+---
+
+## User Stories

--- a/specs/view/tasks.md
+++ b/specs/view/tasks.md
@@ -1,0 +1,5 @@
+---
+spec: view.spec.md
+---
+
+## Tasks

--- a/specs/view/view.spec.md
+++ b/specs/view/view.spec.md
@@ -1,0 +1,98 @@
+---
+module: view
+version: 1
+status: stable
+files:
+  - src/view.rs
+db_tables: []
+depends_on:
+  - specs/parser/parser.spec.md
+---
+
+# View
+
+## Purpose
+
+Filters spec content to show only sections relevant to a specific role (dev, qa, product, agent). Enables focused consumption of specs by different stakeholders without information overload.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `view_spec` | `spec_path: &Path, role: &str` | `Result<String, String>` | Read a spec file and return filtered markdown containing only role-relevant sections |
+| `valid_roles` | — | `&'static [&'static str]` | Returns the list of valid role names: `["dev", "qa", "product", "agent"]` |
+
+### Role → Section Visibility
+
+| Role | Visible Sections |
+|------|-----------------|
+| dev | Purpose, Public API, Invariants, Dependencies, Change Log |
+| qa | Behavioral Examples, Error Cases, Invariants |
+| product | Purpose, Change Log (+ companion requirements.md if present) |
+| agent | Purpose, Public API, Invariants, Behavioral Examples, Error Cases |
+
+## Invariants
+
+1. Four roles are supported: `dev`, `qa`, `product`, `agent`
+2. Unknown roles return an error — never silently fall back
+3. The `agent` role includes `status` and `agent_policy` from frontmatter in the output header
+4. The `product` role appends companion `requirements.md` content if the file exists
+5. `agent_policy` defaults to `"full-access"` if not set in frontmatter
+6. Output includes a role-specific header line (e.g., `# ModuleName (dev view)`)
+7. Section matching is based on `## ` heading prefixes
+
+## Behavioral Examples
+
+### Scenario: Dev view
+
+- **Given** a spec with all standard sections
+- **When** `view_spec(path, "dev")` is called
+- **Then** returns Purpose, Public API, Invariants, Dependencies, and Change Log sections only
+
+### Scenario: Agent view with policy
+
+- **Given** a spec with `agent_policy: read-only` in frontmatter
+- **When** `view_spec(path, "agent")` is called
+- **Then** output header includes `Status: stable` and `Agent Policy: read-only`
+
+### Scenario: Product view with requirements
+
+- **Given** a spec at `specs/auth/auth.spec.md` with a companion `specs/auth/requirements.md`
+- **When** `view_spec(path, "product")` is called
+- **Then** returns Purpose, Change Log, and appended requirements.md content
+
+### Scenario: Invalid role
+
+- **Given** role string `"manager"`
+- **When** `view_spec(path, "manager")` is called
+- **Then** returns `Err` with descriptive message listing valid roles
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Unknown role string | Returns `Err` listing valid roles |
+| Spec file unreadable | Returns `Err` with read error description |
+| Frontmatter parse failure | Returns `Err` with parse error |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| parser | `parse_frontmatter` for extracting module name, status, and agent_policy |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| main | `view_spec`, `valid_roles` via `cmd_view` subcommand |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-06 | Initial spec for v3.3.0 |


### PR DESCRIPTION
## Summary

- **6 new spec modules** with full companion files: `archive`, `compact`, `view`, `github`, `hash_cache`, `merge`
- **4 existing specs updated**: `cli` (5 new subcommands, new flags), `types` (Frontmatter fields, SpecStatus, ValidationRules, GitHubConfig), `config` (github/rules config sections), `validator` (new consumers)
- All 21 specs pass `specsync check --force` with **0 warnings, 0 errors**

## Test plan

- [x] `specsync check --force` — 21 specs, 0 warnings, 0 failures
- [x] 100% file coverage, 100% LOC coverage
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)