### PR TITLE
fix: v3.6.1 — frontmatter formatting + empty dep graph hint

### DIFF
--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -12,10 +12,17 @@ pub fn cmd_deps(root: &Path, format: types::OutputFormat, mermaid: bool, dot: bo
     // --mermaid or --dot: output graph visualization and exit
     if mermaid || dot {
         let graph = deps::build_dep_graph(root, &config.specs_dir);
+        let has_edges = graph.values().any(|n| !n.declared_deps.is_empty());
         if mermaid {
             println!("{}", render_mermaid(&graph));
         } else {
             println!("{}", render_dot(&graph));
+        }
+        if !has_edges && !graph.is_empty() {
+            eprintln!(
+                "\n{} No depends_on relationships found. Add `depends_on: [module_name]` to spec frontmatter to see the dependency graph.",
+                "Hint:".yellow()
+            );
         }
         return;
     }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -31,7 +31,7 @@ pub fn cmd_new(root: &Path, module_name: &str, full: bool) {
     // Auto-detect source files for this module
     let source_files = detect_module_sources(root, module_name, &config);
     let files_yaml = if source_files.is_empty() {
-        "files: []".to_string()
+        "files: []\n".to_string()
     } else {
         let items: String = source_files.iter().map(|f| format!("  - {f}\n")).collect();
         format!("files:\n{items}")


### PR DESCRIPTION
## Summary

Fixes two issues from Leif's v3.6.0 dogfood review:

- **`specsync new` frontmatter bug**: `files: []` and `db_tables: []` were concatenated onto the same line (`files: []db_tables: []`), which would cause a frontmatter parse error. Fixed by ensuring `files_yaml` always ends with a newline.
- **Empty dep graph hint**: When `--mermaid` or `--dot` output has zero edges (no `depends_on` relationships), now prints a hint: *"No depends_on relationships found. Add `depends_on: [module_name]` to spec frontmatter to see the dependency graph."*

## Test plan

- [x] All 80 tests pass
- [ ] `specsync new test-module` generates frontmatter with `files:` and `db_tables:` on separate lines
- [ ] `specsync deps --mermaid` on a project with no `depends_on` entries shows the hint message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
🤖 Agent: CorvidAgent | Model: Opus 4.6