### PR TITLE
fix: close 4 security alerts — redact API keys in Debug, bump time + rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -1246,15 +1246,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -47,13 +47,17 @@ impl std::fmt::Debug for ResolvedProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ResolvedProvider::Cli(cmd) => f.debug_tuple("Cli").field(cmd).finish(),
-            ResolvedProvider::AnthropicApi { model, base_url, .. } => f
+            ResolvedProvider::AnthropicApi {
+                model, base_url, ..
+            } => f
                 .debug_struct("AnthropicApi")
                 .field("api_key", &"[REDACTED]")
                 .field("model", model)
                 .field("base_url", base_url)
                 .finish(),
-            ResolvedProvider::OpenAiApi { model, base_url, .. } => f
+            ResolvedProvider::OpenAiApi {
+                model, base_url, ..
+            } => f
                 .debug_struct("OpenAiApi")
                 .field("api_key", &"[REDACTED]")
                 .field("model", model)

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -23,7 +23,7 @@ fn safe_truncate(s: &str, max_bytes: usize) -> &str {
 }
 
 /// A resolved provider ready to execute — either a CLI command or a direct API call.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ResolvedProvider {
     /// Shell out to a CLI tool (e.g. `claude -p --output-format text`).
     Cli(String),
@@ -41,6 +41,31 @@ pub enum ResolvedProvider {
     },
     /// Call the Google Gemini API directly.
     GeminiApi { api_key: String, model: String },
+}
+
+impl std::fmt::Debug for ResolvedProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolvedProvider::Cli(cmd) => f.debug_tuple("Cli").field(cmd).finish(),
+            ResolvedProvider::AnthropicApi { model, base_url, .. } => f
+                .debug_struct("AnthropicApi")
+                .field("api_key", &"[REDACTED]")
+                .field("model", model)
+                .field("base_url", base_url)
+                .finish(),
+            ResolvedProvider::OpenAiApi { model, base_url, .. } => f
+                .debug_struct("OpenAiApi")
+                .field("api_key", &"[REDACTED]")
+                .field("model", model)
+                .field("base_url", base_url)
+                .finish(),
+            ResolvedProvider::GeminiApi { model, .. } => f
+                .debug_struct("GeminiApi")
+                .field("api_key", &"[REDACTED]")
+                .field("model", model)
+                .finish(),
+        }
+    }
 }
 
 impl std::fmt::Display for ResolvedProvider {

--- a/src/commands/stale.rs
+++ b/src/commands/stale.rs
@@ -107,7 +107,7 @@ pub fn cmd_stale(
     }
 
     // Sort by most stale first
-    stale_specs.sort_by(|a, b| b.max_commits_behind.cmp(&a.max_commits_behind));
+    stale_specs.sort_by_key(|b| std::cmp::Reverse(b.max_commits_behind));
 
     let total = spec_files.len();
     let stale_count = stale_specs.len();

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1225,7 +1225,7 @@ pub fn compute_coverage(
         .iter()
         .map(|f| (f.clone(), file_loc.get(f.as_str()).copied().unwrap_or(0)))
         .collect();
-    unspecced_file_loc.sort_by(|a, b| b.1.cmp(&a.1));
+    unspecced_file_loc.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     // Module coverage
     let specs_dir = root.join(&config.specs_dir);
@@ -1297,11 +1297,7 @@ pub fn compute_coverage(
         (specced_count * 100) / all_source_files.len()
     };
 
-    let loc_coverage_percent = if total_loc == 0 {
-        100
-    } else {
-        (specced_loc * 100) / total_loc
-    };
+    let loc_coverage_percent = (specced_loc * 100).checked_div(total_loc).unwrap_or(100);
 
     CoverageReport {
         total_source_files: all_source_files.len(),


### PR DESCRIPTION
## Summary

- **CodeQL #5 & #6** (High, CWE-532 cleartext logging): `ResolvedProvider` derived `Debug` would expose `api_key` fields in plaintext when debug-printed. Replaced with a custom `Debug` impl that renders all `api_key` fields as `"[REDACTED]"`. The existing `Display` impl already redacted them; this brings `Debug` into alignment.
- **Dependabot #2** (Moderate, GHSA-r6v5-fh4h-64xc): `time` 0.3.45 → 0.3.47, fixes stack exhaustion DoS via crafted input.
- **Dependabot #3 & #4** (Low, GHSA-xgp8-3hg3-c2mh / GHSA-965h-392x-2mh5): `rustls-webpki` 0.103.11 → 0.103.12, fixes two TLS name-constraint bypass issues.

## Test plan

- [x] `cargo check` passes clean
- [x] `specsync check` passes — 57/57 specs, 0 failed
- [x] CI (`dtolnay/rust-toolchain@stable`) will cover build + test suite
- [ ] Confirm CodeQL re-scan clears alerts #5 and #6 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)