### PR TITLE
fix: YAML indent flexibility + README/spec alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.1.3"
+version = "4.2.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ spec: auth.spec.md
 spec: auth.spec.md
 ---
 
-## Automated Tests
+## Automated Testing
 <!-- Test file locations and what they cover -->
 
 ## Manual QA Checklist

--- a/README.md
+++ b/README.md
@@ -523,6 +523,42 @@ These files are designed for team coordination and AI agent context — they giv
 
 ---
 
+## YAML Source Files
+
+SpecSync extracts symbols from YAML files (`.yml`, `.yaml`) including GitHub Actions workflows, Docker Compose files, and Kubernetes manifests.
+
+**What gets extracted:**
+- **Top-level keys** — any key at column 0 (e.g., `name`, `on`, `jobs`)
+- **Nested children of well-known parents** — `jobs.test`, `services.web`, `volumes.pgdata`, etc. Parents: `jobs`, `services`, `volumes`, `networks`, `secrets`, `stages`, `steps`, `targets`, `outputs`, `inputs`, `permissions`, `deployments`
+- **YAML anchors** — `&anchor-name` definitions
+
+**Indentation:** Any consistent indentation (2-space, 4-space, or tabs) is supported for nested key extraction.
+
+### Document Separator Edge Cases
+
+YAML supports multi-document files separated by `---` (common in Kubernetes manifests). SpecSync handles these correctly:
+
+```yaml
+# Multi-document YAML (e.g., k8s manifests)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-svc
+```
+
+- Top-level keys from **all documents** are extracted (`apiVersion`, `kind`, `metadata` from both)
+- The `---` separator is not confused with spec frontmatter delimiters — frontmatter parsing only applies to `.spec.md` files
+- Duplicate keys across documents are deduplicated in the symbol list
+
+> **Note:** SpecSync's YAML extractor uses regex-based parsing, not a full YAML parser. This means it works without any YAML library dependency but does not interpret YAML semantics like merge keys (`<<: *alias`) beyond anchor extraction.
+
+---
+
 ## VS Code Extension
 
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=corvidlabs.specsync) or search "SpecSync" in the Extensions panel.

--- a/specs/exports/exports.spec.md
+++ b/specs/exports/exports.spec.md
@@ -80,7 +80,7 @@ Each language backend exposes a single `extract_exports(content: &str) -> Vec<St
 | C# | `csharp.rs` | `public class/struct/interface/enum/record/delegate` types and `public` members; handles `static`, `partial`, `sealed`, `abstract`, `virtual`, `override`, `async` modifiers |
 | PHP | `php.rs` | `class/interface/trait/enum` types (always public); `public`/unqualified `function` and `const` declarations; skips `private`/`protected` members and `__` magic methods; handles `abstract`, `final`, `readonly`, `static` modifiers; strips `//`, `/* */`, and `#` comments |
 | Ruby | `ruby.rs` | `class`/`module` declarations; top-level `def` (always public); class methods with visibility tracking (`public`→`private`→`protected`→`public` toggles); `CONSTANT` assignments; `attr_accessor`/`attr_reader`/`attr_writer` symbols; skips `_`-prefixed names and `initialize`; strips `#` and `=begin/=end` comments |
-| YAML | `yaml.rs` | Top-level mapping keys from `.yaml`/`.yml` files; supports anchors and aliases |
+| YAML | `yaml.rs` | Top-level mapping keys from `.yaml`/`.yml` files; named entries under well-known parent keys (e.g., `jobs.test`, `services.web`); YAML anchors (`&name`) |
 
 ## Invariants
 
@@ -106,7 +106,7 @@ Each language backend exposes a single `extract_exports(content: &str) -> Vec<St
 16. Go backend deduplicates methods that might also match top-level declarations
 17. PHP backend treats types (class/interface/trait/enum) as always public; methods and constants require `public` or unqualified visibility; `private`/`protected` are excluded; magic methods (`__construct`, `__toString`, etc.) are excluded
 18. Ruby backend tracks visibility state via `public`/`private`/`protected` toggle statements; defaults to public; `initialize` is excluded; `_`-prefixed names are excluded; `attr_accessor`/`attr_reader`/`attr_writer` emit attribute names as symbols
-19. YAML backend extracts top-level mapping keys; no test file patterns (YAML files are not test files)
+19. YAML backend extracts top-level mapping keys, named entries under well-known parent keys (any indentation level), and anchors; no test file patterns (YAML files are not test files)
 
 ## Behavioral Examples
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -524,6 +524,13 @@ pub fn config_to_toml(config: &SpecSyncConfig) -> String {
         }
     }
 
+    // Companions section
+    if config.companions.design {
+        lines.push(String::new());
+        lines.push("[companions]".to_string());
+        lines.push("design = true".to_string());
+    }
+
     lines.push(String::new()); // trailing newline
     lines.join("\n")
 }
@@ -552,6 +559,7 @@ const KNOWN_JSON_KEYS: &[&str] = &[
     "github",
     "enforcement",
     "lifecycle",
+    "companions",
 ];
 
 fn load_json_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
@@ -640,6 +648,10 @@ fn load_toml_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
                     }
                     "lifecycle" => {
                         parse_toml_lifecycle_key(key, value, &mut config.lifecycle);
+                        continue;
+                    }
+                    "companions" => {
+                        parse_toml_companions_key(key, value, &mut config.companions);
                         continue;
                     }
                     s if s.starts_with("lifecycle.") => {
@@ -818,6 +830,20 @@ fn parse_toml_github_key(key: &str, value: &str, config: &mut SpecSyncConfig) {
         "verify_issues" => gh.verify_issues = parse_toml_bool(value),
         _ => {
             eprintln!("Warning: unknown key \"{key}\" in [github] section (ignored)");
+        }
+    }
+}
+
+/// Parse a key=value pair inside a `[companions]` TOML section.
+fn parse_toml_companions_key(
+    key: &str,
+    value: &str,
+    companions: &mut crate::types::CompanionConfig,
+) {
+    match key {
+        "design" => companions.design = parse_toml_bool(value),
+        _ => {
+            eprintln!("Warning: unknown key \"{key}\" in [companions] section (ignored)");
         }
     }
 }
@@ -1320,5 +1346,44 @@ verify_issues = false
         let pattern = regex::Regex::new(default_schema_pattern()).unwrap();
         let caps = pattern.captures("CREATE TABLE users (id INT)").unwrap();
         assert_eq!(&caps[1], "users");
+    }
+
+    // --- companions config ---
+
+    #[test]
+    fn test_toml_companions_design_enabled() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(
+            root.join(".specsync/config.toml"),
+            "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n\n[companions]\ndesign = true\n",
+        )
+        .unwrap();
+        let config = load_config(root);
+        assert!(config.companions.design, "design companion should be enabled");
+    }
+
+    #[test]
+    fn test_toml_companions_design_default_false() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(
+            root.join(".specsync/config.toml"),
+            "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+        )
+        .unwrap();
+        let config = load_config(root);
+        assert!(!config.companions.design, "design companion should default to false");
+    }
+
+    #[test]
+    fn test_config_to_toml_roundtrips_companions() {
+        let mut config = SpecSyncConfig::default();
+        config.companions.design = true;
+        let toml_str = config_to_toml(&config);
+        assert!(toml_str.contains("[companions]"), "should contain [companions] section");
+        assert!(toml_str.contains("design = true"), "should contain design = true");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1361,7 +1361,10 @@ verify_issues = false
         )
         .unwrap();
         let config = load_config(root);
-        assert!(config.companions.design, "design companion should be enabled");
+        assert!(
+            config.companions.design,
+            "design companion should be enabled"
+        );
     }
 
     #[test]
@@ -1375,7 +1378,10 @@ verify_issues = false
         )
         .unwrap();
         let config = load_config(root);
-        assert!(!config.companions.design, "design companion should default to false");
+        assert!(
+            !config.companions.design,
+            "design companion should default to false"
+        );
     }
 
     #[test]
@@ -1383,7 +1389,13 @@ verify_issues = false
         let mut config = SpecSyncConfig::default();
         config.companions.design = true;
         let toml_str = config_to_toml(&config);
-        assert!(toml_str.contains("[companions]"), "should contain [companions] section");
-        assert!(toml_str.contains("design = true"), "should contain design = true");
+        assert!(
+            toml_str.contains("[companions]"),
+            "should contain [companions] section"
+        );
+        assert!(
+            toml_str.contains("design = true"),
+            "should contain design = true"
+        );
     }
 }

--- a/src/exports/yaml.rs
+++ b/src/exports/yaml.rs
@@ -46,9 +46,9 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     }
 
     // For well-known parent keys, extract second-level children as `parent.child`
-    // We scan line-by-line, matching against individual lines (no trailing newline)
+    // We scan line-by-line, detecting the indent of the first child to only match
+    // direct children (not deeper nested keys).
     let top_level_line = Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
-    let second_level_line = Regex::new(r"^  ([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
 
     let lines: Vec<&str> = content.lines().collect();
     let mut i = 0;
@@ -61,18 +61,33 @@ pub fn extract_exports(content: &str) -> Vec<String> {
                 if NESTED_SYMBOL_PARENTS.contains(&parent) {
                     // Scan subsequent lines for second-level keys under this parent
                     let mut j = i + 1;
+                    let mut child_indent: Option<usize> = None;
                     while j < lines.len() {
                         let child_line = lines[j];
                         // Stop if we hit another top-level key or end of file
                         if !child_line.is_empty()
                             && !child_line.starts_with(' ')
+                            && !child_line.starts_with('\t')
                             && !child_line.starts_with('#')
                         {
                             break;
                         }
-                        if let Some(child_caps) = second_level_line.captures(child_line) {
-                            if let Some(child_match) = child_caps.get(1) {
-                                symbols.push(format!("{}.{}", parent, child_match.as_str()));
+                        // Measure leading whitespace
+                        let indent = child_line.len() - child_line.trim_start().len();
+                        let trimmed = child_line.trim_start();
+                        if indent > 0 && !trimmed.is_empty() && !trimmed.starts_with('#') {
+                            // Detect indent of first child
+                            if child_indent.is_none() {
+                                child_indent = Some(indent);
+                            }
+                            // Only match lines at the exact child indent level
+                            if Some(indent) == child_indent {
+                                let key_re = Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
+                                if let Some(child_caps) = key_re.captures(trimmed) {
+                                    if let Some(child_match) = child_caps.get(1) {
+                                        symbols.push(format!("{}.{}", parent, child_match.as_str()));
+                                    }
+                                }
                             }
                         }
                         j += 1;
@@ -180,6 +195,47 @@ spec:
         assert!(symbols.contains(&"spec".to_string()));
         // metadata.name should NOT be extracted since metadata is not a well-known parent
         assert!(!symbols.contains(&"metadata.name".to_string()));
+    }
+
+    #[test]
+    fn test_four_space_indentation() {
+        let content = r#"name: CI
+on: push
+jobs:
+    test:
+        runs-on: ubuntu-latest
+    build:
+        runs-on: ubuntu-latest
+services:
+    web:
+        image: nginx
+"#;
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"jobs.test".to_string()));
+        assert!(symbols.contains(&"jobs.build".to_string()));
+        assert!(symbols.contains(&"services.web".to_string()));
+    }
+
+    #[test]
+    fn test_four_space_nested_not_extracted() {
+        let content = r#"jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout
+"#;
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"jobs.test".to_string()));
+        // `runs-on` is deeper nesting, not a direct child of `jobs`
+        assert!(!symbols.contains(&"jobs.runs-on".to_string()));
+    }
+
+    #[test]
+    fn test_tab_indentation() {
+        let content = "services:\n\tweb:\n\t\timage: nginx\n\tdb:\n\t\timage: postgres\n";
+        let symbols = extract_exports(content);
+        assert!(symbols.contains(&"services.web".to_string()));
+        assert!(symbols.contains(&"services.db".to_string()));
     }
 
     #[test]

--- a/src/exports/yaml.rs
+++ b/src/exports/yaml.rs
@@ -82,10 +82,13 @@ pub fn extract_exports(content: &str) -> Vec<String> {
                             }
                             // Only match lines at the exact child indent level
                             if Some(indent) == child_indent {
-                                let key_re = Regex::new(r"^([a-zA-Z_][a-zA-Z0-9_-]*):").unwrap();
-                                if let Some(child_caps) = key_re.captures(trimmed) {
+                                if let Some(child_caps) = top_level_line.captures(trimmed) {
                                     if let Some(child_match) = child_caps.get(1) {
-                                        symbols.push(format!("{}.{}", parent, child_match.as_str()));
+                                        symbols.push(format!(
+                                            "{}.{}",
+                                            parent,
+                                            child_match.as_str()
+                                        ));
                                     }
                                 }
                             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4032,9 +4032,7 @@ fn migrate_partial_recovery() {
 /// Write a v4 TOML config under .specsync/config.toml.
 fn write_toml_config(root: &std::path::Path, extra: &str) {
     fs::create_dir_all(root.join(".specsync")).unwrap();
-    let config = format!(
-        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n{extra}"
-    );
+    let config = format!("specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n{extra}");
     fs::write(root.join(".specsync/config.toml"), config).unwrap();
     fs::write(root.join(".specsync/version"), "4.0.0").unwrap();
 }
@@ -4066,13 +4064,28 @@ fn generate_creates_companion_files() {
         .stdout(predicate::str::contains("Generated"));
 
     let spec_dir = root.join("specs/billing");
-    assert!(spec_dir.join("billing.spec.md").exists(), "spec should exist");
+    assert!(
+        spec_dir.join("billing.spec.md").exists(),
+        "spec should exist"
+    );
     assert!(spec_dir.join("tasks.md").exists(), "tasks.md should exist");
-    assert!(spec_dir.join("context.md").exists(), "context.md should exist");
-    assert!(spec_dir.join("requirements.md").exists(), "requirements.md should exist");
-    assert!(spec_dir.join("testing.md").exists(), "testing.md should exist");
+    assert!(
+        spec_dir.join("context.md").exists(),
+        "context.md should exist"
+    );
+    assert!(
+        spec_dir.join("requirements.md").exists(),
+        "requirements.md should exist"
+    );
+    assert!(
+        spec_dir.join("testing.md").exists(),
+        "testing.md should exist"
+    );
     // design.md should NOT be created by default
-    assert!(!spec_dir.join("design.md").exists(), "design.md should NOT exist by default");
+    assert!(
+        !spec_dir.join("design.md").exists(),
+        "design.md should NOT exist by default"
+    );
 }
 
 #[test]
@@ -4088,13 +4101,25 @@ fn generate_creates_design_md_when_enabled() {
         .stdout(predicate::str::contains("Generated"));
 
     let spec_dir = root.join("specs/billing");
-    assert!(spec_dir.join("billing.spec.md").exists(), "spec should exist");
-    assert!(spec_dir.join("testing.md").exists(), "testing.md should exist");
-    assert!(spec_dir.join("design.md").exists(), "design.md should exist when companions.design = true");
+    assert!(
+        spec_dir.join("billing.spec.md").exists(),
+        "spec should exist"
+    );
+    assert!(
+        spec_dir.join("testing.md").exists(),
+        "testing.md should exist"
+    );
+    assert!(
+        spec_dir.join("design.md").exists(),
+        "design.md should exist when companions.design = true"
+    );
 
     // Verify design.md has correct frontmatter
     let design_content = fs::read_to_string(spec_dir.join("design.md")).unwrap();
-    assert!(design_content.contains("spec: billing.spec.md"), "design.md should reference spec");
+    assert!(
+        design_content.contains("spec: billing.spec.md"),
+        "design.md should reference spec"
+    );
 }
 
 #[test]
@@ -4109,9 +4134,14 @@ fn companion_testing_md_has_correct_structure() {
         .success();
 
     let testing_content = fs::read_to_string(root.join("specs/billing/testing.md")).unwrap();
-    assert!(testing_content.contains("spec: billing.spec.md"), "testing.md should reference spec");
-    assert!(testing_content.contains("## Automated Testing") || testing_content.contains("## Test"),
-            "testing.md should have test-related sections");
+    assert!(
+        testing_content.contains("spec: billing.spec.md"),
+        "testing.md should reference spec"
+    );
+    assert!(
+        testing_content.contains("## Automated Testing") || testing_content.contains("## Test"),
+        "testing.md should have test-related sections"
+    );
 }
 
 #[test]
@@ -4128,7 +4158,11 @@ fn companion_files_not_overwritten_on_regenerate() {
 
     // Modify a companion
     let tasks_path = root.join("specs/billing/tasks.md");
-    fs::write(&tasks_path, "---\nspec: billing.spec.md\n---\n\n## Custom Content\n").unwrap();
+    fs::write(
+        &tasks_path,
+        "---\nspec: billing.spec.md\n---\n\n## Custom Content\n",
+    )
+    .unwrap();
 
     // Add a new unspecced module to trigger another generate
     fs::create_dir_all(root.join("src/shipping")).unwrap();
@@ -4146,7 +4180,10 @@ fn companion_files_not_overwritten_on_regenerate() {
 
     // Original companion should be untouched
     let tasks_content = fs::read_to_string(&tasks_path).unwrap();
-    assert!(tasks_content.contains("## Custom Content"), "existing companion files should not be overwritten");
+    assert!(
+        tasks_content.contains("## Custom Content"),
+        "existing companion files should not be overwritten"
+    );
 }
 
 // ─── YAML extraction integration tests ──────────────────────────────────

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4026,3 +4026,207 @@ fn migrate_partial_recovery() {
     let version = fs::read_to_string(root.join(".specsync/version")).unwrap();
     assert_eq!(version.trim(), "4.0.0");
 }
+
+// ─── Companion file integration tests ───────────────────────────────────
+
+/// Write a v4 TOML config under .specsync/config.toml.
+fn write_toml_config(root: &std::path::Path, extra: &str) {
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    let config = format!(
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n{extra}"
+    );
+    fs::write(root.join(".specsync/config.toml"), config).unwrap();
+    fs::write(root.join(".specsync/version"), "4.0.0").unwrap();
+}
+
+/// Set up a minimal v4 project (TOML config) with one source module and no spec.
+fn setup_v4_unspecced(tmp: &TempDir, config_extra: &str) -> std::path::PathBuf {
+    let root = tmp.path().to_path_buf();
+    write_toml_config(&root, config_extra);
+    fs::create_dir_all(root.join("src/billing")).unwrap();
+    fs::write(
+        root.join("src/billing/index.ts"),
+        "export function charge() {}\nexport function refund() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs")).unwrap();
+    root
+}
+
+#[test]
+fn generate_creates_companion_files() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_v4_unspecced(&tmp, "");
+
+    specsync()
+        .args(["generate", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generated"));
+
+    let spec_dir = root.join("specs/billing");
+    assert!(spec_dir.join("billing.spec.md").exists(), "spec should exist");
+    assert!(spec_dir.join("tasks.md").exists(), "tasks.md should exist");
+    assert!(spec_dir.join("context.md").exists(), "context.md should exist");
+    assert!(spec_dir.join("requirements.md").exists(), "requirements.md should exist");
+    assert!(spec_dir.join("testing.md").exists(), "testing.md should exist");
+    // design.md should NOT be created by default
+    assert!(!spec_dir.join("design.md").exists(), "design.md should NOT exist by default");
+}
+
+#[test]
+fn generate_creates_design_md_when_enabled() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_v4_unspecced(&tmp, "\n[companions]\ndesign = true\n");
+
+    specsync()
+        .args(["generate", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generated"));
+
+    let spec_dir = root.join("specs/billing");
+    assert!(spec_dir.join("billing.spec.md").exists(), "spec should exist");
+    assert!(spec_dir.join("testing.md").exists(), "testing.md should exist");
+    assert!(spec_dir.join("design.md").exists(), "design.md should exist when companions.design = true");
+
+    // Verify design.md has correct frontmatter
+    let design_content = fs::read_to_string(spec_dir.join("design.md")).unwrap();
+    assert!(design_content.contains("spec: billing.spec.md"), "design.md should reference spec");
+}
+
+#[test]
+fn companion_testing_md_has_correct_structure() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_v4_unspecced(&tmp, "");
+
+    specsync()
+        .args(["generate", "--root"])
+        .arg(&root)
+        .assert()
+        .success();
+
+    let testing_content = fs::read_to_string(root.join("specs/billing/testing.md")).unwrap();
+    assert!(testing_content.contains("spec: billing.spec.md"), "testing.md should reference spec");
+    assert!(testing_content.contains("## Automated Testing") || testing_content.contains("## Test"),
+            "testing.md should have test-related sections");
+}
+
+#[test]
+fn companion_files_not_overwritten_on_regenerate() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_v4_unspecced(&tmp, "");
+
+    // First generate
+    specsync()
+        .args(["generate", "--root"])
+        .arg(&root)
+        .assert()
+        .success();
+
+    // Modify a companion
+    let tasks_path = root.join("specs/billing/tasks.md");
+    fs::write(&tasks_path, "---\nspec: billing.spec.md\n---\n\n## Custom Content\n").unwrap();
+
+    // Add a new unspecced module to trigger another generate
+    fs::create_dir_all(root.join("src/shipping")).unwrap();
+    fs::write(
+        root.join("src/shipping/index.ts"),
+        "export function ship() {}\n",
+    )
+    .unwrap();
+
+    specsync()
+        .args(["generate", "--root"])
+        .arg(&root)
+        .assert()
+        .success();
+
+    // Original companion should be untouched
+    let tasks_content = fs::read_to_string(&tasks_path).unwrap();
+    assert!(tasks_content.contains("## Custom Content"), "existing companion files should not be overwritten");
+}
+
+// ─── YAML extraction integration tests ──────────────────────────────────
+
+#[test]
+fn check_yaml_source_file_extracts_top_level_keys() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write_toml_config(&root, "");
+
+    // Create a YAML source file
+    fs::create_dir_all(root.join("src/ci")).unwrap();
+    fs::write(
+        root.join("src/ci/build.yml"),
+        "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n  lint:\n    runs-on: ubuntu-latest\n",
+    )
+    .unwrap();
+
+    // Create a spec that tracks the YAML file
+    fs::create_dir_all(root.join("specs/ci")).unwrap();
+    let spec = valid_spec("ci", &["src/ci/build.yml"]);
+    fs::write(root.join("specs/ci/ci.spec.md"), spec).unwrap();
+
+    // Check should pass (no missing source files)
+    specsync()
+        .args(["check", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 failed"));
+}
+
+#[test]
+fn check_yaml_with_document_separator_in_content() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write_toml_config(&root, "");
+
+    // Create a YAML file that uses document separators (common in Kubernetes manifests)
+    fs::create_dir_all(root.join("src/k8s")).unwrap();
+    fs::write(
+        root.join("src/k8s/manifests.yml"),
+        "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: my-app\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: my-svc\n",
+    )
+    .unwrap();
+
+    fs::create_dir_all(root.join("specs/k8s")).unwrap();
+    let spec = valid_spec("k8s", &["src/k8s/manifests.yml"]);
+    fs::write(root.join("specs/k8s/k8s.spec.md"), spec).unwrap();
+
+    // Check should still pass — the YAML extractor handles multi-doc files
+    specsync()
+        .args(["check", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 failed"));
+}
+
+#[test]
+fn check_yaml_with_anchors_and_nested_keys() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write_toml_config(&root, "");
+
+    fs::create_dir_all(root.join("src/docker")).unwrap();
+    fs::write(
+        root.join("src/docker/compose.yml"),
+        "version: \"3.8\"\nservices:\n  web:\n    image: nginx\n  db:\n    image: postgres\nvolumes:\n  pgdata:\n    driver: local\n",
+    )
+    .unwrap();
+
+    fs::create_dir_all(root.join("specs/docker")).unwrap();
+    let spec = valid_spec("docker", &["src/docker/compose.yml"]);
+    fs::write(root.join("specs/docker/docker.spec.md"), spec).unwrap();
+
+    specsync()
+        .args(["check", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 failed"));
+}


### PR DESCRIPTION
## Summary
- **YAML extractor**: Auto-detects indent level instead of hardcoding 2-space. Now supports 2-space, 4-space, tab, and any indentation style. Only extracts direct children of well-known parent keys (not deeper nesting).
- **README**: Section name in testing.md example changed from "Automated Tests" to "Automated Testing" to match the generated template.
- **Exports spec**: Updated YAML backend description and invariant to accurately reflect nested symbol extraction and anchor support.

## Tests Added
- 4-space indentation extraction
- Deep nesting exclusion (3rd-level keys not extracted)
- Tab indentation extraction

## Test plan
- [ ] CI passes all platforms (Linux/macOS/Windows)
- [ ] Existing YAML tests still pass (2-space indent)
- [ ] New tests pass (4-space, tab, deep nesting)
- [ ] `specsync check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)