### PR TITLE
chore: v3.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-04-10
+
+### Added
+
+- **Staleness detection** — new `specsync stale` command identifies specs that haven't been updated since their source files changed. Also available via `specsync check --stale` (#189).
+- **AST-based export parsing** — tree-sitter powered export extraction replaces regex-based parsing for more accurate and reliable results across all supported languages (#192).
+- **Batch operations** — `specsync import --all-issues` and `--from-dir` for bulk import; `specsync score --format table|csv` for tabular output; `specsync generate --uncovered` and `--batch` for generating specs in bulk (#191).
+- **Declarative custom validation rules** — define project-specific validation rules in config that are checked alongside built-in rules (#190).
+- **Cross-repo spec content verification** — `specsync resolve --verify` fetches and validates referenced specs from remote repositories, ensuring cross-project refs point to real, valid content (#159, #195).
+- **MCP resource support** — agents can browse the spec tree via 5 new MCP resources (`specsync:///specs`, `specsync:///specs/{module}`, etc.) without knowing file paths (#194).
+
+### Fixed
+
+- **Requirements convention docs** — clarified that requirements belong in companion `requirements.md` files, not inline in specs (#163, #193).
+
 ## [3.7.0] - 2026-04-10
 
 ### Added
@@ -351,7 +366,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phantom documentation for non-existent exports (errors).
 - Dependency spec cross-referencing and Consumed By section validation.
 
-[3.4.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.4.1
+[3.8.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.8.0
+[3.7.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.7.0
+[3.6.2]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.6.2
+[3.6.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.6.1
+[3.6.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.6.0
 [3.5.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.5.0
 [3.4.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.4.1
 [3.4.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v3.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "3.7.0"
+version = "3.8.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
## Summary

Release v3.8.0 — 6 new features + 1 docs fix since v3.7.0.

### Highlights
- **Staleness detection** — `specsync stale` command (#189)
- **AST-based export parsing** via tree-sitter (#192)
- **Batch operations** — bulk import, tabular score output, batch generate (#191)
- **Declarative custom validation rules** (#190)
- **Cross-repo spec content verification** — `resolve --verify` (#195)
- **MCP resource support** — browsable spec tree for agents (#194)
- **Docs fix** — requirements convention clarification (#193)

### Changes
- `Cargo.toml` version bump: 3.7.0 → 3.8.0
- `Cargo.lock` updated
- `CHANGELOG.md` updated with all new entries

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] `cargo check` compiles clean
- [ ] Tag `v3.8.0` after merge
- [ ] Create GitHub release with binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)