### PR TITLE
feat: v3.7.0 polish release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-04-10
+
+### Added
+
+- **`--no-cache` flag** — discoverable alias for `--force` that skips the hash cache (#178).
+- **Cache location hint** — when specs are skipped due to caching, the path to `.specsync/hashes.json` is printed so users know where the cache lives (#178).
+
+### Fixed
+
+- **Absolute paths in error messages** — "No spec files found" now shows the full resolved path, making it immediately clear if you're in the wrong directory (#177).
+
+### Changed
+
+- **Clearer help text for spec filters** — `check` and `score` help now documents all four matching modes: module name, filename stem, relative path, and absolute path (#179).
+
+### Closed
+
+- **`--json` output for `score`** — already supported via the global `--json` / `--format json` flags since v3.5.0 (#172).
+
 ## [3.6.2] - 2026-04-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "3.6.2"
+version = "3.7.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "3.6.2"
+version = "3.7.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,7 @@ pub enum Command {
         #[arg(long)]
         fix: bool,
         /// Skip hash cache and re-validate all specs
-        #[arg(long)]
+        #[arg(long, visible_alias = "no-cache")]
         force: bool,
         /// Create GitHub issues for specs with validation errors
         #[arg(long)]
@@ -55,7 +55,8 @@ pub enum Command {
         /// Show per-category score breakdown explaining why each spec lost points
         #[arg(long)]
         explain: bool,
-        /// Specific spec files or module names to validate (validates all if omitted)
+        /// Spec filters — validates all if omitted. Matches by: module name (e.g. "cli"),
+        /// filename stem ("cli.spec"), relative path ("specs/cli/cli.spec.md"), or absolute path.
         #[arg(value_name = "SPEC")]
         specs: Vec<String>,
     },
@@ -78,7 +79,8 @@ pub enum Command {
         /// Show detailed per-category breakdown explaining exactly why each spec lost points
         #[arg(long)]
         explain: bool,
-        /// Specific spec files or module names to score (scores all if omitted)
+        /// Spec filters — scores all if omitted. Matches by: module name (e.g. "cli"),
+        /// filename stem ("cli.spec"), relative path ("specs/cli/cli.spec.md"), or absolute path.
         #[arg(value_name = "SPEC")]
         specs: Vec<String>,
     },

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -60,9 +60,10 @@ pub fn cmd_check(
                 println!("No spec files found. Run `specsync generate` to scaffold specs.");
             }
             Text => {
+                let abs_specs = root.join(&config.specs_dir);
                 println!(
                     "No spec files found in {}/. Run `specsync generate` to scaffold specs.",
-                    config.specs_dir
+                    abs_specs.display()
                 );
             }
         }
@@ -85,9 +86,15 @@ pub fn cmd_check(
 
     let skipped = spec_files.len() - specs_to_validate.len();
     if skipped > 0 && matches!(format, Text) {
+        let cache_path = root.join(".specsync").join("hashes.json");
         println!(
-            "{} Skipped {skipped} unchanged spec(s) (use --force to re-validate all)\n",
+            "{} Skipped {skipped} unchanged spec(s) (use --force/--no-cache to re-validate all)",
             "⊘".cyan()
+        );
+        println!(
+            "  {} Cache: {}\n",
+            "ℹ".dimmed(),
+            cache_path.display()
         );
     }
 

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -91,11 +91,7 @@ pub fn cmd_check(
             "{} Skipped {skipped} unchanged spec(s) (use --force/--no-cache to re-validate all)",
             "⊘".cyan()
         );
-        println!(
-            "  {} Cache: {}\n",
-            "ℹ".dimmed(),
-            cache_path.display()
-        );
+        println!("  {} Cache: {}\n", "ℹ".dimmed(), cache_path.display());
     }
 
     if specs_to_validate.is_empty() && matches!(format, Text) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,9 +46,10 @@ pub fn load_and_discover(root: &Path, allow_empty: bool) -> (types::SpecSyncConf
         .collect();
 
     if spec_files.is_empty() && !allow_empty {
+        let abs_specs = root.join(&config.specs_dir);
         println!(
             "No spec files found in {}/. Run `specsync generate` to scaffold specs.",
-            config.specs_dir
+            abs_specs.display()
         );
         process::exit(0);
     }


### PR DESCRIPTION
## Summary

- **`--no-cache` flag** — discoverable alias for `--force` + cache location hint when specs are skipped (#178)
- **Absolute paths in errors** — "No spec files found" now shows the full resolved path (#177)
- **Clearer help text** — spec filter args now document all four matching modes (#179)
- **Close #172** — `--json` on `score` already works via the global `--json` / `--format json` flags

Closes #177 #178 #179 #172

## Test plan

- [x] `cargo test` — 473 unit + 80 integration tests pass
- [x] `cargo run -- score --json cli` — JSON output confirmed working
- [x] `cargo run -- check --help` — `--no-cache` alias visible
- [x] Build compiles clean with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)