### PR TITLE
chore: release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1] - 2026-04-17
+
+### Fixed
+
+- **Hardened section header matching** — regex anchors, whitespace tolerance, and word boundaries prevent false positives and mismatched headers on sections with leading/trailing spaces or similar names (#232).
+- **`--fix` insertion point corrected** — new rows no longer append after non-export subsections on repeated runs; near-miss header detection broadened to catch more variants (#231).
+
+### Security
+
+- **Redact API keys in `Debug` output** — sensitive keys are now masked in debug/trace logs (#230).
+- **Bumped `time` and `rustls-webpki`** — addresses upstream advisories in both crates (#230).
+
 ## [4.2.0] - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
## spec-sync 4.2.1

Patch release. All bug fixes and a security patch — no breaking changes.

### What's in this release

**Security**
- Redact API keys in `Debug` output (#230)
- Bump `time` + `rustls-webpki` to address upstream advisories (#230)

**Fixed**
- `--fix` insertion point corrected; near-miss header detection broadened (#231)
- Section header matching hardened — regex anchors, whitespace tolerance, word boundaries (#232)

### Checklist
- [x] Version bumped in `Cargo.toml` → `4.2.1`
- [x] `Cargo.lock` updated
- [x] `CHANGELOG.md` entry added

After merge: tag `v4.2.1` and publish to crates.io.