### PR TITLE
feat: add scaffold command for new module spec generation

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -499,7 +499,11 @@ fn find_module_source_files(dir: &Path, config: &SpecSyncConfig) -> Vec<String> 
 
 /// Find source files for a module, checking config module definitions first,
 /// then subdirectories, then flat files.
-fn find_files_for_module(root: &Path, module_name: &str, config: &SpecSyncConfig) -> Vec<String> {
+pub fn find_files_for_module(
+    root: &Path,
+    module_name: &str,
+    config: &SpecSyncConfig,
+) -> Vec<String> {
     let mut module_files = Vec::new();
 
     // First: check user-defined module definitions in specsync.json
@@ -551,7 +555,7 @@ fn find_files_for_module(root: &Path, module_name: &str, config: &SpecSyncConfig
 }
 
 /// Generate a spec from a template, using language-aware defaults.
-fn generate_spec(
+pub fn generate_spec(
     module_name: &str,
     source_files: &[String],
     root: &Path,
@@ -695,9 +699,138 @@ fn generate_companion_files(spec_dir: &Path, module_name: &str) {
 }
 
 /// Generate companion files for a given spec, creating the directory if needed.
-/// Used by the `add-spec` command.
+/// Used by the `add-spec` and `scaffold` commands.
 pub fn generate_companion_files_for_spec(spec_dir: &Path, module_name: &str) {
     generate_companion_files(spec_dir, module_name);
+}
+
+/// Generate a spec using templates from a custom template directory.
+/// Looks for `spec.md`, `tasks.md`, `context.md`, `requirements.md` in the template dir.
+/// Falls back to built-in templates for any missing template files.
+pub fn generate_spec_from_custom_template(
+    template_dir: &Path,
+    module_name: &str,
+    source_files: &[String],
+    root: &Path,
+) -> String {
+    let template_file = template_dir.join("spec.md");
+    let template = if template_file.exists() {
+        fs::read_to_string(&template_file).unwrap_or_else(|_| DEFAULT_TEMPLATE.to_string())
+    } else {
+        // No custom spec template — use language-aware default
+        match detect_primary_language(source_files) {
+            Some(lang) => language_template(lang).to_string(),
+            None => DEFAULT_TEMPLATE.to_string(),
+        }
+    };
+
+    let title = module_name
+        .split('-')
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let files_yaml: String = source_files
+        .iter()
+        .map(|f| {
+            let rel = Path::new(f)
+                .strip_prefix(root.to_string_lossy().as_ref())
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| f.clone());
+            format!("  - {rel}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut spec = template;
+
+    let module_re = regex::Regex::new(r"(?m)^module:\s*.+$").unwrap();
+    spec = module_re
+        .replace(&spec, format!("module: {module_name}"))
+        .to_string();
+
+    let status_re = regex::Regex::new(r"(?m)^status:\s*.+$").unwrap();
+    spec = status_re.replace(&spec, "status: draft").to_string();
+
+    let version_re = regex::Regex::new(r"(?m)^version:\s*.+$").unwrap();
+    spec = version_re.replace(&spec, "version: 1").to_string();
+
+    let files_re = regex::Regex::new(r"(?m)^files:\s*\[\]|^files:\n(?:\s+-\s+.+\n?)*").unwrap();
+    if source_files.is_empty() {
+        spec = files_re.replace(&spec, "files: []\n").to_string();
+    } else {
+        spec = files_re
+            .replace(&spec, format!("files:\n{files_yaml}\n"))
+            .to_string();
+    }
+
+    let title_re = regex::Regex::new(r"(?m)^# .+$").unwrap();
+    spec = title_re.replace(&spec, format!("# {title}")).to_string();
+
+    let db_re = regex::Regex::new(r"(?m)^db_tables:\n(?:\s+-\s+.+\n?)*").unwrap();
+    spec = db_re.replace(&spec, "db_tables: []\n").to_string();
+
+    spec
+}
+
+/// Generate companion files from a custom template directory.
+/// Falls back to built-in templates for any missing files.
+pub fn generate_companion_files_from_template(
+    spec_dir: &Path,
+    module_name: &str,
+    template_dir: &Path,
+) {
+    let tasks_path = spec_dir.join("tasks.md");
+    let context_path = spec_dir.join("context.md");
+    let requirements_path = spec_dir.join("requirements.md");
+
+    if !tasks_path.exists() {
+        let template_file = template_dir.join("tasks.md");
+        let content = if template_file.exists() {
+            fs::read_to_string(&template_file)
+                .unwrap_or_else(|_| TASKS_TEMPLATE.to_string())
+                .replace("{module}", module_name)
+        } else {
+            TASKS_TEMPLATE.replace("{module}", module_name)
+        };
+        if fs::write(&tasks_path, &content).is_ok() {
+            println!("    {} Generated tasks.md", "✓".green());
+        }
+    }
+
+    if !context_path.exists() {
+        let template_file = template_dir.join("context.md");
+        let content = if template_file.exists() {
+            fs::read_to_string(&template_file)
+                .unwrap_or_else(|_| CONTEXT_TEMPLATE.to_string())
+                .replace("{module}", module_name)
+        } else {
+            CONTEXT_TEMPLATE.replace("{module}", module_name)
+        };
+        if fs::write(&context_path, &content).is_ok() {
+            println!("    {} Generated context.md", "✓".green());
+        }
+    }
+
+    if !requirements_path.exists() {
+        let template_file = template_dir.join("requirements.md");
+        let content = if template_file.exists() {
+            fs::read_to_string(&template_file)
+                .unwrap_or_else(|_| REQUIREMENTS_TEMPLATE.to_string())
+                .replace("{module}", module_name)
+        } else {
+            REQUIREMENTS_TEMPLATE.replace("{module}", module_name)
+        };
+        if fs::write(&requirements_path, &content).is_ok() {
+            println!("    {} Generated requirements.md", "✓".green());
+        }
+    }
 }
 
 /// Generate spec files for all unspecced modules.

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,17 @@ enum Command {
         /// Module name for the new spec
         name: String,
     },
+    /// Scaffold a new module spec with companion files, auto-detect source files, and register in registry
+    Scaffold {
+        /// Module name for the new spec
+        name: String,
+        /// Target directory for spec output (default: specs dir from config)
+        #[arg(long)]
+        dir: Option<PathBuf>,
+        /// Custom template directory containing spec.md, tasks.md, context.md, requirements.md
+        #[arg(long)]
+        template: Option<PathBuf>,
+    },
     /// Generate a specsync-registry.toml for cross-project references
     InitRegistry {
         /// Project name for the registry
@@ -310,6 +321,11 @@ fn run() {
         Command::Watch => watch::run_watch(&root, cli.strict, cli.require_coverage),
         Command::Mcp => mcp::run_mcp_server(&root),
         Command::AddSpec { name } => cmd_add_spec(&root, &name),
+        Command::Scaffold {
+            name,
+            dir,
+            template,
+        } => cmd_scaffold(&root, &name, dir, template),
         Command::InitRegistry { name } => cmd_init_registry(&root, name),
         Command::Resolve { remote } => cmd_resolve(&root, remote),
         Command::Diff { base } => cmd_diff(&root, &base, format),
@@ -1361,6 +1377,81 @@ depends_on: []
         Err(e) => {
             eprintln!("Failed to write {}: {e}", spec_file.display());
             process::exit(1);
+        }
+    }
+}
+
+fn cmd_scaffold(root: &Path, module_name: &str, dir: Option<PathBuf>, template: Option<PathBuf>) {
+    let config = load_config(root);
+    let specs_dir = dir.unwrap_or_else(|| root.join(&config.specs_dir));
+    let spec_dir = specs_dir.join(module_name);
+    let spec_file = spec_dir.join(format!("{module_name}.spec.md"));
+
+    if spec_file.exists() {
+        println!(
+            "{} Spec already exists: {}",
+            "!".yellow(),
+            spec_file.strip_prefix(root).unwrap_or(&spec_file).display()
+        );
+        // Still generate companion files if missing
+        if let Some(ref tpl_dir) = template {
+            generator::generate_companion_files_from_template(&spec_dir, module_name, tpl_dir);
+        } else {
+            generator::generate_companion_files_for_spec(&spec_dir, module_name);
+        }
+        return;
+    }
+
+    if let Err(e) = fs::create_dir_all(&spec_dir) {
+        eprintln!("Failed to create {}: {e}", spec_dir.display());
+        process::exit(1);
+    }
+
+    // Auto-detect source files matching the module name
+    let module_files = generator::find_files_for_module(root, module_name, &config);
+
+    // Generate spec content
+    let spec_content = if let Some(ref tpl_dir) = template {
+        generator::generate_spec_from_custom_template(tpl_dir, module_name, &module_files, root)
+    } else {
+        generator::generate_spec(module_name, &module_files, root, &specs_dir)
+    };
+
+    match fs::write(&spec_file, &spec_content) {
+        Ok(_) => {
+            let rel = spec_file.strip_prefix(root).unwrap_or(&spec_file).display();
+            println!("  {} Created {rel}", "✓".green());
+            if !module_files.is_empty() {
+                println!(
+                    "    {} Auto-detected {} source file(s)",
+                    "ℹ".cyan(),
+                    module_files.len()
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to write {}: {e}", spec_file.display());
+            process::exit(1);
+        }
+    }
+
+    // Generate companion files
+    if let Some(ref tpl_dir) = template {
+        generator::generate_companion_files_from_template(&spec_dir, module_name, tpl_dir);
+    } else {
+        generator::generate_companion_files_for_spec(&spec_dir, module_name);
+    }
+
+    // Auto-register in specsync-registry.toml if one exists
+    let registry_path = root.join("specsync-registry.toml");
+    if registry_path.exists() {
+        let spec_rel = spec_file
+            .strip_prefix(root)
+            .unwrap_or(&spec_file)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if registry::register_module(root, module_name, &spec_rel) {
+            println!("    {} Registered in specsync-registry.toml", "✓".green());
         }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -158,6 +158,37 @@ pub fn generate_registry(root: &Path, project_name: &str, specs_dir: &str) -> St
     output
 }
 
+/// Add a module entry to an existing `specsync-registry.toml`.
+/// If the module already exists, it is not duplicated.
+/// Returns `true` if the entry was added, `false` if it already existed or the file is missing.
+pub fn register_module(root: &Path, module_name: &str, spec_rel_path: &str) -> bool {
+    let path = root.join(REGISTRY_FILENAME);
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+
+    // Check if module already registered
+    if let Some(entry) = parse_registry(&content) {
+        if entry.specs.iter().any(|(m, _)| m == module_name) {
+            return false;
+        }
+    }
+
+    // Append to the [specs] section
+    let new_line = format!("{module_name} = \"{spec_rel_path}\"\n");
+
+    // If there's a [specs] section, append after it
+    if content.contains("[specs]") {
+        let updated = format!("{}\n{new_line}", content.trim_end());
+        if fs::write(&path, updated).is_ok() {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Extract module name from spec frontmatter.
 fn extract_module_name(content: &str) -> Option<String> {
     for line in content.lines() {


### PR DESCRIPTION
## Summary

Closes #127

Adds a `spec-sync scaffold <module-name>` command that generates a complete spec module with all companion files:

1. **Auto-detects source files** matching the module name across configured source directories
2. **Generates spec file** (`<name>.spec.md`) with correct YAML frontmatter, language-aware templates
3. **Generates companion files**: `tasks.md`, `context.md`, `requirements.md`
4. **Auto-registers** the module in `specsync-registry.toml` if one exists
5. **Custom templates** via `--template <path>` flag

### Usage
```bash
spec-sync scaffold auth              # scaffold specs/auth/ with auto-detected files
spec-sync scaffold auth --dir src/   # override source directory
spec-sync scaffold auth --template ./my-templates/  # use custom templates
```

### Changes
- `src/main.rs` — new `Scaffold` command variant and `cmd_scaffold()` implementation
- `src/generator.rs` — made helpers public, added custom template support
- `src/registry.rs` — added `register_module()` for auto-registration

Existing `add-spec` command preserved for backward compatibility.

## Test plan

- [x] `cargo build` — zero errors, zero warnings
- [x] `cargo clippy` — clean
- [x] `cargo test` — all tests pass
- [ ] Manual testing with `spec-sync scaffold` on a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)