### PR TITLE
feat(mcp): add resource support for browsable spec tree

### DIFF
--- a/specs/mcp/mcp.spec.md
+++ b/specs/mcp/mcp.spec.md
@@ -13,6 +13,7 @@ depends_on:
   - specs/scoring/scoring.spec.md
   - specs/generator/generator.spec.md
   - specs/ai/ai.spec.md
+  - specs/deps/deps.spec.md
 ---
 
 # Mcp
@@ -32,13 +33,15 @@ Model Context Protocol (MCP) server for AI agent integration. Implements JSON-RP
 ## Invariants
 
 1. Protocol version is "2024-11-05"
-2. Server reports capabilities with `tools: {}` — no prompts or resources
-3. Six tools are exposed: `specsync_check`, `specsync_coverage`, `specsync_generate`, `specsync_list_specs`, `specsync_init`, `specsync_score`
+2. Server reports capabilities with `tools: {}` and `resources: {}`
+3. Seven tools are exposed: `specsync_check`, `specsync_coverage`, `specsync_generate`, `specsync_list_specs`, `specsync_init`, `specsync_score`, `specsync_issues`
 4. All tool responses use `content: [{ type: "text", text: "..." }]` format
-5. Errors are returned as `isError: true` in the result, not as JSON-RPC errors (except parse errors and method-not-found)
+5. Errors are returned as `isError: true` in the result, not as JSON-RPC errors (except parse errors, method-not-found, and resource-not-found)
 6. Notifications (requests without `id`) receive no response
 7. `ping` method returns an empty result object
 8. Each tool accepts an optional `root` parameter to override the default project root
+9. Four static resources are exposed: `specsync:///specs`, `specsync:///graph`, `specsync:///config`, `specsync:///coverage`
+10. One resource template is exposed: `specsync:///specs/{module}` for reading individual specs
 
 ## Behavioral Examples
 
@@ -54,6 +57,18 @@ Model Context Protocol (MCP) server for AI agent integration. Implements JSON-RP
 - **When** the server processes the request
 - **Then** responds with validation results including passed/failed status, errors, and warnings
 
+### Scenario: List available resources
+
+- **Given** a client sends `{"jsonrpc":"2.0","id":2,"method":"resources/list"}`
+- **When** the server processes the request
+- **Then** responds with 4 static resources and 1 resource template
+
+### Scenario: Read a spec by module name
+
+- **Given** a client sends `{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"specsync:///specs/auth"}}`
+- **When** the module "auth" exists in the project
+- **Then** responds with the full spec content as text/markdown
+
 ### Scenario: Unknown method
 
 - **Given** a client sends a request with `method: "unknown/method"` and an `id`
@@ -67,6 +82,8 @@ Model Context Protocol (MCP) server for AI agent integration. Implements JSON-RP
 | Malformed JSON input | JSON-RPC error -32700 "Parse error" |
 | Unknown method with id | JSON-RPC error -32601 "Method not found" |
 | Unknown tool name | Tool error: "Unknown tool: {name}" |
+| Unknown resource URI | JSON-RPC error -32602 "Unknown resource URI: {uri}" |
+| Spec module not found | JSON-RPC error -32602 "No spec found for module: {name}" |
 | No spec files found | Tool error with suggestion to run `specsync generate` |
 | stdin EOF | Server exits gracefully |
 
@@ -83,6 +100,7 @@ Model Context Protocol (MCP) server for AI agent integration. Implements JSON-RP
 | ai | `resolve_ai_provider` |
 | parser | `parse_frontmatter` |
 | types | `SpecSyncConfig` |
+| deps | `build_dep_graph`, `validate_deps`, `topological_sort` |
 
 ### Consumed By
 
@@ -94,4 +112,5 @@ Model Context Protocol (MCP) server for AI agent integration. Implements JSON-RP
 
 | Date | Change |
 |------|--------|
+| 2026-04-10 | Add MCP resources: specs list, spec by module, dependency graph, config, coverage |
 | 2026-03-25 | Initial spec |

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -382,7 +382,10 @@ fn resource_specs_list(root: &Path) -> Result<(String, &'static str), String> {
         .collect();
 
     let output = json!({ "specs": specs, "count": specs.len() });
-    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
+    Ok((
+        serde_json::to_string_pretty(&output).unwrap(),
+        "application/json",
+    ))
 }
 
 fn resource_spec_by_module(root: &Path, module: &str) -> Result<(String, &'static str), String> {
@@ -453,7 +456,10 @@ fn resource_graph(root: &Path) -> Result<(String, &'static str), String> {
         "topological_order": topo,
     });
 
-    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
+    Ok((
+        serde_json::to_string_pretty(&output).unwrap(),
+        "application/json",
+    ))
 }
 
 fn resource_config(root: &Path) -> Result<(String, &'static str), String> {
@@ -467,7 +473,10 @@ fn resource_config(root: &Path) -> Result<(String, &'static str), String> {
         "schema_dir": config.schema_dir,
     });
 
-    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
+    Ok((
+        serde_json::to_string_pretty(&output).unwrap(),
+        "application/json",
+    ))
 }
 
 fn resource_coverage(root: &Path) -> Result<(String, &'static str), String> {
@@ -509,7 +518,10 @@ fn resource_coverage(root: &Path) -> Result<(String, &'static str), String> {
         "uncovered_files": uncovered_files,
     });
 
-    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
+    Ok((
+        serde_json::to_string_pretty(&output).unwrap(),
+        "application/json",
+    ))
 }
 
 // ─── Tool Implementations ────────────────────────────────────────────────
@@ -1251,7 +1263,10 @@ mod tests {
         assert_eq!(resp["jsonrpc"], "2.0");
         let resources = resp["result"]["resources"].as_array().unwrap();
         assert_eq!(resources.len(), 4);
-        let uris: Vec<&str> = resources.iter().map(|r| r["uri"].as_str().unwrap()).collect();
+        let uris: Vec<&str> = resources
+            .iter()
+            .map(|r| r["uri"].as_str().unwrap())
+            .collect();
         assert!(uris.contains(&"specsync:///specs"));
         assert!(uris.contains(&"specsync:///graph"));
         assert!(uris.contains(&"specsync:///config"));
@@ -1316,10 +1331,12 @@ mod tests {
         let tmp = setup_project();
         let params = json!({ "uri": "specsync:///specs/nonexistent" });
         let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
-        assert!(resp["error"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("No spec found"));
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("No spec found")
+        );
     }
 
     #[test]
@@ -1358,9 +1375,11 @@ mod tests {
         let tmp = setup_project();
         let params = json!({ "uri": "specsync:///bogus" });
         let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
-        assert!(resp["error"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("Unknown resource URI"));
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("Unknown resource URI")
+        );
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,5 +1,6 @@
 use crate::ai;
 use crate::config::{detect_source_dirs, load_config};
+use crate::deps::build_dep_graph;
 use crate::generator::generate_specs_for_unspecced_modules_paths;
 use crate::scoring;
 use crate::types::SpecSyncConfig;
@@ -54,6 +55,11 @@ pub fn run_mcp_server(root: &Path) {
                 let params = request.get("params").cloned().unwrap_or(json!({}));
                 Some(handle_tools_call(id, &params, root))
             }
+            "resources/list" => Some(handle_resources_list(id)),
+            "resources/read" => {
+                let params = request.get("params").cloned().unwrap_or(json!({}));
+                Some(handle_resources_read(id, &params, root))
+            }
             "ping" => Some(json!({ "jsonrpc": "2.0", "id": id, "result": {} })),
             _ => {
                 // Notifications (no id) get no response
@@ -83,7 +89,8 @@ fn handle_initialize(id: Option<Value>) -> Value {
         "result": {
             "protocolVersion": PROTOCOL_VERSION,
             "capabilities": {
-                "tools": {}
+                "tools": {},
+                "resources": {}
             },
             "serverInfo": {
                 "name": SERVER_NAME,
@@ -252,6 +259,257 @@ fn handle_tools_call(id: Option<Value>, params: &Value, default_root: &Path) -> 
             }
         }),
     }
+}
+
+// ─── Resource Handlers ──────────────────────────────────────────────────
+
+fn handle_resources_list(id: Option<Value>) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "resources": [
+                {
+                    "uri": "specsync:///specs",
+                    "name": "All Specs",
+                    "description": "List all spec modules with metadata (name, path, version, status, score)",
+                    "mimeType": "application/json"
+                },
+                {
+                    "uri": "specsync:///graph",
+                    "name": "Dependency Graph",
+                    "description": "Cross-module dependency graph with edges, cycles, and topological order",
+                    "mimeType": "application/json"
+                },
+                {
+                    "uri": "specsync:///config",
+                    "name": "Configuration",
+                    "description": "Current specsync.json configuration",
+                    "mimeType": "application/json"
+                },
+                {
+                    "uri": "specsync:///coverage",
+                    "name": "Coverage Report",
+                    "description": "File and LOC coverage metrics — which modules have specs and which don't",
+                    "mimeType": "application/json"
+                }
+            ],
+            "resourceTemplates": [
+                {
+                    "uriTemplate": "specsync:///specs/{module}",
+                    "name": "Spec by Module",
+                    "description": "Read a specific spec's full content with parsed frontmatter and score",
+                    "mimeType": "text/markdown"
+                }
+            ]
+        }
+    })
+}
+
+fn handle_resources_read(id: Option<Value>, params: &Value, root: &Path) -> Value {
+    let uri = params.get("uri").and_then(|u| u.as_str()).unwrap_or("");
+
+    let result = match uri {
+        "specsync:///specs" => resource_specs_list(root),
+        "specsync:///graph" => resource_graph(root),
+        "specsync:///config" => resource_config(root),
+        "specsync:///coverage" => resource_coverage(root),
+        _ if uri.starts_with("specsync:///specs/") => {
+            let module = &uri["specsync:///specs/".len()..];
+            resource_spec_by_module(root, module)
+        }
+        _ => Err(format!("Unknown resource URI: {uri}")),
+    };
+
+    match result {
+        Ok((content, mime_type)) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": mime_type,
+                    "text": content
+                }]
+            }
+        }),
+        Err(msg) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": -32602, "message": msg }
+        }),
+    }
+}
+
+// ─── Resource Implementations ───────────────────────────────────────────
+
+fn resource_specs_list(root: &Path) -> Result<(String, &'static str), String> {
+    let (config, spec_files) = load_and_discover(root, true)?;
+
+    let specs: Vec<Value> = spec_files
+        .iter()
+        .map(|f| {
+            let content = std::fs::read_to_string(f).unwrap_or_default();
+            let parsed = crate::parser::parse_frontmatter(&content);
+            let score = scoring::score_spec(f, root, &config);
+            let relative = f
+                .strip_prefix(root)
+                .unwrap_or(f)
+                .to_string_lossy()
+                .to_string();
+
+            if let Some(parsed) = parsed {
+                let fm = parsed.frontmatter;
+                json!({
+                    "path": relative,
+                    "module": fm.module,
+                    "version": fm.version,
+                    "status": fm.status,
+                    "files": fm.files,
+                    "depends_on": fm.depends_on,
+                    "score": score.total,
+                    "grade": score.grade,
+                })
+            } else {
+                json!({
+                    "path": relative,
+                    "module": null,
+                    "score": score.total,
+                    "grade": score.grade,
+                })
+            }
+        })
+        .collect();
+
+    let output = json!({ "specs": specs, "count": specs.len() });
+    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
+}
+
+fn resource_spec_by_module(root: &Path, module: &str) -> Result<(String, &'static str), String> {
+    let (_config, spec_files) = load_and_discover(root, true)?;
+
+    // Find the spec file matching this module name
+    for f in &spec_files {
+        let content = match std::fs::read_to_string(f) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let parsed = crate::parser::parse_frontmatter(&content);
+        let matches = parsed
+            .as_ref()
+            .and_then(|p| p.frontmatter.module.as_deref())
+            .map(|m| m == module)
+            .unwrap_or(false);
+
+        if matches {
+            return Ok((content, "text/markdown"));
+        }
+    }
+
+    Err(format!("No spec found for module: {module}"))
+}
+
+fn resource_graph(root: &Path) -> Result<(String, &'static str), String> {
+    let config = load_config(root);
+    let graph = build_dep_graph(root, &config.specs_dir);
+
+    let nodes: Vec<Value> = graph
+        .values()
+        .map(|node| {
+            json!({
+                "module": node.module,
+                "spec_path": node.spec_path,
+                "depends_on": node.declared_deps,
+                "files": node.files,
+            })
+        })
+        .collect();
+
+    // Build edges list
+    let mut edges: Vec<Value> = Vec::new();
+    for node in graph.values() {
+        for dep in &node.declared_deps {
+            edges.push(json!({
+                "from": node.module,
+                "to": dep,
+            }));
+        }
+    }
+
+    // Detect cycles
+    let cycles = crate::deps::validate_deps(root, &config.specs_dir).cycles;
+    let cycle_values: Vec<Value> = cycles.iter().map(|c| json!(c)).collect();
+
+    // Topological order
+    let topo = crate::deps::topological_sort(&graph);
+
+    let output = json!({
+        "modules": nodes,
+        "edges": edges,
+        "module_count": graph.len(),
+        "edge_count": edges.len(),
+        "cycles": cycle_values,
+        "topological_order": topo,
+    });
+
+    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
+}
+
+fn resource_config(root: &Path) -> Result<(String, &'static str), String> {
+    let config = load_config(root);
+    let output = json!({
+        "specs_dir": config.specs_dir,
+        "source_dirs": config.source_dirs,
+        "required_sections": config.required_sections,
+        "exclude_dirs": config.exclude_dirs,
+        "exclude_patterns": config.exclude_patterns,
+        "schema_dir": config.schema_dir,
+    });
+
+    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
+}
+
+fn resource_coverage(root: &Path) -> Result<(String, &'static str), String> {
+    let (config, spec_files) = load_and_discover(root, true)?;
+    let coverage = compute_coverage(root, &spec_files, &config);
+
+    let file_coverage = if coverage.total_source_files == 0 {
+        100.0
+    } else {
+        (coverage.specced_file_count as f64 / coverage.total_source_files as f64) * 100.0
+    };
+
+    let loc_coverage = if coverage.total_loc == 0 {
+        100.0
+    } else {
+        (coverage.specced_loc as f64 / coverage.total_loc as f64) * 100.0
+    };
+
+    let uncovered_modules: Vec<Value> = coverage
+        .unspecced_modules
+        .iter()
+        .map(|m| json!({ "name": m }))
+        .collect();
+
+    let uncovered_files: Vec<Value> = coverage
+        .unspecced_file_loc
+        .iter()
+        .map(|(f, loc)| json!({ "file": f, "loc": loc }))
+        .collect();
+
+    let output = json!({
+        "file_coverage_percent": (file_coverage * 100.0).round() / 100.0,
+        "files_covered": coverage.specced_file_count,
+        "files_total": coverage.total_source_files,
+        "loc_coverage_percent": (loc_coverage * 100.0).round() / 100.0,
+        "loc_covered": coverage.specced_loc,
+        "loc_total": coverage.total_loc,
+        "uncovered_modules": uncovered_modules,
+        "uncovered_files": uncovered_files,
+    });
+
+    Ok((serde_json::to_string_pretty(&output).unwrap(), "application/json"))
 }
 
 // ─── Tool Implementations ────────────────────────────────────────────────
@@ -675,6 +933,7 @@ mod tests {
         assert_eq!(resp["result"]["protocolVersion"], PROTOCOL_VERSION);
         assert_eq!(resp["result"]["serverInfo"]["name"], "specsync");
         assert!(resp["result"]["capabilities"]["tools"].is_object());
+        assert!(resp["result"]["capabilities"]["resources"].is_object());
     }
 
     #[test]
@@ -982,5 +1241,126 @@ mod tests {
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 99);
         assert_eq!(resp["result"]["isError"], true);
+    }
+
+    // --- handle_resources_list ---
+
+    #[test]
+    fn test_handle_resources_list_returns_resources() {
+        let resp = handle_resources_list(Some(json!(1)));
+        assert_eq!(resp["jsonrpc"], "2.0");
+        let resources = resp["result"]["resources"].as_array().unwrap();
+        assert_eq!(resources.len(), 4);
+        let uris: Vec<&str> = resources.iter().map(|r| r["uri"].as_str().unwrap()).collect();
+        assert!(uris.contains(&"specsync:///specs"));
+        assert!(uris.contains(&"specsync:///graph"));
+        assert!(uris.contains(&"specsync:///config"));
+        assert!(uris.contains(&"specsync:///coverage"));
+    }
+
+    #[test]
+    fn test_handle_resources_list_has_templates() {
+        let resp = handle_resources_list(Some(json!(1)));
+        let templates = resp["result"]["resourceTemplates"].as_array().unwrap();
+        assert_eq!(templates.len(), 1);
+        assert_eq!(
+            templates[0]["uriTemplate"].as_str().unwrap(),
+            "specsync:///specs/{module}"
+        );
+    }
+
+    // --- handle_resources_read ---
+
+    #[test]
+    fn test_resource_specs_list_empty() {
+        let tmp = setup_project();
+        let params = json!({ "uri": "specsync:///specs" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        assert_eq!(resp["jsonrpc"], "2.0");
+        let text = resp["result"]["contents"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["count"], 0);
+    }
+
+    #[test]
+    fn test_resource_specs_list_with_spec() {
+        let spec_content = "---\nmodule: auth\nversion: 2.0.0\nstatus: stable\nfiles:\n  - src/auth.rs\n---\n\n# Purpose\nAuth\n";
+        let tmp = setup_project_with_spec("auth", spec_content);
+
+        let params = json!({ "uri": "specsync:///specs" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        let text = resp["result"]["contents"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["count"], 1);
+        assert_eq!(parsed["specs"][0]["module"], "auth");
+        assert!(parsed["specs"][0]["score"].is_number());
+    }
+
+    #[test]
+    fn test_resource_spec_by_module() {
+        let spec_content = "---\nmodule: auth\nversion: 1.0.0\nstatus: draft\nfiles:\n  - src/auth.rs\n---\n\n# Purpose\nAuth module\n";
+        let tmp = setup_project_with_spec("auth", spec_content);
+
+        let params = json!({ "uri": "specsync:///specs/auth" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        let text = resp["result"]["contents"][0]["text"].as_str().unwrap();
+        assert!(text.contains("module: auth"));
+        assert_eq!(
+            resp["result"]["contents"][0]["mimeType"].as_str().unwrap(),
+            "text/markdown"
+        );
+    }
+
+    #[test]
+    fn test_resource_spec_by_module_not_found() {
+        let tmp = setup_project();
+        let params = json!({ "uri": "specsync:///specs/nonexistent" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        assert!(resp["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("No spec found"));
+    }
+
+    #[test]
+    fn test_resource_graph_empty() {
+        let tmp = setup_project();
+        let params = json!({ "uri": "specsync:///graph" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        let text = resp["result"]["contents"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["module_count"], 0);
+        assert_eq!(parsed["edge_count"], 0);
+    }
+
+    #[test]
+    fn test_resource_config() {
+        let tmp = setup_project();
+        let params = json!({ "uri": "specsync:///config" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        let text = resp["result"]["contents"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["specs_dir"], "specs");
+    }
+
+    #[test]
+    fn test_resource_coverage_empty() {
+        let tmp = setup_project();
+        let params = json!({ "uri": "specsync:///coverage" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        let text = resp["result"]["contents"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["file_coverage_percent"], 100.0);
+    }
+
+    #[test]
+    fn test_resource_unknown_uri() {
+        let tmp = setup_project();
+        let params = json!({ "uri": "specsync:///bogus" });
+        let resp = handle_resources_read(Some(json!(1)), &params, tmp.path());
+        assert!(resp["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("Unknown resource URI"));
     }
 }


### PR DESCRIPTION
## Summary

Adds MCP resource support so AI agents can browse and read spec files through the protocol — not just invoke tools. Closes #158.

- **4 static resources**: `specsync:///specs` (all specs with metadata/scores), `specsync:///graph` (dependency graph), `specsync:///config` (configuration), `specsync:///coverage` (coverage report)
- **1 resource template**: `specsync:///specs/{module}` — read a specific spec's full markdown content
- Updated `handle_initialize` to declare `resources: {}` capability
- 10 new unit tests covering all resource endpoints and error cases
- Updated MCP spec with new invariants, behavioral examples, error cases, and dependency on `deps` module

## Test plan

- [x] All 37 MCP unit tests pass (10 new resource tests)
- [x] All 9 MCP integration tests pass
- [x] Full test suite (97 tests) passes
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)