### PR TITLE
feat: cross-repo spec content verification (#159)

### DIFF
--- a/specs/cmd_resolve/cmd_resolve.spec.md
+++ b/specs/cmd_resolve/cmd_resolve.spec.md
@@ -1,11 +1,11 @@
 ---
 module: cmd_resolve
-version: 1
+version: 2
 status: stable
 files:
   - src/commands/resolve.rs
 db_tables: []
-tracks: []
+tracks: [159]
 depends_on:
   - specs/commands/commands.spec.md
   - specs/parser/parser.spec.md
@@ -17,7 +17,7 @@ depends_on:
 
 ## Purpose
 
-Implements the `specsync resolve` command. Resolves dependency references — local by file existence, cross-project via registry lookups. `--remote` fetches remote registries from GitHub.
+Implements the `specsync resolve` command. Resolves dependency references — local by file existence, cross-project via registry lookups. `--remote` fetches remote registries from GitHub. `--verify` performs deep content verification: fetches actual remote spec files, checks exports, validates bidirectional dependencies, and detects drift.
 
 ## Public API
 
@@ -25,29 +25,76 @@ Implements the `specsync resolve` command. Resolves dependency references — lo
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `cmd_resolve` | `root: &Path, remote: bool` | `()` | Resolve all dependency references; optionally fetch remote registries |
+| `cmd_resolve` | `root: &Path, remote: bool, verify: bool, cache_ttl: u64` | `()` | Resolve all dependency references; optionally verify remote content |
 
 ## Invariants
 
 1. Classifies deps as local vs cross-project
 2. Local verified by file existence
-3. No network calls without `--remote`
-4. Warnings for unresolvable refs (does not exit non-zero)
+3. No network calls without `--remote` or `--verify`
+4. `--verify` implies `--remote` — registry check always runs first
+5. Warnings for unresolvable refs (does not exit non-zero)
+6. `--verify` exits 1 on breaking drift (deprecated status, missing exports)
+7. Bidirectional dependency mismatches are warnings, not errors
+8. Remote spec content is cached with configurable TTL (default 1 hour)
+9. Cache stored in `.specsync-cache/remote-specs/` under project root
 
 ## Behavioral Examples
 
 ### Scenario: All local deps resolve
 
 - **Given** all `depends_on` point to existing files
-- **When** `cmd_resolve(root, false)` runs
-- **Then** prints "All N dependencies resolved"
+- **When** `cmd_resolve(root, false, false, 3600)` runs
+- **Then** prints green checkmarks for each resolved dependency
+
+### Scenario: Remote registry check
+
+- **Given** a spec with `depends_on: ["corvid-labs/algochat@auth"]`
+- **When** `cmd_resolve(root, true, false, 3600)` runs
+- **Then** fetches `specsync-registry.toml` from `corvid-labs/algochat`
+- **And** prints checkmark if `auth` module exists in the registry
+
+### Scenario: Verify detects deprecated remote spec
+
+- **Given** a cross-project ref to `remote-repo@parser`
+- **When** `cmd_resolve(root, true, true, 3600)` runs
+- **And** the remote spec's status is `deprecated`
+- **Then** prints `DRIFT remote-repo@parser: remote spec status is "deprecated"`
+- **And** exits with code 1
+
+### Scenario: Verify detects missing export
+
+- **Given** local spec consumes `parse_ast` from `remote-repo@parser`
+- **When** `cmd_resolve(root, true, true, 3600)` runs
+- **And** `parse_ast` no longer exists in remote spec's Public API table
+- **Then** prints `DRIFT ... but export 'parse_ast' no longer exists in remote spec`
+- **And** exits with code 1
+
+### Scenario: Verify warns on non-bidirectional dependency
+
+- **Given** local spec depends on `remote-repo@parser`
+- **When** `cmd_resolve(root, true, true, 3600)` runs
+- **And** remote spec does not reference our repo in its `depends_on`
+- **Then** prints `WARN ... but remote spec does not reference <our-repo>`
+- **And** does NOT exit non-zero (warning only)
+
+### Scenario: Cache avoids redundant fetches
+
+- **Given** a prior `--verify` run cached remote spec content
+- **When** `cmd_resolve(root, true, true, 3600)` runs within the TTL window
+- **Then** reads from `.specsync-cache/remote-specs/` instead of fetching
 
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
 | Local dep missing | Warning printed |
-| Remote fetch fails | Warning, continues |
+| Remote registry fetch fails | Warning, continues |
+| Remote spec fetch fails | Warning, continues |
+| Remote spec unparseable | Warning, continues |
+| Remote spec deprecated/removed | DRIFT error, exit 1 |
+| Consumed export missing from remote | DRIFT error, exit 1 |
+| Non-bidirectional dependency | Warning only |
 
 ## Dependencies
 
@@ -56,9 +103,10 @@ Implements the `specsync resolve` command. Resolves dependency references — lo
 | Module | What is used |
 |--------|-------------|
 | commands | `load_and_discover` |
-| parser | `parse_frontmatter` |
-| registry | `fetch_remote_registry` |
-| validator | `find_spec_files` |
+| parser | `parse_frontmatter`, `get_spec_symbols` |
+| registry | `fetch_remote_registry`, `fetch_remote_spec`, `parse_remote_spec`, `RemoteSpec` |
+| validator | `is_cross_project_ref`, `parse_cross_project_ref` |
+| github | `detect_repo` |
 
 ### Consumed By
 
@@ -70,4 +118,5 @@ Implements the `specsync resolve` command. Resolves dependency references — lo
 
 | Date | Change |
 |------|--------|
+| 2026-04-10 | v2: Added `--verify` for deep content verification, `--cache-ttl`, drift detection, exit codes |
 | 2026-04-09 | Initial spec |

--- a/specs/registry/registry.spec.md
+++ b/specs/registry/registry.spec.md
@@ -1,6 +1,6 @@
 ---
 module: registry
-version: 1
+version: 2
 status: stable
 files:
   - src/registry.rs
@@ -23,18 +23,22 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 | Type | Description |
 |------|-------------|
 | `RemoteRegistry` | A parsed remote registry with project name and list of (module, spec_path) entries |
+| `RemoteSpec` | Fetched remote spec content with parsed module, status, depends_on, exports, and body |
 
 ### Exported RemoteRegistry Functions
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `has_spec` | `module: &str` | `bool` | Check whether a module name exists in this registry |
+| `spec_path` | `module: &str` | `Option<&str>` | Get the spec file path for a module from the registry |
 
 ### Exported Functions
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `fetch_remote_registry` | `repo: &str` | `Result<RemoteRegistry, String>` | Fetch `specsync-registry.toml` from a GitHub repo's default branch via raw content URL |
+| `fetch_remote_spec` | `repo: &str, spec_path: &str` | `Result<String, String>` | Fetch a spec file's raw content from a GitHub repo |
+| `parse_remote_spec` | `module: &str, content: &str` | `Option<RemoteSpec>` | Parse fetched spec content into metadata for verification |
 | `load_registry` | `root: &Path` | `Option<RegistryEntry>` | Load a registry from a local `specsync-registry.toml` file |
 | `generate_registry` | `root, project_name, specs_dir` | `String` | Generate registry TOML content by scanning for spec files |
 | `register_module` | `root, module_name, spec_rel_path` | `bool` | Append a module entry to the registry file; returns false if already exists or file missing |
@@ -99,3 +103,4 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 |------|--------|
 | 2026-03-25 | Initial spec |
 | 2026-04-07 | Document register_module function |
+| 2026-04-10 | v2: Added `fetch_remote_spec`, `parse_remote_spec`, `RemoteSpec`, `spec_path` for cross-repo content verification |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,6 +130,14 @@ pub enum Command {
         /// network calls without this flag.
         #[arg(long)]
         remote: bool,
+        /// Deep-verify remote spec content: fetch actual spec files, check
+        /// exports still exist, validate bidirectional dependencies, and
+        /// detect drift. Implies --remote. Exit 1 if drift is detected.
+        #[arg(long)]
+        verify: bool,
+        /// Cache TTL in seconds for remote spec content (default: 3600 = 1 hour)
+        #[arg(long, default_value = "3600")]
+        cache_ttl: u64,
     },
     /// Show export changes since last commit (useful for CI/PR comments)
     Diff {

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -1,6 +1,8 @@
 use colored::Colorize;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 use crate::parser;
 use crate::registry;
@@ -8,10 +10,85 @@ use crate::validator;
 
 use super::load_and_discover;
 
-pub fn cmd_resolve(root: &Path, remote: bool) {
+/// Result of verifying a single cross-project reference.
+#[derive(Debug)]
+struct VerifyResult {
+    spec: String,
+    repo: String,
+    module: String,
+    issues: Vec<DriftIssue>,
+}
+
+/// A specific drift issue found during verification.
+#[derive(Debug)]
+#[allow(dead_code)]
+enum DriftIssue {
+    /// The remote spec has been deprecated.
+    Deprecated { status: String },
+    /// An export referenced locally no longer exists in the remote spec.
+    MissingExport { export: String },
+    /// The dependency is not bidirectional — remote spec doesn't depend back.
+    NotBidirectional { local_repo: String },
+    /// The remote spec file could not be fetched.
+    FetchFailed { reason: String },
+    /// The remote spec file could not be parsed.
+    ParseFailed,
+}
+
+/// Simple file-based cache for remote spec content.
+struct SpecCache {
+    cache_dir: std::path::PathBuf,
+    ttl: Duration,
+}
+
+impl SpecCache {
+    fn new(root: &Path, ttl_secs: u64) -> Self {
+        let cache_dir = root.join(".specsync-cache").join("remote-specs");
+        Self {
+            cache_dir,
+            ttl: Duration::from_secs(ttl_secs),
+        }
+    }
+
+    /// Get cached content if it exists and hasn't expired.
+    fn get(&self, repo: &str, spec_path: &str) -> Option<String> {
+        let cache_file = self.cache_path(repo, spec_path);
+        let metadata = fs::metadata(&cache_file).ok()?;
+        let modified = metadata.modified().ok()?;
+        let age = SystemTime::now().duration_since(modified).ok()?;
+        if age > self.ttl {
+            return None;
+        }
+        fs::read_to_string(&cache_file).ok()
+    }
+
+    /// Store content in cache.
+    fn set(&self, repo: &str, spec_path: &str, content: &str) {
+        let cache_file = self.cache_path(repo, spec_path);
+        if let Some(parent) = cache_file.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::write(&cache_file, content);
+    }
+
+    fn cache_path(&self, repo: &str, spec_path: &str) -> std::path::PathBuf {
+        // Sanitize repo and path for filesystem: owner/repo -> owner_repo
+        let safe_repo = repo.replace('/', "_");
+        let safe_path = spec_path.replace('/', "_");
+        self.cache_dir.join(format!("{safe_repo}__{safe_path}"))
+    }
+}
+
+pub fn cmd_resolve(root: &Path, remote: bool, verify: bool, cache_ttl: u64) {
     let (_config, spec_files) = load_and_discover(root, false);
     let mut cross_refs: Vec<(String, String, String)> = Vec::new();
     let mut local_refs: Vec<(String, String, bool)> = Vec::new();
+
+    // Track local spec exports for bidirectional checking
+    let mut local_exports: HashMap<String, Vec<String>> = HashMap::new();
+
+    // Detect our own repo for bidirectional checking
+    let local_repo = crate::github::detect_repo(root);
 
     for spec_file in &spec_files {
         let content = match fs::read_to_string(spec_file) {
@@ -28,6 +105,12 @@ pub fn cmd_resolve(root: &Path, remote: bool) {
             .unwrap_or(spec_file)
             .to_string_lossy()
             .to_string();
+
+        // Collect local exports for bidirectional checking
+        if let Some(module) = &parsed.frontmatter.module {
+            let exports = parser::get_spec_symbols(&parsed.body);
+            local_exports.insert(module.clone(), exports);
+        }
 
         for dep in &parsed.frontmatter.depends_on {
             if validator::is_cross_project_ref(dep) {
@@ -69,8 +152,7 @@ pub fn cmd_resolve(root: &Path, remote: bool) {
             // Fetch remote registries to verify cross-project refs
             let mut remote_errors = 0;
             // Group refs by repo to avoid duplicate fetches
-            let mut repos: std::collections::HashMap<String, Option<registry::RemoteRegistry>> =
-                std::collections::HashMap::new();
+            let mut repos: HashMap<String, Option<registry::RemoteRegistry>> = HashMap::new();
 
             for (_spec, repo, _module) in &cross_refs {
                 repos
@@ -87,6 +169,7 @@ pub fn cmd_resolve(root: &Path, remote: bool) {
                     });
             }
 
+            // Phase 1: Registry-level checks
             for (spec, repo, module) in &cross_refs {
                 match repos.get(repo) {
                     Some(Some(reg)) => {
@@ -121,6 +204,102 @@ pub fn cmd_resolve(root: &Path, remote: bool) {
                     "Warning:".yellow()
                 );
             }
+
+            // Phase 2: Deep content verification (--verify)
+            if verify {
+                let drift_issues = verify_remote_specs(
+                    &cross_refs,
+                    &repos,
+                    &local_exports,
+                    local_repo.as_deref(),
+                    root,
+                    cache_ttl,
+                );
+
+                if !drift_issues.is_empty() {
+                    println!("\n  {} Content verification:", "Verify".bold());
+
+                    let mut drift_count = 0;
+                    for result in &drift_issues {
+                        for issue in &result.issues {
+                            drift_count += 1;
+                            match issue {
+                                DriftIssue::Deprecated { status } => {
+                                    println!(
+                                        "    {} {repo}@{module}: remote spec status is \"{status}\"",
+                                        "DRIFT".red().bold(),
+                                        repo = result.repo,
+                                        module = result.module,
+                                    );
+                                }
+                                DriftIssue::MissingExport { export } => {
+                                    println!(
+                                        "    {} {spec} references {repo}@{module}, but export `{export}` no longer exists in remote spec",
+                                        "DRIFT".red().bold(),
+                                        spec = result.spec,
+                                        repo = result.repo,
+                                        module = result.module,
+                                    );
+                                }
+                                DriftIssue::NotBidirectional { local_repo } => {
+                                    println!(
+                                        "    {} {spec} depends on {repo}@{module}, but remote spec does not reference {local_repo}",
+                                        "WARN".yellow().bold(),
+                                        spec = result.spec,
+                                        repo = result.repo,
+                                        module = result.module,
+                                    );
+                                }
+                                DriftIssue::FetchFailed { reason } => {
+                                    println!(
+                                        "    {} {repo}@{module}: could not fetch spec content — {reason}",
+                                        "WARN".yellow().bold(),
+                                        repo = result.repo,
+                                        module = result.module,
+                                    );
+                                }
+                                DriftIssue::ParseFailed => {
+                                    println!(
+                                        "    {} {repo}@{module}: remote spec could not be parsed",
+                                        "WARN".yellow().bold(),
+                                        repo = result.repo,
+                                        module = result.module,
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    let drift_errors: usize = drift_issues
+                        .iter()
+                        .flat_map(|r| &r.issues)
+                        .filter(|i| {
+                            matches!(
+                                i,
+                                DriftIssue::Deprecated { .. } | DriftIssue::MissingExport { .. }
+                            )
+                        })
+                        .count();
+
+                    if drift_errors > 0 {
+                        println!(
+                            "\n  {} {drift_errors} drift issue(s) detected — specs have diverged from remote",
+                            "Error:".red().bold()
+                        );
+                        std::process::exit(1);
+                    } else {
+                        println!(
+                            "\n  {} {drift_count} warning(s), no breaking drift",
+                            "Info:".cyan()
+                        );
+                    }
+                } else {
+                    println!(
+                        "\n  {} All cross-project references verified — no drift detected",
+                        "✓".green()
+                    );
+                }
+            }
         } else {
             for (spec, repo, module) in &cross_refs {
                 println!("    {} {spec} -> {repo}@{module}", "→".cyan());
@@ -130,6 +309,310 @@ pub fn cmd_resolve(root: &Path, remote: bool) {
                 "Tip:".cyan()
             );
             println!("  Use --remote to fetch registries and verify they exist.");
+            println!("  Use --verify for deep content verification and drift detection.");
         }
+    }
+}
+
+/// Deep-verify remote spec content for drift.
+fn verify_remote_specs(
+    cross_refs: &[(String, String, String)],
+    repos: &HashMap<String, Option<registry::RemoteRegistry>>,
+    local_exports: &HashMap<String, Vec<String>>,
+    local_repo: Option<&str>,
+    root: &Path,
+    cache_ttl: u64,
+) -> Vec<VerifyResult> {
+    let cache = SpecCache::new(root, cache_ttl);
+    let mut results: Vec<VerifyResult> = Vec::new();
+
+    // Cache fetched+parsed remote specs to avoid re-fetching for duplicate refs
+    let mut remote_specs: HashMap<(String, String), Option<registry::RemoteSpec>> = HashMap::new();
+
+    for (spec, repo, module) in cross_refs {
+        let key = (repo.clone(), module.clone());
+
+        // Get or fetch the remote spec
+        let remote_spec = remote_specs.entry(key).or_insert_with(|| {
+            // Look up the spec path from the registry
+            let reg = repos.get(repo)?.as_ref()?;
+            let spec_path = reg.spec_path(module)?;
+
+            // Try cache first
+            let content = if let Some(cached) = cache.get(repo, spec_path) {
+                cached
+            } else {
+                match registry::fetch_remote_spec(repo, spec_path) {
+                    Ok(content) => {
+                        cache.set(repo, spec_path, &content);
+                        content
+                    }
+                    Err(_) => return None,
+                }
+            };
+
+            registry::parse_remote_spec(module, &content)
+        });
+
+        let mut issues = Vec::new();
+
+        match remote_spec {
+            Some(remote) => {
+                // Check 1: Status — is the remote spec deprecated?
+                if let Some(status) = &remote.status {
+                    let s = status.to_lowercase();
+                    if s == "deprecated" || s == "removed" || s == "archived" {
+                        issues.push(DriftIssue::Deprecated {
+                            status: status.clone(),
+                        });
+                    }
+                }
+
+                // Check 2: Exports — do the local spec's consumed exports still exist?
+                if !remote.exports.is_empty() {
+                    let consumed = find_consumed_exports(root, spec, module);
+                    for export in &consumed {
+                        if !remote.exports.iter().any(|e| e == export) {
+                            issues.push(DriftIssue::MissingExport {
+                                export: export.clone(),
+                            });
+                        }
+                    }
+                }
+
+                // Check 3: Bidirectional — does the remote depend back on us?
+                if let Some(our_repo) = local_repo {
+                    let remote_refs_us = remote.depends_on.iter().any(|dep| {
+                        if let Some((dep_repo, _)) = validator::parse_cross_project_ref(dep) {
+                            dep_repo == our_repo
+                        } else {
+                            false
+                        }
+                    });
+                    // Only warn if we have exports that the remote could consume
+                    if !remote_refs_us && !local_exports.is_empty() {
+                        issues.push(DriftIssue::NotBidirectional {
+                            local_repo: our_repo.to_string(),
+                        });
+                    }
+                }
+            }
+            None => {
+                // Could not fetch or parse — only flag if registry said it existed
+                if let Some(Some(reg)) = repos.get(repo) {
+                    if reg.has_spec(module) {
+                        issues.push(DriftIssue::FetchFailed {
+                            reason: "spec listed in registry but content unavailable".to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        if !issues.is_empty() {
+            results.push(VerifyResult {
+                spec: spec.clone(),
+                repo: repo.clone(),
+                module: module.clone(),
+                issues,
+            });
+        }
+    }
+
+    results
+}
+
+/// Find export names consumed from a specific remote module.
+///
+/// Scans the local spec's "### Consumes" table for rows matching the module name.
+/// Expected table format: `| module | What is used |`
+fn find_consumed_exports(root: &Path, spec_path: &str, remote_module: &str) -> Vec<String> {
+    let full_path = root.join(spec_path);
+    let content = match fs::read_to_string(&full_path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    let mut in_consumes = false;
+    let mut exports = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == "### Consumes" {
+            in_consumes = true;
+            continue;
+        }
+        if in_consumes && trimmed.starts_with("### ") {
+            break;
+        }
+        if !in_consumes {
+            continue;
+        }
+
+        // Parse table rows: | module | what_is_used |
+        if trimmed.starts_with('|') && !trimmed.contains("---") {
+            let cols: Vec<&str> = trimmed.split('|').map(|c| c.trim()).collect();
+            // cols[0] is empty (before first |), cols[1] is module, cols[2] is what's used
+            if cols.len() >= 3 {
+                let module_col = cols[1].trim_matches('`').trim();
+                if module_col.eq_ignore_ascii_case(remote_module) {
+                    // Parse "what is used" — may contain backtick-wrapped function names
+                    let usage = cols[2];
+                    for part in usage.split(',') {
+                        let part = part.trim();
+                        // Extract backtick-wrapped identifiers
+                        if let Some(start) = part.find('`') {
+                            if let Some(end) = part[start + 1..].find('`') {
+                                let name = &part[start + 1..start + 1 + end];
+                                if !name.is_empty() {
+                                    exports.push(name.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    exports
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_consumed_exports_parses_table() {
+        let spec_content = r#"---
+module: my_module
+version: 1
+status: stable
+files:
+  - src/my_module.rs
+depends_on:
+  - corvid-labs/algochat@auth
+---
+
+# My Module
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| auth | `verify_token`, `create_session` |
+| messaging | `send_message` |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| cli | Entry point |
+"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let spec_path = "specs/my_module/my_module.spec.md";
+        let full_path = dir.path().join(spec_path);
+        fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+        fs::write(&full_path, spec_content).unwrap();
+
+        let exports = find_consumed_exports(dir.path(), spec_path, "auth");
+        assert_eq!(exports, vec!["verify_token", "create_session"]);
+
+        let msg_exports = find_consumed_exports(dir.path(), spec_path, "messaging");
+        assert_eq!(msg_exports, vec!["send_message"]);
+
+        let none = find_consumed_exports(dir.path(), spec_path, "nonexistent");
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn test_find_consumed_exports_skips_header_row() {
+        let spec_content = r#"---
+module: test
+version: 1
+status: stable
+files: []
+depends_on: []
+---
+
+# Test
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| auth | `login` |
+"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let spec_path = "specs/test/test.spec.md";
+        let full_path = dir.path().join(spec_path);
+        fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+        fs::write(&full_path, spec_content).unwrap();
+
+        // "Module" is the header, should not match
+        let exports = find_consumed_exports(dir.path(), spec_path, "Module");
+        assert!(exports.is_empty());
+
+        let exports = find_consumed_exports(dir.path(), spec_path, "auth");
+        assert_eq!(exports, vec!["login"]);
+    }
+
+    #[test]
+    fn test_spec_cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = SpecCache::new(dir.path(), 3600);
+
+        cache.set("owner/repo", "specs/auth/auth.spec.md", "# Auth spec");
+        let cached = cache.get("owner/repo", "specs/auth/auth.spec.md");
+        assert_eq!(cached, Some("# Auth spec".to_string()));
+    }
+
+    #[test]
+    fn test_spec_cache_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = SpecCache::new(dir.path(), 3600);
+
+        let cached = cache.get("owner/repo", "specs/auth/auth.spec.md");
+        assert!(cached.is_none());
+    }
+
+    #[test]
+    fn test_spec_cache_expired() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = SpecCache::new(dir.path(), 0); // TTL = 0 seconds
+
+        cache.set("owner/repo", "specs/auth/auth.spec.md", "# Auth spec");
+        std::thread::sleep(Duration::from_millis(10));
+        let cached = cache.get("owner/repo", "specs/auth/auth.spec.md");
+        assert!(cached.is_none());
+    }
+
+    #[test]
+    fn test_verify_detects_deprecated_status() {
+        let remote = registry::RemoteSpec {
+            module: "auth".to_string(),
+            status: Some("deprecated".to_string()),
+            depends_on: vec![],
+            exports: vec![],
+            body: String::new(),
+        };
+        assert_eq!(remote.status.as_deref(), Some("deprecated"));
+    }
+
+    #[test]
+    fn test_cache_path_sanitizes_slashes() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = SpecCache::new(dir.path(), 3600);
+
+        let path = cache.cache_path("owner/repo", "specs/auth/auth.spec.md");
+        let filename = path.file_name().unwrap().to_str().unwrap();
+        assert!(!filename.contains('/'));
+        assert!(filename.contains("owner_repo__specs_auth_auth.spec.md"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,11 @@ fn run() {
             template,
         } => commands::scaffold::cmd_scaffold(&root, &name, dir, template),
         Command::InitRegistry { name } => commands::init_registry::cmd_init_registry(&root, name),
-        Command::Resolve { remote } => commands::resolve::cmd_resolve(&root, remote),
+        Command::Resolve {
+            remote,
+            verify,
+            cache_ttl,
+        } => commands::resolve::cmd_resolve(&root, remote || verify, verify, cache_ttl),
         Command::Diff { base } => commands::diff::cmd_diff(&root, &base, format),
         Command::Hooks { action } => commands::hooks::cmd_hooks(&root, action),
         Command::Compact { keep, dry_run } => commands::compact::cmd_compact(&root, keep, dry_run),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -19,6 +19,74 @@ impl RemoteRegistry {
     pub fn has_spec(&self, module: &str) -> bool {
         self.specs.iter().any(|(m, _)| m == module)
     }
+
+    /// Get the spec file path for a module.
+    pub fn spec_path(&self, module: &str) -> Option<&str> {
+        self.specs
+            .iter()
+            .find(|(m, _)| m == module)
+            .map(|(_, p)| p.as_str())
+    }
+}
+
+/// Fetched remote spec content with parsed metadata.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct RemoteSpec {
+    pub module: String,
+    pub status: Option<String>,
+    pub depends_on: Vec<String>,
+    pub exports: Vec<String>,
+    pub body: String,
+}
+
+/// Fetch a spec file's raw content from a GitHub repo.
+///
+/// `repo` is `owner/repo`, `spec_path` is the relative path from the registry.
+pub fn fetch_remote_spec(repo: &str, spec_path: &str) -> Result<String, String> {
+    let url = format!("https://raw.githubusercontent.com/{repo}/HEAD/{spec_path}");
+
+    let agent = ureq::Agent::new_with_config(
+        ureq::config::Config::builder()
+            .timeout_global(Some(Duration::from_secs(10)))
+            .build(),
+    );
+
+    let mut response = agent
+        .get(&url)
+        .call()
+        .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+    if response.status() != 200 {
+        return Err(format!(
+            "HTTP {} — could not fetch {spec_path} from {repo}",
+            response.status()
+        ));
+    }
+
+    response
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| format!("Failed to read response body: {e}"))
+}
+
+/// Parse a fetched spec into its relevant metadata for verification.
+pub fn parse_remote_spec(module: &str, content: &str) -> Option<RemoteSpec> {
+    use crate::parser;
+
+    let parsed = parser::parse_frontmatter(content)?;
+    let exports = parser::get_spec_symbols(&parsed.body);
+
+    Some(RemoteSpec {
+        module: parsed
+            .frontmatter
+            .module
+            .unwrap_or_else(|| module.to_string()),
+        status: parsed.frontmatter.status,
+        depends_on: parsed.frontmatter.depends_on,
+        exports,
+        body: parsed.body,
+    })
 }
 
 /// Fetch `specsync-registry.toml` from a GitHub repo's default branch.


### PR DESCRIPTION
## Summary

Implements #159 — cross-repo spec content verification via `specsync resolve --verify`.

- **`--verify` flag** — deep content verification that fetches actual remote spec files, not just registry existence checks
- **Drift detection** — checks for deprecated/removed status, missing exports (parsed from `### Consumes` tables), and non-bidirectional dependencies
- **TTL-based caching** — remote spec content cached in `.specsync-cache/remote-specs/` with configurable `--cache-ttl` (default 1 hour)
- **CI-friendly exit codes** — exits 1 on breaking drift (deprecated status, missing exports); warnings (non-bidirectional deps, fetch failures) don't block
- **6 new unit tests** for consumed-export parsing, cache roundtrip/expiry/miss, and path sanitization
- **Updated specs** — `cmd_resolve` v2 and `registry` v2 with new functions/types documented

### New registry.rs additions
- `RemoteSpec` struct — parsed remote spec with module, status, depends_on, exports, body
- `fetch_remote_spec()` — fetches raw spec file content from GitHub
- `parse_remote_spec()` — parses fetched content into verification metadata
- `RemoteRegistry::spec_path()` — get spec file path for a module

Full suite: 521 unit + 97 integration = 618 tests, all passing. Clippy clean.

## Test plan

- [x] `cargo clippy` — clean
- [x] `cargo test` — 618 tests pass (6 new)
- [ ] Manual: `specsync resolve --verify` against a repo with cross-project refs
- [ ] Manual: verify cache TTL behavior (run twice, check `.specsync-cache/`)
- [ ] Manual: verify exit code 1 on deprecated remote spec

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)