### PR TITLE
fix: detect merge conflicts in all spec .md files, not just *.spec.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.2] - 2026-04-11
+
+### Fixed
+
+- **`specsync comment` now respects `--strict` and `--require-coverage`** — Previously, `specsync comment` hardcoded pass/fail as `total_errors == 0`, ignoring strict mode, enforcement level, and coverage requirements. PR comments could show "✅ Passed" even when `specsync check --strict` correctly failed with exit code 1. Now uses the same `compute_exit_code()` logic as `check` (#213).
+
 ## [4.1.1] - 2026-04-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.1.1"
+version = "4.1.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.1.1"
+version = "4.1.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -107,7 +107,7 @@ fn detect_conflicted_specs(root: &Path, specs_dir: &Path) -> Vec<std::path::Path
 
     String::from_utf8_lossy(&output.stdout)
         .lines()
-        .filter(|l| l.starts_with(specs_rel.as_ref()) && l.ends_with(".spec.md"))
+        .filter(|l| l.starts_with(specs_rel.as_ref()) && l.ends_with(".md"))
         .map(|l| root.join(l))
         .collect()
 }


### PR DESCRIPTION
## Summary

- `specsync merge` only detected conflicts in `*.spec.md` files, silently skipping companion files like `tasks.md`, `requirements.md`, and `context.md`
- Broadens the filter in `detect_conflicted_specs()` to match any `.md` file under the specs directory

## Reproduction

Rebase a branch with conflicts in `specs/pet/tasks.md` → `specsync merge` reports "No spec files with merge conflicts found" despite active conflict markers.

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo test merge` — all 10 merge tests pass
- [ ] Manual: create a conflict in a non-`.spec.md` file under specs/, verify `specsync merge` now detects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)