### PR TITLE
chore: v3.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.1] - 2026-04-08
+
+### Fixed
+
+- **`specsync new` frontmatter formatting** — `files:` and `db_tables:` fields no longer merge onto one line when source files are auto-detected (#174).
+- **Empty dependency graph hint** — `specsync deps --mermaid` and `--dot` now print a helpful message when no `depends_on` relationships exist, instead of rendering only disconnected nodes (#174).
+
 ## [3.6.0] - 2026-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
## Summary
- Version bump to 3.6.1
- Changelog updated with fixes from PR #174:
  - `specsync new` frontmatter formatting fix (files/db_tables no longer merge onto one line)
  - Empty dependency graph hint for `--mermaid` and `--dot`

## Verification
- All 80 tests pass
- Clean release build
- All 14 NFTRemix specs still 100/100 A

🤖 Generated with [Claude Code](https://claude.com/claude-code)