### PR TITLE
feat: add 42 unit tests, interactive wizard, and onboarding docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +289,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +336,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1065,6 +1097,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1127,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "dialoguer",
  "notify",
  "notify-debouncer-full",
  "predicates",
@@ -1161,6 +1200,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1271,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1399,6 +1464,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ notify = "7"
 notify-debouncer-full = "0.4"
 sha2 = "0.10"
 ureq = { version = "3", features = ["json"] }
+dialoguer = "0.11"
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,8 @@ nav_order: 1
 Bidirectional spec-to-code validation. Written in Rust. Single binary. 11 languages. VS Code extension.
 {: .fs-6 .fw-300 }
 
-[Get Started](#quick-start){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Get Started](quickstart){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Why SpecSync?](why-specsync){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/CorvidLabs/spec-sync){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
@@ -59,4 +60,12 @@ Auto-detected from file extensions. No per-language configuration.
 
 TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby.
 
-See [Workflow Guide](workflow) for the end-to-end workflow, [Spec Format](spec-format) for how to write specs, [CLI Reference](cli) for all commands, [VS Code Extension](vscode-extension) for editor integration, [Cross-Project References](cross-project-refs) for multi-repo validation, and [Configuration](configuration) for `specsync.json` options.
+## Learn More
+
+| New to SpecSync? | Already using it? |
+|:-----------------|:-----------------|
+| [Quick Start Guide](quickstart) — up and running in 5 min | [CLI Reference](cli) — all 14 commands |
+| [Why SpecSync?](why-specsync) — comparison with alternatives | [Configuration](configuration) — `specsync.json` options |
+| [Spec Format](spec-format) — how to write specs | [Cross-Project Refs](cross-project-refs) — multi-repo validation |
+| [Workflow Guide](workflow) — full lifecycle | [AI Agents](ai-agents) — MCP server + AI generation |
+| [Architecture](architecture) — how it works | [VS Code Extension](vscode-extension) — editor integration |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,233 @@
+---
+title: Quick Start
+layout: default
+nav_order: 3
+---
+
+# Quick Start Guide
+{: .fs-9 }
+
+Get SpecSync running on your project in under 5 minutes.
+{: .fs-6 .fw-300 }
+
+---
+
+## Install
+
+Choose your preferred method:
+
+```bash
+# Via cargo (recommended)
+cargo install specsync
+
+# Via GitHub releases (no Rust toolchain needed)
+# Download the binary for your platform from:
+# https://github.com/CorvidLabs/spec-sync/releases
+
+# Via GitHub Action (CI only)
+# See github-action.md
+```
+
+Verify the installation:
+
+```bash
+specsync --version
+```
+
+---
+
+## 1. Initialize Your Project
+
+Navigate to your project root and run:
+
+```bash
+specsync init
+```
+
+This creates a `specsync.json` config file with auto-detected source directories. The config looks like:
+
+```json
+{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "requiredSections": [
+    "Purpose",
+    "Public API",
+    "Invariants",
+    "Behavioral Examples",
+    "Error Cases",
+    "Dependencies",
+    "Change Log"
+  ]
+}
+```
+
+**Key settings:**
+- `specsDir` — where spec files live (default: `specs/`)
+- `sourceDirs` — where your source code lives (auto-detected from package manifests)
+- `requiredSections` — what every spec must contain
+
+See [Configuration](configuration.md) for all options.
+
+---
+
+## 2. Generate Specs
+
+Generate template specs for all source modules:
+
+```bash
+# Template-based (instant, no AI needed)
+specsync generate
+
+# AI-powered (richer content, requires AI provider)
+specsync generate --ai
+```
+
+This creates a directory structure like:
+
+```
+specs/
+├── auth/
+│   ├── auth.spec.md        ← The spec (validated)
+│   ├── requirements.md     ← User stories & acceptance criteria
+│   ├── tasks.md            ← Work items & sign-offs
+│   └── context.md          ← Architecture notes & key files
+├── database/
+│   ├── database.spec.md
+│   ├── requirements.md
+│   ├── tasks.md
+│   └── context.md
+└── ...
+```
+
+Each `.spec.md` file has YAML frontmatter and required sections:
+
+```markdown
+---
+module: auth
+version: 1.0.0
+status: draft
+files:
+  - src/auth.ts
+  - src/auth.utils.ts
+---
+
+# Purpose
+Handles user authentication via JWT tokens.
+
+# Public API
+| Export | Type | Description |
+|--------|------|-------------|
+| `login(email, password)` | function | Authenticates a user |
+| `logout(token)` | function | Invalidates a session |
+| `AuthConfig` | interface | Configuration options |
+
+# Invariants
+- Tokens expire after 24 hours
+- Failed login attempts are rate-limited
+
+# Behavioral Examples
+...
+```
+
+---
+
+## 3. Validate
+
+Run validation to check specs against your code:
+
+```bash
+specsync check
+```
+
+You'll see output like:
+
+```
+✓ specs/auth/auth.spec.md
+✗ specs/database/database.spec.md
+  ERROR: Spec references `createUser` but export not found in src/database.ts
+  WARNING: `deleteUser` exported from code but not documented in spec
+
+1 passed, 1 failed (2 errors, 1 warning)
+File coverage: 85.7% (6/7 files)
+```
+
+**Errors** mean the spec claims something exists that doesn't. **Warnings** mean the code has something the spec doesn't mention yet.
+
+### Strict Mode
+
+In CI, use strict mode to fail on warnings too:
+
+```bash
+specsync check --strict
+```
+
+### Coverage Threshold
+
+Require a minimum percentage of source files to have specs:
+
+```bash
+specsync check --require-coverage 80
+```
+
+---
+
+## 4. Iterate
+
+Fix the issues SpecSync found:
+
+1. **Export renamed?** Update the spec's Public API table
+2. **New export not in spec?** Add it to the table
+3. **Deleted file?** Remove it from the spec's `files` list or archive the spec
+
+Then run `specsync check` again until everything passes.
+
+---
+
+## 5. Add to CI
+
+### GitHub Action
+
+```yaml
+# .github/workflows/specsync.yml
+name: SpecSync
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: CorvidLabs/spec-sync@v3
+        with:
+          strict: true
+          require-coverage: 80
+```
+
+### Manual CI
+
+```bash
+# In any CI system
+cargo install specsync
+specsync check --strict --require-coverage 80
+```
+
+---
+
+## What's Next?
+
+Once you're up and running, explore these features:
+
+| Feature | Command | Guide |
+|---------|---------|-------|
+| Quality scoring | `specsync score` | [CLI Reference](cli.md#score) |
+| Watch mode | `specsync watch` | [CLI Reference](cli.md#watch) |
+| AI generation | `specsync generate --ai` | [AI Agents](ai-agents.md) |
+| Schema validation | Add `schemaDir` to config | [Configuration](configuration.md) |
+| Cross-project refs | `owner/repo@module` syntax | [Cross-Project Refs](cross-project-refs.md) |
+| MCP server | `specsync mcp` | [AI Agents](ai-agents.md) |
+| VS Code extension | Install from marketplace | [VS Code Extension](vscode-extension.md) |
+| Agent instructions | `specsync hooks` | [CLI Reference](cli.md#hooks) |
+| Merge conflicts | `specsync merge` | [CLI Reference](cli.md#merge) |
+
+For the full lifecycle guide (create → validate → iterate → stabilize → maintain → compact → archive), see the [Workflow Guide](workflow.md).

--- a/docs/why-specsync.md
+++ b/docs/why-specsync.md
@@ -1,0 +1,151 @@
+---
+title: Why SpecSync?
+layout: default
+nav_order: 2
+---
+
+# Why SpecSync?
+{: .fs-9 }
+
+How SpecSync compares to other documentation validation approaches.
+{: .fs-6 .fw-300 }
+
+---
+
+## The Documentation Problem
+
+Every team has experienced it: someone renames a function, the docs still reference the old name, and nobody notices for months. Or worse — an AI agent reads your stale docs and generates code against an API that no longer exists.
+
+Traditional documentation tools fall into two camps:
+
+1. **Auto-generated docs** (JSDoc, rustdoc, Godoc) — accurate but shallow. They tell you _what_ exists, not _why_ it exists or how pieces fit together.
+2. **Hand-written docs** (Notion, Confluence, markdown) — rich context but drift from reality within days of being written.
+
+SpecSync occupies a third space: **validated hand-written specs**. You write the spec, SpecSync ensures it stays true.
+
+---
+
+## Comparison Matrix
+
+| Feature | SpecSync | OpenAPI / Swagger | TypeDoc / JSDoc | ADRs | Notion / Confluence |
+|:--------|:--------:|:-----------------:|:---------------:|:----:|:-------------------:|
+| Validates against source code | **Yes** | Partial (runtime) | No | No | No |
+| Catches renamed exports | **Yes** | No | No | No | No |
+| Schema/DB drift detection | **Yes** | No | No | No | No |
+| Cross-project references | **Yes** | Via `$ref` | No | No | No |
+| Works with any language | **11 languages** | Language-specific | JS/TS only | N/A | N/A |
+| AI agent integration (MCP) | **Yes** | Via plugins | No | No | No |
+| CI/CD integration | **GitHub Action** | Various | Various | Manual | No |
+| Spec lifecycle management | **Yes** | No | No | No | Manual |
+| Quality scoring | **Yes** | No | No | No | No |
+| Single binary, zero deps | **Yes** | Varies | Node.js | N/A | SaaS |
+| Git merge conflict resolution | **Yes** | No | No | No | N/A |
+
+---
+
+## Detailed Comparisons
+
+### vs. OpenAPI / Swagger
+
+OpenAPI is excellent for HTTP APIs — it defines request/response schemas and can generate client SDKs. But it only covers the API boundary. It doesn't validate that your internal modules match their documentation, doesn't catch renamed helper functions, and doesn't track database schema drift.
+
+**Use OpenAPI when:** You need to define and document REST/GraphQL APIs for external consumers.
+
+**Use SpecSync when:** You need to ensure internal module documentation stays accurate across your entire codebase — not just the API surface.
+
+**Use both when:** You have a large project with both public APIs and complex internal architecture.
+
+### vs. TypeDoc / JSDoc / rustdoc
+
+Auto-generated documentation tools extract comments from source code. They're always accurate (by definition), but they only document _what's there_ — not architectural decisions, invariants, behavioral constraints, or cross-module relationships.
+
+**Use auto-doc tools when:** You want API reference docs generated from code comments.
+
+**Use SpecSync when:** You need specs that capture _why_ something works the way it does, what invariants must hold, and how modules relate to each other — and you want those specs validated against the real code.
+
+### vs. Architecture Decision Records (ADRs)
+
+ADRs document _decisions_ — why you chose Postgres over MongoDB, or why the auth middleware uses JWTs. They're valuable but static: once written, they don't get validated against the codebase.
+
+**Use ADRs when:** You want to record architectural decisions and their rationale.
+
+**Use SpecSync when:** You want living documentation that stays synchronized with your code. SpecSync specs can include ADR-like context in companion files (`context.md`) while the core spec stays validated.
+
+### vs. Notion / Confluence
+
+Wiki-style tools are great for onboarding docs, runbooks, and team knowledge bases. But they have no connection to source code — documentation rot is inevitable.
+
+**Use wikis when:** You need free-form collaborative documentation for processes, onboarding, and team knowledge.
+
+**Use SpecSync when:** You need technical specs that are provably accurate. If it's in the spec, it's in the code.
+
+---
+
+## What Makes SpecSync Different
+
+### Bidirectional Validation
+
+Most tools check in one direction — either "does the code match the docs?" or "do the docs describe the code?" SpecSync checks both:
+
+- **Spec references something missing from code** → Error (your spec is lying)
+- **Code exports something not in the spec** → Warning (your spec is incomplete)
+
+### Language Agnostic
+
+One tool, one format, 11 languages. Whether your project is TypeScript, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, or Ruby — same `*.spec.md` format, same validation.
+
+### AI-Native
+
+SpecSync was built for the AI-assisted development era:
+
+- **MCP server mode** lets AI agents query your specs, check coverage, and generate new specs in real time
+- **AI-powered generation** creates meaningful spec content (not just templates) using Claude, OpenAI, Ollama, or Copilot
+- **Structured output** (JSON mode) integrates cleanly with agent workflows
+- **AGENTS.md generation** produces instruction files for Claude Code, Cursor, and Copilot
+
+### Spec Lifecycle
+
+Specs aren't static documents — they have a lifecycle:
+
+```
+create → validate → iterate → stabilize → maintain → compact → archive
+```
+
+SpecSync manages this lifecycle with companion files (requirements, tasks, context), quality scoring, changelog compaction, and task archival.
+
+### Zero Dependencies
+
+SpecSync is a single Rust binary. No Node.js runtime, no Python virtualenv, no Docker container. Download it and run it. Installs via `cargo install specsync`, a GitHub Action, or a VS Code extension.
+
+---
+
+## When NOT to Use SpecSync
+
+SpecSync is not the right tool if:
+
+- **You only need API reference docs** — use auto-doc tools (TypeDoc, rustdoc) instead
+- **Your project has < 3 modules** — the overhead isn't worth it for tiny projects
+- **Your team doesn't write specs** — SpecSync validates specs, it doesn't replace the need to write them (though AI generation helps bootstrap)
+- **You need runtime API contract testing** — use OpenAPI + contract testing tools instead
+
+---
+
+## Getting Started
+
+Ready to try it?
+
+```bash
+# Install
+cargo install specsync
+
+# Initialize in your project
+specsync init
+
+# Generate specs for all modules
+specsync generate
+
+# Validate
+specsync check
+```
+
+Or see the [full workflow guide](workflow.md) for a step-by-step walkthrough.

--- a/specs/cli/cli.spec.md
+++ b/specs/cli/cli.spec.md
@@ -63,6 +63,7 @@ Three Clap derive structs define the CLI: Cli (root parser with global flags), C
 | view | Filter spec content by stakeholder role | --role (dev\|qa\|product\|agent), --spec PATH |
 | merge | Auto-resolve git merge conflicts in spec files | --dry-run, --all, --json |
 | issues | Verify GitHub issue references in spec frontmatter | --create (create drift issues for failures) |
+| wizard | Interactive step-by-step spec creation with prompts and preview | — |
 
 ### Global Flags
 
@@ -95,6 +96,7 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 - **cmd_view** — Filter and display spec content for a specific role
 - **cmd_merge** — Auto-resolve git merge conflicts in spec files
 - **cmd_issues** — Verify GitHub issue references in spec frontmatter
+- **cmd_wizard** — Interactive wizard for step-by-step spec creation with template selection and preview
 - **auto_fix_specs** — Scan source files for undocumented exports and auto-add stubs to spec Public API tables
 - **collect_hook_targets** — Convert boolean flags to Vec of HookTarget
 - **load_and_discover** — Load config and find all spec files (filtering _-prefixed templates)

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,8 @@ enum Command {
         #[arg(long)]
         create: bool,
     },
+    /// Interactive wizard for creating new specs step by step
+    Wizard,
 }
 
 #[derive(Subcommand)]
@@ -287,6 +289,7 @@ fn run() {
         Command::View { role, spec } => cmd_view(&root, &role, spec.as_deref()),
         Command::Merge { dry_run, all } => cmd_merge(&root, dry_run, all, format),
         Command::Issues { create } => cmd_issues(&root, format, create),
+        Command::Wizard => cmd_wizard(&root),
     }
 }
 
@@ -1298,6 +1301,322 @@ depends_on: []
             let rel = spec_file.strip_prefix(root).unwrap_or(&spec_file).display();
             println!("  {} Created {rel}", "✓".green());
             generator::generate_companion_files_for_spec(&spec_dir, module_name);
+        }
+        Err(e) => {
+            eprintln!("Failed to write {}: {e}", spec_file.display());
+            process::exit(1);
+        }
+    }
+}
+
+fn cmd_wizard(root: &Path) {
+    use dialoguer::{Confirm, Input, Select};
+
+    let config = load_config(root);
+    let specs_dir = root.join(&config.specs_dir);
+
+    println!(
+        "\n{}",
+        "═══════════════════════════════════════════════════".cyan()
+    );
+    println!("{}", "  SpecSync — New Spec Wizard".cyan().bold());
+    println!(
+        "{}\n",
+        "═══════════════════════════════════════════════════".cyan()
+    );
+
+    // 1. Module name
+    let module_name: String = Input::new()
+        .with_prompt("Module name")
+        .interact_text()
+        .unwrap_or_else(|_| process::exit(0));
+    let module_name = module_name.trim().to_string();
+
+    if module_name.is_empty() {
+        eprintln!("{} Module name cannot be empty", "Error:".red());
+        process::exit(1);
+    }
+
+    let spec_dir = specs_dir.join(&module_name);
+    let spec_file = spec_dir.join(format!("{module_name}.spec.md"));
+    if spec_file.exists() {
+        eprintln!(
+            "{} Spec already exists: {}",
+            "!".yellow(),
+            spec_file.strip_prefix(root).unwrap_or(&spec_file).display()
+        );
+        process::exit(1);
+    }
+
+    // 2. Purpose
+    let purpose: String = Input::new()
+        .with_prompt("What does this module do? (one sentence)")
+        .interact_text()
+        .unwrap_or_else(|_| process::exit(0));
+
+    // 3. Template type
+    let templates = vec![
+        "Generic module",
+        "API endpoint / route handler",
+        "Data model / database layer",
+        "Utility / helper library",
+        "UI component",
+    ];
+    let template_idx = Select::new()
+        .with_prompt("Module type")
+        .items(&templates)
+        .default(0)
+        .interact()
+        .unwrap_or_else(|_| process::exit(0));
+
+    // 4. Status
+    let statuses = vec!["draft", "unstable", "stable", "locked"];
+    let status_idx = Select::new()
+        .with_prompt("Initial status")
+        .items(&statuses)
+        .default(0)
+        .interact()
+        .unwrap_or_else(|_| process::exit(0));
+    let status = statuses[status_idx];
+
+    // 5. Auto-detect source files
+    let module_files: Vec<String> = config
+        .source_dirs
+        .iter()
+        .flat_map(|src_dir| {
+            let full_src = root.join(src_dir);
+            if !full_src.is_dir() {
+                return vec![];
+            }
+            walkdir::WalkDir::new(&full_src)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    if !e.path().is_file() {
+                        return false;
+                    }
+                    let name = e.path().file_stem().and_then(|n| n.to_str()).unwrap_or("");
+                    let parent = e
+                        .path()
+                        .parent()
+                        .and_then(|p| p.file_name())
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("");
+                    (name == module_name || parent == module_name)
+                        && crate::exports::has_extension(e.path(), &config.source_extensions)
+                })
+                .map(|e| {
+                    e.path()
+                        .strip_prefix(root)
+                        .unwrap_or(e.path())
+                        .to_string_lossy()
+                        .replace('\\', "/")
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let files_yaml = if module_files.is_empty() {
+        println!(
+            "\n{} No source files auto-detected for '{module_name}'.",
+            "i".blue()
+        );
+        let manual_file: String = Input::new()
+            .with_prompt("Source file path (or leave empty to skip)")
+            .allow_empty(true)
+            .interact_text()
+            .unwrap_or_else(|_| process::exit(0));
+        if manual_file.is_empty() {
+            "  # - path/to/source/file".to_string()
+        } else {
+            format!("  - {manual_file}")
+        }
+    } else {
+        println!(
+            "\n{} Found {} source file(s):",
+            "✓".green(),
+            module_files.len()
+        );
+        for f in &module_files {
+            println!("    {f}");
+        }
+        module_files
+            .iter()
+            .map(|f| format!("  - {f}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // 6. Dependencies
+    let deps: String = Input::new()
+        .with_prompt("Dependencies (comma-separated module names, or empty)")
+        .allow_empty(true)
+        .interact_text()
+        .unwrap_or_else(|_| process::exit(0));
+    let depends_on: Vec<String> = deps
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // Build the title
+    let title = module_name
+        .split('-')
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let depends_yaml = if depends_on.is_empty() {
+        "[]".to_string()
+    } else {
+        format!(
+            "\n{}",
+            depends_on
+                .iter()
+                .map(|d| format!("  - {d}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    };
+
+    // Template-specific sections
+    let (extra_invariants, extra_api_hint) = match template_idx {
+        1 => (
+            "1. All endpoints validate input before processing\n2. Authentication is required unless explicitly marked public",
+            "### Endpoints\n\n| Method | Path | Description |\n|--------|------|-------------|\n",
+        ),
+        2 => (
+            "1. All mutations go through a single write path\n2. Schema migrations are backward-compatible",
+            "### Models\n\n| Model | Description |\n|-------|-------------|\n",
+        ),
+        3 => (
+            "1. All functions are pure (no side effects) unless documented\n2. All inputs are validated",
+            "",
+        ),
+        4 => (
+            "1. Component renders without crashing given any valid props\n2. Accessibility requirements are met (ARIA labels, keyboard nav)",
+            "### Props\n\n| Prop | Type | Default | Description |\n|------|------|---------|-------------|\n",
+        ),
+        _ => ("1. <!-- TODO -->", ""),
+    };
+
+    let spec_content = format!(
+        r#"---
+module: {module_name}
+version: 1
+status: {status}
+files:
+{files_yaml}
+db_tables: []
+depends_on: {depends_yaml}
+---
+
+# {title}
+
+## Purpose
+
+{purpose}
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+
+{extra_api_hint}
+## Invariants
+
+{extra_invariants}
+
+## Behavioral Examples
+
+### Scenario: TODO
+
+- **Given** precondition
+- **When** action
+- **Then** result
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+"#
+    );
+
+    // 7. Preview
+    println!(
+        "\n{}",
+        "─── Preview ────────────────────────────────────────".cyan()
+    );
+    // Show first ~30 lines of the spec
+    for (i, line) in spec_content.lines().enumerate() {
+        if i > 30 {
+            println!("  ...(truncated)");
+            break;
+        }
+        println!("  {line}");
+    }
+    println!(
+        "{}",
+        "────────────────────────────────────────────────────".cyan()
+    );
+
+    let confirmed = Confirm::new()
+        .with_prompt("Write this spec?")
+        .default(true)
+        .interact()
+        .unwrap_or(false);
+
+    if !confirmed {
+        println!("{}", "Cancelled.".yellow());
+        return;
+    }
+
+    // Write the spec
+    if let Err(e) = fs::create_dir_all(&spec_dir) {
+        eprintln!("Failed to create {}: {e}", spec_dir.display());
+        process::exit(1);
+    }
+
+    match fs::write(&spec_file, &spec_content) {
+        Ok(_) => {
+            let rel = spec_file.strip_prefix(root).unwrap_or(&spec_file).display();
+            println!("\n  {} Created {rel}", "✓".green());
+            generator::generate_companion_files_for_spec(&spec_dir, &module_name);
+            println!(
+                "\n{} Run {} to validate your new spec.",
+                "Tip:".cyan().bold(),
+                "specsync check".bold()
+            );
         }
         Err(e) => {
             eprintln!("Failed to write {}: {e}", spec_file.display());

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -634,3 +634,353 @@ fn tool_issues(root: &Path) -> Result<Value, String> {
         "specs": results,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup_project() -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let config = json!({
+            "specsDir": "specs",
+            "sourceDirs": ["src"],
+            "requiredSections": ["Purpose", "Public API"]
+        });
+        std::fs::write(
+            tmp.path().join("specsync.json"),
+            serde_json::to_string_pretty(&config).unwrap(),
+        )
+        .unwrap();
+        std::fs::create_dir_all(tmp.path().join("specs")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        tmp
+    }
+
+    fn setup_project_with_spec(spec_name: &str, spec_content: &str) -> TempDir {
+        let tmp = setup_project();
+        let spec_dir = tmp.path().join("specs").join(spec_name);
+        std::fs::create_dir_all(&spec_dir).unwrap();
+        std::fs::write(spec_dir.join(format!("{spec_name}.spec.md")), spec_content).unwrap();
+        tmp
+    }
+
+    // --- handle_initialize ---
+
+    #[test]
+    fn test_handle_initialize_response_format() {
+        let resp = handle_initialize(Some(json!(1)));
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 1);
+        assert_eq!(resp["result"]["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(resp["result"]["serverInfo"]["name"], "specsync");
+        assert!(resp["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn test_handle_initialize_null_id() {
+        let resp = handle_initialize(None);
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert!(resp["result"]["protocolVersion"].is_string());
+    }
+
+    #[test]
+    fn test_handle_initialize_string_id() {
+        let resp = handle_initialize(Some(json!("req-42")));
+        assert_eq!(resp["id"], "req-42");
+    }
+
+    // --- handle_tools_list ---
+
+    #[test]
+    fn test_handle_tools_list_returns_all_tools() {
+        let resp = handle_tools_list(Some(json!(2)));
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 7);
+    }
+
+    #[test]
+    fn test_handle_tools_list_tool_names() {
+        let resp = handle_tools_list(Some(json!(1)));
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"specsync_check"));
+        assert!(names.contains(&"specsync_coverage"));
+        assert!(names.contains(&"specsync_generate"));
+        assert!(names.contains(&"specsync_list_specs"));
+        assert!(names.contains(&"specsync_init"));
+        assert!(names.contains(&"specsync_score"));
+        assert!(names.contains(&"specsync_issues"));
+    }
+
+    #[test]
+    fn test_handle_tools_list_all_have_schemas() {
+        let resp = handle_tools_list(Some(json!(1)));
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        for tool in tools {
+            assert!(
+                tool["inputSchema"].is_object(),
+                "Tool {} missing inputSchema",
+                tool["name"]
+            );
+            assert_eq!(tool["inputSchema"]["type"], "object");
+        }
+    }
+
+    // --- handle_tools_call ---
+
+    #[test]
+    fn test_handle_tools_call_unknown_tool() {
+        let tmp = setup_project();
+        let params = json!({ "name": "nonexistent_tool", "arguments": {} });
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path());
+        assert_eq!(resp["result"]["isError"], true);
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("Unknown tool"));
+    }
+
+    #[test]
+    fn test_handle_tools_call_custom_root() {
+        let tmp = setup_project();
+        // coverage tool should work with empty specs
+        let params = json!({
+            "name": "specsync_coverage",
+            "arguments": { "root": tmp.path().to_string_lossy() }
+        });
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path());
+        assert!(!resp["result"]["isError"].as_bool().unwrap_or(false));
+    }
+
+    // --- load_and_discover ---
+
+    #[test]
+    fn test_load_and_discover_empty_allowed() {
+        let tmp = setup_project();
+        let result = load_and_discover(tmp.path(), true);
+        assert!(result.is_ok());
+        let (config, specs) = result.unwrap();
+        assert_eq!(config.specs_dir, "specs");
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn test_load_and_discover_empty_not_allowed() {
+        let tmp = setup_project();
+        let result = load_and_discover(tmp.path(), false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("No spec files found"));
+    }
+
+    #[test]
+    fn test_load_and_discover_filters_private_specs() {
+        let tmp = setup_project();
+        let spec_dir = tmp.path().join("specs").join("_private");
+        std::fs::create_dir_all(&spec_dir).unwrap();
+        std::fs::write(
+            spec_dir.join("_private.spec.md"),
+            "---\nmodule: private\n---",
+        )
+        .unwrap();
+
+        let result = load_and_discover(tmp.path(), true);
+        assert!(result.is_ok());
+        let (_config, specs) = result.unwrap();
+        // Private specs (starting with _) should be filtered out
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn test_load_and_discover_finds_real_specs() {
+        let spec_content = "---\nmodule: auth\nversion: 1.0.0\nstatus: draft\nfiles:\n  - src/auth.rs\n---\n\n# Purpose\nAuth module\n\n# Public API\nNone\n";
+        let tmp = setup_project_with_spec("auth", spec_content);
+
+        let result = load_and_discover(tmp.path(), false);
+        assert!(result.is_ok());
+        let (_config, specs) = result.unwrap();
+        assert_eq!(specs.len(), 1);
+    }
+
+    // --- tool_init ---
+
+    #[test]
+    fn test_tool_init_creates_config() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+        let result = tool_init(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert_eq!(val["created"], true);
+        assert!(tmp.path().join("specsync.json").exists());
+    }
+
+    #[test]
+    fn test_tool_init_already_exists() {
+        let tmp = setup_project();
+        let result = tool_init(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert_eq!(val["created"], false);
+        assert!(val["message"].as_str().unwrap().contains("already exists"));
+    }
+
+    // --- tool_coverage ---
+
+    #[test]
+    fn test_tool_coverage_empty_project() {
+        let tmp = setup_project();
+        let result = tool_coverage(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert_eq!(val["file_coverage"], 100.0);
+        assert_eq!(val["files_total"], 0);
+    }
+
+    #[test]
+    fn test_tool_coverage_with_unspecced_files() {
+        let tmp = setup_project();
+        // Create a source file without a spec
+        std::fs::write(tmp.path().join("src").join("main.rs"), "fn main() {}").unwrap();
+
+        let result = tool_coverage(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert!(val["files_total"].as_u64().unwrap() > 0);
+    }
+
+    // --- tool_list_specs ---
+
+    #[test]
+    fn test_tool_list_specs_empty() {
+        let tmp = setup_project();
+        let result = tool_list_specs(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert_eq!(val["count"], 0);
+        assert!(val["specs"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_tool_list_specs_with_frontmatter() {
+        let spec_content = "---\nmodule: auth\nversion: 2.0.0\nstatus: stable\nfiles:\n  - src/auth.rs\n---\n\n# Purpose\nAuth\n";
+        let tmp = setup_project_with_spec("auth", spec_content);
+
+        let result = tool_list_specs(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert_eq!(val["count"], 1);
+        let spec = &val["specs"][0];
+        assert_eq!(spec["module"], "auth");
+        assert_eq!(spec["version"], "2.0.0");
+        assert_eq!(spec["status"], "stable");
+    }
+
+    #[test]
+    fn test_tool_list_specs_malformed_frontmatter() {
+        let tmp = setup_project();
+        let spec_dir = tmp.path().join("specs").join("bad");
+        std::fs::create_dir_all(&spec_dir).unwrap();
+        std::fs::write(spec_dir.join("bad.spec.md"), "no frontmatter here").unwrap();
+
+        let result = tool_list_specs(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert_eq!(val["count"], 1);
+        let spec = &val["specs"][0];
+        assert!(spec["module"].is_null());
+    }
+
+    // --- tool_check ---
+
+    #[test]
+    fn test_tool_check_strict_mode() {
+        let spec_content = "---\nmodule: auth\nversion: 1.0.0\nstatus: draft\nfiles:\n  - src/auth.rs\n---\n\n# Purpose\nAuth module\n\n# Public API\nNone\n";
+        let tmp = setup_project_with_spec("auth", spec_content);
+        std::fs::write(tmp.path().join("src").join("auth.rs"), "pub fn login() {}").unwrap();
+
+        let result_normal = tool_check(tmp.path(), &json!({ "strict": false }));
+        assert!(result_normal.is_ok());
+
+        let result_strict = tool_check(tmp.path(), &json!({ "strict": true }));
+        assert!(result_strict.is_ok());
+    }
+
+    #[test]
+    fn test_tool_check_no_specs_error() {
+        let tmp = setup_project();
+        let result = tool_check(tmp.path(), &json!({}));
+        assert!(result.is_err());
+    }
+
+    // --- tool_score ---
+
+    #[test]
+    fn test_tool_score_no_specs_error() {
+        let tmp = setup_project();
+        let result = tool_score(tmp.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tool_score_with_spec() {
+        let spec_content = "---\nmodule: auth\nversion: 1.0.0\nstatus: draft\nfiles:\n  - src/auth.rs\n---\n\n# Purpose\nAuth module\n\n# Public API\nNone\n\n# Invariants\nNone\n\n# Behavioral Examples\nNone\n\n# Error Cases\nNone\n\n# Dependencies\nNone\n\n# Change Log\nNone\n";
+        let tmp = setup_project_with_spec("auth", spec_content);
+        std::fs::write(tmp.path().join("src").join("auth.rs"), "pub fn login() {}").unwrap();
+
+        let result = tool_score(tmp.path());
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert!(val["average_score"].as_f64().unwrap() >= 0.0);
+        assert!(val["grade"].is_string());
+        assert_eq!(val["total_specs"], 1);
+        assert!(val["distribution"].is_object());
+    }
+
+    // --- tool_generate ---
+
+    #[test]
+    fn test_tool_generate_no_uncovered() {
+        let spec_content = "---\nmodule: auth\nversion: 1.0.0\nstatus: draft\nfiles:\n  - src/auth.rs\n---\n\n# Purpose\nAuth\n";
+        let tmp = setup_project_with_spec("auth", spec_content);
+        std::fs::write(tmp.path().join("src").join("auth.rs"), "pub fn login() {}").unwrap();
+
+        let result = tool_generate(tmp.path(), &json!({}));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_tool_generate_creates_spec() {
+        let tmp = setup_project();
+        std::fs::write(tmp.path().join("src").join("main.rs"), "fn main() {}").unwrap();
+
+        let result = tool_generate(tmp.path(), &json!({}));
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        assert!(val["count"].as_u64().unwrap() >= 0);
+    }
+
+    // --- JSONRPC response structure ---
+
+    #[test]
+    fn test_tools_call_success_response_structure() {
+        let tmp = setup_project();
+        let params = json!({ "name": "specsync_coverage", "arguments": {} });
+        let resp = handle_tools_call(Some(json!(42)), &params, tmp.path());
+
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 42);
+        assert!(resp["result"]["content"].is_array());
+        assert_eq!(resp["result"]["content"][0]["type"], "text");
+    }
+
+    #[test]
+    fn test_tools_call_error_response_structure() {
+        let tmp = setup_project();
+        let params = json!({ "name": "bogus", "arguments": {} });
+        let resp = handle_tools_call(Some(json!(99)), &params, tmp.path());
+
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 99);
+        assert_eq!(resp["result"]["isError"], true);
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -150,22 +150,38 @@ fn print_separator(changed_file: Option<&str>) {
     );
 }
 
+fn build_check_args(
+    root: &Path,
+    strict: bool,
+    require_coverage: Option<usize>,
+    force: bool,
+) -> Vec<std::ffi::OsString> {
+    let mut args: Vec<std::ffi::OsString> = Vec::new();
+    args.push("check".into());
+    args.push("--root".into());
+    args.push(root.as_os_str().to_owned());
+    if strict {
+        args.push("--strict".into());
+    }
+    if force {
+        args.push("--force".into());
+    }
+    if let Some(cov) = require_coverage {
+        args.push("--require-coverage".into());
+        args.push(cov.to_string().into());
+    }
+    args
+}
+
 fn run_check(root: &Path, strict: bool, require_coverage: Option<usize>, force: bool) {
     // Fork a child process to isolate exit calls from the check command.
     use std::process::Command;
 
     let start = Instant::now();
+    let args = build_check_args(root, strict, require_coverage, force);
     let mut cmd = Command::new(std::env::current_exe().expect("Cannot find current executable"));
-    cmd.arg("check");
-    cmd.arg("--root").arg(root);
-    if strict {
-        cmd.arg("--strict");
-    }
-    if force {
-        cmd.arg("--force");
-    }
-    if let Some(cov) = require_coverage {
-        cmd.arg("--require-coverage").arg(cov.to_string());
+    for arg in &args {
+        cmd.arg(arg);
     }
 
     match cmd.status() {
@@ -188,5 +204,240 @@ fn run_check(root: &Path, strict: bool, require_coverage: Option<usize>, force: 
         Err(e) => {
             eprintln!("{} Failed to run check: {e}", "Error:".red());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{AccessKind, CreateKind, ModifyKind, RemoveKind};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_event(kind: EventKind) -> DebouncedEvent {
+        DebouncedEvent {
+            event: notify::Event {
+                kind,
+                paths: vec![],
+                attrs: Default::default(),
+            },
+            time: Instant::now(),
+        }
+    }
+
+    fn make_event_with_path(kind: EventKind, path: PathBuf) -> DebouncedEvent {
+        DebouncedEvent {
+            event: notify::Event {
+                kind,
+                paths: vec![path],
+                attrs: Default::default(),
+            },
+            time: Instant::now(),
+        }
+    }
+
+    // --- is_relevant_event ---
+
+    #[test]
+    fn test_is_relevant_event_create() {
+        let event = make_event(EventKind::Create(CreateKind::File));
+        assert!(is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_is_relevant_event_modify() {
+        let event = make_event(EventKind::Modify(ModifyKind::Data(
+            notify::event::DataChange::Content,
+        )));
+        assert!(is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_is_relevant_event_remove() {
+        let event = make_event(EventKind::Remove(RemoveKind::File));
+        assert!(is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_is_relevant_event_rejects_access() {
+        let event = make_event(EventKind::Access(AccessKind::Read));
+        assert!(!is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_is_relevant_event_rejects_other() {
+        let event = make_event(EventKind::Other);
+        assert!(!is_relevant_event(&event));
+    }
+
+    #[test]
+    fn test_is_relevant_event_create_any() {
+        let event = make_event(EventKind::Create(CreateKind::Any));
+        assert!(is_relevant_event(&event));
+    }
+
+    // --- build_check_args ---
+
+    #[test]
+    fn test_build_check_args_basic() {
+        let tmp = TempDir::new().unwrap();
+        let args = build_check_args(tmp.path(), false, None, false);
+        let strs: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(strs[0], "check");
+        assert_eq!(strs[1], "--root");
+        assert_eq!(strs[2], tmp.path().to_string_lossy());
+        assert_eq!(strs.len(), 3);
+    }
+
+    #[test]
+    fn test_build_check_args_strict() {
+        let tmp = TempDir::new().unwrap();
+        let args = build_check_args(tmp.path(), true, None, false);
+        let strs: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(strs.contains(&"--strict".to_string()));
+        assert!(!strs.contains(&"--force".to_string()));
+    }
+
+    #[test]
+    fn test_build_check_args_force() {
+        let tmp = TempDir::new().unwrap();
+        let args = build_check_args(tmp.path(), false, None, true);
+        let strs: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(strs.contains(&"--force".to_string()));
+        assert!(!strs.contains(&"--strict".to_string()));
+    }
+
+    #[test]
+    fn test_build_check_args_require_coverage() {
+        let tmp = TempDir::new().unwrap();
+        let args = build_check_args(tmp.path(), false, Some(80), false);
+        let strs: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(strs.contains(&"--require-coverage".to_string()));
+        assert!(strs.contains(&"80".to_string()));
+    }
+
+    #[test]
+    fn test_build_check_args_all_flags() {
+        let tmp = TempDir::new().unwrap();
+        let args = build_check_args(tmp.path(), true, Some(95), true);
+        let strs: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(strs.contains(&"--strict".to_string()));
+        assert!(strs.contains(&"--force".to_string()));
+        assert!(strs.contains(&"--require-coverage".to_string()));
+        assert!(strs.contains(&"95".to_string()));
+        assert_eq!(strs.len(), 7); // check --root <path> --strict --force --require-coverage 95
+    }
+
+    // --- run_watch empty directories ---
+
+    #[test]
+    fn test_run_watch_collects_watch_dirs() {
+        // Verify that the watch directory collection logic works correctly
+        let tmp = TempDir::new().unwrap();
+        let specs_dir = tmp.path().join("specs");
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&specs_dir).unwrap();
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        // Write a basic config
+        let config_content = r#"{"specsDir": "specs", "sourceDirs": ["src"]}"#;
+        std::fs::write(tmp.path().join("specsync.json"), config_content).unwrap();
+
+        let config = load_config(tmp.path());
+        let specs = tmp.path().join(&config.specs_dir);
+        let source_dirs: Vec<PathBuf> = config
+            .source_dirs
+            .iter()
+            .map(|d| tmp.path().join(d))
+            .collect();
+
+        let mut watch_dirs: Vec<PathBuf> = Vec::new();
+        if specs.is_dir() {
+            watch_dirs.push(specs);
+        }
+        for dir in &source_dirs {
+            if dir.is_dir() {
+                watch_dirs.push(dir.clone());
+            }
+        }
+
+        assert_eq!(watch_dirs.len(), 2);
+    }
+
+    #[test]
+    fn test_run_watch_empty_dirs_detected() {
+        // Verify that empty watch dirs are detected
+        let tmp = TempDir::new().unwrap();
+        // No specs or source dirs exist
+        let config_content = r#"{"specsDir": "specs", "sourceDirs": ["src"]}"#;
+        std::fs::write(tmp.path().join("specsync.json"), config_content).unwrap();
+
+        let config = load_config(tmp.path());
+        let specs = tmp.path().join(&config.specs_dir);
+        let source_dirs: Vec<PathBuf> = config
+            .source_dirs
+            .iter()
+            .map(|d| tmp.path().join(d))
+            .collect();
+
+        let mut watch_dirs: Vec<PathBuf> = Vec::new();
+        if specs.is_dir() {
+            watch_dirs.push(specs);
+        }
+        for dir in &source_dirs {
+            if dir.is_dir() {
+                watch_dirs.push(dir.clone());
+            }
+        }
+
+        assert!(watch_dirs.is_empty());
+    }
+
+    // --- event path extraction ---
+
+    #[test]
+    fn test_event_path_extraction() {
+        let root = PathBuf::from("/project");
+        let event = make_event_with_path(
+            EventKind::Modify(ModifyKind::Data(notify::event::DataChange::Content)),
+            PathBuf::from("/project/specs/auth/auth.spec.md"),
+        );
+
+        let changed_file: Option<String> = event
+            .paths
+            .first()
+            .and_then(|p| p.strip_prefix(&root).ok())
+            .map(|p| p.display().to_string());
+
+        assert_eq!(changed_file, Some("specs/auth/auth.spec.md".to_string()));
+    }
+
+    #[test]
+    fn test_event_path_extraction_no_paths() {
+        let root = PathBuf::from("/project");
+        let event = make_event(EventKind::Create(CreateKind::File));
+
+        let changed_file: Option<String> = event
+            .paths
+            .first()
+            .and_then(|p| p.strip_prefix(&root).ok())
+            .map(|p| p.display().to_string());
+
+        assert_eq!(changed_file, None);
     }
 }


### PR DESCRIPTION
## Summary

- **42 new unit tests**: 15 for `watch.rs` (event filtering, arg construction, directory collection) and 27 for `mcp.rs` (initialize, tools list, all tool calls, JSONRPC structure, private spec filtering)
- **Interactive `specsync wizard` command**: Step-by-step spec creation with module type templates (API, data model, utility, UI component), auto-detected source files, dependency input, and preview before writing
- **"Why SpecSync?" comparison doc**: Detailed comparison vs OpenAPI, TypeDoc/JSDoc, ADRs, and Notion/Confluence with feature matrix
- **Quick Start guide**: 5-minute onboarding doc with install → init → generate → validate → CI flow
- **Updated docs index**: Added learning path table and links to new docs

Closes #113, closes #114, closes #99, closes #100

## Verification

- `cargo fmt -- --check` — clean
- `cargo test` — 80 tests pass (0 failures)
- `specsync check --force` — 21 specs pass, 0 warnings, 100% file + LOC coverage

## Test plan

- [ ] Verify `cargo test watch::tests` passes all 15 tests
- [ ] Verify `cargo test mcp::tests` passes all 27 tests
- [ ] Verify `specsync wizard` launches interactive prompts correctly
- [ ] Verify new docs render correctly on docs site
- [ ] CI passes on all platforms (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)