### PR TITLE
docs: update all documentation for v4.0.0

### DIFF
--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -88,24 +88,21 @@ specsync generate --provider auto
 ### Configuring the AI command
 
 The AI command is resolved in order:
-1. `"aiCommand"` in `specsync.json`
+1. `ai_command` in `.specsync/config.toml` (or `.specsync/config.local.toml` for per-developer overrides)
 2. `SPECSYNC_AI_COMMAND` environment variable
 3. `claude -p --output-format text` (default, requires Claude CLI)
 
 Any command that reads a prompt from stdin and writes markdown to stdout works:
 
-```json
-{
-  "aiCommand": "claude -p --output-format text",
-  "aiTimeout": 300
-}
+```toml
+# .specsync/config.toml (or .specsync/config.local.toml for per-developer overrides)
+ai_command = "claude -p --output-format text"
+ai_timeout = 300
 ```
 
-```json
-{
-  "aiCommand": "ollama run llama3",
-  "aiTimeout": 60
-}
+```toml
+ai_command = "ollama run llama3"
+ai_timeout = 60
 ```
 
 If AI generation fails for a module, it falls back to template generation automatically.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ How SpecSync is built. Useful for contributors and anyone adding language suppor
 src/
 ├── main.rs              CLI entry point (clap) + output formatting
 ├── types.rs             Core data types, config schema, enums
-├── config.rs            specsync.json / specsync.toml loading + auto-detection
+├── config.rs            .specsync/config.toml loading + legacy fallback
 ├── parser.rs            Frontmatter + spec body parsing
 ├── validator.rs         Validation pipeline + coverage computation
 ├── generator.rs         Spec scaffolding (template + AI-powered)
@@ -34,7 +34,7 @@ src/
 ├── mcp.rs               MCP server (JSON-RPC over stdio, tools for check/generate/score)
 ├── watch.rs             File watcher (notify, 500ms debounce)
 ├── hash_cache.rs        Content-hash cache for incremental validation
-├── registry.rs          Cross-project module registry (specsync-registry.toml)
+├── registry.rs          Cross-project module registry (.specsync/registry.toml)
 ├── manifest.rs          Package manifest parsing (package.json, Cargo.toml, go.mod, etc.)
 ├── schema.rs            SQL schema parsing for db_tables validation
 ├── merge.rs             Git conflict resolution for spec files

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,7 +112,7 @@ Companion files sit alongside the spec and give agents structured context:
 
 ### `init-registry`
 
-Generate a `specsync-registry.toml` listing all modules in the project. Other projects reference your modules via this registry.
+Generate a `.specsync/registry.toml` listing all modules in the project. Other projects reference your modules via this registry.
 
 ```bash
 specsync init-registry                     # uses project folder name
@@ -130,7 +130,7 @@ specsync resolve                           # verify local refs
 specsync resolve --remote                  # also verify cross-project refs via GitHub
 ```
 
-Cross-project refs use the `owner/repo@module` syntax in `depends_on`. The `--remote` flag fetches the target repo's `specsync-registry.toml` from GitHub to confirm the module exists. See [Cross-Project References](cross-project-refs) for details.
+Cross-project refs use the `owner/repo@module` syntax in `depends_on`. The `--remote` flag fetches the target repo's `.specsync/registry.toml` from GitHub to confirm the module exists. See [Cross-Project References](cross-project-refs) for details.
 
 ### `hooks`
 
@@ -340,13 +340,13 @@ specsync lifecycle enforce --allowed       # check specs are in allowed statuses
 - Supports `--format json` for machine-readable output
 
 **Transition guards:**
-- Configure in `specsync.json` under `lifecycle.guards` (see [Configuration](../README.md#lifecycle-guards))
+- Configure in `.specsync/config.toml` under `[lifecycle.guards]` (see [Configuration](configuration))
 - Guards can require minimum score, required sections, or no-stale status
 - Use `lifecycle guard` to dry-run guard checks without changing status
 - Blocked transitions show which guards failed and why
 
 **Transition history:**
-- When `lifecycle.trackHistory` is enabled (default), transitions are recorded in frontmatter `lifecycle_log`
+- When `lifecycle.trackHistory` is enabled (default), transitions are recorded in `.specsync/lifecycle/<module>.json`
 - Use `lifecycle history <spec>` to view the full audit trail
 
 **Auto-promote:**
@@ -356,8 +356,8 @@ specsync lifecycle enforce --allowed       # check specs are in allowed statuses
 
 **CI enforcement (`enforce`):**
 - `--require-status`: every spec must have a valid `status` field in frontmatter
-- `--max-age`: flag specs stuck in a status longer than configured in `lifecycle.maxAge` (days per status)
-- `--allowed`: require all specs to have a status in `lifecycle.allowedStatuses`
+- `--max-age`: flag specs stuck in a status longer than configured in `[lifecycle] max_age` (days per status)
+- `--allowed`: require all specs to have a status in `[lifecycle] allowed_statuses`
 - `--all`: run all three checks at once
 - Exits non-zero if any violations are found — designed for CI pipelines
 
@@ -373,7 +373,7 @@ specsync diff v1.0.0 --json            # machine-readable output
 
 ### `init`
 
-Create a default `specsync.json` in the current directory.
+Create a default `.specsync/config.toml` in the current directory.
 
 ```bash
 specsync init

--- a/docs/cross-project-refs.md
+++ b/docs/cross-project-refs.md
@@ -37,7 +37,7 @@ depends_on:
 
 1. **You declare a cross-project dependency** in your spec's `depends_on`
 2. **`specsync resolve --remote`** parses the `owner/repo@module` syntax
-3. **Fetches `specsync-registry.toml`** from the target repo's default branch on GitHub
+3. **Fetches `.specsync/registry.toml`** from the target repo's default branch on GitHub
 4. **Checks that the module exists** in the registry
 
 No authentication required for public repos. Private repos need a `GITHUB_TOKEN` environment variable.
@@ -46,12 +46,12 @@ No authentication required for public repos. Private repos need a `GITHUB_TOKEN`
 
 ## Publishing Your Registry
 
-For other projects to reference your modules, commit a `specsync-registry.toml` to your repo's default branch:
+For other projects to reference your modules, commit `.specsync/registry.toml` to your repo's default branch:
 
 ```bash
 specsync init-registry                     # uses project folder name
 specsync init-registry --name myapp        # custom name
-git add specsync-registry.toml
+git add .specsync/registry.toml
 git commit -m "chore: add spec registry for cross-project refs"
 git push
 ```
@@ -115,5 +115,5 @@ Add `resolve --remote` to your CI pipeline to catch broken cross-project refs:
 |:---------|:-------|
 | Module not in registry | `✗ module not in registry` |
 | Repository not found | `! HTTP 404` + `? registry fetch failed` |
-| No registry file | `? registry fetch failed` (registry not committed) |
+| No registry file | `? registry fetch failed` (`.specsync/registry.toml` not committed) |
 | Network error | `? registry fetch failed` with details |

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -22,7 +22,7 @@ Run SpecSync in CI with zero setup. Auto-detects OS/arch, downloads the binary, 
 ## Basic Usage
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v3
+- uses: CorvidLabs/spec-sync@v4
   with:
     strict: 'true'
     require-coverage: '100'
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v3
+      - uses: CorvidLabs/spec-sync@v4
         with:
           strict: 'true'
           require-coverage: '100'
@@ -80,7 +80,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v3
+      - uses: CorvidLabs/spec-sync@v4
         with:
           strict: 'true'
           comment: 'true'
@@ -95,7 +95,7 @@ jobs:
 **Custom token (e.g., for private registries or cross-repo refs):**
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v3
+- uses: CorvidLabs/spec-sync@v4
   with:
     comment: 'true'
     token: ${{ secrets.MY_PAT }}
@@ -114,7 +114,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v3
+      - uses: CorvidLabs/spec-sync@v4
         with:
           strict: 'true'
 ```
@@ -124,7 +124,7 @@ jobs:
 ## Monorepo
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v3
+- uses: CorvidLabs/spec-sync@v4
   with:
     root: './packages/backend'
     strict: 'true'

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Specs reference functions that were renamed. Code exports things the spec doesn'
 
 ```bash
 cargo install specsync          # or use the GitHub Action, or download a binary
-specsync init                   # create specsync.json
+specsync init                   # create .specsync/config.toml
 specsync check                  # validate specs against code
 specsync coverage               # see what's covered
 specsync generate               # scaffold specs for unspecced modules
@@ -65,7 +65,7 @@ TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby.
 | New to SpecSync? | Already using it? |
 |:-----------------|:-----------------|
 | [Quick Start Guide](quickstart) — up and running in 5 min | [CLI Reference](cli) — all 14 commands |
-| [Why SpecSync?](why-specsync) — comparison with alternatives | [Configuration](configuration) — `specsync.json` options |
+| [Why SpecSync?](why-specsync) — comparison with alternatives | [Configuration](configuration) — `.specsync/config.toml` options |
 | [Spec Format](spec-format) — how to write specs | [Cross-Project Refs](cross-project-refs) — multi-repo validation |
 | [Workflow Guide](workflow) — full lifecycle | [AI Agents](ai-agents) — MCP server + AI generation |
 | [Architecture](architecture) — how it works | [VS Code Extension](vscode-extension) — editor integration |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,28 +44,26 @@ Navigate to your project root and run:
 specsync init
 ```
 
-This creates a `specsync.json` config file with auto-detected source directories. The config looks like:
+This creates `.specsync/config.toml` with auto-detected source directories. The config looks like:
 
-```json
-{
-  "specsDir": "specs",
-  "sourceDirs": ["src"],
-  "requiredSections": [
+```toml
+specs_dir = "specs"
+source_dirs = ["src"]
+required_sections = [
     "Purpose",
     "Public API",
     "Invariants",
     "Behavioral Examples",
     "Error Cases",
     "Dependencies",
-    "Change Log"
-  ]
-}
+    "Change Log",
+]
 ```
 
 **Key settings:**
-- `specsDir` — where spec files live (default: `specs/`)
-- `sourceDirs` — where your source code lives (auto-detected from package manifests)
-- `requiredSections` — what every spec must contain
+- `specs_dir` — where spec files live (default: `specs/`)
+- `source_dirs` — where your source code lives (auto-detected from package manifests)
+- `required_sections` — what every spec must contain
 
 See [Configuration](configuration.md) for all options.
 
@@ -198,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v3
+      - uses: CorvidLabs/spec-sync@v4
         with:
           strict: true
           require-coverage: 80

--- a/docs/spec-format.md
+++ b/docs/spec-format.md
@@ -61,13 +61,13 @@ depends_on:
   - corvid-labs/algochat@messaging           # Cross-project ref (validated by resolve --remote)
 ```
 
-Cross-project refs use the `owner/repo@module` syntax. Local refs are verified by `specsync check` and `specsync resolve`. Cross-project refs require `specsync resolve --remote` which fetches the target repo's `specsync-registry.toml` from GitHub. See [Cross-Project References](cross-project-refs) for the full workflow.
+Cross-project refs use the `owner/repo@module` syntax. Local refs are verified by `specsync check` and `specsync resolve`. Cross-project refs require `specsync resolve --remote` which fetches the target repo's `.specsync/registry.toml` from GitHub. See [Cross-Project References](cross-project-refs) for the full workflow.
 
 ---
 
 ## Required Sections
 
-Every spec must include these `## Heading` sections (configurable via `requiredSections` in `specsync.json`):
+Every spec must include these `## Heading` sections (configurable via `required_sections` in `.specsync/config.toml`):
 
 | Section | What SpecSync checks |
 |:--------|:---------------------|
@@ -81,8 +81,9 @@ Every spec must include these `## Heading` sections (configurable via `requiredS
 
 Override the list in config:
 
-```json
-{ "requiredSections": ["Purpose", "Public API"] }
+```toml
+# .specsync/config.toml
+required_sections = ["Purpose", "Public API"]
 ```
 
 ---

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -36,8 +36,10 @@ The extension requires the `specsync` CLI binary to be installed and on your PAT
 
 The extension activates automatically when your workspace contains any of:
 
-- `specsync.json`
-- `.specsync.toml`
+- `.specsync/config.toml` (v4)
+- `.specsync/config.json`
+- `specsync.json` (legacy)
+- `.specsync.toml` (legacy)
 - A `specs/` directory
 
 On activation, it runs an initial validation and displays results in the status bar.
@@ -67,7 +69,7 @@ All commands are available via the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+
 | `SpecSync: Show Coverage` | Open the coverage report webview |
 | `SpecSync: Score Spec Quality` | Open the scoring report webview |
 | `SpecSync: Generate Missing Specs` | Scaffold specs for unspecced modules |
-| `SpecSync: Initialize Config` | Create a `specsync.json` in the workspace root |
+| `SpecSync: Initialize Config` | Create `.specsync/config.toml` in the workspace root |
 
 ---
 
@@ -134,7 +136,7 @@ The scoring report (`SpecSync: Score Spec Quality`) shows:
 ## Troubleshooting
 
 **"SpecSync" not activating?**
-Ensure your workspace contains `specsync.json`, `.specsync.toml`, or a `specs/` directory.
+Ensure your workspace contains `.specsync/config.toml`, `specsync.json` (legacy), `.specsync.toml` (legacy), or a `specs/` directory.
 
 **"Command not found" errors?**
 The `specsync` binary must be on your PATH or configured via `specsync.binaryPath`. Check the Output panel (View → Output → SpecSync) for detailed logs.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -47,7 +47,7 @@ create → validate → iterate → stabilize → maintain → compact → archi
 specsync init
 ```
 
-This creates `specsync.json` with auto-detected source directories. Review it and adjust `specsDir`, `sourceDirs`, `excludeDirs`, and `requiredSections` as needed. See [Configuration](configuration) for all options.
+This creates `.specsync/config.toml` with auto-detected source directories. Review it and adjust `specs_dir`, `source_dirs`, `exclude_dirs`, and `required_sections` as needed. See [Configuration](configuration) for all options.
 
 ### Install hooks and agent instructions
 


### PR DESCRIPTION
## Summary

- Updates **10 docs files** to reflect the v4.0.0 directory structure
- `specsync.json` → `.specsync/config.toml` throughout
- `specsync-registry.toml` → `.specsync/registry.toml`
- `lifecycle_log` frontmatter → `.specsync/lifecycle/*.json`
- GitHub Action references `@v3` → `@v4`
- camelCase config keys → snake_case (TOML format)
- JSON config examples replaced with TOML where appropriate
- Legacy paths still mentioned where relevant (config fallback chain, VS Code activation) but clearly marked as legacy

## Test plan

- [ ] Verify docs site builds cleanly
- [ ] Spot-check rendered pages for broken formatting
- [ ] Confirm no stale v3 references remain (except legacy fallback mentions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)