### PR TITLE
feat: --fix dry-run/backup, config path in errors, large file guard

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,12 @@ pub enum Command {
         /// Auto-add undocumented exports to spec Public API tables
         #[arg(long)]
         fix: bool,
+        /// Preview --fix changes without writing files
+        #[arg(long)]
+        dry_run: bool,
+        /// Create .bak backup files before --fix modifies specs
+        #[arg(long)]
+        backup: bool,
         /// Skip hash cache and re-validate all specs
         #[arg(long, visible_alias = "no-cache")]
         force: bool,

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -30,6 +30,8 @@ pub fn cmd_check(
     require_coverage: Option<usize>,
     format: types::OutputFormat,
     fix: bool,
+    dry_run: bool,
+    backup: bool,
     force: bool,
     create_issues: bool,
     explain: bool,
@@ -199,13 +201,39 @@ pub fn cmd_check(
 
     // If --fix is requested, auto-add undocumented exports to specs
     if fix {
-        let fixed = auto_fix_specs(root, &specs_to_validate, &config);
+        if backup && !dry_run {
+            let backup_dir = root.join(".specsync/backup-fix");
+            let _ = fs::create_dir_all(&backup_dir);
+            for spec_file in &specs_to_validate {
+                let rel = spec_file.strip_prefix(root).unwrap_or(spec_file);
+                let dest = backup_dir.join(rel);
+                if let Some(parent) = dest.parent() {
+                    let _ = fs::create_dir_all(parent);
+                }
+                let _ = fs::copy(spec_file, &dest);
+            }
+            if matches!(format, Text) {
+                println!(
+                    "{} Backed up {} spec(s) to {}\n",
+                    "✓".green(),
+                    specs_to_validate.len(),
+                    backup_dir.display()
+                );
+            }
+        }
+
+        let fixed = auto_fix_specs(root, &specs_to_validate, &config, dry_run);
         if fixed > 0 && matches!(format, Text) {
-            println!("{} Auto-added exports to {fixed} spec(s)\n", "✓".green());
+            let verb = if dry_run {
+                "Would auto-add"
+            } else {
+                "Auto-added"
+            };
+            println!("{} {verb} exports to {fixed} spec(s)\n", "✓".green());
         }
 
         // --fix + requirements changed: regenerate spec via AI
-        if !requirements_stale_specs.is_empty() {
+        if !dry_run && !requirements_stale_specs.is_empty() {
             let regen_count =
                 auto_regen_stale_specs(root, &requirements_stale_specs, &config, format);
             if regen_count > 0 && matches!(format, Text) {
@@ -577,7 +605,12 @@ fn fix_near_miss_required_headers(content: &mut String, required_sections: &[Str
     modified
 }
 
-fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncConfig) -> usize {
+fn auto_fix_specs(
+    root: &Path,
+    spec_files: &[PathBuf],
+    config: &types::SpecSyncConfig,
+    dry_run: bool,
+) -> usize {
     use crate::exports::get_exported_symbols_full;
     use crate::parser::{get_spec_symbols, parse_frontmatter};
 
@@ -594,21 +627,27 @@ fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncC
         let mut content = content;
         if fix_near_miss_required_headers(&mut content, &config.required_sections) {
             let rel = spec_file.strip_prefix(root).unwrap_or(spec_file).display();
+            let verb = if dry_run { "would rename" } else { "renamed" };
             println!(
-                "  {} {rel}: renamed near-miss required section header(s) to canonical form",
+                "  {} {rel}: {verb} near-miss required section header(s) to canonical form",
                 "✓".green()
             );
-            let _ = fs::write(spec_file, &content);
+            if !dry_run {
+                let _ = fs::write(spec_file, &content);
+            }
         }
 
         // Second pass: fix near-miss export subsection headers (### level)
         if fix_near_miss_headers(&mut content) {
             let rel = spec_file.strip_prefix(root).unwrap_or(spec_file).display();
+            let verb = if dry_run { "would rename" } else { "renamed" };
             println!(
-                "  {} {rel}: renamed near-miss export header(s) to canonical form",
+                "  {} {rel}: {verb} near-miss export header(s) to canonical form",
                 "✓".green()
             );
-            let _ = fs::write(spec_file, &content);
+            if !dry_run {
+                let _ = fs::write(spec_file, &content);
+            }
         }
 
         let parsed = match parse_frontmatter(&content) {
@@ -756,7 +795,15 @@ fn auto_fix_specs(root: &Path, spec_files: &[PathBuf], config: &types::SpecSyncC
             new_content.push_str(&section);
         }
 
-        if let Ok(()) = fs::write(spec_file, &new_content) {
+        if dry_run {
+            fixed_count += 1;
+            let rel = spec_file.strip_prefix(root).unwrap_or(spec_file).display();
+            println!(
+                "  {} {rel}: would add {} export(s)",
+                "✓".green(),
+                undocumented.len()
+            );
+        } else if let Ok(()) = fs::write(spec_file, &new_content) {
             fixed_count += 1;
             let rel = spec_file.strip_prefix(root).unwrap_or(spec_file).display();
             println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,20 +173,25 @@ pub fn load_config(root: &Path) -> SpecSyncConfig {
     let legacy_toml = root.join(".specsync.toml");
     let legacy_json = root.join("specsync.json");
 
-    let mut config = if v4_toml.exists() {
-        load_toml_config(&v4_toml, root)
+    let (mut config, config_path) = if v4_toml.exists() {
+        (load_toml_config(&v4_toml, root), Some(v4_toml))
     } else if v4_json.exists() {
-        load_json_config(&v4_json, root)
+        (load_json_config(&v4_json, root), Some(v4_json))
     } else if legacy_toml.exists() {
-        load_toml_config(&legacy_toml, root)
+        (load_toml_config(&legacy_toml, root), Some(legacy_toml))
     } else if legacy_json.exists() {
-        load_json_config(&legacy_json, root)
+        (load_json_config(&legacy_json, root), Some(legacy_json))
     } else {
-        SpecSyncConfig {
-            source_dirs: detect_source_dirs(root),
-            ..Default::default()
-        }
+        (
+            SpecSyncConfig {
+                source_dirs: detect_source_dirs(root),
+                ..Default::default()
+            },
+            None,
+        )
     };
+
+    config.config_path = config_path;
 
     // Merge local overrides (gitignored, per-developer config)
     let local_toml = root.join(".specsync/config.local.toml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,8 @@ fn run() {
 
     let command = cli.command.unwrap_or(Command::Check {
         fix: false,
+        dry_run: false,
+        backup: false,
         force: false,
         create_issues: false,
         explain: false,
@@ -83,6 +85,8 @@ fn run() {
         Command::Init => commands::init::cmd_init(&root),
         Command::Check {
             fix,
+            dry_run,
+            backup,
             force,
             create_issues,
             explain,
@@ -95,6 +99,8 @@ fn run() {
             cli.require_coverage,
             format,
             fix,
+            dry_run,
+            backup,
             force,
             create_issues,
             explain,

--- a/src/types.rs
+++ b/src/types.rs
@@ -521,6 +521,10 @@ pub struct SpecSyncConfig {
     /// Companion file settings.
     #[serde(default)]
     pub companions: CompanionConfig,
+
+    /// Path to the config file that was loaded (not serialized — set at runtime).
+    #[serde(skip)]
+    pub config_path: Option<std::path::PathBuf>,
 }
 
 /// Configuration for companion file generation.
@@ -870,6 +874,7 @@ impl Default for SpecSyncConfig {
             enforcement: EnforcementMode::default(),
             lifecycle: LifecycleConfig::default(),
             companions: CompanionConfig::default(),
+            config_path: None,
         }
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -181,11 +181,28 @@ pub fn validate_spec(
     let fm = &parsed.frontmatter;
     let body = &parsed.body;
 
+    // File size guard: warn early if the spec is unusually large
+    if let Ok(meta) = std::fs::metadata(spec_path) {
+        let size_kb = meta.len() / 1024;
+        if size_kb > 512 {
+            result.warnings.push(format!(
+                "Spec file is {} KB — consider splitting into smaller specs for maintainability",
+                size_kb
+            ));
+        }
+    }
+
     // Archived specs: skip all validation with zero diagnostics.
     // Must be invisible to --strict mode.
     if fm.parsed_status() == Some(crate::types::SpecStatus::Archived) {
         return result;
     }
+
+    let config_hint = config
+        .config_path
+        .as_deref()
+        .map(|p| format!(" (check config: {})", p.display()))
+        .unwrap_or_default();
 
     // ─── Level 1: Structural ──────────────────────────────────────────
 
@@ -362,9 +379,9 @@ pub fn validate_spec(
                     "Run `spec-sync check --fix` to rename `## {found}` → `## {section}`"
                 ));
             } else {
-                result
-                    .errors
-                    .push(format!("Missing required section: ## {section}"));
+                result.errors.push(format!(
+                    "Missing required section: ## {section}{config_hint}"
+                ));
                 result
                     .fixes
                     .push(format!("Add `## {section}` heading to the spec body"));
@@ -525,7 +542,7 @@ pub fn validate_spec(
     }
 
     // ─── Custom Validation Rules ─────────────────────────────────────
-    apply_custom_rules(spec_path, body, fm, config, &mut result);
+    apply_custom_rules(spec_path, body, fm, config, &config_hint, &mut result);
 
     result
 }
@@ -536,6 +553,7 @@ fn apply_custom_rules(
     body: &str,
     fm: &Frontmatter,
     config: &SpecSyncConfig,
+    config_hint: &str,
     result: &mut ValidationResult,
 ) {
     let rules = &config.rules;
@@ -546,7 +564,7 @@ fn apply_custom_rules(
             let size_kb = meta.len() as usize / 1024;
             if size_kb > max_kb {
                 result.warnings.push(format!(
-                    "Spec file is {size_kb} KB — exceeds limit of {max_kb} KB"
+                    "Spec file is {size_kb} KB — exceeds limit of {max_kb} KB{config_hint}"
                 ));
             }
         }
@@ -598,7 +616,7 @@ fn apply_custom_rules(
             continue;
         }
         if let Some(msg) = evaluate_custom_rule(rule, body) {
-            let tagged = format!("{msg} (rule: {})", rule.name);
+            let tagged = format!("{msg} (rule: {}){config_hint}", rule.name);
             match rule.severity {
                 RuleSeverity::Error => result.errors.push(tagged),
                 RuleSeverity::Warning => result.warnings.push(tagged),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4503,3 +4503,128 @@ fn custom_rule_applies_to_filter_skips_non_matching_modules() {
         "Module filter ^auth should skip utils module. Got:\n{stdout}"
     );
 }
+
+// ─── #244: --fix --dry-run does not modify files ────────────────────────
+
+#[test]
+fn fix_dry_run_does_not_write_files() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("specs/mymod")).unwrap();
+    fs::create_dir_all(root.join("src/mymod")).unwrap();
+    fs::write(
+        root.join("src/mymod/index.ts"),
+        "export function hello() {}\nexport function world() {}\n",
+    )
+    .unwrap();
+    // Spec only documents 'hello', so --fix would add 'world'
+    let spec_content = valid_spec("mymod", &["src/mymod/index.ts"]);
+    let spec_with_hello = spec_content.replace(
+        "| Function | Parameters | Returns | Description |",
+        "| Function | Parameters | Returns | Description |\n| `hello` | | void | Says hello |",
+    );
+    fs::write(root.join("specs/mymod/mymod.spec.md"), &spec_with_hello).unwrap();
+    // Also create companion requirements.md to suppress warning
+    fs::write(root.join("specs/mymod/requirements.md"), "# Requirements\n").unwrap();
+
+    let original = fs::read_to_string(root.join("specs/mymod/mymod.spec.md")).unwrap();
+
+    specsync()
+        .args([
+            "check",
+            "--fix",
+            "--dry-run",
+            "--root",
+            root.to_str().unwrap(),
+            "--force",
+        ])
+        .assert()
+        .success();
+
+    let after = fs::read_to_string(root.join("specs/mymod/mymod.spec.md")).unwrap();
+    assert_eq!(original, after, "--dry-run should not modify spec files");
+}
+
+// ─── #244: --fix --backup creates backup files ────────���─────────────────
+
+#[test]
+fn fix_backup_creates_backup_dir() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("specs/bmod")).unwrap();
+    fs::create_dir_all(root.join("src/bmod")).unwrap();
+    fs::write(
+        root.join("src/bmod/index.ts"),
+        "export function alpha() {}\nexport function beta() {}\n",
+    )
+    .unwrap();
+    let spec_content = valid_spec("bmod", &["src/bmod/index.ts"]);
+    let spec_with_alpha = spec_content.replace(
+        "| Function | Parameters | Returns | Description |",
+        "| Function | Parameters | Returns | Description |\n| `alpha` | | void | Alpha |",
+    );
+    fs::write(root.join("specs/bmod/bmod.spec.md"), &spec_with_alpha).unwrap();
+    fs::write(root.join("specs/bmod/requirements.md"), "# Requirements\n").unwrap();
+
+    specsync()
+        .args([
+            "check",
+            "--fix",
+            "--backup",
+            "--root",
+            root.to_str().unwrap(),
+            "--force",
+        ])
+        .assert()
+        .success();
+
+    let backup_dir = root.join(".specsync/backup-fix");
+    assert!(
+        backup_dir.exists(),
+        "--backup should create .specsync/backup-fix/"
+    );
+    assert!(
+        backup_dir.join("specs/bmod/bmod.spec.md").exists(),
+        "Backup should contain the original spec file"
+    );
+}
+
+// ─── #245: Error messages include config file location ──────────────────
+
+#[test]
+fn error_messages_include_config_path() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("specs/cfgmod")).unwrap();
+    fs::create_dir_all(root.join("src/cfgmod")).unwrap();
+    fs::write(root.join("src/cfgmod/index.ts"), "export function f() {}").unwrap();
+    // Spec missing required sections — errors should mention config location
+    let spec = r#"---
+module: cfgmod
+version: 1
+status: active
+files:
+  - src/cfgmod/index.ts
+---
+
+## Purpose
+Test module
+"#;
+    fs::write(root.join("specs/cfgmod/cfgmod.spec.md"), spec).unwrap();
+
+    let output = specsync()
+        .args(["check", "--root", root.to_str().unwrap(), "--force"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("check config:") || stdout.contains("specsync.json"),
+        "Missing section errors should reference config file. Got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the final 3 open issues (#243, #244, #245) — bringing spec-sync to zero open issues.

- **#244 `--fix` dry-run & backup**: `check --fix --dry-run` previews changes without writing files. `check --fix --backup` copies specs to `.specsync/backup-fix/` before modifying them. Both can be combined.
- **#245 Config path in errors**: Validation errors driven by config (missing required sections, custom rule violations, size limits) now include the config file path, e.g. `(check config: .specsync/config.toml)`. Makes debugging much easier in monorepos with multiple config files.
- **#243 Large file guard**: Specs exceeding 512 KB trigger a warning suggesting they be split into smaller specs. This catches the scaling concern before it becomes a problem.

## Changes

| File | What |
|------|------|
| `src/cli.rs` | Added `--dry-run` and `--backup` flags to Check command |
| `src/main.rs` | Thread new flags through to cmd_check |
| `src/commands/check.rs` | Backup dir creation, dry-run guards on all `fs::write` calls |
| `src/config.rs` | `load_config` now records which config file was loaded |
| `src/types.rs` | Added `config_path: Option<PathBuf>` to SpecSyncConfig |
| `src/validator.rs` | Config path in error messages, 512 KB file size guard |
| `tests/integration.rs` | 3 new integration tests for dry-run, backup, and config path |

## Test plan

- [x] 120 tests pass (117 existing + 3 new), zero failures
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] Pre-commit spec-sync hook passes on all 6 touched spec files

Closes #243, closes #244, closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)