### PR TITLE
fix(site): broken cli.html link, missing RSS, canonical/twitter meta, dynamic language counts

### DIFF
--- a/site/src/content/docs/index.md
+++ b/site/src/content/docs/index.md
@@ -4,7 +4,7 @@ section: "Getting started"
 order: 0
 ---
 
-Bidirectional spec-to-code validation. Written in Rust. Single binary. 11 languages. VS Code extension.
+Bidirectional spec-to-code validation. Written in Rust. Single binary. 12 languages. VS Code extension.
 
 [Get Started](quickstart.md)
 [Why SpecSync?](why-specsync.md)

--- a/site/src/content/docs/integrations/vscode-extension.md
+++ b/site/src/content/docs/integrations/vscode-extension.md
@@ -16,7 +16,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 code --install-extension corvidlabs.specsync
 ```
 
-The extension requires the `specsync` CLI binary to be installed and on your PATH. See the [CLI Reference](cli.html) for installation instructions.
+The extension requires the `specsync` CLI binary to be installed and on your PATH. See the [CLI Reference](../cli.md) for installation instructions.
 
 ---
 

--- a/site/src/content/docs/why-specsync.md
+++ b/site/src/content/docs/why-specsync.md
@@ -29,7 +29,7 @@ SpecSync occupies a third space: **validated hand-written specs**. You write the
 | Catches renamed exports | **Yes** | No | No | No | No |
 | Schema/DB drift detection | **Yes** | No | No | No | No |
 | Cross-project references | **Yes** | Via `$ref` | No | No | No |
-| Works with any language | **11 languages** | Language-specific | JS/TS only | N/A | N/A |
+| Works with any language | **12 languages** | Language-specific | JS/TS only | N/A | N/A |
 | AI agent integration (MCP) | **Yes** | Via plugins | No | No | No |
 | CI/CD integration | **GitHub Action** | Various | Various | Manual | No |
 | Spec lifecycle management | **Yes** | No | No | No | Manual |
@@ -88,7 +88,7 @@ Most tools check in one direction — either "does the code match the docs?" or 
 
 ### Language Agnostic
 
-One tool, one format, 11 languages. Whether your project is TypeScript, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, or Ruby — same `*.spec.md` format, same validation.
+One tool, one format, 12 languages. Whether your project is TypeScript, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, or Ruby — same `*.spec.md` format, same validation.
 
 ### AI-Native
 

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -8,6 +8,10 @@ interface Props {
   description?: string
 }
 const { title, description = "Bidirectional spec-to-code validation. Keep your docs honest." } = Astro.props
+// Canonical: prefer the site origin + the current pathname so crawlers don't
+// treat trailing-slash/no-slash or query-string variants as duplicates.
+const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin).toString()
+const ogImage = new URL(`${base}og-default.png`, Astro.site ?? Astro.url.origin).toString()
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -17,11 +21,16 @@ const { title, description = "Bidirectional spec-to-code validation. Keep your d
   <title>{title}</title>
   <meta name="description" content={description} />
   <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
+  <link rel="canonical" href={canonical} />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content={Astro.url.href} />
-  <meta property="og:image" content={`${base}og-default.png`} />
+  <meta property="og:url" content={canonical} />
+  <meta property="og:image" content={ogImage} />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={description} />
+  <meta name="twitter:image" content={ogImage} />
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to main content</a>

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro'
 import Button from '../components/Button.astro'
+import languages from '../data/languages.json' with { type: 'json' }
 import { base } from '../lib/path'
 ---
 <BaseLayout title="404 — spec-sync">
@@ -12,7 +13,7 @@ import { base } from '../lib/path'
     </p>
     <div style="display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;">
       <Button href={`${base}docs`} variant="primary">Read the docs</Button>
-      <Button href={`${base}languages`} variant="secondary">Browse 12 languages</Button>
+      <Button href={`${base}languages`} variant="secondary">Browse {languages.length} languages</Button>
     </div>
   </main>
 </BaseLayout>

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content'
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import PostCard from '../../components/PostCard.astro'
 import CategoryTag from '../../components/CategoryTag.astro'
+import languages from '../../data/languages.json' with { type: 'json' }
 import { base } from '../../lib/path'
 const posts = (await getCollection('blog', p => !p.data.draft))
   .sort((a, b) => +b.data.date - +a.data.date)
@@ -56,7 +57,7 @@ const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month:
 
 <section class="read-more">
   <div class="container">
-    <a href={`${base}languages`} class="rm-card">Browse 12 languages <span aria-hidden="true">→</span></a>
+    <a href={`${base}languages`} class="rm-card">Browse {languages.length} languages <span aria-hidden="true">→</span></a>
     <a href={`${base}docs`} class="rm-card">Read the docs <span aria-hidden="true">→</span></a>
     <a href="https://github.com/CorvidLabs/spec-sync" class="rm-card">Star on GitHub <span aria-hidden="true">↗</span></a>
   </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -4,7 +4,9 @@ import Badge from '../components/Badge.astro'
 import Button from '../components/Button.astro'
 import SpecCodeDiff from '../components/SpecCodeDiff.astro'
 import Pillar from '../components/Pillar.astro'
+import languages from '../data/languages.json' with { type: 'json' }
 import { base } from '../lib/path'
+const languageCount = languages.length
 ---
 <BaseLayout title="spec-sync — keep your docs honest">
 <main id="main">
@@ -13,12 +15,12 @@ import { base } from '../lib/path'
   <div class="container">
     <div class="hero-grid">
       <div>
-        <Badge dot>12 languages · GitHub Marketplace</Badge>
+        <Badge dot>{languageCount} languages · GitHub Marketplace</Badge>
         <h1 class="hero-h1" id="hero-h">Keep your docs<br>ready to <span class="honest">be honest.</span></h1>
         <p class="hero-sub">Bidirectional spec-to-code validation. Cross-project refs. AI generation. CI-enforced contract checking — in any language.</p>
         <div class="hero-actions">
           <Button href={`${base}docs/quickstart`} variant="primary">Get started <span aria-hidden="true">→</span></Button>
-          <Button href={`${base}languages`} variant="secondary">Browse 12 languages</Button>
+          <Button href={`${base}languages`} variant="secondary">Browse {languageCount} languages</Button>
         </div>
         <p class="hero-fineprint">Install in a single command: <code>cargo install specsync</code></p>
       </div>
@@ -32,7 +34,7 @@ import { base } from '../lib/path'
 <section class="stats" aria-label="Key numbers">
   <div class="container">
     <ul class="stats-grid">
-      <li class="stat"><div class="num">12</div><div class="lbl">languages</div><div class="sub">supported</div></li>
+      <li class="stat"><div class="num">{languageCount}</div><div class="lbl">languages</div><div class="sub">supported</div></li>
       <li class="stat"><div class="num">6</div><div class="lbl">powers</div><div class="sub">validate · languages · generate · integrate · cross-refs · extend</div></li>
       <li class="stat"><div class="num">1</div><div class="lbl">spec format</div><div class="sub">open, portable, language-agnostic</div></li>
       <li class="stat"><div class="num">1</div><div class="lbl">binary</div><div class="sub">install, done</div></li>
@@ -50,7 +52,7 @@ import { base } from '../lib/path'
     </header>
     <ul class="pillars-grid">
       <Pillar numeral="i."   title="Validate"   command="$ spec-sync check">Bidirectional. Code → spec and spec → code. Errors on drift.</Pillar>
-      <Pillar numeral="ii."  title="Languages"  command="12 detected">TypeScript, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby, YAML.</Pillar>
+      <Pillar numeral="ii."  title="Languages"  command={`${languageCount} detected`}>TypeScript, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby, YAML.</Pillar>
       <Pillar numeral="iii." title="Generate"   command="$ spec-sync generate">AI-assisted spec generation from existing code. Any provider.</Pillar>
       <Pillar numeral="iv."  title="Integrate"  command="vscode | gh actions">VS Code extension + GitHub Action + CLI. Drop into any CI.</Pillar>
       <Pillar numeral="v."   title="Cross-refs" command="$ spec-sync graph">Reference exports across repos. Dependency graph included.</Pillar>
@@ -63,7 +65,7 @@ import { base } from '../lib/path'
 <section class="langs-strip" aria-labelledby="langs-h">
   <div class="container">
     <div class="strip-head">
-      <h2 id="langs-h">12 languages <em>and counting.</em></h2>
+      <h2 id="langs-h">{languageCount} languages <em>and counting.</em></h2>
       <a href={`${base}languages`} class="link">Browse all languages <span aria-hidden="true">→</span></a>
     </div>
     <ul class="lang-grid">

--- a/site/src/pages/languages/index.astro
+++ b/site/src/pages/languages/index.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro'
 import LanguageCard from '../../components/LanguageCard.astro'
-import languages from '../../data/languages.json'
+import languages from '../../data/languages.json' with { type: 'json' }
 ---
 
 <BaseLayout

--- a/site/src/pages/languages/index.astro
+++ b/site/src/pages/languages/index.astro
@@ -6,7 +6,7 @@ import languages from '../../data/languages.json'
 
 <BaseLayout
   title="Languages — spec-sync"
-  description="12 supported languages with auto-detection. One spec format, any stack."
+  description={`${languages.length} supported languages with auto-detection. One spec format, any stack.`}
 >
 <main id="main">
 
@@ -14,10 +14,10 @@ import languages from '../../data/languages.json'
   <div class="container">
     <p class="eyebrow">Languages</p>
     <h1 id="langs-h">Spec-sync speaks <em>your stack.</em></h1>
-    <p class="lede">12 languages, auto-detected, one spec format. Drop <code>spec-sync check</code> into any CI and it figures out the rest.</p>
+    <p class="lede">{languages.length} languages, auto-detected, one spec format. Drop <code>spec-sync check</code> into any CI and it figures out the rest.</p>
 
     <ul class="stats-strip" aria-label="Registry stats">
-      <li><strong>12</strong> languages</li>
+      <li><strong>{languages.length}</strong> languages</li>
       <li aria-hidden="true">·</li>
       <li>auto-detected</li>
       <li aria-hidden="true">·</li>

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal RSS 2.0 feed for the spec-sync blog.
+ *
+ * Avoids pulling in @astrojs/rss as a new dependency — the feed shape is small
+ * and we already escape the few characters that matter (XML doesn't allow
+ * unescaped &, <, > in element text or CDATA-less descriptions).
+ */
+import type { APIContext } from 'astro'
+import { getCollection } from 'astro:content'
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export async function GET(context: APIContext) {
+  const site = context.site?.toString().replace(/\/$/, '') ?? 'https://corvidlabs.github.io'
+  const base = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '')
+  const posts = (await getCollection('blog', (p) => !p.data.draft)).sort(
+    (a, b) => +b.data.date - +a.data.date,
+  )
+
+  const items = posts
+    .map((p) => {
+      const url = `${site}${base}/blog/${p.slug}`
+      return `    <item>
+      <title>${xmlEscape(p.data.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${p.data.date.toUTCString()}</pubDate>
+      <description>${xmlEscape(p.data.description)}</description>
+      <author>noreply@corvidlabs.xyz (${xmlEscape(p.data.author)})</author>
+    </item>`
+    })
+    .join('\n')
+
+  const lastBuild = (posts[0]?.data.date ?? new Date()).toUTCString()
+  const channelLink = `${site}${base}/blog`
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>spec-sync blog</title>
+    <link>${channelLink}</link>
+    <description>Release notes, language additions, and integration deep-dives for spec-sync.</description>
+    <language>en-us</language>
+    <lastBuildDate>${lastBuild}</lastBuildDate>
+    <atom:link href="${site}${base}/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
## Summary

Post-review cleanup turned up after PR #266 (hero redesign) landed. Independent of that work; no overlap.

- **Broken link**: `integrations/vscode-extension.md` referenced `cli.html` (404). Now `../cli.md`, which the existing remark plugin rewrites correctly.
- **Missing RSS feed**: blog page links `/rss.xml` but no endpoint existed. Added `src/pages/rss.xml.ts` (minimal RSS 2.0, no new dependency).
- **Missing canonical / twitter card meta on every page**: added `rel="canonical"` and `twitter:card` (plus `twitter:title`/`description`/`image`) to `BaseLayout`. Was causing crawlers to treat trailing-slash variants as duplicate content.
- **Hardcoded `"12 languages"` in 9 places**: replaced with `languages.length` (single source of truth). Matches what fledge does for plugin counts. The `Phase 4` TODO comment for the dynamic language list in the langs strip is preserved — that's a separate refactor.

## Test plan

- [x] `bun test` — 21 pass, 0 fail
- [x] `bun run lint` — 0 errors / 0 warnings / 0 hints across 33 files
- [x] `bun run build` — 34 pages built
- [x] Local crawl of `dist/`: **0 broken internal links** (down from 2 pre-fix)
- [x] Canonical/twitter audit: 0 missing
- [ ] On deploy, verify `/spec-sync/rss.xml` resolves and `/spec-sync/docs/integrations/vscode-extension` links to a 200 cli page

🤖 Generated with [Claude Code](https://claude.com/claude-code)