### PR TITLE
fix(docs): clarify requirements convention — companion file, not inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Every spec must include these `##` sections (configurable in `specsync.json`):
 
 Purpose, Public API, Invariants, Behavioral Examples, Error Cases, Dependencies, Change Log
 
+> **Note:** Requirements (user stories, acceptance criteria) belong in a companion `requirements.md` file, not inline in the spec. Specs are technical contracts; requirements are product intent. See [Companion Files](#companion-files) below.
+
 ### Public API Tables
 
 SpecSync extracts the first backtick-quoted name per row and cross-references it against code exports:
@@ -378,6 +380,8 @@ When you run `specsync generate` or `specsync add-spec`, three companion files a
 | `requirements.md` | Product/Design | No | The ask, acceptance criteria |
 
 All scaffolded by SpecSync, all human-filled. Only the spec gets bidirectional validation.
+
+> **Convention:** Requirements (user stories, acceptance criteria) must live in `requirements.md`, not as inline `## Requirements` sections inside the spec. Specs define the *technical contract*; requirements capture *product intent*. Inline requirements in non-draft specs produce a warning prompting you to move them to the companion file.
 
 **`requirements.md`** — Product requirements and acceptance criteria:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -82,6 +82,8 @@ Creates `specs/auth/` with four files:
 
 The spec file is the only one SpecSync validates against code. The companion files provide structured context for humans and AI agents working on the module.
 
+> **Convention:** Requirements (user stories, acceptance criteria) belong in `requirements.md`, not as inline sections in the spec. Non-draft specs with inline `## Requirements` or `## Acceptance Criteria` sections will produce a warning.
+
 ### Option B: Scaffold all unspecced modules
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,7 +88,7 @@ pub enum Command {
     Watch,
     /// Run as an MCP (Model Context Protocol) server over stdio
     Mcp,
-    /// Scaffold a new spec with companion files (tasks.md, context.md)
+    /// Scaffold a new spec with companion files (requirements.md, tasks.md, context.md)
     AddSpec {
         /// Module name for the new spec
         name: String,

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -199,13 +199,13 @@ mod tests {
     fn test_classify_requirements_companion() {
         assert_eq!(
             WarningCategory::classify(
-                "Missing companion requirements.md — run `specsync generate` or create one manually"
+                "Missing companion requirements.md — run `specsync add-spec <name>` or `specsync generate` to scaffold one"
             ),
             Some(WarningCategory::RequirementsCompanion)
         );
         assert_eq!(
             WarningCategory::classify(
-                "Requirements appear inline in the spec body — move to a companion requirements.md file"
+                "Inline requirements detected — specs are technical contracts; user stories and acceptance criteria belong in a companion requirements.md file"
             ),
             Some(WarningCategory::RequirementsCompanion)
         );
@@ -286,7 +286,7 @@ mod tests {
 
         let inline = HashSet::new();
         assert!(rules.is_suppressed(
-            "Missing companion requirements.md — run `specsync generate`",
+            "Missing companion requirements.md — run `specsync add-spec <name>` or `specsync generate` to scaffold one",
             "specs/auth/auth.spec.md",
             &inline,
         ));

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -471,10 +471,10 @@ pub fn validate_spec(
         };
         if has_inline_requirements {
             result.warnings.push(
-                "Requirements appear inline in the spec body — move to a companion requirements.md file".to_string()
+                "Inline requirements detected — specs are technical contracts; user stories and acceptance criteria belong in a companion requirements.md file".to_string()
             );
             result.fixes.push(
-                "Create a requirements.md alongside the spec with ## User Stories and ## Acceptance Criteria sections".to_string()
+                "Run `specsync add-spec <name>` to scaffold requirements.md, then move ## Requirements / ## Acceptance Criteria content there".to_string()
             );
         }
 
@@ -483,7 +483,7 @@ pub fn validate_spec(
             let req_path = parent.join("requirements.md");
             if !req_path.exists() {
                 result.warnings.push(
-                    "Missing companion requirements.md — run `specsync generate` or create one manually".to_string()
+                    "Missing companion requirements.md — run `specsync add-spec <name>` or `specsync generate` to scaffold one".to_string()
                 );
             }
         }


### PR DESCRIPTION
## Summary

Closes #163. Resolves ambiguity about whether requirements should be inline in the spec or in a separate companion file.

- **README**: Added notes in "Required Sections" and "Companion Files" sections making the convention explicit — requirements belong in `requirements.md`, not inline
- **Validator**: Improved warning messages to explain *why* (specs are technical contracts; requirements capture product intent)
- **CLI**: Fixed `add-spec` help text to list `requirements.md` among companion files
- **docs/workflow.md**: Added convention callout after the four-file table
- **Tests**: Updated hardcoded warning strings in `ignore.rs`

## Test plan

- [ ] CI passes (Rust build + tests)
- [ ] `specsync check` on a spec with inline `## Requirements` shows the improved warning
- [ ] `specsync add-spec --help` lists `requirements.md` in companion files


🤖 Generated with [Claude Code](https://claude.com/claude-code)