### PR TITLE
feat: penalize stub-heavy specs in depth scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1] - 2026-04-17
+
+### Fixed
+
+- **Hardened section header matching** — regex anchors, whitespace tolerance, and word boundaries prevent false positives and mismatched headers on sections with leading/trailing spaces or similar names (#232).
+- **`--fix` insertion point corrected** — new rows no longer append after non-export subsections on repeated runs; near-miss header detection broadened to catch more variants (#231).
+
+### Security
+
+- **Redact API keys in `Debug` output** — sensitive keys are now masked in debug/trace logs (#230).
+- **Bumped `time` and `rustls-webpki`** — addresses upstream advisories in both crates (#230).
+
 ## [4.2.0] - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"

--- a/specsync.json
+++ b/specsync.json
@@ -1,0 +1,4 @@
+{
+  "specsDir": "specs",
+  "sourceDir": "src"
+}

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -186,6 +186,18 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
     // Check each required section has meaningful content (stubs don't count)
     let sections_with_content = count_sections_with_content(body, &config.required_sections);
     let stub_sections = find_stub_sections(body, &config.required_sections);
+    let stub_ratio = if !config.required_sections.is_empty() {
+        stub_sections.len() as f64 / config.required_sections.len() as f64
+    } else {
+        0.0
+    };
+    let stub_penalty = if stub_ratio >= 0.5 {
+        10
+    } else if stub_ratio >= 0.33 {
+        5
+    } else {
+        0
+    };
     let content_ratio = if config.required_sections.is_empty() {
         1.0
     } else {
@@ -203,6 +215,7 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
             "Content depth: fill in {todo_count} TODO placeholder(s) with real content"
         ));
     }
+    depth_points = depth_points.saturating_sub(stub_penalty);
     score.depth_score = depth_points.min(20);
     if score.depth_score < 20 {
         let lost = 20 - score.depth_score;
@@ -231,6 +244,11 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
         score.suggestions.push(format!(
             "Stub sections: ## {names}{suffix} — replace placeholder text (TBD, N/A, TODO, etc.) with real content"
         ));
+        if stub_penalty > 0 {
+            score.suggestions.push(
+                "Stub ratio is high — fill in TBD sections to improve depth score.".to_string(),
+            );
+        }
     }
 
     // ─── Freshness (0-20) ────────────────────────────────────────────
@@ -630,9 +648,9 @@ None.
         let config = SpecSyncConfig::default();
         let score = score_spec(&spec_file, tmp.path(), &config);
 
-        // Depth score should be penalized because most sections are stubs
+        // Depth score should be penalized because most sections are stubs (>=50% → -10pts ceiling)
         assert!(
-            score.depth_score < 14,
+            score.depth_score <= 10,
             "Expected low depth score for stub sections, got {}",
             score.depth_score
         );


### PR DESCRIPTION
## Summary
- Specs with ≥50% stub sections (TBD/N/A/TODO) now lose 10 depth points; 33–50% stub ratio loses 5
- Added suggestion message: "Stub ratio is high — fill in TBD sections to improve depth score."
- Updated `test_score_spec_stub_sections_penalized` threshold from `< 14` to `<= 10` to reflect the new penalty ceiling

## Test plan
- [x] `cargo test test_score_spec_stub_sections_penalized` passes
- [x] Full `cargo test` suite passes (577 tests)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)