### PR TITLE
feat: support YAML as source language for symbol extraction

### DIFF
--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -10,6 +10,7 @@ mod ruby;
 mod rust_lang;
 mod swift;
 mod typescript;
+mod yaml;
 
 use crate::types::{ExportLevel, Language, ParseMode};
 use std::path::Path;
@@ -122,6 +123,7 @@ fn extract_with_regex(content: &str, lang: Language, file_path: &Path) -> Vec<St
         Language::Dart => dart::extract_exports(content),
         Language::Php => php::extract_exports(content),
         Language::Ruby => ruby::extract_exports(content),
+        Language::Yaml => yaml::extract_exports(content),
     }
 }
 
@@ -183,6 +185,10 @@ fn filter_type_level_exports(content: &str, symbols: &[String], lang: Language) 
         }
         Language::Ruby => {
             Regex::new(r"(?m)(?:class|module)\s+([A-Z]\w*)").ok()
+        }
+        Language::Yaml => {
+            // YAML has no type declarations
+            return symbols.to_vec();
         }
     };
 

--- a/src/exports/yaml.rs
+++ b/src/exports/yaml.rs
@@ -1,0 +1,203 @@
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Top-level key: a line starting at column 0 with `key:` followed by space, newline, or EOF
+static TOP_LEVEL_KEY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^([a-zA-Z_][a-zA-Z0-9_-]*):(?:\s|$)").unwrap());
+
+/// YAML anchor: `&anchor-name`
+static ANCHOR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"&([a-zA-Z_][a-zA-Z0-9_.-]*)").unwrap());
+
+/// Well-known YAML keys whose children represent named entries worth extracting.
+/// e.g., `jobs:` in GitHub Actions, `services:` in Docker Compose.
+const NESTED_SYMBOL_PARENTS: &[&str] = &[
+    "jobs",
+    "services",
+    "volumes",
+    "networks",
+    "secrets",
+    "stages",
+    "steps",
+    "targets",
+    "outputs",
+    "inputs",
+    "permissions",
+    "deployments",
+];
+
+/// Extract symbols from YAML source content.
+///
+/// Symbols extracted:
+/// - All top-level keys
+/// - Named entries under well-known parent keys (e.g., `jobs.test`, `services.web`)
+/// - YAML anchors (`&anchor-name`)
+pub fn extract_exports(content: &str) -> Vec<String> {
+    let mut symbols = Vec::new();
+
+    // Collect top-level keys
+    let top_level_keys: Vec<String> = TOP_LEVEL_KEY
+        .captures_iter(content)
+        .filter_map(|caps| caps.get(1).map(|m| m.as_str().to_string()))
+        .collect();
+
+    for key in &top_level_keys {
+        symbols.push(key.clone());
+    }
+
+    // For well-known parent keys, extract second-level children as `parent.child`
+    // We scan line-by-line, matching against individual lines (no trailing newline)
+    let top_level_line =
+        Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
+    let second_level_line =
+        Regex::new(r"^  ([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
+
+    let lines: Vec<&str> = content.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        // Check if this is a top-level key that's a well-known parent
+        if let Some(caps) = top_level_line.captures(line) {
+            if let Some(key_match) = caps.get(1) {
+                let parent = key_match.as_str();
+                if NESTED_SYMBOL_PARENTS.contains(&parent) {
+                    // Scan subsequent lines for second-level keys under this parent
+                    let mut j = i + 1;
+                    while j < lines.len() {
+                        let child_line = lines[j];
+                        // Stop if we hit another top-level key or end of file
+                        if !child_line.is_empty()
+                            && !child_line.starts_with(' ')
+                            && !child_line.starts_with('#')
+                        {
+                            break;
+                        }
+                        if let Some(child_caps) = second_level_line.captures(child_line) {
+                            if let Some(child_match) = child_caps.get(1) {
+                                symbols
+                                    .push(format!("{}.{}", parent, child_match.as_str()));
+                            }
+                        }
+                        j += 1;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+
+    // Extract anchors
+    for caps in ANCHOR.captures_iter(content) {
+        if let Some(anchor) = caps.get(1) {
+            let name = anchor.as_str().to_string();
+            if !symbols.contains(&name) {
+                symbols.push(name);
+            }
+        }
+    }
+
+    symbols
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_github_actions_workflow() {
+        let content = r#"name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: []
+  lint:
+    runs-on: ubuntu-latest
+    steps: []
+  build:
+    runs-on: ubuntu-latest
+    steps: []
+"#;
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"name".to_string()));
+        assert!(symbols.contains(&"on".to_string()));
+        assert!(symbols.contains(&"jobs".to_string()));
+        assert!(symbols.contains(&"jobs.test".to_string()));
+        assert!(symbols.contains(&"jobs.lint".to_string()));
+        assert!(symbols.contains(&"jobs.build".to_string()));
+    }
+
+    #[test]
+    fn test_docker_compose() {
+        let content = r#"version: "3.8"
+services:
+  web:
+    image: nginx
+    ports: ["80:80"]
+  db:
+    image: postgres
+    environment: {}
+volumes:
+  pgdata:
+    driver: local
+"#;
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"version".to_string()));
+        assert!(symbols.contains(&"services".to_string()));
+        assert!(symbols.contains(&"services.web".to_string()));
+        assert!(symbols.contains(&"services.db".to_string()));
+        assert!(symbols.contains(&"volumes".to_string()));
+        assert!(symbols.contains(&"volumes.pgdata".to_string()));
+    }
+
+    #[test]
+    fn test_anchors() {
+        let content = r#"defaults: &defaults
+  timeout: 30
+  retries: 3
+jobs:
+  test:
+    <<: *defaults
+    command: test
+"#;
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"defaults".to_string()));
+        assert!(symbols.contains(&"jobs".to_string()));
+        assert!(symbols.contains(&"jobs.test".to_string()));
+        assert!(symbols.contains(&"defaults".to_string())); // anchor name matches key
+    }
+
+    #[test]
+    fn test_top_level_only() {
+        let content = r#"apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 3
+"#;
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"apiVersion".to_string()));
+        assert!(symbols.contains(&"kind".to_string()));
+        assert!(symbols.contains(&"metadata".to_string()));
+        assert!(symbols.contains(&"spec".to_string()));
+        // metadata.name should NOT be extracted since metadata is not a well-known parent
+        assert!(!symbols.contains(&"metadata.name".to_string()));
+    }
+
+    #[test]
+    fn test_comments_and_empty_lines() {
+        let content = r#"# This is a comment
+name: test
+
+# Another comment
+on:
+  push:
+    branches: [main]
+"#;
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"name".to_string()));
+        assert!(symbols.contains(&"on".to_string()));
+        assert_eq!(symbols.len(), 2);
+    }
+}

--- a/src/exports/yaml.rs
+++ b/src/exports/yaml.rs
@@ -47,10 +47,8 @@ pub fn extract_exports(content: &str) -> Vec<String> {
 
     // For well-known parent keys, extract second-level children as `parent.child`
     // We scan line-by-line, matching against individual lines (no trailing newline)
-    let top_level_line =
-        Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
-    let second_level_line =
-        Regex::new(r"^  ([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
+    let top_level_line = Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
+    let second_level_line = Regex::new(r"^  ([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
 
     let lines: Vec<&str> = content.lines().collect();
     let mut i = 0;
@@ -74,8 +72,7 @@ pub fn extract_exports(content: &str) -> Vec<String> {
                         }
                         if let Some(child_caps) = second_level_line.captures(child_line) {
                             if let Some(child_match) = child_caps.get(1) {
-                                symbols
-                                    .push(format!("{}.{}", parent, child_match.as_str()));
+                                symbols.push(format!("{}.{}", parent, child_match.as_str()));
                             }
                         }
                         j += 1;

--- a/src/types.rs
+++ b/src/types.rs
@@ -708,6 +708,7 @@ pub enum Language {
     Dart,
     Php,
     Ruby,
+    Yaml,
 }
 
 impl Language {
@@ -725,6 +726,7 @@ impl Language {
             "dart" => Some(Language::Dart),
             "php" => Some(Language::Php),
             "rb" => Some(Language::Ruby),
+            "yaml" | "yml" => Some(Language::Yaml),
             _ => None,
         }
     }
@@ -744,6 +746,7 @@ impl Language {
             Language::Dart => &["dart"],
             Language::Php => &["php"],
             Language::Ruby => &["rb"],
+            Language::Yaml => &["yaml", "yml"],
         }
     }
 
@@ -778,6 +781,7 @@ impl Language {
             Language::Dart => &["_test.dart"],
             Language::Php => &["Test.php", "test_"],
             Language::Ruby => &["_spec.rb", "_test.rb", "test_"],
+            Language::Yaml => &[], // YAML files are typically not test files
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Yaml` variant to the `Language` enum with `.yaml`/`.yml` extensions
- Creates `src/exports/yaml.rs` with regex-based symbol extraction
- Extracts top-level keys, named entries under well-known parent keys (e.g., `jobs.test`, `services.web`), and YAML anchors
- Wires into `extract_with_regex()` and `filter_type_level_exports()` dispatch

## Symbols Extracted

| Category | Example | Symbol |
|----------|---------|--------|
| Top-level keys | `name: CI` | `name` |
| Nested (well-known parents) | `jobs:\n  test:` | `jobs.test` |
| Anchors | `&defaults` | `defaults` |

Well-known parent keys: `jobs`, `services`, `volumes`, `networks`, `secrets`, `stages`, `steps`, `targets`, `outputs`, `inputs`, `permissions`, `deployments`

## Test plan

- [x] GitHub Actions workflow extraction (top-level + job names)
- [x] Docker Compose extraction (services + volumes)
- [x] YAML anchor extraction
- [x] K8s manifest (top-level only, no nested for non-well-known parents)
- [x] Comments and empty lines handled correctly
- [x] Full test suite passes (106/106)

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)