### PR TITLE
feat: add testing.md companion file support

### DIFF
--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -64,6 +64,7 @@ Creates `specs/auth/` with four files:
 | `requirements.md` | User stories, acceptance criteria, constraints | Product / Design |
 | `tasks.md` | Outstanding work items, review sign-offs | Anyone |
 | `context.md` | Design decisions, key files, current status | Developer / Agent |
+| `testing.md` | Test strategy, QA checklists, edge cases | QA / Developer |
 
 The spec file is the only one SpecSync validates against code. The companion files provide structured context for humans and AI agents working on the module.
 

--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -56,7 +56,7 @@ Check what's installed with `specsync hooks status`.
 specsync add-spec auth
 ```
 
-Creates `specs/auth/` with four files:
+Creates `specs/auth/` with five files:
 
 | File | Purpose | Who writes it |
 |:-----|:--------|:--------------|

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1192,6 +1192,14 @@ mod tests {
     }
 
     #[test]
+    fn testing_template_has_required_sections() {
+        assert!(TESTING_TEMPLATE.contains("## Automated Testing"));
+        assert!(TESTING_TEMPLATE.contains("## Manual Testing"));
+        assert!(TESTING_TEMPLATE.contains("## Edge Cases & Boundary Conditions"));
+        assert!(TESTING_TEMPLATE.contains("{module}"));
+    }
+
+    #[test]
     fn default_template_has_all_required_sections() {
         assert!(DEFAULT_TEMPLATE.contains("## Purpose"));
         assert!(DEFAULT_TEMPLATE.contains("## Public API"));
@@ -1214,12 +1222,17 @@ mod tests {
         assert!(spec_dir.join("tasks.md").exists());
         assert!(spec_dir.join("context.md").exists());
         assert!(spec_dir.join("requirements.md").exists());
+        assert!(spec_dir.join("testing.md").exists());
 
         let tasks = fs::read_to_string(spec_dir.join("tasks.md")).unwrap();
         assert!(tasks.contains("spec: auth.spec.md"));
 
         let reqs = fs::read_to_string(spec_dir.join("requirements.md")).unwrap();
         assert!(reqs.contains("spec: auth.spec.md"));
+
+        let testing = fs::read_to_string(spec_dir.join("testing.md")).unwrap();
+        assert!(testing.contains("spec: auth.spec.md"));
+        assert!(testing.contains("## Automated Testing"));
     }
 
     #[test]
@@ -1228,10 +1241,45 @@ mod tests {
         let spec_dir = tmp.path();
 
         fs::write(spec_dir.join("tasks.md"), "existing content").unwrap();
+        fs::write(spec_dir.join("testing.md"), "existing tests").unwrap();
         generate_companion_files(spec_dir, "auth");
 
         let tasks = fs::read_to_string(spec_dir.join("tasks.md")).unwrap();
         assert_eq!(tasks, "existing content");
+        let testing = fs::read_to_string(spec_dir.join("testing.md")).unwrap();
+        assert_eq!(testing, "existing tests");
+    }
+
+    #[test]
+    fn companion_files_from_template_uses_custom_testing() {
+        let tmp = TempDir::new().unwrap();
+        let spec_dir = tmp.path();
+        let template_dir = tmp.path().join("templates");
+        fs::create_dir_all(&template_dir).unwrap();
+
+        let custom = "---\nspec: {module}.spec.md\n---\n\n## Custom Tests\n\nCustom testing template\n";
+        fs::write(template_dir.join("testing.md"), custom).unwrap();
+
+        generate_companion_files_from_template(spec_dir, "auth", &template_dir);
+
+        let testing = fs::read_to_string(spec_dir.join("testing.md")).unwrap();
+        assert!(testing.contains("Custom testing template"));
+        assert!(testing.contains("spec: auth.spec.md"));
+    }
+
+    #[test]
+    fn companion_files_from_template_falls_back_for_testing() {
+        let tmp = TempDir::new().unwrap();
+        let spec_dir = tmp.path();
+        let template_dir = tmp.path().join("templates");
+        fs::create_dir_all(&template_dir).unwrap();
+        // No testing.md in template dir — should fall back to built-in
+
+        generate_companion_files_from_template(spec_dir, "auth", &template_dir);
+
+        let testing = fs::read_to_string(spec_dir.join("testing.md")).unwrap();
+        assert!(testing.contains("## Automated Testing"));
+        assert!(testing.contains("spec: auth.spec.md"));
     }
 
     // ── find_files_for_module ──────────────────────────────────────

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -69,6 +69,31 @@ spec: {module}.spec.md
 <!-- Free-form notes, links, or context -->
 "#;
 
+const TESTING_TEMPLATE: &str = r#"---
+spec: {module}.spec.md
+---
+
+## Automated Testing
+
+<!-- Expected test file locations, coverage targets, fixture descriptions -->
+
+| Test File | Type | What It Covers |
+|-----------|------|----------------|
+
+## Manual Testing
+
+<!-- Step-by-step QA checklists, device/browser matrices, user flow walkthroughs -->
+
+- [ ] <!-- Add manual test steps -->
+
+## Edge Cases & Boundary Conditions
+
+<!-- Boundary values, race conditions, permission matrices, error paths -->
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+"#;
+
 const DEFAULT_TEMPLATE: &str = r#"---
 module: module-name
 version: 1
@@ -670,11 +695,12 @@ fn generate_module_spec(
     )
 }
 
-/// Generate companion files (tasks.md, context.md, requirements.md) alongside a spec file.
+/// Generate companion files (tasks.md, context.md, requirements.md, testing.md) alongside a spec file.
 fn generate_companion_files(spec_dir: &Path, module_name: &str) {
     let tasks_path = spec_dir.join("tasks.md");
     let context_path = spec_dir.join("context.md");
     let requirements_path = spec_dir.join("requirements.md");
+    let testing_path = spec_dir.join("testing.md");
 
     if !tasks_path.exists() {
         let content = TASKS_TEMPLATE.replace("{module}", module_name);
@@ -696,6 +722,13 @@ fn generate_companion_files(spec_dir: &Path, module_name: &str) {
             println!("    {} Generated requirements.md", "✓".green());
         }
     }
+
+    if !testing_path.exists() {
+        let content = TESTING_TEMPLATE.replace("{module}", module_name);
+        if fs::write(&testing_path, &content).is_ok() {
+            println!("    {} Generated testing.md", "✓".green());
+        }
+    }
 }
 
 /// Generate companion files for a given spec, creating the directory if needed.
@@ -705,7 +738,7 @@ pub fn generate_companion_files_for_spec(spec_dir: &Path, module_name: &str) {
 }
 
 /// Generate a spec using templates from a custom template directory.
-/// Looks for `spec.md`, `tasks.md`, `context.md`, `requirements.md` in the template dir.
+/// Looks for `spec.md`, `tasks.md`, `context.md`, `requirements.md`, `testing.md` in the template dir.
 /// Falls back to built-in templates for any missing template files.
 pub fn generate_spec_from_custom_template(
     template_dir: &Path,
@@ -789,6 +822,7 @@ pub fn generate_companion_files_from_template(
     let tasks_path = spec_dir.join("tasks.md");
     let context_path = spec_dir.join("context.md");
     let requirements_path = spec_dir.join("requirements.md");
+    let testing_path = spec_dir.join("testing.md");
 
     if !tasks_path.exists() {
         let template_file = template_dir.join("tasks.md");
@@ -829,6 +863,20 @@ pub fn generate_companion_files_from_template(
         };
         if fs::write(&requirements_path, &content).is_ok() {
             println!("    {} Generated requirements.md", "✓".green());
+        }
+    }
+
+    if !testing_path.exists() {
+        let template_file = template_dir.join("testing.md");
+        let content = if template_file.exists() {
+            fs::read_to_string(&template_file)
+                .unwrap_or_else(|_| TESTING_TEMPLATE.to_string())
+                .replace("{module}", module_name)
+        } else {
+            TESTING_TEMPLATE.replace("{module}", module_name)
+        };
+        if fs::write(&testing_path, &content).is_ok() {
+            println!("    {} Generated testing.md", "✓".green());
         }
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1257,7 +1257,8 @@ mod tests {
         let template_dir = tmp.path().join("templates");
         fs::create_dir_all(&template_dir).unwrap();
 
-        let custom = "---\nspec: {module}.spec.md\n---\n\n## Custom Tests\n\nCustom testing template\n";
+        let custom =
+            "---\nspec: {module}.spec.md\n---\n\n## Custom Tests\n\nCustom testing template\n";
         fs::write(template_dir.join("testing.md"), custom).unwrap();
 
         generate_companion_files_from_template(spec_dir, "auth", &template_dir);

--- a/src/hash_cache.rs
+++ b/src/hash_cache.rs
@@ -139,8 +139,8 @@ impl ChangeClassification {
 /// and the legacy `{module}.` prefixed names.
 const COMPANION_REQ_NAMES: &[&str] = &["requirements.md"];
 const COMPANION_REQ_LEGACY_SUFFIX: &str = "req.md";
-const COMPANION_OTHER_NAMES: &[&str] = &["context.md", "tasks.md"];
-const COMPANION_OTHER_LEGACY_SUFFIXES: &[&str] = &["context.md", "tasks.md"];
+const COMPANION_OTHER_NAMES: &[&str] = &["context.md", "tasks.md", "testing.md"];
+const COMPANION_OTHER_LEGACY_SUFFIXES: &[&str] = &["context.md", "tasks.md", "testing.md"];
 
 /// Find all companion files for a spec, checking both naming conventions.
 fn find_companion_files(spec_path: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {

--- a/src/hash_cache.rs
+++ b/src/hash_cache.rs
@@ -140,6 +140,8 @@ impl ChangeClassification {
 const COMPANION_REQ_NAMES: &[&str] = &["requirements.md"];
 const COMPANION_REQ_LEGACY_SUFFIX: &str = "req.md";
 const COMPANION_OTHER_NAMES: &[&str] = &["context.md", "tasks.md", "testing.md"];
+/// Legacy suffixes check for `{module}.suffix` naming. testing.md is included
+/// for forward-consistency even though no legacy-named testing files exist yet.
 const COMPANION_OTHER_LEGACY_SUFFIXES: &[&str] = &["context.md", "tasks.md", "testing.md"];
 
 /// Find all companion files for a spec, checking both naming conventions.
@@ -432,6 +434,22 @@ mod tests {
     }
 
     #[test]
+    fn classify_detects_testing_companion_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let specs = root.join("specs/auth");
+        fs::create_dir_all(&specs).unwrap();
+        let spec_path = specs.join("auth.spec.md");
+        fs::write(&spec_path, "---\nmodule: auth\nfiles:\n---").unwrap();
+        fs::write(specs.join("testing.md"), "# Testing").unwrap();
+
+        let mut cache = HashCache::default();
+        cache.update(root, "specs/auth/auth.spec.md");
+        let result = classify_changes(root, &spec_path, &cache);
+        assert!(result.has(&ChangeKind::Companion));
+    }
+
+    #[test]
     fn classify_detects_source_change() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -462,11 +480,13 @@ mod tests {
         fs::write(specs.join("requirements.md"), "").unwrap();
         fs::write(specs.join("context.md"), "").unwrap();
         fs::write(specs.join("tasks.md"), "").unwrap();
+        fs::write(specs.join("testing.md"), "").unwrap();
 
         let (req, other) = find_companion_files(&specs.join("auth.spec.md"));
         assert_eq!(req.len(), 1);
         assert!(req[0].ends_with("requirements.md"));
-        assert_eq!(other.len(), 2);
+        assert_eq!(other.len(), 3);
+        assert!(other.iter().any(|p| p.ends_with("testing.md")));
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -15,11 +15,12 @@ Each spec in `specs/<module>/` has companion files — read them before working,
 - **`tasks.md`** — Work items for this module. Check off tasks (`- [x]`) as you complete them. Add new tasks if you discover work needed.
 - **`requirements.md`** — Acceptance criteria and user stories. These are permanent invariants, not tasks — do not check them off. Update if requirements change.
 - **`context.md`** — Architectural decisions, key files, and current status. Update when you make design decisions or change what's in progress.
+- **`testing.md`** — Test strategy: automated test locations, manual QA checklists, and edge cases/boundary conditions.
 
 ## Before modifying any module
 
 1. Read the relevant spec in `specs/<module>/<module>.spec.md`
-2. Read companion files: `tasks.md`, `requirements.md`, and `context.md`
+2. Read companion files: `tasks.md`, `requirements.md`, `context.md`, and `testing.md`
 3. After changes, run `specsync check` to verify specs still pass
 
 ## After completing work
@@ -27,6 +28,7 @@ Each spec in `specs/<module>/` has companion files — read them before working,
 1. Mark completed items in `tasks.md` — check off finished tasks, add new ones discovered
 2. Update `context.md` — record decisions made, update current status
 3. If requirements changed, update `requirements.md` acceptance criteria
+4. If test coverage changed, update `testing.md` with new test files or edge cases
 
 ## Before creating a PR
 
@@ -57,11 +59,12 @@ Each spec directory has companion files — read before working, update after:
 - `tasks.md` — Work items. Check off completed tasks, add new ones discovered.
 - `requirements.md` — Acceptance criteria and user stories. Permanent invariants, not tasks.
 - `context.md` — Decisions, key files, current status. Update when you make design choices.
+- `testing.md` — Test strategy: automated test locations, manual QA checklists, edge cases.
 
 ## Rules
 
 - Before editing a module, read its spec at `specs/<module>/<module>.spec.md`
-- Read `tasks.md`, `requirements.md`, and `context.md` for outstanding work, requirements, and decisions
+- Read `tasks.md`, `requirements.md`, `context.md`, and `testing.md` for outstanding work, requirements, decisions, and test strategy
 - After modifying code, ensure `specsync check` still passes
 - After completing work, update `tasks.md` (check off done items) and `context.md` (record decisions, update status)
 - When creating new modules, run `specsync add-spec <module-name>` first
@@ -80,11 +83,12 @@ Each spec directory has companion files — read before working, update after:
 - `tasks.md` — Work items to check off as completed. Add new tasks if you discover work needed.
 - `requirements.md` — Acceptance criteria and user stories. Permanent invariants, not checkable tasks.
 - `context.md` — Architectural decisions, key files, and current status. Update with decisions made.
+- `testing.md` — Test strategy: automated test locations, manual QA checklists, edge cases.
 
 ## Guidelines
 
 - Specs are in `specs/<module>/<module>.spec.md` — read the relevant spec before modifying a module
-- Read companion files `tasks.md`, `requirements.md`, and `context.md` before starting work
+- Read companion files `tasks.md`, `requirements.md`, `context.md`, and `testing.md` before starting work
 - After changes, `specsync check` should pass with no errors
 - After completing work, update `tasks.md` (mark done items) and `context.md` (record decisions, update status)
 - New modules need specs: run `specsync add-spec <module-name>`
@@ -102,11 +106,12 @@ Each spec in `specs/<module>/` has companion files — read them before working,
 - **`tasks.md`** — Work items for this module. Check off tasks (`- [x]`) as you complete them. Add new tasks if you discover work needed.
 - **`requirements.md`** — Acceptance criteria and user stories. These are permanent invariants, not tasks — do not check them off. Update if requirements change.
 - **`context.md`** — Architectural decisions, key files, and current status. Update when you make design decisions or change what's in progress.
+- **`testing.md`** — Test strategy: automated test locations, manual QA checklists, and edge cases/boundary conditions.
 
 ## Before modifying any module
 
 1. Read the relevant spec in `specs/<module>/<module>.spec.md`
-2. Read companion files: `tasks.md`, `requirements.md`, and `context.md`
+2. Read companion files: `tasks.md`, `requirements.md`, `context.md`, and `testing.md`
 3. After changes, run `specsync check` to verify specs still pass
 
 ## After completing work
@@ -114,6 +119,7 @@ Each spec in `specs/<module>/` has companion files — read them before working,
 1. Mark completed items in `tasks.md` — check off finished tasks, add new ones discovered
 2. Update `context.md` — record decisions made, update current status
 3. If requirements changed, update `requirements.md` acceptance criteria
+4. If test coverage changed, update `testing.md` with new test files or edge cases
 
 ## Before creating a PR
 


### PR DESCRIPTION
## Summary

Adds `testing.md` as a new companion file type, bridging the gap between specs (what a module does) and verification (how you prove it works).

- Adds `TESTING_TEMPLATE` with three sections: Automated Testing, Manual Testing, and Edge Cases & Boundary Conditions
- Generates `testing.md` alongside other companions in both built-in and custom template paths
- Registers `testing.md` in companion file discovery (`hash_cache.rs`) so changes are tracked
- Updates all 4 agent instruction snippets (CLAUDE.md, .cursorrules, Copilot, AGENTS.md) to reference the new file
- Updates workflow documentation with the new companion in the file table

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — all 665 tests pass (559 unit + 106 integration)
- [ ] Verify `specsync add-spec test-module` generates `testing.md` alongside other companions
- [ ] Verify `specsync hooks install` includes `testing.md` in agent instructions

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)