### PR TITLE
Release v4.3.3 — RAW_STR regex fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v4.3.3] - 2026-05-18
+
+### Fixed
+
+- **Word boundary added to RAW_STR regexes** — prevents false matches where raw string patterns were incorrectly matching substrings of longer tokens (#262).
+
+### Site
+
+- New Astro-based marketing site at corvidlabs.github.io/spec-sync — replaces the prior mdBook. Includes a Languages registry, examples, blog, and migrated docs.
+
 ## [4.3.2] - 2026-04-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.3.2"
+version = "4.3.3"
 edition = "2024"
 rust-version = "1.88"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -2,7 +2,7 @@
 import Button from './Button.astro'
 import { base } from '../lib/path'
 const current = Astro.url.pathname.replace(/\/$/, '') || base.replace(/\/$/, '')
-const VERSION = 'v4.3.2'
+const VERSION = 'v4.3.3'
 const links = [
   { href: `${base}languages`, label: 'Languages' },
   { href: `${base}examples`, label: 'Examples' },


### PR DESCRIPTION
## Summary

- **fix(#262):** Add word boundary to RAW_STR regexes — prevents false matches where raw string patterns were matching substrings of longer tokens.
- **Site:** New Astro-based marketing site at corvidlabs.github.io/spec-sync — replaces the prior mdBook. Includes a Languages registry, examples, blog, and migrated docs.
- **Version:** `specsync` crate bumped `4.3.2 → 4.3.3` in `Cargo.toml`; `Cargo.lock` updated; `site/src/components/Header.astro` VERSION constant updated to `v4.3.3`.

## Test plan

- [x] `cargo build` — clean compile at v4.3.3
- [x] `cargo test` — 585 unit + 123 integration tests, 0 failures
- [x] `cd site && bun run lint` — 0 errors, 0 warnings across 34 Astro files
- [x] `cd site && bun run build` — 34 pages built, sitemap generated, clean

## Tagging note

**Do not push a tag from this branch.** After merging, tag the merge commit on `main` as `v4.3.3`:

```
git tag v4.3.3 <merge-commit-sha>
git push origin v4.3.3
```

This will trigger `release.yml` (fires on `push: tags: v*`), which builds cross-platform binaries and creates the GitHub release via `softprops/action-gh-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)