### PR TITLE
fix: add word boundary to RAW_STR regexes to prevent false matches

### DIFF
--- a/src/exports/rust_lang.rs
+++ b/src/exports/rust_lang.rs
@@ -8,10 +8,13 @@ static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?
 /// Raw string literals: r###"..."###, r##"..."##, r#"..."#, r"..."
 /// Processed from most hashes to fewest so inner patterns don't match prematurely.
 static RAW_STR_3: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)r\#\#\#".*?"\#\#\#"#).unwrap());
-static RAW_STR_2: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)r\#\#".*?"\#\#"#).unwrap());
-static RAW_STR_1: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)r\#".*?"\#"#).unwrap());
-static RAW_STR_0: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)r"[^"]*""#).unwrap());
+    LazyLock::new(|| Regex::new(r#"(?s)\br\#\#\#".*?"\#\#\#"#).unwrap());
+static RAW_STR_2: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?s)\br\#\#".*?"\#\#"#).unwrap());
+static RAW_STR_1: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?s)\br\#".*?"\#"#).unwrap());
+static RAW_STR_0: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?s)\br"[^"]*""#).unwrap());
 
 /// Char literals that contain a double quote: '"' or '\"'
 static CHAR_DQUOTE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"'(?:\\.|")'"#).unwrap());
@@ -160,6 +163,28 @@ pub fn after_char_lit() {}
 "#;
         let symbols = extract_exports(src);
         assert_eq!(symbols, vec!["after_char_lit"]);
+    }
+
+    #[test]
+    fn test_identifier_trailing_r_not_raw_string() {
+        let src = r#"
+pub fn setup_hooks() {
+    hooks.push(("pre_pr", c.as_str()));
+}
+
+pub struct PluginEntry {
+    name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pinned_ref: Option<String>,
+}
+"#;
+        let symbols = extract_exports(src);
+        assert!(
+            symbols.contains(&"PluginEntry".to_string()),
+            "PluginEntry should not be eaten by false raw-string match: {:?}",
+            symbols
+        );
+        assert_eq!(symbols, vec!["setup_hooks", "PluginEntry"]);
     }
 
     #[test]

--- a/src/exports/rust_lang.rs
+++ b/src/exports/rust_lang.rs
@@ -11,10 +11,8 @@ static RAW_STR_3: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?s)\br\#\#\#".*?"\#\#\#"#).unwrap());
 static RAW_STR_2: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?s)\br\#\#".*?"\#\#"#).unwrap());
-static RAW_STR_1: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\br\#".*?"\#"#).unwrap());
-static RAW_STR_0: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\br"[^"]*""#).unwrap());
+static RAW_STR_1: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)\br\#".*?"\#"#).unwrap());
+static RAW_STR_0: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)\br"[^"]*""#).unwrap());
 
 /// Char literals that contain a double quote: '"' or '\"'
 static CHAR_DQUOTE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"'(?:\\.|")'"#).unwrap());


### PR DESCRIPTION
## Summary

- Adds `\b` word boundary anchor before `r` in all four `RAW_STR_*` regex patterns (`RAW_STR_0` through `RAW_STR_3`) in `src/exports/rust_lang.rs`
- Prevents identifiers ending in `r` adjacent to `"` (e.g. `"pre_pr"`) from being misinterpreted as raw string literal starts, which could span many lines and swallow `pub` declarations
- Adds regression test reproducing the exact scenario from the issue

## Test plan

- [x] All 15 `rust_lang` tests pass (including new regression test)
- [x] Existing raw string stripping still works correctly (tested via `test_ignores_pub_inside_string_literals` and `test_pub_after_raw_string_with_hash_in_content`)
- [x] Real file tests (`test_real_ai_rs`, `test_real_registry_rs`) still pass

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)