### PR TITLE
chore: add fledge.toml for dev lifecycle management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/fledge.toml
+++ b/fledge.toml
@@ -1,0 +1,29 @@
+[tasks.build]
+cmd = "cargo build --release"
+
+[tasks.test]
+cmd = "cargo test"
+
+[tasks.lint]
+cmd = "cargo clippy -- -D warnings"
+
+[tasks.fmt]
+cmd = "cargo fmt --check"
+
+[tasks.audit]
+cmd = "cargo audit"
+
+[tasks.check-types]
+cmd = "cargo check"
+
+[flows.check]
+description = "Quick pre-commit check"
+steps = [{ parallel = ["fmt", "lint"] }, "test"]
+
+[flows.ci]
+description = "Full CI pipeline"
+steps = ["fmt", "lint", "test", "build"]
+
+[flows.pre-commit]
+description = "Fast gate before committing"
+steps = [{ parallel = ["fmt", "lint"] }, "check-types"]

--- a/fledge.toml
+++ b/fledge.toml
@@ -16,14 +16,14 @@ cmd = "cargo audit"
 [tasks.check-types]
 cmd = "cargo check"
 
-[flows.check]
+[lanes.check]
 description = "Quick pre-commit check"
 steps = [{ parallel = ["fmt", "lint"] }, "test"]
 
-[flows.ci]
+[lanes.ci]
 description = "Full CI pipeline"
 steps = ["fmt", "lint", "test", "build"]
 
-[flows.pre-commit]
+[lanes.pre-commit]
 description = "Fast gate before committing"
 steps = [{ parallel = ["fmt", "lint"] }, "check-types"]


### PR DESCRIPTION
## Summary

Adds `fledge.toml` to dogfood [fledge v0.16.0](https://crates.io/crates/fledge) as the project's dev lifecycle CLI.

**Tasks defined:**
- `build` — `cargo build --release`
- `test` — `cargo test`
- `lint` — `cargo clippy -- -D warnings`
- `fmt` — `cargo fmt --check`
- `audit` — `cargo audit`
- `check-types` — `cargo check`

**Lanes defined:**
- `check` — parallel fmt+lint → test
- `ci` — fmt → lint → test → build
- `pre-commit` — parallel fmt+lint → check-types

## Usage
```sh
fledge run test
fledge lanes run ci
```

Part of CorvidLabs-wide fledge dogfooding initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)