### PR TITLE
chore: release v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-04-18
+
+### Added
+
+- **`--explain` per-criterion breakdown** — `specsync score --explain` now prints a per-criterion table showing the score, weight, and a one-line rationale for every dimension. Makes it easy to see exactly why a spec lands at a given grade (#234).
+- **Stub/TBD depth penalty** — sections whose content is `TBD`, `Coming soon`, or equivalent placeholders are now penalized in the depth score. A spec filled with stubs can no longer score A (#235).
+
+### Fixed
+
+- **Near-miss required headers** — `specsync check` now reports near-miss section headers (e.g. `Overviews` instead of `Overview`) as actionable errors rather than silently missing them (#236).
+- **A-grade stub cap** — specs with a high ratio of stub sections are capped below A regardless of other scores (#236).
+
 ## [4.2.1] - 2026-04-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -108,9 +108,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -156,9 +156,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -694,9 +694,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libredox"
@@ -704,7 +704,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall",
@@ -774,7 +774,7 @@ version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -933,7 +933,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -985,7 +985,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "itoa",
@@ -1246,15 +1246,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1488,7 +1488,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1496,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1747,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.2.1"
+version = "4.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"

--- a/specs/parser/parser.spec.md
+++ b/specs/parser/parser.spec.md
@@ -36,6 +36,7 @@ Parses spec markdown files — extracts YAML frontmatter into structured data, e
 | `find_stub_sections` | `body: &str` | `Vec<String>` | Returns section names whose `## Section` blocks are present but contain no substantive content |
 | `find_section_offset` | `body: &str, section: &str` | `Option<usize>` | Returns byte offset of the `## Section` heading line, using anchored regex with trailing-whitespace tolerance |
 | `body_has_section` | `body: &str, section: &str` | `bool` | Returns true if the spec body contains an exact `## Section` heading (delegates to `find_section_offset`) |
+| `get_near_miss_sections` | `body: &str, required_sections: &[String]` | `Vec<(String, String)>` | For each missing required section, returns `(canonical_name, found_heading)` pairs where a `## Heading` exists within Levenshtein distance ≤ 2 — used to detect typos and suggest `--fix` |
 
 ## Invariants
 
@@ -44,6 +45,7 @@ Parses spec markdown files — extracts YAML frontmatter into structured data, e
 3. `get_spec_symbols` only extracts from `### Exported ...` subsections (allowlist) and top-level tables; skips non-export subsections (e.g., `### API Endpoints`, `### Route Handlers`, `### Configuration`) and `####` method/constructor/properties sub-tables
 4. Symbols are deduplicated while preserving order
 5. `get_missing_sections` uses regex matching for `## SectionName` headings — case-sensitive
+8. `get_near_miss_sections` only reports sections that are already in `get_missing_sections` — it does not flag sections that are present but close to another required name
 6. Frontmatter parsing handles both scalar fields (module, version, status) and list fields (files, db_tables, depends_on)
 7. Empty list syntax `[]` is handled correctly, producing an empty Vec
 
@@ -89,8 +91,9 @@ Parses spec markdown files — extracts YAML frontmatter into structured data, e
 
 | Module | What is used |
 |--------|-------------|
-| validator | `parse_frontmatter`, `get_spec_symbols`, `get_missing_sections` |
+| validator | `parse_frontmatter`, `get_spec_symbols`, `get_missing_sections`, `get_near_miss_sections` |
 | scoring | `parse_frontmatter`, `get_spec_symbols`, `get_missing_sections` |
+| commands/check | `get_near_miss_sections` (via `fix_near_miss_required_headers`) |
 | mcp | `parse_frontmatter` (for listing specs) |
 
 ## Change Log

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -579,10 +579,7 @@ fn fix_near_miss_headers(content: &mut String) -> bool {
 /// Uses the same Levenshtein ≤ 2 approach as export-subsection fixing,
 /// applied to the top-level required sections from config.
 /// Returns true if the content was modified.
-fn fix_near_miss_required_headers(
-    content: &mut String,
-    required_sections: &[String],
-) -> bool {
+fn fix_near_miss_required_headers(content: &mut String, required_sections: &[String]) -> bool {
     let near_misses = crate::parser::get_near_miss_sections(content, required_sections);
     if near_misses.is_empty() {
         return false;

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -575,6 +575,30 @@ fn fix_near_miss_headers(content: &mut String) -> bool {
     modified
 }
 
+/// Rename near-miss `## Required Section` headings in the spec body.
+/// Uses the same Levenshtein ≤ 2 approach as export-subsection fixing,
+/// applied to the top-level required sections from config.
+/// Returns true if the content was modified.
+fn fix_near_miss_required_headers(
+    content: &mut String,
+    required_sections: &[String],
+) -> bool {
+    let near_misses = crate::parser::get_near_miss_sections(content, required_sections);
+    if near_misses.is_empty() {
+        return false;
+    }
+    let mut modified = false;
+    for (canonical, found) in &near_misses {
+        let old = format!("## {found}");
+        let new = format!("## {canonical}");
+        if content.contains(&old) {
+            *content = content.replacen(&old, &new, 1);
+            modified = true;
+        }
+    }
+    modified
+}
+
 fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncConfig) -> usize {
     use crate::exports::get_exported_symbols_full;
     use crate::parser::{get_spec_symbols, parse_frontmatter};
@@ -588,12 +612,22 @@ fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncC
             Err(_) => continue,
         };
 
-        // First pass: fix near-miss headers
+        // First pass: fix near-miss required section headers (## level)
         let mut content = content;
+        if fix_near_miss_required_headers(&mut content, &config.required_sections) {
+            let rel = spec_file.strip_prefix(root).unwrap_or(spec_file).display();
+            println!(
+                "  {} {rel}: renamed near-miss required section header(s) to canonical form",
+                "✓".green()
+            );
+            let _ = fs::write(spec_file, &content);
+        }
+
+        // Second pass: fix near-miss export subsection headers (### level)
         if fix_near_miss_headers(&mut content) {
             let rel = spec_file.strip_prefix(root).unwrap_or(spec_file).display();
             println!(
-                "  {} {rel}: renamed near-miss header(s) to canonical form",
+                "  {} {rel}: renamed near-miss export header(s) to canonical form",
                 "✓".green()
             );
             let _ = fs::write(spec_file, &content);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -274,6 +274,54 @@ pub fn get_missing_sections(body: &str, required_sections: &[String]) -> Vec<Str
     missing
 }
 
+/// Levenshtein edit distance between two strings.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    let mut prev: Vec<usize> = (0..=n).collect();
+    let mut curr = vec![0usize; n + 1];
+    for i in 1..=m {
+        curr[0] = i;
+        for j in 1..=n {
+            curr[j] = if a[i - 1] == b[j - 1] {
+                prev[j - 1]
+            } else {
+                1 + prev[j - 1].min(prev[j]).min(curr[j - 1])
+            };
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[n]
+}
+
+/// For each required section that is missing an exact heading, check whether
+/// a near-miss `## Heading` exists (edit distance ≤ 2, case-insensitive).
+/// Returns `(required_name, actual_heading_in_body)` pairs.
+pub fn get_near_miss_sections(body: &str, required_sections: &[String]) -> Vec<(String, String)> {
+    let heading_re = Regex::new(r"(?m)^## (.+?)\s*$").unwrap();
+    let headings: Vec<String> = heading_re
+        .captures_iter(body)
+        .map(|cap| cap.get(1).unwrap().as_str().to_string())
+        .collect();
+
+    let missing = get_missing_sections(body, required_sections);
+    let mut near_misses = Vec::new();
+    for section in &missing {
+        let section_lower = section.to_ascii_lowercase();
+        if let Some(nearest) = headings
+            .iter()
+            .map(|h| (h, levenshtein(&h.to_ascii_lowercase(), &section_lower)))
+            .filter(|(_, d)| *d > 0 && *d <= 2)
+            .min_by_key(|(_, d)| *d)
+            .map(|(h, _)| h.clone())
+        {
+            near_misses.push((section.clone(), nearest));
+        }
+    }
+    near_misses
+}
+
 // ─── Stub/Placeholder Detection ─────────────────────────────────────────
 
 /// Common stub phrases that indicate a section has no real content.

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -585,6 +585,19 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
         _ => "F",
     };
 
+    // A-grade requires real content — specs with ≥50% stub sections are capped at B.
+    // This prevents fully-stubbed specs with clean metadata from reaching an A.
+    let total_req = config.required_sections.len();
+    if score.grade == "A" && total_req > 0 && stub_sections.len() * 2 >= total_req {
+        score.grade = "B";
+        score.total = score.total.min(89);
+        score.suggestions.push(format!(
+            "Grade capped at B: {}/{} required sections contain only stub/placeholder content — replace TBD/N/A/TODO with real documentation",
+            stub_sections.len(),
+            total_req
+        ));
+    }
+
     score
 }
 

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -357,9 +357,9 @@ pub fn validate_spec(
                 result.errors.push(format!(
                     "Missing required section: ## {section} (found '## {found}' — typo? Run --fix to rename)"
                 ));
-                result
-                    .fixes
-                    .push(format!("Run `spec-sync check --fix` to rename `## {found}` → `## {section}`"));
+                result.fixes.push(format!(
+                    "Run `spec-sync check --fix` to rename `## {found}` → `## {section}`"
+                ));
             } else {
                 result
                     .errors

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -2,7 +2,7 @@ use crate::config::{default_schema_pattern, discover_manifest_modules};
 use crate::exports::{get_exported_symbols_full, has_extension, is_test_file};
 use crate::parser::{
     body_has_section, find_section_offset, find_stub_sections, get_missing_sections,
-    get_spec_symbols, parse_frontmatter,
+    get_near_miss_sections, get_spec_symbols, parse_frontmatter,
 };
 use crate::schema::{self, SchemaTable};
 use crate::types::{
@@ -347,16 +347,27 @@ pub fn validate_spec(
 
     if !is_draft {
         let missing = get_missing_sections(body, &config.required_sections);
+        let near_misses = get_near_miss_sections(body, &config.required_sections);
         for section in &missing {
             if is_review && section == "Public API" {
                 continue; // review specs can skip Public API
             }
-            result
-                .errors
-                .push(format!("Missing required section: ## {section}"));
-            result
-                .fixes
-                .push(format!("Add `## {section}` heading to the spec body"));
+            // Check if a near-miss heading exists — give a targeted hint
+            if let Some((_, found)) = near_misses.iter().find(|(req, _)| req == section) {
+                result.errors.push(format!(
+                    "Missing required section: ## {section} (found '## {found}' — typo? Run --fix to rename)"
+                ));
+                result
+                    .fixes
+                    .push(format!("Run `spec-sync check --fix` to rename `## {found}` → `## {section}`"));
+            } else {
+                result
+                    .errors
+                    .push(format!("Missing required section: ## {section}"));
+                result
+                    .fixes
+                    .push(format!("Add `## {section}` heading to the spec body"));
+            }
         }
     }
 


### PR DESCRIPTION
## v4.3.0 Release

### Added
- `--explain` per-criterion breakdown for `specsync score` (#234)
- Stub/TBD depth penalty — specs filled with placeholders can no longer score A (#235)

### Fixed
- Near-miss required headers now reported as actionable errors (#236)
- A-grade stub cap — high stub ratio capped below A (#236)

This closes the remaining gaps from the 7/10 feedback review. Changelog and version bump included.

---
🤖 Agent: Rook | Model: Sonnet 4.6