### PR TITLE
fix: 100% spec coverage — resolve warnings, add missing specs

### DIFF
--- a/specs/changelog/changelog.spec.md
+++ b/specs/changelog/changelog.spec.md
@@ -1,0 +1,97 @@
+---
+module: changelog
+version: 1
+status: stable
+files:
+  - src/changelog.rs
+db_tables: []
+tracks: [141]
+depends_on:
+  - specs/parser/parser.spec.md
+  - specs/types/types.spec.md
+---
+
+# Changelog
+
+## Purpose
+
+Automated changelog generation for spec changes between git refs. Compares specs at two git commits/tags and produces a structured diff showing which specs were added, removed, or modified — and which specific fields changed for modified specs.
+
+## Public API
+
+### Exported Structs
+
+| Type | Description |
+|------|-------------|
+| `FieldChange` | A single field change within a modified spec (field name, old value, new value) |
+| `ModifiedSpec` | A spec that was modified between two refs, with its list of field changes |
+| `ChangelogReport` | The full changelog comparing two git refs — added, removed, and modified specs |
+| `SpecEntry` | A spec entry for added/removed lists (module name, path, status, version) |
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `parse_range` | `range: &str` | `Option<(String, String)>` | Parse a range string like "v0.1..v0.2" into (from, to) tuple |
+| `generate_changelog` | `root, specs_dir, from_ref, to_ref` | `ChangelogReport` | Generate a changelog comparing specs between two git refs |
+| `format_text` | `report: &ChangelogReport` | `String` | Format changelog as colored terminal text |
+| `format_json` | `report: &ChangelogReport` | `String` | Format changelog as JSON |
+| `format_markdown` | `report: &ChangelogReport` | `String` | Format changelog as markdown |
+
+## Invariants
+
+1. Spec comparison uses git `ls-tree` and `show` to read spec state at each ref — never touches the working tree
+2. Field-level diffing compares frontmatter fields: module, version, status, files, db_tables, depends_on
+3. `parse_range` only accepts `..` as separator and requires non-empty parts on both sides
+4. Added/removed/modified lists are sorted by spec path (BTreeMap/BTreeSet ordering)
+5. A spec is "modified" only if at least one frontmatter field changed between the two refs
+6. Output formatters (text, json, markdown) share the same ChangelogReport — formatting is decoupled from analysis
+
+## Behavioral Examples
+
+### Scenario: Generate changelog between two tags
+
+- **Given** specs at `v1.0.0` and `v1.1.0` where `auth.spec.md` was added and `config.spec.md` had its version bumped
+- **When** `generate_changelog(root, "specs", "v1.0.0", "v1.1.0")` is called
+- **Then** returns a report with auth in `added` and config in `modified` with a version FieldChange
+
+### Scenario: Parse valid range
+
+- **Given** the string "v1.0..v2.0"
+- **When** `parse_range("v1.0..v2.0")` is called
+- **Then** returns `Some(("v1.0", "v2.0"))`
+
+### Scenario: Parse invalid range
+
+- **Given** the string "v1.0"
+- **When** `parse_range("v1.0")` is called
+- **Then** returns `None`
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Git ref doesn't exist | `list_specs_at_ref` returns empty list — no crash |
+| Range string has no `..` separator | `parse_range` returns `None` |
+| Spec frontmatter unparseable at a ref | Spec is silently skipped in diff |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| parser | `parse_frontmatter` |
+| types | `Frontmatter` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| cli | `generate_changelog`, `parse_range`, formatters |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-07 | Initial spec |

--- a/specs/changelog/context.md
+++ b/specs/changelog/context.md
@@ -1,0 +1,3 @@
+# changelog — Context
+
+The changelog module was added in v3.3.0 (#141) to provide automated release notes by diffing spec state between git refs. It relies on git plumbing commands (`ls-tree`, `show`) to read spec files at arbitrary commits without touching the working tree.

--- a/specs/changelog/requirements.md
+++ b/specs/changelog/requirements.md
@@ -1,0 +1,5 @@
+# changelog — Requirements
+
+- Must produce deterministic output for the same two git refs
+- Must support text, JSON, and markdown output formats
+- Must not modify the working tree or index

--- a/specs/changelog/tasks.md
+++ b/specs/changelog/tasks.md
@@ -1,0 +1,3 @@
+# changelog — Tasks
+
+No active tasks.

--- a/specs/comment/comment.spec.md
+++ b/specs/comment/comment.spec.md
@@ -1,0 +1,94 @@
+---
+module: comment
+version: 1
+status: stable
+files:
+  - src/comment.rs
+db_tables: []
+tracks: [140]
+depends_on:
+  - specs/types/types.spec.md
+---
+
+# Comment
+
+## Purpose
+
+GitHub PR comment formatting with spec links and actionable suggestions. Produces GitHub-flavored markdown output designed for posting as PR comments, including direct links to spec files, actionable checklists, and diff-aware suggestions for updating specs.
+
+## Public API
+
+### Exported Structs
+
+| Type | Description |
+|------|-------------|
+| `SpecViolation` | A spec violation with path, errors, warnings, and fix suggestions |
+
+### Exported SpecViolation Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `from_result` | `result: &ValidationResult` | `Self` | Build a SpecViolation from a ValidationResult |
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `render_check_comment` | `total, passed, warnings, errors, all_errors, all_warnings, coverage, overall_passed, repo, branch` | `String` | Render full GitHub PR comment for `specsync check --format github` |
+| `render_comment_body` | `violations, coverage, repo, branch` | `String` | Render PR comment for `specsync comment` subcommand with diff-aware suggestions |
+| `detect_branch` | `root: &Path` | `Option<String>` | Detect the current git branch name via `git rev-parse` |
+
+## Invariants
+
+1. When `repo` and `branch` are provided, spec links are full GitHub URLs (`https://github.com/{repo}/blob/{branch}/{path}`); otherwise relative markdown links
+2. Error messages are classified into actionable suggestion categories: missing sections, missing source files, DB table issues, frontmatter problems, dependency issues
+3. The comment header includes a pass/fail icon and status based on `overall_passed`
+4. Coverage metrics (file and LOC percentages) are always included in the summary table
+5. `detect_branch` returns `None` if not in a git repository or git command fails
+
+## Behavioral Examples
+
+### Scenario: Render passing check comment
+
+- **Given** 10 specs checked, all passed, 0 errors, 0 warnings
+- **When** `render_check_comment(10, 10, 0, 0, &[], &[], &coverage, true, Some("org/repo"), Some("main"))` is called
+- **Then** returns markdown with "✅ SpecSync: Passed" header and summary table
+
+### Scenario: Render failing comment with spec links
+
+- **Given** violations with errors pointing to `specs/auth/auth.spec.md` and repo "org/repo" on branch "feat/auth"
+- **When** `render_comment_body` is called
+- **Then** error lines include clickable GitHub links to the spec file
+
+### Scenario: Detect branch
+
+- **Given** a git repository on branch `feat/new-module`
+- **When** `detect_branch(root)` is called
+- **Then** returns `Some("feat/new-module")`
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Not in a git repository | `detect_branch` returns `None` |
+| No repo/branch provided | Spec links use relative markdown format instead of GitHub URLs |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| types | `CoverageReport`, `ValidationResult` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| cli | `render_check_comment`, `render_comment_body`, `detect_branch`, `SpecViolation` |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-07 | Initial spec |

--- a/specs/comment/context.md
+++ b/specs/comment/context.md
@@ -1,0 +1,3 @@
+# comment — Context
+
+The comment module was added in v3.3.0 (#140) to produce actionable GitHub PR comments from spec validation results. It generates GitHub-flavored markdown with direct links to spec files and classifies errors into actionable suggestions.

--- a/specs/comment/requirements.md
+++ b/specs/comment/requirements.md
@@ -1,0 +1,5 @@
+# comment — Requirements
+
+- Must produce valid GitHub-flavored markdown
+- Must include clickable spec file links when repo/branch are provided
+- Must classify errors into actionable suggestion categories

--- a/specs/comment/tasks.md
+++ b/specs/comment/tasks.md
@@ -1,0 +1,3 @@
+# comment — Tasks
+
+No active tasks.

--- a/specs/deps/context.md
+++ b/specs/deps/context.md
@@ -1,0 +1,3 @@
+# deps — Context
+
+The deps module was added in v3.3.0 (#139) to validate cross-module dependency declarations. It builds a dependency graph from spec frontmatter `depends_on` fields and cross-references them against actual import statements found in source code for Rust, TypeScript, and Python.

--- a/specs/deps/deps.spec.md
+++ b/specs/deps/deps.spec.md
@@ -1,0 +1,97 @@
+---
+module: deps
+version: 1
+status: stable
+files:
+  - src/deps.rs
+db_tables: []
+tracks: [139]
+depends_on:
+  - specs/parser/parser.spec.md
+  - specs/types/types.spec.md
+  - specs/validator/validator.spec.md
+---
+
+# Deps
+
+## Purpose
+
+Cross-module dependency validation. Parses `depends_on` declarations from spec frontmatter, builds a dependency graph, validates that declared dependencies exist, detects circular dependency chains, and cross-references declared dependencies against actual import statements in source code (Rust, TypeScript, Python).
+
+## Public API
+
+### Exported Structs
+
+| Type | Description |
+|------|-------------|
+| `DepNode` | A node in the dependency graph with module name, spec path, declared deps, and source files |
+| `DepsReport` | Validation result with errors, warnings, module count, edge count, and circular chains |
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `build_dep_graph` | `root, specs_dir` | `HashMap<String, DepNode>` | Parse all specs and build the dependency graph |
+| `validate_deps` | `root, specs_dir` | `DepsReport` | Full dependency validation: missing deps, cycles, undeclared imports |
+| `extract_imports` | `file_path, content` | `HashSet<String>` | Extract import/use statements from source code (Rust, TypeScript, Python) |
+| `format_report` | `report: &DepsReport` | `String` | Format dependency report as colored terminal text |
+| `topological_sort` | `graph: &HashMap<String, DepNode>` | `Option<Vec<String>>` | Topologically sort modules; returns None if cycles exist |
+
+## Invariants
+
+1. Import extraction uses language-specific regex: Rust (`use crate::`, `mod`), TypeScript (`import from`, `require`), Python (`import`, `from .module`)
+2. Circular dependency detection traverses the full graph — reports all cycles, not just the first
+3. `topological_sort` returns `None` when cycles are present — does not partial-sort
+4. Cross-project refs (containing `/`) in `depends_on` are skipped — only local deps are validated
+5. Undeclared imports (found in source but not in `depends_on`) are reported as warnings, not errors
+6. Module names in `depends_on` paths are extracted from the path's directory component
+
+## Behavioral Examples
+
+### Scenario: Detect missing dependency
+
+- **Given** spec A declares `depends_on: [specs/nonexistent/nonexistent.spec.md]`
+- **When** `validate_deps` is called
+- **Then** report contains an error about the missing dependency spec
+
+### Scenario: Detect circular dependency
+
+- **Given** spec A depends on B and spec B depends on A
+- **When** `validate_deps` is called
+- **Then** report's `cycles` field contains the chain `[A, B, A]`
+
+### Scenario: Extract Rust imports
+
+- **Given** a file containing `use crate::config::load_config;`
+- **When** `extract_imports(path, content)` is called
+- **Then** returns a set containing `"config"`
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Source file unreadable | Skipped during import extraction |
+| Spec frontmatter unparseable | Module excluded from dependency graph |
+| No specs found in specs_dir | Returns empty graph and clean DepsReport |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| parser | `parse_frontmatter` |
+| types | `Language` |
+| validator | `find_spec_files`, `is_cross_project_ref` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| cli | `validate_deps`, `build_dep_graph`, `format_report`, `topological_sort` |
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-04-07 | Initial spec |

--- a/specs/deps/requirements.md
+++ b/specs/deps/requirements.md
@@ -1,0 +1,5 @@
+# deps — Requirements
+
+- Must detect circular dependencies and report all cycles
+- Must support import extraction for Rust, TypeScript, and Python
+- Must skip cross-project refs during local validation

--- a/specs/deps/tasks.md
+++ b/specs/deps/tasks.md
@@ -1,0 +1,3 @@
+# deps — Tasks
+
+No active tasks.

--- a/specs/generator/generator.spec.md
+++ b/specs/generator/generator.spec.md
@@ -27,6 +27,10 @@ Scaffolds spec files and companion files (tasks.md, context.md) for unspecced mo
 | `generate_specs_for_unspecced_modules` | `root, report, config, provider` | `usize` | Generate specs for all unspecced modules, returning count of generated specs |
 | `generate_specs_for_unspecced_modules_paths` | `root, report, config, provider` | `Vec<String>` | Generate specs for all unspecced modules, returning paths of generated files |
 | `generate_companion_files_for_spec` | `spec_dir, module_name` | `()` | Generate tasks.md and context.md companion files alongside a spec |
+| `find_files_for_module` | `root, module_name, config` | `Vec<String>` | Find source files for a module by checking config definitions, subdirectories, then flat files |
+| `generate_spec` | `module_name, source_files, root, specs_dir` | `String` | Generate a spec from a template (custom or language-aware default) |
+| `generate_spec_from_custom_template` | `template_dir, module_name, source_files, root` | `String` | Generate a spec using files from a custom template directory |
+| `generate_companion_files_from_template` | `spec_dir, module_name, template_dir` | `()` | Generate companion files from a custom template directory with fallback to defaults |
 
 ## Invariants
 
@@ -90,3 +94,4 @@ Scaffolds spec files and companion files (tasks.md, context.md) for unspecced mo
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial spec |
+| 2026-04-07 | Document find_files_for_module, generate_spec, generate_spec_from_custom_template, generate_companion_files_from_template |

--- a/specs/registry/registry.spec.md
+++ b/specs/registry/registry.spec.md
@@ -37,6 +37,7 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 | `fetch_remote_registry` | `repo: &str` | `Result<RemoteRegistry, String>` | Fetch `specsync-registry.toml` from a GitHub repo's default branch via raw content URL |
 | `load_registry` | `root: &Path` | `Option<RegistryEntry>` | Load a registry from a local `specsync-registry.toml` file |
 | `generate_registry` | `root, project_name, specs_dir` | `String` | Generate registry TOML content by scanning for spec files |
+| `register_module` | `root, module_name, spec_rel_path` | `bool` | Append a module entry to the registry file; returns false if already exists or file missing |
 
 ## Invariants
 
@@ -97,3 +98,4 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 | Date | Change |
 |------|--------|
 | 2026-03-25 | Initial spec |
+| 2026-04-07 | Document register_module function |

--- a/specs/types/types.spec.md
+++ b/specs/types/types.spec.md
@@ -26,6 +26,7 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 | `OutputFormat` | CLI output format: Text (colored terminal, default), Json (machine-readable), Markdown (PR comments / agent consumption) |
 | `ExportLevel` | Export extraction granularity: Type (top-level declarations only) or Member (all public symbols, default) |
 | `SpecStatus` | Spec lifecycle status: draft, stable, deprecated. Parsed from frontmatter `status` field |
+| `EnforcementMode` | Graduated enforcement level: Warn (always exit 0), EnforceNew (exit 1 for unspecced files), Strict (exit 1 on any error) |
 
 ### Exported Structs
 
@@ -148,3 +149,4 @@ Core data structures and enums shared across the entire spec-sync codebase. Defi
 | 2026-03-25 | Initial spec |
 | 2026-03-28 | Document OutputFormat, ExportLevel, ModuleDefinition |
 | 2026-04-06 | Add Frontmatter implements/tracks/agent_policy fields, ValidationRules, GitHubConfig structs |
+| 2026-04-07 | Document EnforcementMode enum |


### PR DESCRIPTION
## Summary

- **9 undocumented export warnings → 0**: Added missing exports to generator (4), registry (1), and types (1) specs
- **3 new module specs**: `changelog`, `deps`, and `comment` — each with companion files (context.md, tasks.md, requirements.md)
- **Coverage: 91% → 100% file, 88% → 100% LOC**

## Details

### Export warnings fixed
- `generator.spec.md`: `find_files_for_module`, `generate_spec`, `generate_spec_from_custom_template`, `generate_companion_files_from_template`
- `registry.spec.md`: `register_module`
- `types.spec.md`: `EnforcementMode`

### New specs
| Module | LOC | Tracks |
|--------|-----|--------|
| changelog | 1191 | #141 |
| deps | 824 | #139 |
| comment | 579 | #140 |

## Verification
```
25 specs checked: 25 passed, 0 warning(s), 0 failed
File coverage: 36/36 (100%)
LOC coverage:  22047/22047 (100%)
test result: ok. 80 passed; 0 failed
```

## Test plan
- [x] `cargo test` — 80/80 pass
- [x] `specsync check --force` — 25/25 pass, 0 warnings
- [x] Coverage at 100% file and LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6