### PR TITLE
Redesign hero: spec ↔ code drift visual replaces terminal

### DIFF
--- a/site/src/components/SpecCodeDiff.astro
+++ b/site/src/components/SpecCodeDiff.astro
@@ -1,0 +1,223 @@
+---
+interface Props {
+  ariaLabel?: string
+}
+const { ariaLabel = 'Spec to code drift example' } = Astro.props
+---
+<figure class="diff-visual" aria-label={ariaLabel}>
+  <div class="diff-panels">
+    <!-- Spec panel -->
+    <div class="diff-panel" role="img" aria-label="Spec file with phantom entry highlighted">
+      <div class="diff-panel-header">
+        <span class="diff-icon" aria-hidden="true">▣</span>
+        <span class="diff-filename">specs/auth.spec.md</span>
+      </div>
+      <div class="diff-panel-body">
+        <div class="diff-line diff-section">## Exports</div>
+        <div class="diff-line diff-blank"></div>
+        <div class="diff-line diff-entry">- <code>login(creds) -&gt; Token</code></div>
+        <div class="diff-line diff-blank"></div>
+        <div class="diff-line diff-entry diff-drift-line">- <code>validateToken(t) -&gt; bool</code></div>
+        <div class="diff-line diff-drift-marker">
+          <span class="drift-icon" aria-label="Phantom entry warning">⚠</span>
+          <span class="drift-label">phantom — not in code</span>
+        </div>
+        <div class="diff-line diff-blank"></div>
+        <div class="diff-line diff-entry">- <code>logout(token)</code></div>
+      </div>
+    </div>
+
+    <!-- Code panel -->
+    <div class="diff-panel" role="img" aria-label="Source code with undocumented export highlighted">
+      <div class="diff-panel-header">
+        <span class="diff-icon" aria-hidden="true">⌥</span>
+        <span class="diff-filename">src/auth.rs</span>
+      </div>
+      <div class="diff-panel-body">
+        <div class="diff-line"><span class="kw">pub fn</span> <span class="fn-name">login</span><span class="dim">(creds) -&gt; Token &#123;</span></div>
+        <div class="diff-line diff-indent dim">// ...</div>
+        <div class="diff-line dim">&#125;</div>
+        <div class="diff-line diff-blank"></div>
+        <div class="diff-line"><span class="kw">pub fn</span> <span class="fn-name">logout</span><span class="dim">(token: &amp;Token) &#123;</span></div>
+        <div class="diff-line diff-indent dim">// ...</div>
+        <div class="diff-line dim">&#125;</div>
+        <div class="diff-line diff-blank"></div>
+        <div class="diff-line diff-drift-line"><span class="kw">pub fn</span> <span class="fn-name">delete_user</span><span class="dim">(id: UserId) &#123;</span></div>
+        <div class="diff-line diff-drift-marker">
+          <span class="drift-icon" aria-label="Undocumented export warning">⚠</span>
+          <span class="drift-label">undocumented export</span>
+        </div>
+        <div class="diff-line dim">&#125;</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="diff-footer" aria-live="polite">
+    <span class="drift-count">✗ 2 drifts detected</span>
+    <span class="drift-hint"> — run <code>spec-sync generate --fix</code></span>
+  </div>
+</figure>
+
+<style>
+  .diff-visual {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    font-family: var(--mono);
+    font-size: 0.875rem;
+    line-height: 1.75;
+  }
+
+  .diff-panels {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  .diff-panel {
+    background: var(--bg-raised);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4), 0 0 40px var(--accent-glow);
+  }
+
+  .diff-panel-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .diff-icon {
+    color: var(--accent-bright);
+    font-size: 0.9375rem;
+    line-height: 1;
+  }
+
+  .diff-filename {
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    letter-spacing: 0.01em;
+  }
+
+  .diff-panel-body {
+    padding: 16px 18px;
+  }
+
+  .diff-line {
+    white-space: pre;
+    color: var(--text);
+    min-height: 1.75em;
+  }
+
+  .diff-blank {
+    min-height: 0.75em;
+  }
+
+  .diff-indent {
+    padding-left: 1.5em;
+  }
+
+  .diff-section {
+    color: var(--accent-bright);
+    font-weight: 600;
+  }
+
+  .diff-entry {
+    color: var(--text-muted);
+  }
+
+  .diff-entry code {
+    color: var(--text);
+    font-family: var(--mono);
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  .dim {
+    color: var(--text-dim);
+  }
+
+  .kw {
+    color: var(--accent-bright);
+  }
+
+  .fn-name {
+    color: var(--text);
+  }
+
+  /* Drift highlighting */
+  .diff-drift-line {
+    background: rgba(251, 191, 36, 0.08);
+    border-left: 2px solid #fbbf24;
+    margin-left: -18px;
+    padding-left: 16px;
+    margin-right: -18px;
+    padding-right: 18px;
+  }
+
+  .diff-drift-marker {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0 2px 2px;
+    color: #fbbf24;
+    font-size: 0.8125rem;
+    background: rgba(251, 191, 36, 0.06);
+    margin-left: -18px;
+    padding-left: 18px;
+    margin-right: -18px;
+    padding-right: 18px;
+    border-left: 2px solid #fbbf24;
+    margin-bottom: 2px;
+  }
+
+  .drift-icon {
+    font-size: 0.875rem;
+    line-height: 1;
+  }
+
+  .drift-label {
+    font-style: italic;
+    letter-spacing: 0.01em;
+    opacity: 0.9;
+  }
+
+  /* Footer drift count */
+  .diff-footer {
+    margin-top: 14px;
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--text-dim);
+  }
+
+  .drift-count {
+    color: #fbbf24;
+    font-weight: 600;
+  }
+
+  .drift-hint {
+    color: var(--text-dim);
+  }
+
+  .drift-hint code {
+    color: var(--text-muted);
+    font-family: var(--mono);
+    font-size: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+  }
+
+  /* Narrow viewports: stack panels */
+  @media (max-width: 600px) {
+    .diff-panels {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro'
 import Badge from '../components/Badge.astro'
 import Button from '../components/Button.astro'
-import Terminal from '../components/Terminal.astro'
+import SpecCodeDiff from '../components/SpecCodeDiff.astro'
 import Pillar from '../components/Pillar.astro'
 import { base } from '../lib/path'
 ---
@@ -23,19 +23,7 @@ import { base } from '../lib/path'
         <p class="hero-fineprint">Install in a single command: <code>cargo install specsync</code></p>
       </div>
       <div>
-        <Terminal title="~/myproject — spec-sync">
-          <div class="term-line term-comment"># spec-sync: keep your docs honest</div>
-          <div class="term-line"><span class="term-prompt">$ </span>spec-sync check</div>
-          <div class="term-line term-out">  Reading 12 *.spec.md files...</div>
-          <div class="term-line term-bad">  ✗ src/api/users.rs: undocumented export `delete_user`</div>
-          <div class="term-line term-bad">  ✗ specs/auth.spec.md: phantom entry `validateToken` (not in code)</div>
-          <div class="term-line"><span class="term-prompt">$ </span>spec-sync generate --module auth</div>
-          <div class="term-line term-good">  ★ Generated specs/auth.spec.md</div>
-          <div class="term-line term-good">  ★ Drafted 8 missing entries</div>
-          <div class="term-line"><span class="term-prompt">$ </span>spec-sync check</div>
-          <div class="term-line term-good">  ✓ all 12 specs in sync</div>
-          <div class="term-line"><span class="term-prompt">$ </span><span class="blink" aria-hidden="true" /></div>
-        </Terminal>
+        <SpecCodeDiff />
       </div>
     </div>
   </div>
@@ -150,7 +138,7 @@ import { base } from '../lib/path'
 <style>
   main { background-image: radial-gradient(ellipse 1200px 600px at 50% -200px, rgba(14,165,233,0.12), transparent 70%); }
   .hero { padding: 80px 0 60px; }
-  .hero-grid { display: grid; grid-template-columns: 1.05fr 1fr; gap: 56px; align-items: center; }
+  .hero-grid { display: grid; grid-template-columns: 1fr 1.15fr; gap: 56px; align-items: center; }
   .hero-h1 { font-size: clamp(2.4rem, 5vw, 3.6rem); line-height: 1.05; letter-spacing: -0.025em; margin: 22px 0; }
   .hero-h1 .honest { background: linear-gradient(120deg, var(--accent-bright) 0%, var(--accent) 60%, var(--accent-deep) 100%);
     -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
@@ -168,7 +156,6 @@ import { base } from '../lib/path'
     color: var(--accent-bright); font-family: var(--serif); line-height: 1; }
   .stat .lbl { color: var(--text); font-size: 1rem; margin-top: 8px; font-weight: 500; }
   .stat .sub { color: var(--text-muted); font-size: 0.875rem; margin-top: 4px; }
-  .term-bad { color: #f87171; }
   .pillars { padding: 100px 0 40px; }
   .section-head { margin-bottom: 48px; }
   .section-eyebrow { color: var(--accent-bright); font-size: 0.875rem; font-weight: 600;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -33,7 +33,7 @@ import { base } from '../lib/path'
   <div class="container">
     <ul class="stats-grid">
       <li class="stat"><div class="num">12</div><div class="lbl">languages</div><div class="sub">supported</div></li>
-      <li class="stat"><div class="num">6</div><div class="lbl">powers</div><div class="sub">validate · generate · integrate · cross-refs · extend</div></li>
+      <li class="stat"><div class="num">6</div><div class="lbl">powers</div><div class="sub">validate · languages · generate · integrate · cross-refs · extend</div></li>
       <li class="stat"><div class="num">1</div><div class="lbl">spec format</div><div class="sub">open, portable, language-agnostic</div></li>
       <li class="stat"><div class="num">1</div><div class="lbl">binary</div><div class="sub">install, done</div></li>
     </ul>


### PR DESCRIPTION
## What changed

- **Hero visual swap**: The right column of the hero grid, previously a generic terminal demo (`<Terminal>`), is replaced with a new `SpecCodeDiff` component — a side-by-side panel showing `specs/auth.spec.md` on the left and `src/auth.rs` on the right. Amber drift markers call out one phantom entry (`validateToken` — in the spec but not in code) and one undocumented export (`delete_user` — in code but not in the spec). A footer line reads "✗ 2 drifts detected — run \`spec-sync generate --fix\`".
- **Hero grid ratio**: Adjusted from `1.05fr 1fr` to `1fr 1.15fr` to give the code panel more breathing room.
- **Stats sub-label fix**: The "6 powers" stat previously enumerated only 5 powers in the sub-label. Added "languages" to match the six pillars shown in the pillars grid below.

New file: `site/src/components/SpecCodeDiff.astro`

## Why

The old hero was a near-clone of the fledge sibling site — a split grid with prose on the left and a terminal on the right. The terminal shows command output, which any CLI tool could show. The spec ↔ code drift visual is specific to spec-sync's value prop: bidirectional validation, phantom detection, undocumented export detection. It tells the product story in a single image without reading a word of prose.

## Test plan

- [ ] Merge and wait for the GitHub Pages deploy action to complete
- [ ] Open https://corvidlabs.github.io/spec-sync/ and confirm the right hero column shows the two-panel diff visual (not a terminal)
- [ ] Confirm amber ⚠ markers appear on the `validateToken` row (spec panel) and `delete_user` row (code panel)
- [ ] Confirm footer reads "✗ 2 drifts detected — run \`spec-sync generate --fix\`"
- [ ] Confirm stats grid now reads "validate · languages · generate · integrate · cross-refs · extend"
- [ ] Resize to < 900px and confirm hero grid stacks vertically; confirm diff panels also stack at < 600px

🤖 Generated with [Claude Code](https://claude.com/claude-code)