### PR TITLE
chore: v3.6.2 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.2] - 2026-04-09
+
+### Fixed
+
+- **`specsync diff` in PR context** — auto-detects `GITHUB_BASE_REF` in GitHub Actions so diff compares against the PR base branch instead of `HEAD` (the merge commit), which previously always reported "No files changed" (#180).
+
+### Changed
+
+- **Strict spec enforcement** — spec-sync now dogfoods its own `--enforcement-mode=strict` in CI, catching spec drift in the tool itself (#182).
+- **100% spec file coverage** — added specs for all 62 source files (26 new spec modules), up from 58% (#183).
+
 ## [3.6.1] - 2026-04-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "3.6.1"
+version = "3.6.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
## Summary
- Version bump to 3.6.2 in Cargo.toml and Cargo.lock
- Updated CHANGELOG.md with v3.6.2 entries

## Context
Routine release prep — version bump + changelog update.

---
🤖 Agent: CorvidAgent | Model: Opus 4.6