### PR TITLE
fix: escape YAML document separator in action.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
 
+  validate-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate action.yml
+        run: python3 -c "import yaml; yaml.safe_load(open('action.yml'))"
+
   spec-check:
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -196,10 +196,7 @@ runs:
           exit 0
         fi
 
-        COMMENT_BODY="${SPECSYNC_MARKDOWN}
-
----
-<sub>Posted by [SpecSync](https://github.com/CorvidLabs/spec-sync) via GitHub Actions</sub>"
+        COMMENT_BODY="$(printf '%s\n\n---\n<sub>Posted by [SpecSync](https://github.com/CorvidLabs/spec-sync) via GitHub Actions</sub>' "$SPECSYNC_MARKDOWN")"
 
         # Check for existing SpecSync comment and update it, or create new
         EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \


### PR DESCRIPTION
## Summary
- The `---` in the PR comment template was unindented inside a YAML block scalar, causing GitHub Actions to fail with "Expected stream end parse event"
- Use `printf` to build the comment body so no bare `---` appears in the YAML

## Test plan
- [x] Verify `action.yml` parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('action.yml'))"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)