### PR TITLE
chore: v4.1.2 release prep — changelog + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.2] - 2026-04-11
+
+### Fixed
+
+- **`specsync comment` now respects `--strict` and `--require-coverage`** — Previously, `specsync comment` hardcoded pass/fail as `total_errors == 0`, ignoring strict mode, enforcement level, and coverage requirements. PR comments could show "✅ Passed" even when `specsync check --strict` correctly failed with exit code 1. Now uses the same `compute_exit_code()` logic as `check` (#213).
+
 ## [4.1.1] - 2026-04-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.1.1"
+version = "4.1.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.1.1"
+version = "4.1.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
## Summary
- Bump version to 4.1.2
- Add changelog entry for #213 (`specsync comment` now respects `--strict` and `--require-coverage`)

## After merge
Tag `v4.1.2` on main to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)