### PR TITLE
chore: v4.1.3 release prep — changelog + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.3] - 2026-04-11
+
+### Fixed
+
+- **`specsync merge` now detects conflicts in all spec `.md` files** — Previously, merge conflict detection only matched `*.spec.md` files, silently skipping `tasks.md`, `requirements.md`, `context.md`, and other markdown files under the specs directory. Now matches any `.md` file in the specs path (#215).
+
 ## [4.1.2] - 2026-04-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.1.2"
+version = "4.1.3"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
## Summary

- Bumps version from 4.1.2 → 4.1.3
- Adds changelog entry for the `specsync merge` fix (#215) — merge conflict detection now finds all `.md` files under specs, not just `*.spec.md`

## Release checklist

- [x] Version bumped in `Cargo.toml`
- [x] `Cargo.lock` updated
- [x] Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)