### PR TITLE
fix: correct --fix insertion point and broaden near-miss header detection

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -488,8 +488,31 @@ fn auto_regen_stale_specs(
 
 // ─── Auto-fix: add undocumented exports to spec ─────────────────────────
 
+/// Compute the Levenshtein edit distance between two strings.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr = vec![0usize; n + 1];
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            curr[j] = if a[i - 1] == b[j - 1] {
+                prev[j - 1]
+            } else {
+                1 + prev[j - 1].min(prev[j]).min(curr[j - 1])
+            };
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[n]
+}
+
 /// Normalize near-miss export headers within ## Public API.
 /// E.g., "### Exportd Functions" → "### Exported Functions"
+/// Uses Levenshtein distance ≤ 2 against a canonical list to catch typos,
+/// singular/plural mismatches, and uncommon variations.
 /// Returns true if the content was modified.
 fn fix_near_miss_headers(content: &mut String) -> bool {
     use regex::Regex;
@@ -509,26 +532,16 @@ fn fix_near_miss_headers(content: &mut String) -> bool {
     let api_section = content[api_start..api_end].to_string();
     let mut modified = false;
 
-    // Known canonical headers and their near-miss patterns
-    let canonical_map: &[(&[&str], &str)] = &[
-        (
-            &[
-                "exportd function",
-                "exportd func",
-                "exproted function",
-                "expported function",
-            ],
-            "Exported Functions",
-        ),
-        (
-            &["exportd type", "exproted type", "expported type"],
-            "Exported Types",
-        ),
-        (&["exportd class", "exproted class"], "Exported Classes"),
-        (
-            &["exportd constant", "exportd const", "exproted constant"],
-            "Exported Constants",
-        ),
+    // Canonical export subsection names. Levenshtein distance ≤ 2 triggers a rename.
+    let canonicals: &[&str] = &[
+        "Exported Functions",
+        "Exported Types",
+        "Exported Classes",
+        "Exported Constants",
+        "Exported Components",
+        "Exported Hooks",
+        "Exported Interfaces",
+        "Exported Enums",
     ];
 
     let mut new_section = api_section.clone();
@@ -536,22 +549,22 @@ fn fix_near_miss_headers(content: &mut String) -> bool {
         let header_text = cap.get(2).unwrap().as_str();
         let lower = header_text.to_ascii_lowercase();
 
-        // Skip headers that already match via is_export_header
+        // Skip headers that already pass is_export_header
         if crate::parser::is_export_header(&format!("### {header_text}")) {
             continue;
         }
 
-        // Check for near-miss (Levenshtein distance ≤ 2 from any canonical)
-        for (patterns, canonical) in canonical_map {
-            for pattern in *patterns {
-                if lower.contains(pattern) {
-                    let old = format!("### {header_text}");
-                    let new = format!("### {canonical}");
-                    new_section = new_section.replacen(&old, &new, 1);
-                    modified = true;
-                    break;
-                }
-            }
+        // Find closest canonical by edit distance; fix if within 2 edits
+        if let Some((&canonical, _)) = canonicals
+            .iter()
+            .map(|c| (c, levenshtein(&lower, &c.to_ascii_lowercase())))
+            .min_by_key(|(_, d)| *d)
+            .filter(|(_, d)| *d > 0 && *d <= 2)
+        {
+            let old = format!("### {header_text}");
+            let new = format!("### {canonical}");
+            new_section = new_section.replacen(&old, &new, 1);
+            modified = true;
         }
     }
 
@@ -567,6 +580,7 @@ fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncC
     use crate::parser::{get_spec_symbols, parse_frontmatter};
 
     let mut fixed_count = 0;
+    let sub_re = regex::Regex::new(r"(?m)^### ").unwrap();
 
     for spec_file in spec_files {
         let content = match fs::read_to_string(spec_file) {
@@ -652,29 +666,82 @@ fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncC
             .collect::<Vec<_>>()
             .join("\n");
 
-        // Find insertion point: end of "## Public API" section, before next "## " heading
+        // Find insertion point: end of the last recognized export subsection within
+        // ## Public API, so new rows land where get_spec_symbols will find them.
+        // Inserting at the end of the whole section causes duplicates when non-export
+        // subsections (e.g. ### API Endpoints) come after the export table.
         let mut new_content = content.clone();
         if let Some(api_start) = content.find("## Public API") {
             let after = &content[api_start..];
-            // Find the next ## heading after Public API
-            let next_section = after[1..].find("\n## ").map(|pos| api_start + 1 + pos);
+            let api_end = after[1..]
+                .find("\n## ")
+                .map(|p| api_start + 1 + p)
+                .unwrap_or(content.len());
+            let api_section = &content[api_start..api_end];
 
-            let insert_pos = match next_section {
-                Some(pos) => pos,
-                None => content.len(),
-            };
+            // Collect start offsets (relative to api_section) of every ### subsection
+            let sub_positions: Vec<usize> = sub_re
+                .find_iter(api_section)
+                .map(|m| m.start())
+                .collect();
 
-            // Insert new rows before the next section
-            new_content = format!(
-                "{}\n{}\n{}",
-                content[..insert_pos].trim_end(),
-                new_rows,
-                &content[insert_pos..]
-            );
+            // Find the absolute end of the last recognized export subsection
+            let export_insert = sub_positions
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(i, &rel_pos)| {
+                    let header_line = api_section[rel_pos..].lines().next().unwrap_or("");
+                    if crate::parser::is_export_header(header_line) {
+                        let rel_end = sub_positions
+                            .get(i + 1)
+                            .copied()
+                            .unwrap_or(api_section.len());
+                        Some(api_start + rel_end)
+                    } else {
+                        None
+                    }
+                });
+
+            match export_insert {
+                Some(pos) => {
+                    // Append rows at end of last recognized export subsection
+                    new_content = format!(
+                        "{}\n{}\n{}",
+                        content[..pos].trim_end(),
+                        new_rows,
+                        &content[pos..]
+                    );
+                }
+                None if sub_positions.is_empty() => {
+                    // No ### subsections — flat table or empty body; insert at section end
+                    new_content = format!(
+                        "{}\n{}\n{}",
+                        content[..api_end].trim_end(),
+                        new_rows,
+                        &content[api_end..]
+                    );
+                }
+                None => {
+                    // Has subsections but none are recognized export headers;
+                    // create a new ### Exported Functions subsection at the top of the section
+                    let api_header_end =
+                        api_start + api_section.find('\n').unwrap_or(api_section.len());
+                    let header_block = format!(
+                        "\n\n### Exported Functions\n\n| Export | Description |\n|--------|-------------|\n{new_rows}"
+                    );
+                    new_content = format!(
+                        "{}{}{}",
+                        &content[..api_header_end],
+                        header_block,
+                        &content[api_header_end..]
+                    );
+                }
+            }
         } else {
             // No Public API section — append one
             let section = format!(
-                "\n## Public API\n\n| Export | Description |\n|--------|-------------|\n{new_rows}\n"
+                "\n## Public API\n\n### Exported Functions\n\n| Export | Description |\n|--------|-------------|\n{new_rows}\n"
             );
             new_content.push_str(&section);
         }

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -680,10 +680,8 @@ fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncC
             let api_section = &content[api_start..api_end];
 
             // Collect start offsets (relative to api_section) of every ### subsection
-            let sub_positions: Vec<usize> = sub_re
-                .find_iter(api_section)
-                .map(|m| m.start())
-                .collect();
+            let sub_positions: Vec<usize> =
+                sub_re.find_iter(api_section).map(|m| m.start()).collect();
 
             // Find the absolute end of the last recognized export subsection
             let export_insert = sub_positions

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2437,6 +2437,165 @@ fn fix_with_json_output() {
     assert!(json["specs_checked"].is_number());
 }
 
+// Regression: --fix used to insert new rows at the end of ## Public API, which put
+// them inside non-export subsections (e.g. ### API Endpoints). get_spec_symbols skips
+// non-export subsections, so the symbol remained "undocumented" and --fix would append
+// it again on every run, producing duplicates.
+#[test]
+fn fix_does_not_duplicate_when_non_export_subsections_present() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    write_config(root, "specs", &["src"]);
+
+    fs::create_dir_all(root.join("src/auth")).unwrap();
+    fs::write(
+        root.join("src/auth/service.ts"),
+        "export function login() {}\nexport function logout() {}\n",
+    )
+    .unwrap();
+
+    // Spec has login documented under a recognized export header, plus a
+    // non-export ### API Endpoints subsection that would previously swallow new rows.
+    fs::create_dir_all(root.join("specs/auth")).unwrap();
+    let spec = r#"---
+module: auth
+version: 1
+status: active
+files:
+  - src/auth/service.ts
+db_tables: []
+depends_on: []
+---
+
+# Auth
+
+## Purpose
+
+Auth module.
+
+## Public API
+
+### Exported Functions
+
+| Export | Description |
+|--------|-------------|
+| `login` | Authenticates a user |
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/login` | POST | Login endpoint |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+"#;
+    fs::write(root.join("specs/auth/auth.spec.md"), spec).unwrap();
+
+    // First --fix run: should add logout
+    specsync()
+        .args(["check", "--fix", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let after_first = fs::read_to_string(root.join("specs/auth/auth.spec.md")).unwrap();
+    assert!(
+        after_first.contains("`logout`"),
+        "logout should be added after first --fix"
+    );
+
+    // Second --fix run: logout must not be duplicated
+    specsync()
+        .args(["check", "--fix", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let after_second = fs::read_to_string(root.join("specs/auth/auth.spec.md")).unwrap();
+    let logout_count = after_second.matches("`logout`").count();
+    assert_eq!(
+        logout_count, 1,
+        "logout should not be duplicated after second --fix; found {logout_count}"
+    );
+
+    // login must also remain unduplicated
+    let login_count = after_second.matches("`login`").count();
+    assert_eq!(
+        login_count, 1,
+        "login should not be duplicated; found {login_count}"
+    );
+}
+
+// Regression: fix_near_miss_headers used a small hardcoded pattern list and missed
+// many real-world typos (singular forms, uncommon letter transpositions, etc.).
+// Now uses Levenshtein distance ≤ 2 against a canonical list.
+#[test]
+fn fix_near_miss_handles_levenshtein_typos() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    write_config(root, "specs", &["src"]);
+
+    fs::create_dir_all(root.join("src/utils")).unwrap();
+    fs::write(
+        root.join("src/utils/helpers.ts"),
+        "export function doStuff() {}\n",
+    )
+    .unwrap();
+
+    // Spec with a near-miss header that the old code didn't cover:
+    // "### Exporteed Functions" has edit distance 1 from "Exported Functions"
+    // (extra 'e'), but didn't match any old hardcoded pattern.
+    fs::create_dir_all(root.join("specs/utils")).unwrap();
+    let spec = r#"---
+module: utils
+version: 1
+status: active
+files:
+  - src/utils/helpers.ts
+db_tables: []
+depends_on: []
+---
+
+# Utils
+
+## Purpose
+
+Utility helpers.
+
+## Public API
+
+### Exporteed Functions
+
+| Export | Description |
+|--------|-------------|
+| `doStuff` | does stuff |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+"#;
+    fs::write(root.join("specs/utils/utils.spec.md"), spec).unwrap();
+
+    specsync()
+        .args(["check", "--fix", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let updated = fs::read_to_string(root.join("specs/utils/utils.spec.md")).unwrap();
+    assert!(
+        updated.contains("### Exported Functions"),
+        "near-miss header should have been renamed to '### Exported Functions'"
+    );
+    assert!(
+        !updated.contains("### Exporteed Functions"),
+        "original near-miss header should be gone"
+    );
+}
+
 // ─── Diff Command Tests ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- **`--fix` duplicate bug**: New export rows were being inserted at the end of the entire `## Public API` section. When non-export subsections (e.g. `### API Endpoints`) followed the export table, `get_spec_symbols` would skip those rows on the next run and `--fix` would duplicate them indefinitely. Fix: locate the last recognized export subsection and insert there; fall back to creating `### Exported Functions` if none exists.

- **Near-miss header detection**: `fix_near_miss_headers` used a hardcoded list of ~10 specific typos, missing singular forms, uncommon transpositions, and any variation not explicitly listed. Replaced with a `levenshtein()` helper and distance ≤ 2 matching against a full canonical list (Functions, Types, Classes, Constants, Components, Hooks, Interfaces, Enums).

## Test plan

- [ ] `cargo test fix` — all 8 fix-related tests pass (6 existing + 2 new regression tests)
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo build` — clean
- [ ] New test `fix_does_not_duplicate_when_non_export_subsections_present` reproduces the insertion-point bug and verifies it's fixed
- [ ] New test `fix_near_miss_handles_levenshtein_typos` verifies `### Exporteed Functions` (edit distance 1) is normalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)