### PR TITLE
fix: backup error handling, size warning dedup, dry-run guard (#249, #250, #251)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # spec-sync hash cache (regenerated locally)
 .specsync/hashes.json
+
+# spec-sync backup directories (created by --fix --backup)
+.specsync/backup-fix/
+.specsync/backup-3x/

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -199,24 +199,66 @@ pub fn cmd_check(
     let schema_columns = build_schema_columns(root, &config);
     let ignore_rules = IgnoreRules::load(root);
 
+    if dry_run && !fix {
+        eprintln!(
+            "{} --dry-run has no effect without --fix (nothing to preview)",
+            "⚠".yellow()
+        );
+    }
+
     // If --fix is requested, auto-add undocumented exports to specs
     if fix {
         if backup && !dry_run {
             let backup_dir = root.join(".specsync/backup-fix");
-            let _ = fs::create_dir_all(&backup_dir);
+            if let Err(e) = fs::create_dir_all(&backup_dir) {
+                eprintln!(
+                    "{} Failed to create backup directory {}: {e}",
+                    "✗".red(),
+                    backup_dir.display()
+                );
+                eprintln!("  Aborting --fix to avoid data loss. Fix the backup path and retry.");
+                process::exit(1);
+            }
+            let mut backed_up = 0usize;
             for spec_file in &specs_to_validate {
-                let rel = spec_file.strip_prefix(root).unwrap_or(spec_file);
+                let rel = match spec_file.strip_prefix(root) {
+                    Ok(r) => r,
+                    Err(_) => {
+                        eprintln!(
+                            "{} Cannot backup {}: path is not under project root",
+                            "✗".red(),
+                            spec_file.display()
+                        );
+                        process::exit(1);
+                    }
+                };
                 let dest = backup_dir.join(rel);
                 if let Some(parent) = dest.parent() {
-                    let _ = fs::create_dir_all(parent);
+                    if let Err(e) = fs::create_dir_all(parent) {
+                        eprintln!(
+                            "{} Failed to create backup subdirectory {}: {e}",
+                            "✗".red(),
+                            parent.display()
+                        );
+                        process::exit(1);
+                    }
                 }
-                let _ = fs::copy(spec_file, &dest);
+                if let Err(e) = fs::copy(spec_file, &dest) {
+                    eprintln!(
+                        "{} Failed to backup {}: {e}",
+                        "✗".red(),
+                        spec_file.display()
+                    );
+                    eprintln!("  Aborting --fix to avoid data loss.");
+                    process::exit(1);
+                }
+                backed_up += 1;
             }
             if matches!(format, Text) {
                 println!(
                     "{} Backed up {} spec(s) to {}\n",
                     "✓".green(),
-                    specs_to_validate.len(),
+                    backed_up,
                     backup_dir.display()
                 );
             }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -181,14 +181,16 @@ pub fn validate_spec(
     let fm = &parsed.frontmatter;
     let body = &parsed.body;
 
-    // File size guard: warn early if the spec is unusually large
-    if let Ok(meta) = std::fs::metadata(spec_path) {
-        let size_kb = meta.len() / 1024;
-        if size_kb > 512 {
-            result.warnings.push(format!(
-                "Spec file is {} KB — consider splitting into smaller specs for maintainability",
-                size_kb
-            ));
+    // File size guard: warn if the spec exceeds the configurable limit (default 512 KB)
+    {
+        let limit_kb = config.rules.max_spec_size_kb.unwrap_or(512) as u64;
+        if let Ok(meta) = std::fs::metadata(spec_path) {
+            let size_kb = meta.len() / 1024;
+            if size_kb > limit_kb {
+                result.warnings.push(format!(
+                    "Spec file is {size_kb} KB — exceeds limit of {limit_kb} KB, consider splitting into smaller specs"
+                ));
+            }
         }
     }
 
@@ -558,17 +560,7 @@ fn apply_custom_rules(
 ) {
     let rules = &config.rules;
 
-    // max_spec_size_kb: warn if spec file is too large
-    if let Some(max_kb) = rules.max_spec_size_kb {
-        if let Ok(meta) = fs::metadata(spec_path) {
-            let size_kb = meta.len() as usize / 1024;
-            if size_kb > max_kb {
-                result.warnings.push(format!(
-                    "Spec file is {size_kb} KB — exceeds limit of {max_kb} KB{config_hint}"
-                ));
-            }
-        }
-    }
+    // max_spec_size_kb check is now handled in validate_spec() to avoid duplicate warnings
 
     // max_changelog_entries: warn if Change Log has too many rows
     if let Some(max_entries) = rules.max_changelog_entries {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -551,7 +551,7 @@ pub fn validate_spec(
 
 /// Apply project-specific custom validation rules from config.
 fn apply_custom_rules(
-    spec_path: &Path,
+    _spec_path: &Path,
     body: &str,
     fm: &Frontmatter,
     config: &SpecSyncConfig,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4628,3 +4628,133 @@ Test module
         "Missing section errors should reference config file. Got:\n{stdout}"
     );
 }
+
+// ─── #249: File size warning uses configurable limit, no duplicate ──────
+
+#[test]
+fn file_size_warning_respects_max_spec_size_kb() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    let toml_config = r#"specs_dir = "specs"
+source_dirs = ["src"]
+required_sections = ["Purpose", "Public API", "Invariants", "Behavioral Examples", "Error Cases", "Dependencies", "Change Log"]
+exclude_dirs = ["__tests__"]
+exclude_patterns = ["**/__tests__/**"]
+
+[rules]
+max_spec_size_kb = 1
+"#;
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(root.join(".specsync/config.toml"), toml_config).unwrap();
+    fs::create_dir_all(root.join("specs/bigmod")).unwrap();
+    fs::create_dir_all(root.join("src/bigmod")).unwrap();
+    fs::write(root.join("src/bigmod/index.ts"), "export function f() {}").unwrap();
+
+    let mut big_spec = valid_spec("bigmod", &["src/bigmod/index.ts"]);
+    while big_spec.len() < 2048 {
+        big_spec.push_str("<!-- padding to exceed 1 KB -->\n");
+    }
+    fs::write(root.join("specs/bigmod/bigmod.spec.md"), &big_spec).unwrap();
+    fs::write(
+        root.join("specs/bigmod/requirements.md"),
+        "# Requirements\n",
+    )
+    .unwrap();
+
+    let output = specsync()
+        .args(["check", "--root", root.to_str().unwrap(), "--force"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("exceeds limit of 1 KB"),
+        "Should warn at configured 1 KB limit. Got:\n{stdout}"
+    );
+    let count = stdout.matches("exceeds limit").count();
+    assert_eq!(
+        count, 1,
+        "Should produce exactly one size warning, got {count}"
+    );
+}
+
+// ─── #250: --dry-run without --fix warns ────────────────────────────────
+
+#[test]
+fn dry_run_without_fix_warns() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("specs/dmod")).unwrap();
+    fs::create_dir_all(root.join("src/dmod")).unwrap();
+    fs::write(root.join("src/dmod/index.ts"), "export function f() {}").unwrap();
+    fs::write(
+        root.join("specs/dmod/dmod.spec.md"),
+        valid_spec("dmod", &["src/dmod/index.ts"]),
+    )
+    .unwrap();
+    fs::write(root.join("specs/dmod/requirements.md"), "# Requirements\n").unwrap();
+
+    let output = specsync()
+        .args([
+            "check",
+            "--dry-run",
+            "--root",
+            root.to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--dry-run has no effect without --fix"),
+        "Should warn about --dry-run without --fix. Got stderr:\n{stderr}"
+    );
+}
+
+// ─── #251: --fix --backup preserves original content ────────────────────
+
+#[test]
+fn fix_backup_preserves_original_on_success() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("specs/bkmod")).unwrap();
+    fs::create_dir_all(root.join("src/bkmod")).unwrap();
+    fs::write(
+        root.join("src/bkmod/index.ts"),
+        "export function alpha() {}\nexport function beta() {}\n",
+    )
+    .unwrap();
+    let spec_content = valid_spec("bkmod", &["src/bkmod/index.ts"]);
+    let spec_with_alpha = spec_content.replace(
+        "| Function | Parameters | Returns | Description |",
+        "| Function | Parameters | Returns | Description |\n| `alpha` | | void | Alpha |",
+    );
+    let original = spec_with_alpha.clone();
+    fs::write(root.join("specs/bkmod/bkmod.spec.md"), &spec_with_alpha).unwrap();
+    fs::write(root.join("specs/bkmod/requirements.md"), "# Requirements\n").unwrap();
+
+    specsync()
+        .args([
+            "check",
+            "--fix",
+            "--backup",
+            "--root",
+            root.to_str().unwrap(),
+            "--force",
+        ])
+        .assert()
+        .success();
+
+    let backup_content =
+        fs::read_to_string(root.join(".specsync/backup-fix/specs/bkmod/bkmod.spec.md"))
+            .expect("backup file should exist");
+    assert_eq!(
+        backup_content, original,
+        "Backup should contain the original spec content before --fix modifications"
+    );
+}


### PR DESCRIPTION
## Summary

Addresses all 3 follow-up issues from Rook's code review of PR #248:

- **#251 (Bug)**: Backup error handling now propagates errors and aborts `--fix` if backup fails. Previously `let _ =` silently swallowed `fs::create_dir_all` and `fs::copy` errors, risking data loss if backup fails but fix proceeds.
- **#249 (Bug)**: Consolidated duplicate file size warning into a single configurable check in `validate_spec()` (default 512 KB). Removed the redundant check in `apply_custom_rules()` that could produce duplicate warnings or conflict with the hardcoded limit.
- **#250 (Enhancement)**: `--dry-run` without `--fix` now emits a warning. Added `.specsync/backup-fix/` and `.specsync/backup-3x/` to `.gitignore`.

## Test plan

- [x] 3 new integration tests added (one per issue)
- [x] All 123 tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Pre-commit spec validation passes

Closes #249, closes #250, closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)