### PR TITLE
docs: add community scaffolding files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in SpecSync
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Run `specsync ...`
+2. ...
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include the full error output if possible.
+
+## Environment
+
+- **SpecSync version:** (`specsync --version`)
+- **OS:**
+- **Rust version:** (`rustc --version`)
+
+## Additional Context
+
+- Relevant spec files (redacted if needed)
+- Configuration (`specsync.toml`)
+- CI environment details if applicable

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for SpecSync
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this feature solve? What's the use case?
+
+## Proposed Solution
+
+Describe your preferred solution. How should it work?
+
+## Alternatives Considered
+
+Have you considered other approaches? Why is this one better?
+
+## Additional Context
+
+- Links to related issues or discussions
+- Examples from other tools that handle this well
+- Mockups, spec file examples, or CLI output examples

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+Brief description of what this PR does and why.
+
+Closes #<!-- issue number -->
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] `cargo fmt` applied
+- [ ] Documentation updated (if behavior changed)
+- [ ] Spec files updated (if adding/changing features)
+- [ ] Added/updated tests for new functionality
+
+## Testing
+
+How was this tested? Include relevant commands or test output.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in the SpecSync project a welcoming experience for everyone, regardless of background or identity.
+
+## Our Standards
+
+**Positive behaviors include:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+**Unacceptable behaviors include:**
+
+- Trolling, insulting/derogatory comments, and personal attacks
+- Publishing others' private information without permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers at **conduct@corvidlabs.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+Project maintainers who do not follow or enforce this Code of Conduct may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to SpecSync
+
+Thank you for your interest in contributing to SpecSync! This guide will help you get started.
+
+## Getting Started
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/) (stable, 1.85+)
+- Git
+
+### Development Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/CorvidLabs/spec-sync.git
+cd spec-sync
+
+# Build
+cargo build
+
+# Run tests
+cargo test
+
+# Run lints
+cargo clippy -- -D warnings
+
+# Format code
+cargo fmt
+```
+
+### Running Locally
+
+```bash
+# Validate specs in the current directory
+cargo run -- validate
+
+# Generate a spec from source files
+cargo run -- generate src/parser.rs
+
+# Check with verbose output
+cargo run -- validate --verbose
+```
+
+## How to Contribute
+
+### Reporting Bugs
+
+Use the [Bug Report](https://github.com/CorvidLabs/spec-sync/issues/new?template=bug_report.md) issue template. Include:
+
+- SpecSync version (`specsync --version`)
+- OS and Rust version
+- Minimal reproduction steps
+- Expected vs actual behavior
+
+### Suggesting Features
+
+Use the [Feature Request](https://github.com/CorvidLabs/spec-sync/issues/new?template=feature_request.md) issue template. Describe:
+
+- The problem you're trying to solve
+- Your proposed solution
+- Alternatives you've considered
+
+### Pull Requests
+
+1. Fork the repo and create a branch from `main`
+2. Make your changes
+3. Add or update tests as needed
+4. Run `cargo test` and `cargo clippy` — everything must pass
+5. Update documentation if you changed behavior
+6. Open a PR using the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+
+### Adding a Language Parser
+
+SpecSync supports 11 languages via parsers in `src/parser/`. To add a new one:
+
+1. Create `src/parser/<language>.rs` implementing the `Parser` trait
+2. Register the parser in `src/parser/mod.rs` with its file extensions
+3. Add test fixtures in `tests/fixtures/<language>/`
+4. Add tests covering:
+   - Export detection (functions, classes, types, constants)
+   - Visibility filtering (skip private/internal items)
+   - Test file exclusion patterns
+5. Update `README.md` with the language in the supported languages table
+6. Update `docs/spec-format.md` if the language has any special behaviors
+
+### Commit Messages
+
+Write clear, concise commit messages. Use the imperative mood:
+
+- `fix: handle wildcard re-exports in TypeScript parser`
+- `feat: add Elixir language support`
+- `docs: update CLI reference for new --format flag`
+- `test: add cross-project reference validation tests`
+
+## Code Style
+
+- Follow standard Rust conventions (`cargo fmt`)
+- No warnings from `cargo clippy`
+- Public items should have doc comments
+- Tests go in the same file (`#[cfg(test)]` module) or in `tests/`
+
+## Project Structure
+
+```
+src/
+  parser/       # Language parsers (one per language)
+  validator/    # Spec validation logic
+  generator/    # Spec generation from source
+  reporter/     # Output formatting (text, JSON, SARIF)
+  config/       # Configuration loading
+tests/
+  fixtures/     # Test fixture files per language
+  integration/  # Integration tests
+docs/           # Documentation site (Jekyll)
+```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 3.x     | Yes       |
+| < 3.0   | No        |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in SpecSync, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please email: **security@corvidlabs.com**
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment** within 48 hours
+- **Assessment** within 1 week
+- **Fix or mitigation** for confirmed vulnerabilities as soon as possible
+- Credit in the release notes (unless you prefer anonymity)
+
+### Scope
+
+SpecSync is a local CLI tool and GitHub Action. The primary security concerns are:
+
+- **Path traversal** — spec file paths or cross-project references escaping the intended directory
+- **Code injection** — malicious spec content causing unexpected behavior during parsing
+- **GitHub Action security** — token exposure, unsafe input handling in CI
+- **Dependency vulnerabilities** — issues in upstream Rust crates
+
+### Out of Scope
+
+- Bugs that require physical access to the machine running SpecSync
+- Issues in dependencies that have already been reported upstream
+- Denial of service via extremely large files (SpecSync is a local tool)
+
+## Security Best Practices for Users
+
+- Pin SpecSync to a specific version in CI (`uses: CorvidLabs/spec-sync@v3`)
+- Review spec files from untrusted sources before running validation
+- Use `--no-cross-project` if you don't need cross-project references in CI


### PR DESCRIPTION
## Summary
- Add **CODE_OF_CONDUCT.md** (Contributor Covenant 2.1)
- Add **CONTRIBUTING.md** (dev setup, adding parsers, PR guidelines, commit conventions)
- Add **SECURITY.md** (vulnerability reporting policy, scope, best practices)
- Add **issue templates** (bug report + feature request)
- Add **PR template** (summary, changes, checklist)

Completes the standard open-source community scaffolding for the project.

## Test plan
- [x] All 6 files created and well-formatted
- [ ] Verify templates render correctly on GitHub (new issue / new PR views)

🤖 Generated with [Claude Code](https://claude.com/claude-code)