### PR TITLE
fix(site): every-page mobile + content sweep

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -44,7 +44,7 @@ import { base } from '../lib/path'
   .foot-brand .logo { display: flex; align-items: center; gap: 8px;
     color: var(--text); font-weight: 600; font-size: 1.0625rem; }
   .foot-brand .foot-tagline { color: var(--text-muted); font-size: 0.9375rem; line-height: 1.5; }
-  .foot-brand .foot-tagline a { color: var(--accent-bright); }
+  .foot-brand .foot-tagline a { color: var(--accent-bright); display: inline-block; padding: 4px 0; }
   .foot-brand .foot-tagline a:hover { text-decoration: underline; }
   .foot-col h3 { color: var(--text); font-size: 0.9375rem; margin-bottom: 14px; font-weight: 600; }
   .foot-col a { display: block; color: var(--text-muted); font-size: 0.9375rem; padding: 6px 0; }

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -92,7 +92,7 @@ const isActive = (href: string) => current === href.replace(/\/$/, '')
   .ham-bar { display: block; width: 18px; height: 2px; background: var(--accent-bright);
     border-radius: 2px; transition: opacity .15s, transform .15s; }
 
-  @media (max-width: 760px) {
+  @media (max-width: 768px) {
     .nav-hamburger { display: flex; }
     .nav-links { display: none; }
     .nav-links.nav-open {

--- a/site/src/content/docs/index.md
+++ b/site/src/content/docs/index.md
@@ -54,7 +54,7 @@ specsync watch                  # re-validate on file changes
 
 Auto-detected from file extensions. No per-language configuration.
 
-TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby.
+TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby, YAML.
 
 ## Learn More
 

--- a/site/src/content/docs/why-specsync.md
+++ b/site/src/content/docs/why-specsync.md
@@ -88,7 +88,7 @@ Most tools check in one direction — either "does the code match the docs?" or 
 
 ### Language Agnostic
 
-One tool, one format, 12 languages. Whether your project is TypeScript, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, or Ruby — same `*.spec.md` format, same validation.
+One tool, one format, 12 languages. Whether your project is TypeScript, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby, or YAML — same `*.spec.md` format, same validation.
 
 ### AI-Native
 

--- a/site/src/layouts/ArticleLayout.astro
+++ b/site/src/layouts/ArticleLayout.astro
@@ -32,7 +32,8 @@ const { title, description, eyebrow, meta } = Astro.props
   .art-body :global(p) { margin-bottom: 16px; color: var(--text); line-height: 1.7; }
   .art-body :global(ul), .art-body :global(ol) { margin-bottom: 16px; padding-left: 24px; }
   .art-body :global(li) { margin-bottom: 6px; line-height: 1.7; }
-  .art-body :global(a) { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 3px; }
+  .art-body :global(a) { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 3px;
+    display: inline-block; padding: 2px 0; }
   .art-body :global(code) { font-family: var(--mono); font-size: 0.875em; padding: 2px 6px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 4px; color: var(--accent-bright); }
   .art-body :global(pre) { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; overflow-x: auto; margin-bottom: 20px; }
   .art-body :global(pre code) { background: transparent; border: 0; padding: 0; color: var(--text); }

--- a/site/src/layouts/ArticleLayout.astro
+++ b/site/src/layouts/ArticleLayout.astro
@@ -35,6 +35,8 @@ const { title, description, eyebrow, meta } = Astro.props
   .art-body :global(a) { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 3px;
     display: inline-block; padding: 2px 0; }
   .art-body :global(code) { font-family: var(--mono); font-size: 0.875em; padding: 2px 6px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 4px; color: var(--accent-bright); }
-  .art-body :global(pre) { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; overflow-x: auto; margin-bottom: 20px; }
-  .art-body :global(pre code) { background: transparent; border: 0; padding: 0; color: var(--text); }
+  .art-body :global(pre) { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; overflow-x: auto; margin-bottom: 20px; max-width: 100%; box-sizing: border-box; white-space: pre; }
+  .art-body :global(pre code) { background: transparent; border: 0; padding: 0; color: var(--text); white-space: pre; word-break: normal; }
+  .art-body :global(table) { display: block; overflow-x: auto; max-width: 100%; box-sizing: border-box; width: 100%; border-collapse: collapse; }
+  .art-body :global(thead), .art-body :global(tbody), .art-body :global(tr) { max-width: 100%; }
 </style>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -46,14 +46,15 @@ const { title, description, section } = Astro.props
 </script>
 
 <style>
-  .docs-grid { display: grid; grid-template-columns: 260px 1fr; max-width: 1400px; margin: 0 auto; }
-  .article { padding: 48px 56px; max-width: 800px; min-width: 0; overflow-x: hidden; }
+  .docs-grid { display: grid; grid-template-columns: 260px 1fr; max-width: 1400px; margin: 0 auto; overflow-x: hidden; }
+  .article { padding: 48px 56px; max-width: 800px; min-width: 0; overflow-x: hidden; width: 100%; box-sizing: border-box; }
   .contents-toggle { display: none; }
   .breadcrumb { display: flex; gap: 8px; align-items: center; color: var(--text-dim); font-size: 0.875rem; margin-bottom: 20px; flex-wrap: wrap; }
   .breadcrumb a { color: var(--text-muted); display: inline-flex; align-items: center; min-height: 44px; }
   .breadcrumb a:hover { color: var(--accent-bright); }
   .breadcrumb .sep { color: var(--border-strong); }
   .article h1 { font-size: clamp(2rem, 4vw, 2.6rem); letter-spacing: -0.02em; margin-bottom: 12px; line-height: 1.15; }
+  .doc-body { min-width: 0; max-width: 100%; overflow-x: hidden; box-sizing: border-box; }
   .doc-body :global(h2) { font-size: 1.625rem; margin: 48px 0 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
   .doc-body :global(h3) { font-size: 1.25rem; margin: 32px 0 12px; }
   .doc-body :global(p) { margin-bottom: 16px; line-height: 1.7; }
@@ -62,8 +63,10 @@ const { title, description, section } = Astro.props
   .doc-body :global(a) { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 3px;
     display: inline-block; padding: 2px 0; }
   .doc-body :global(code) { font-family: var(--mono); font-size: 0.875em; padding: 2px 6px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 4px; color: var(--accent-bright); }
-  .doc-body :global(pre) { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; overflow-x: auto; margin-bottom: 20px; max-width: 100%; box-sizing: border-box; }
-  .doc-body :global(pre code) { background: transparent; border: 0; padding: 0; color: var(--text); }
+  .doc-body :global(pre) { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; overflow-x: auto; margin-bottom: 20px; max-width: 100%; box-sizing: border-box; white-space: pre; }
+  .doc-body :global(pre code) { background: transparent; border: 0; padding: 0; color: var(--text); white-space: pre; word-break: normal; }
+  .doc-body :global(table) { display: block; overflow-x: auto; max-width: 100%; box-sizing: border-box; width: 100%; border-collapse: collapse; }
+  .doc-body :global(thead), .doc-body :global(tbody), .doc-body :global(tr) { max-width: 100%; }
   @media (max-width: 900px) {
     .docs-grid { grid-template-columns: 1fr; }
     :global(.sidebar) { display: none; }

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -47,10 +47,10 @@ const { title, description, section } = Astro.props
 
 <style>
   .docs-grid { display: grid; grid-template-columns: 260px 1fr; max-width: 1400px; margin: 0 auto; }
-  .article { padding: 48px 56px; max-width: 800px; }
+  .article { padding: 48px 56px; max-width: 800px; min-width: 0; overflow-x: hidden; }
   .contents-toggle { display: none; }
   .breadcrumb { display: flex; gap: 8px; align-items: center; color: var(--text-dim); font-size: 0.875rem; margin-bottom: 20px; flex-wrap: wrap; }
-  .breadcrumb a { color: var(--text-muted); }
+  .breadcrumb a { color: var(--text-muted); display: inline-flex; align-items: center; min-height: 44px; }
   .breadcrumb a:hover { color: var(--accent-bright); }
   .breadcrumb .sep { color: var(--border-strong); }
   .article h1 { font-size: clamp(2rem, 4vw, 2.6rem); letter-spacing: -0.02em; margin-bottom: 12px; line-height: 1.15; }
@@ -59,9 +59,10 @@ const { title, description, section } = Astro.props
   .doc-body :global(p) { margin-bottom: 16px; line-height: 1.7; }
   .doc-body :global(ul), .doc-body :global(ol) { margin-bottom: 16px; padding-left: 24px; }
   .doc-body :global(li) { margin-bottom: 6px; line-height: 1.7; }
-  .doc-body :global(a) { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 3px; }
+  .doc-body :global(a) { color: var(--accent-bright); text-decoration: underline; text-underline-offset: 3px;
+    display: inline-block; padding: 2px 0; }
   .doc-body :global(code) { font-family: var(--mono); font-size: 0.875em; padding: 2px 6px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 4px; color: var(--accent-bright); }
-  .doc-body :global(pre) { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; overflow-x: auto; margin-bottom: 20px; }
+  .doc-body :global(pre) { background: var(--bg-raised); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; overflow-x: auto; margin-bottom: 20px; max-width: 100%; box-sizing: border-box; }
   .doc-body :global(pre code) { background: transparent; border: 0; padding: 0; color: var(--text); }
   @media (max-width: 900px) {
     .docs-grid { grid-template-columns: 1fr; }

--- a/site/src/pages/languages/[slug].astro
+++ b/site/src/pages/languages/[slug].astro
@@ -52,7 +52,7 @@ const styleLabel: Record<string, string> = {
   title={`${lang.name} — spec-sync`}
   description={lang.description}
 >
-<main id="main">
+<main id="main" style="overflow-x: hidden; width: 100%;">
 
 <div class="container">
 
@@ -201,10 +201,15 @@ const styleLabel: Record<string, string> = {
 </BaseLayout>
 
 <style>
-  .container { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--container-pad); }
+  .container { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--container-pad);
+    box-sizing: border-box; }
+
+  @media (max-width: 600px) {
+    .container { padding: 0 16px; }
+  }
 
   .breadcrumb { padding: 32px 0 0; }
-  .breadcrumb a { color: var(--accent-bright); font-size: 0.9375rem; }
+  .breadcrumb a { color: var(--accent-bright); font-size: 0.9375rem; display: inline-flex; align-items: center; min-height: 44px; }
   .breadcrumb a:hover { text-decoration: underline; }
 
   .lang-header { padding: 32px 0 0; border-bottom: 1px solid var(--border); margin-bottom: 48px; padding-bottom: 40px; }
@@ -305,6 +310,7 @@ const styleLabel: Record<string, string> = {
   .footer-cta { border-top: 1px solid var(--border); padding: 48px 0 72px;
     display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
   .footer-cta p { color: var(--text-muted); font-size: 1.0625rem; }
-  .cta-link { color: var(--accent-bright); font-weight: 500; font-size: 0.9375rem; }
+  .cta-link { color: var(--accent-bright); font-weight: 500; font-size: 0.9375rem;
+    display: inline-flex; align-items: center; min-height: 44px; }
   .cta-link:hover { text-decoration: underline; }
 </style>

--- a/site/src/pages/languages/[slug].astro
+++ b/site/src/pages/languages/[slug].astro
@@ -202,7 +202,7 @@ const styleLabel: Record<string, string> = {
 
 <style>
   .container { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--container-pad);
-    box-sizing: border-box; }
+    box-sizing: border-box; width: 100%; overflow-x: hidden; }
 
   @media (max-width: 600px) {
     .container { padding: 0 16px; }
@@ -271,7 +271,8 @@ const styleLabel: Record<string, string> = {
   /* Example split */
   .example-split { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
   @media (max-width: 800px) { .example-split { grid-template-columns: 1fr; } }
-  .example-pane { display: flex; flex-direction: column; gap: 10px; }
+  @media (max-width: 768px) { .example-split { grid-template-columns: 1fr; } }
+  .example-pane { display: flex; flex-direction: column; gap: 10px; min-width: 0; }
   .pane-label { color: var(--text-dim); font-size: 0.875rem; font-weight: 600;
     letter-spacing: 0.06em; text-transform: uppercase; }
   .source-block { height: 100%; }
@@ -279,7 +280,7 @@ const styleLabel: Record<string, string> = {
   /* Spec-rendered prose */
   .spec-rendered { background: var(--bg-raised); border: 1px solid var(--border);
     border-radius: 8px; padding: 20px 24px; font-size: 0.9375rem;
-    overflow-x: auto; min-height: 120px; }
+    overflow-x: hidden; min-height: 120px; max-width: 100%; box-sizing: border-box; }
   .spec-rendered :global(h2) { font-size: 1.0625rem; margin: 16px 0 8px; color: var(--text); }
   .spec-rendered :global(p) { color: var(--text-muted); line-height: 1.6; margin-bottom: 10px; }
   .spec-rendered :global(table) { width: 100%; border-collapse: collapse; font-size: 0.875rem; margin: 12px 0; }
@@ -289,8 +290,11 @@ const styleLabel: Record<string, string> = {
   .spec-rendered :global(code) { font-family: var(--mono); font-size: 0.875em; color: var(--accent-bright);
     background: var(--bg); border: 1px solid var(--border); border-radius: 3px; padding: 1px 5px; }
   .spec-rendered :global(pre) { background: var(--bg); border: 1px solid var(--border);
-    border-radius: 6px; padding: 12px 14px; overflow-x: auto; margin: 8px 0; }
-  .spec-rendered :global(pre code) { background: none; border: none; padding: 0; }
+    border-radius: 6px; padding: 12px 14px; overflow-x: auto; margin: 8px 0;
+    max-width: 100%; box-sizing: border-box; white-space: pre; }
+  .spec-rendered :global(pre code) { background: none; border: none; padding: 0;
+    white-space: pre; word-break: normal; }
+  .spec-rendered :global(table) { display: block; overflow-x: auto; max-width: 100%; box-sizing: border-box; }
   .spec-rendered :global(ul), .spec-rendered :global(ol) { list-style: disc; padding-left: 20px; color: var(--text-muted); margin-bottom: 10px; }
   .spec-rendered :global(hr) { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
 

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -38,7 +38,11 @@ button { font-family: inherit; cursor: pointer; }
 pre, code { max-width: 100%; }
 pre { overflow-x: auto; }
 
-.container { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--container-pad); }
+.container { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--container-pad); box-sizing: border-box; }
+
+@media (max-width: 480px) {
+  :root { --container-pad: 16px; }
+}
 
 a:focus-visible, button:focus-visible, input:focus-visible,
 select:focus-visible, [tabindex]:focus-visible {

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -36,7 +36,20 @@ a { color: inherit; text-decoration: none; }
 img, svg { display: block; max-width: 100%; }
 button { font-family: inherit; cursor: pointer; }
 pre, code { max-width: 100%; }
-pre { overflow-x: auto; }
+pre { overflow-x: auto; max-width: 100%; box-sizing: border-box; }
+pre code { white-space: pre; word-break: normal; word-wrap: normal; }
+
+/* Shiki / astro syntax-highlighted blocks */
+pre.astro-code { max-width: 100%; box-sizing: border-box; overflow-x: auto; contain: layout; }
+
+/* Responsive tables */
+table { max-width: 100%; box-sizing: border-box; }
+.doc-body table, .art-body table {
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+  box-sizing: border-box;
+}
 
 .container { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--container-pad); box-sizing: border-box; }
 


### PR DESCRIPTION
## Summary

- **Mobile nav (all 34 pages):** hamburger breakpoint was `760px` — tablets at 768px saw desktop nav with no hamburger. Fixed to `768px`.
- **DocsLayout side-scroll (all /docs pages):** `docs-grid` 260px+article layout forced side-scroll at ≤768px. Added `min-width: 0; overflow-x: hidden` to `.article` to let the grid column collapse correctly; added `max-width: 100%; box-sizing: border-box` to `pre` blocks.
- **Language [slug] side-scroll (all 12 /languages/{slug} pages):** code blocks overflowed container. Added `overflow-x: hidden` to `main`, `box-sizing: border-box` to container, and `padding: 0 16px` override at ≤600px.
- **Global container:** added `box-sizing: border-box` + `--container-pad: 16px` override at ≤480px so 320px viewports get breathing room.
- **Tap targets:** breadcrumb "← Back to languages" (18px → 44px via `min-height`); `.cta-link` "Open an issue" (24px → 44px); CorvidLabs footer link (`inline-block + padding`); doc/article inline links (`padding: 2px 0`); DocsLayout breadcrumb "Docs" link (`min-height: 44px`).
- **Content — YAML omitted from language lists:** `docs/index.md` and `docs/why-specsync.md` both listed 11 languages without YAML; both updated to include it.

## What was audited

- 34 pages × 3 viewports (320×568, 375×667, 768×1024) via Playwright
- All `/docs/*`, `/languages/{slug}`, `/examples/*`, `/blog/*`, `/404`
- Content: version refs (v4.3.2 is current — all correct), detection_style accuracy (TypeScript is legitimately AST; all others are regex/hybrid — correct), broken links (none found), anchor links, TODO/placeholder leakage (internal comment in index.astro:107 left — it's a code comment, not rendered)

## Left for manual follow-up

- GitHub repo description missing `📐` emoji prefix — requires admin PATCH access that isn't available to this agent.

## Test plan

- [x] `bun run lint` — 0 errors, 0 warnings
- [x] `bun run build` — 34 pages built successfully
- [ ] Re-run Playwright audit after deploy to confirm zero side-scroll regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)