### PR TITLE
Fix Jules review findings: perf, security hardening, tests

### DIFF
--- a/specs/git_utils/git_utils.spec.md
+++ b/specs/git_utils/git_utils.spec.md
@@ -13,7 +13,7 @@ depends_on: []
 
 ## Purpose
 
-Shared git utility functions for querying repository history. Provides commit hash lookup, commit distance counting, and git repository detection. Used by the `stale`, `report`, and `scoring` modules to determine spec freshness relative to source file changes.
+Shared git utility functions for querying repository history. Provides commit hash lookup, commit distance counting, and git repository detection. Used by the `stale`, `report`, `check`, `lifecycle`, and `scoring` modules to determine spec freshness relative to source file changes. Callers resolve a spec's commit hash once via `git_last_commit_hash`, then count divergence per source file via `git_commits_since` to avoid redundant `git log` invocations.
 
 ## Public API
 
@@ -22,7 +22,7 @@ Shared git utility functions for querying repository history. Provides commit ha
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `git_last_commit_hash` | `root: &Path, file: &str` | `Option<String>` | Get the SHA hash of the last commit that touched a file |
-| `git_commits_between` | `root: &Path, spec_file: &str, source_file: &str` | `usize` | Count commits to source_file since spec_file was last modified |
+| `git_commits_since` | `root: &Path, spec_commit: &str, source_file: &str` | `usize` | Count commits to source_file since a precomputed spec commit hash |
 | `is_git_repo` | `root: &Path` | `bool` | Check if a directory is inside a git work tree |
 
 ### Exported Types
@@ -35,7 +35,7 @@ Shared git utility functions for querying repository history. Provides commit ha
 
 1. All git commands execute with `current_dir(root)` to ensure correct repository context
 2. Functions return safe defaults (None, 0, false) when git is unavailable or commands fail
-3. `git_commits_between` uses `git rev-list --count {spec_commit}..HEAD -- {source_file}` to count divergence
+3. `git_commits_since` uses `git rev-list --count {spec_commit}..HEAD -- {source_file}` to count divergence, taking the spec commit hash as a parameter so it is resolved once per spec rather than once per source file
 4. `StaleInfo.source_details` only includes files with commits_behind > 0
 
 ## Behavioral Examples
@@ -49,7 +49,7 @@ Shared git utility functions for querying repository history. Provides commit ha
 ### Scenario: Source file changed after spec
 
 - **Given** a spec last committed at commit A, and a source file with 3 commits after A
-- **When** `git_commits_between` is called
+- **When** `git_commits_since` is called with commit A's hash
 - **Then** returns `3`
 
 ## Error Cases
@@ -69,3 +69,4 @@ None (only uses `std::process::Command` for git CLI calls).
 | Date | Change |
 |------|--------|
 | 2026-04-10 | Initial — extracted from cmd_report for shared use by stale, report, and scoring |
+| 2026-06-07 | Replaced `git_commits_between` with `git_commits_since`, which takes a precomputed spec commit hash so callers resolve it once per spec instead of once per source file (eliminates N+1 `git log` calls) |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -408,3 +408,94 @@ pub enum HooksAction {
     /// Show installation status of all hooks
     Status,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_subcommand_yields_none_and_text_default() {
+        let cli = Cli::try_parse_from(["specsync"]).unwrap();
+        assert!(cli.command.is_none());
+        assert!(!cli.strict);
+        assert_eq!(cli.format, types::OutputFormat::Text);
+        assert!(cli.require_coverage.is_none());
+    }
+
+    #[test]
+    fn global_flags_parse_before_subcommand() {
+        let cli = Cli::try_parse_from([
+            "specsync",
+            "--strict",
+            "--require-coverage",
+            "80",
+            "coverage",
+        ])
+        .unwrap();
+        assert!(cli.strict);
+        assert_eq!(cli.require_coverage, Some(80));
+        assert!(matches!(cli.command, Some(Command::Coverage)));
+    }
+
+    #[test]
+    fn json_format_value_enum_parses() {
+        let cli = Cli::try_parse_from(["specsync", "--format", "json", "check"]).unwrap();
+        assert_eq!(cli.format, types::OutputFormat::Json);
+    }
+
+    #[test]
+    fn check_collects_flags_and_positional_specs() {
+        let cli = Cli::try_parse_from(["specsync", "check", "--fix", "--dry-run", "cli", "parser"])
+            .unwrap();
+        match cli.command {
+            Some(Command::Check {
+                fix,
+                dry_run,
+                specs,
+                ..
+            }) => {
+                assert!(fix);
+                assert!(dry_run);
+                assert_eq!(specs, vec!["cli".to_string(), "parser".to_string()]);
+            }
+            _ => panic!("expected a Check command"),
+        }
+    }
+
+    #[test]
+    fn stale_threshold_defaults_and_overrides() {
+        let default = Cli::try_parse_from(["specsync", "stale"]).unwrap();
+        assert!(matches!(
+            default.command,
+            Some(Command::Stale { threshold: 5 })
+        ));
+
+        let overridden = Cli::try_parse_from(["specsync", "stale", "--threshold", "10"]).unwrap();
+        assert!(matches!(
+            overridden.command,
+            Some(Command::Stale { threshold: 10 })
+        ));
+    }
+
+    #[test]
+    fn exclude_status_splits_on_commas() {
+        let cli = Cli::try_parse_from([
+            "specsync",
+            "--exclude-status",
+            "deprecated,archived",
+            "check",
+        ])
+        .unwrap();
+        assert_eq!(cli.exclude_status, vec!["deprecated", "archived"]);
+    }
+
+    #[test]
+    fn unknown_subcommand_is_rejected() {
+        assert!(Cli::try_parse_from(["specsync", "definitely-not-a-command"]).is_err());
+    }
+
+    #[test]
+    fn non_numeric_threshold_is_rejected() {
+        assert!(Cli::try_parse_from(["specsync", "stale", "--threshold", "abc"]).is_err());
+    }
+}

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -326,10 +326,10 @@ pub fn cmd_check(
                 .to_string_lossy()
                 .to_string();
 
-            let spec_commit = git_utils::git_last_commit_hash(root, &rel_spec);
-            if spec_commit.is_none() {
-                continue;
-            }
+            let spec_commit = match git_utils::git_last_commit_hash(root, &rel_spec) {
+                Some(commit) => commit,
+                None => continue,
+            };
 
             let mut max_behind: usize = 0;
             let mut drifted_files: Vec<(String, usize)> = Vec::new();
@@ -337,7 +337,7 @@ pub fn cmd_check(
                 if !root.join(source_file).exists() {
                     continue;
                 }
-                let behind = git_utils::git_commits_between(root, &rel_spec, source_file);
+                let behind = git_utils::git_commits_since(root, &spec_commit, source_file);
                 if behind >= threshold {
                     drifted_files.push((source_file.clone(), behind));
                 }

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -22,9 +22,11 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
     };
     let base = effective_base.as_str();
 
-    // Get list of files changed since base ref
+    // Get list of files changed since base ref.
+    // `--end-of-options` ensures `base` is always parsed as a revision, never as
+    // a git flag — even if it's user-supplied and starts with `-`.
     let output = match std::process::Command::new("git")
-        .args(["diff", "--name-only", base])
+        .args(["diff", "--name-only", "--end-of-options", base])
         .current_dir(root)
         .output()
     {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -77,3 +77,48 @@ pub fn ensure_hashes_gitignored(root: &Path) -> Result<bool, String> {
     fs::write(&gitignore_path, content).map_err(|e| format!("Failed to update .gitignore: {e}"))?;
     Ok(true)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn adds_entry_to_missing_gitignore() {
+        let tmp = TempDir::new().unwrap();
+        let changed = ensure_hashes_gitignored(tmp.path()).unwrap();
+        assert!(changed, "should report it wrote the entry");
+
+        let content = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+        assert!(content.contains(".specsync/hashes.json"));
+    }
+
+    #[test]
+    fn is_idempotent_when_entry_already_present() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".gitignore"),
+            "target/\n.specsync/hashes.json\n",
+        )
+        .unwrap();
+
+        let changed = ensure_hashes_gitignored(tmp.path()).unwrap();
+        assert!(!changed, "entry already present — nothing to add");
+
+        // Existing content is untouched (no duplicate entry appended).
+        let content = fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+        assert_eq!(content.matches(".specsync/hashes.json").count(), 1);
+    }
+
+    #[test]
+    fn errors_when_gitignore_path_is_unwritable() {
+        let tmp = TempDir::new().unwrap();
+        // Make `.gitignore` a directory so the write fails — exercises the
+        // error path that maps the io::Error into a String.
+        fs::create_dir(tmp.path().join(".gitignore")).unwrap();
+
+        let result = ensure_hashes_gitignored(tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to update .gitignore"));
+    }
+}

--- a/src/commands/lifecycle.rs
+++ b/src/commands/lifecycle.rs
@@ -212,13 +212,21 @@ pub fn evaluate_guards(
                     let parsed = parser::parse_frontmatter(&content.replace("\r\n", "\n"));
                     match parsed {
                         Some(parsed) => {
-                            for source_file in &parsed.frontmatter.files {
-                                let commits =
-                                    git_utils::git_commits_between(root, &rel, source_file);
-                                if commits >= threshold {
-                                    failures.push(format!(
-                                        "guard: stale — {source_file} has {commits} commits since spec was last updated (threshold: {threshold})"
-                                    ));
+                            // Resolve the spec commit once, then count per source
+                            // file — avoids re-running `git log` for the spec on
+                            // every file.
+                            if let Some(spec_commit) = git_utils::git_last_commit_hash(root, &rel) {
+                                for source_file in &parsed.frontmatter.files {
+                                    let commits = git_utils::git_commits_since(
+                                        root,
+                                        &spec_commit,
+                                        source_file,
+                                    );
+                                    if commits >= threshold {
+                                        failures.push(format!(
+                                            "guard: stale — {source_file} has {commits} commits since spec was last updated (threshold: {threshold})"
+                                        ));
+                                    }
                                 }
                             }
                         }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -1152,3 +1152,53 @@ fn discover_specs(root: &Path) -> Vec<PathBuf> {
 
     crate::validator::find_spec_files(&specs_dir)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn ctx(root: &Path) -> MigrationContext {
+        MigrationContext {
+            root: root.to_path_buf(),
+            dry_run: false,
+            no_backup: false,
+            format: OutputFormat::Json,
+            spec_files: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn apply_create_directories_creates_v4_layout() {
+        let tmp = TempDir::new().unwrap();
+        let mut report = MigrationReport::default();
+
+        apply_create_directories(&ctx(tmp.path()), &mut report).unwrap();
+
+        for dir in [
+            ".specsync",
+            ".specsync/lifecycle",
+            ".specsync/changes",
+            ".specsync/archive",
+        ] {
+            assert!(tmp.path().join(dir).is_dir(), "{dir} should exist");
+        }
+        assert_eq!(report.dirs_created.len(), 4);
+        assert_eq!(report.steps_completed.len(), 1);
+    }
+
+    #[test]
+    fn apply_create_directories_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+
+        // First run creates everything.
+        let mut first = MigrationReport::default();
+        apply_create_directories(&ctx(tmp.path()), &mut first).unwrap();
+        assert_eq!(first.dirs_created.len(), 4);
+
+        // Second run finds them already present and creates nothing new.
+        let mut second = MigrationReport::default();
+        apply_create_directories(&ctx(tmp.path()), &mut second).unwrap();
+        assert!(second.dirs_created.is_empty());
+    }
+}

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use std::fs;
 use std::path::Path;
 
-use crate::git_utils::{git_commits_between, git_last_commit_hash};
+use crate::git_utils::{git_commits_since, git_last_commit_hash};
 use crate::parser;
 use crate::types;
 use crate::validator::compute_coverage;
@@ -73,20 +73,19 @@ pub fn cmd_report(
         let mut stale = false;
         let mut max_behind: usize = 0;
         if !fm.files.is_empty() {
-            let spec_commit = git_last_commit_hash(root, &rel_spec);
-            for source_file in &fm.files {
-                if !root.join(source_file).exists() {
-                    continue;
+            // Resolve the spec commit once; if git has no record of the spec we
+            // can't determine staleness, so leave `stale` false.
+            if let Some(spec_commit) = git_last_commit_hash(root, &rel_spec) {
+                for source_file in &fm.files {
+                    if !root.join(source_file).exists() {
+                        continue;
+                    }
+                    let behind = git_commits_since(root, &spec_commit, source_file);
+                    if behind >= stale_threshold {
+                        stale = true;
+                        max_behind = max_behind.max(behind);
+                    }
                 }
-                let behind = git_commits_between(root, &rel_spec, source_file);
-                if behind >= stale_threshold {
-                    stale = true;
-                    max_behind = max_behind.max(behind);
-                }
-            }
-            // If we couldn't get git info, skip stale
-            if spec_commit.is_none() {
-                stale = false;
             }
         }
 

--- a/src/commands/stale.rs
+++ b/src/commands/stale.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use std::fs;
 use std::path::Path;
 
-use crate::git_utils::{StaleInfo, git_commits_between, git_last_commit_hash, is_git_repo};
+use crate::git_utils::{StaleInfo, git_commits_since, git_last_commit_hash, is_git_repo};
 use crate::parser;
 use crate::types;
 
@@ -72,12 +72,14 @@ pub fn cmd_stale(
             continue;
         }
 
-        let spec_commit = git_last_commit_hash(root, &rel_spec);
-        if spec_commit.is_none() {
-            // Spec not yet tracked by git — skip
-            fresh_count += 1;
-            continue;
-        }
+        let spec_commit = match git_last_commit_hash(root, &rel_spec) {
+            Some(commit) => commit,
+            None => {
+                // Spec not yet tracked by git — skip
+                fresh_count += 1;
+                continue;
+            }
+        };
 
         let mut max_behind: usize = 0;
         let mut source_details: Vec<(String, usize)> = Vec::new();
@@ -86,7 +88,7 @@ pub fn cmd_stale(
             if !root.join(source_file).exists() {
                 continue;
             }
-            let behind = git_commits_between(root, &rel_spec, source_file);
+            let behind = git_commits_since(root, &spec_commit, source_file);
             if behind > 0 {
                 source_details.push((source_file.clone(), behind));
             }

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -12,13 +12,12 @@ pub fn git_last_commit_hash(root: &Path, file: &str) -> Option<String> {
     if hash.is_empty() { None } else { Some(hash) }
 }
 
-/// Count commits that touched `source_file` since `spec_file` was last modified.
-pub fn git_commits_between(root: &Path, spec_file: &str, source_file: &str) -> usize {
-    let spec_commit = match git_last_commit_hash(root, spec_file) {
-        Some(h) => h,
-        None => return 0,
-    };
-
+/// Count commits that touched `source_file` since the given `spec_commit`.
+///
+/// Takes a precomputed spec commit hash (from [`git_last_commit_hash`]) so
+/// callers iterating over a spec's source files spawn one `git rev-list` per
+/// file instead of also re-resolving the spec's commit each time.
+pub fn git_commits_since(root: &Path, spec_commit: &str, source_file: &str) -> usize {
     let output = match Command::new("git")
         .args([
             "rev-list",
@@ -61,4 +60,125 @@ pub struct StaleInfo {
     pub max_commits_behind: usize,
     /// Per-source-file commit distances (file, commits_behind).
     pub source_details: Vec<(String, usize)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Run a git command in `root`, asserting it succeeds.
+    fn git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Initialize an empty git repo with a deterministic identity.
+    fn init_repo() -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        git(root, &["init"]);
+        git(root, &["config", "user.email", "test@test.com"]);
+        git(root, &["config", "user.name", "Test"]);
+        git(root, &["config", "commit.gpgsign", "false"]);
+        tmp
+    }
+
+    /// Write a file (creating parent dirs), stage everything, and commit.
+    fn commit_file(root: &Path, rel: &str, contents: &str, message: &str) {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, contents).unwrap();
+        git(root, &["add", "-A"]);
+        git(root, &["commit", "-m", message]);
+    }
+
+    #[test]
+    fn last_commit_hash_returns_none_for_untracked_file() {
+        let tmp = init_repo();
+        assert_eq!(
+            git_last_commit_hash(tmp.path(), "specs/missing.spec.md"),
+            None
+        );
+    }
+
+    #[test]
+    fn last_commit_hash_returns_hash_for_tracked_file() {
+        let tmp = init_repo();
+        commit_file(tmp.path(), "specs/auth.spec.md", "spec v1", "add spec");
+
+        let hash = git_last_commit_hash(tmp.path(), "specs/auth.spec.md")
+            .expect("tracked file should have a commit hash");
+        assert_eq!(
+            hash.len(),
+            40,
+            "expected a full 40-char SHA-1, got {hash:?}"
+        );
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn commits_since_is_zero_when_source_unchanged_after_spec() {
+        let tmp = init_repo();
+        let root = tmp.path();
+        commit_file(root, "src/auth.rs", "fn login() {}", "add source");
+        commit_file(root, "specs/auth.spec.md", "spec v1", "add spec");
+
+        let spec_commit = git_last_commit_hash(root, "specs/auth.spec.md").unwrap();
+        // Source has not changed since the spec was committed.
+        assert_eq!(git_commits_since(root, &spec_commit, "src/auth.rs"), 0);
+    }
+
+    #[test]
+    fn commits_since_counts_source_changes_after_spec() {
+        let tmp = init_repo();
+        let root = tmp.path();
+        commit_file(root, "specs/auth.spec.md", "spec v1", "add spec");
+        let spec_commit = git_last_commit_hash(root, "specs/auth.spec.md").unwrap();
+
+        // Three commits touch the source file after the spec was last committed.
+        commit_file(root, "src/auth.rs", "v1", "change 1");
+        commit_file(root, "src/auth.rs", "v2", "change 2");
+        commit_file(root, "src/auth.rs", "v3", "change 3");
+
+        assert_eq!(git_commits_since(root, &spec_commit, "src/auth.rs"), 3);
+        // A different, untouched file reports zero.
+        assert_eq!(git_commits_since(root, &spec_commit, "src/other.rs"), 0);
+    }
+
+    #[test]
+    fn commits_since_returns_zero_for_invalid_commit() {
+        let tmp = init_repo();
+        let root = tmp.path();
+        commit_file(root, "src/auth.rs", "v1", "add source");
+        // A bogus commit ref makes `git rev-list` fail; we degrade to zero.
+        assert_eq!(
+            git_commits_since(
+                root,
+                "0000000000000000000000000000000000000000",
+                "src/auth.rs"
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn is_git_repo_detects_repo_and_non_repo() {
+        let repo = init_repo();
+        assert!(is_git_repo(repo.path()));
+
+        let plain = TempDir::new().unwrap();
+        assert!(!is_git_repo(plain.path()));
+    }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -7,6 +7,19 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 
+/// Redact a token from an error message before surfacing it.
+///
+/// The token is sent in the `Authorization` header, not the URL, so HTTP errors
+/// should never contain it — this strips any verbatim occurrence as
+/// defense-in-depth in case a proxy or future change echoes it back.
+fn redact_token(message: String, token: &str) -> String {
+    if !token.is_empty() && message.contains(token) {
+        message.replace(token, "[REDACTED]")
+    } else {
+        message
+    }
+}
+
 /// A GitHub issue's relevant fields.
 #[derive(Debug, Clone)]
 pub struct GitHubIssue {
@@ -143,7 +156,7 @@ pub fn fetch_issue_api(repo: &str, number: u64) -> Result<GitHubIssue, String> {
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "specsync")
         .call()
-        .map_err(|e| format!("GitHub API request failed: {e}"))?;
+        .map_err(|e| redact_token(format!("GitHub API request failed: {e}"), &token))?;
 
     if response.status() == 404 {
         return Err(format!("Issue #{number} not found in {repo}"));
@@ -309,7 +322,7 @@ fn list_issues_api(repo: &str, label: Option<&str>) -> Result<Vec<GitHubIssue>, 
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "specsync")
         .call()
-        .map_err(|e| format!("GitHub API request failed: {e}"))?;
+        .map_err(|e| redact_token(format!("GitHub API request failed: {e}"), &token))?;
 
     if response.status() != 200 {
         return Err(format!("GitHub API returned HTTP {}", response.status()));

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -160,6 +160,20 @@ fn today() -> String {
     }
 }
 
+/// Redact a secret from an error message before surfacing it to the user.
+///
+/// Auth tokens are sent in request headers, so well-behaved HTTP errors should
+/// never echo them back — but a misbehaving proxy, redirect, or future client
+/// change could. This strips any verbatim occurrence of the token as
+/// defense-in-depth, mirroring the sanitization used in the AI provider client.
+fn redact_secret(message: String, secret: &str) -> String {
+    if !secret.is_empty() && message.contains(secret) {
+        message.replace(secret, "[REDACTED]")
+    } else {
+        message
+    }
+}
+
 /// Slugify a title into a valid module name.
 pub fn slugify(title: &str) -> String {
     title
@@ -234,7 +248,7 @@ fn import_github_issue_api(repo: &str, number: u64) -> Result<ImportedItem, Stri
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "specsync")
         .call()
-        .map_err(|e| format!("GitHub API request failed: {e}"))?;
+        .map_err(|e| redact_secret(format!("GitHub API request failed: {e}"), &token))?;
 
     if response.status() == 404 {
         return Err(format!("Issue #{number} not found in {repo}"));
@@ -325,7 +339,7 @@ pub fn import_jira_issue(issue_key: &str) -> Result<ImportedItem, String> {
 
     let mut response = req
         .call()
-        .map_err(|e| format!("Jira API request failed: {e}"))?;
+        .map_err(|e| redact_secret(format!("Jira API request failed: {e}"), &token))?;
 
     if response.status() == 404 {
         return Err(format!("Jira issue {issue_key} not found"));
@@ -449,7 +463,7 @@ pub fn import_confluence_page(page_id: &str) -> Result<ImportedItem, String> {
 
     let mut response = req
         .call()
-        .map_err(|e| format!("Confluence API request failed: {e}"))?;
+        .map_err(|e| redact_secret(format!("Confluence API request failed: {e}"), &token))?;
 
     if response.status() == 404 {
         return Err(format!("Confluence page {page_id} not found"));

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,7 +3,9 @@ use colored::Colorize;
 use crate::types;
 
 pub fn print_summary(total: usize, passed: usize, warnings: usize, _errors: usize) {
-    let failed = total - passed;
+    // saturating_sub guards against an underflow panic if `passed` is ever
+    // reported higher than `total`.
+    let failed = total.saturating_sub(passed);
     println!(
         "\n{total} specs checked: {} passed, {} warning(s), {} failed",
         passed.to_string().green(),
@@ -211,6 +213,45 @@ pub fn print_diff_markdown(
             println!();
         } else {
             println!("No drift — spec is up to date.\n");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn coverage(file_pct: usize, loc_pct: usize) -> types::CoverageReport {
+        types::CoverageReport {
+            total_source_files: 1,
+            specced_file_count: 1,
+            unspecced_files: Vec::new(),
+            unspecced_modules: Vec::new(),
+            coverage_percent: file_pct,
+            total_loc: 1,
+            specced_loc: 1,
+            loc_coverage_percent: loc_pct,
+            unspecced_file_loc: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn print_summary_does_not_underflow_when_passed_exceeds_total() {
+        // Regression: `total - passed` used to panic on underflow in debug.
+        print_summary(2, 5, 0, 0);
+    }
+
+    #[test]
+    fn print_summary_handles_zero_and_all_passed() {
+        print_summary(0, 0, 0, 0);
+        print_summary(3, 3, 0, 0);
+    }
+
+    #[test]
+    fn print_coverage_line_handles_color_threshold_boundaries() {
+        // Exercises each color branch: <80 (red), ==80 (yellow), 100 (green).
+        for pct in [0usize, 79, 80, 99, 100] {
+            print_coverage_line(&coverage(pct, pct));
         }
     }
 }

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -537,11 +537,11 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
             .unwrap_or(spec_path)
             .to_string_lossy()
             .to_string();
-        if git_utils::git_last_commit_hash(root, &rel_path).is_some() {
+        if let Some(spec_commit) = git_utils::git_last_commit_hash(root, &rel_path) {
             let mut max_behind: usize = 0;
             for file in &fm.files {
                 if root.join(file).exists() {
-                    let behind = git_utils::git_commits_between(root, &rel_path, file);
+                    let behind = git_utils::git_commits_since(root, &spec_commit, file);
                     max_behind = max_behind.max(behind);
                 }
             }
@@ -642,13 +642,17 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
 /// - Descriptive prose where TODO is used as a concept (e.g., "TODO comments", "detect TODO")
 fn count_placeholder_todos(body: &str) -> usize {
     use regex::Regex;
+    use std::sync::LazyLock;
+
+    // Compiled once and reused across every spec scored in a run, rather than
+    // recompiling both patterns on each call.
+    static CODE_BLOCK_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?s)```[^\n]*\n.*?```").expect("valid code-block regex"));
+    static TODO_LINE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^TODO\s*(:.*)?$").expect("valid TODO-line regex"));
 
     // Strip fenced code blocks
-    let code_block_re = Regex::new(r"(?s)```[^\n]*\n.*?```").unwrap();
-    let stripped = code_block_re.replace_all(body, "");
-
-    // Placeholder pattern: line is just "TODO"/"todo", or starts with "TODO:"
-    let todo_line_re = Regex::new(r"(?i)^TODO\s*(:.*)?$").unwrap();
+    let stripped = CODE_BLOCK_RE.replace_all(body, "");
 
     let mut count = 0;
     for line in stripped.lines() {
@@ -656,7 +660,7 @@ fn count_placeholder_todos(body: &str) -> usize {
             .trim()
             .trim_start_matches("- ")
             .trim_start_matches("* ");
-        if todo_line_re.is_match(trimmed) {
+        if TODO_LINE_RE.is_match(trimmed) {
             count += 1;
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4820,3 +4820,66 @@ fn action_requires_release_checksums() {
         "Unix archive checksums should be verified before extraction"
     );
 }
+
+// ─── specsync stale ──────────────────────────────────────────────────────
+
+#[test]
+fn stale_outside_git_repo_fails_with_message() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_minimal_project(&tmp);
+    // No `git init` — staleness detection requires git history.
+
+    specsync()
+        .arg("stale")
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Not a git repository"));
+}
+
+#[test]
+fn stale_outside_git_repo_json_reports_error() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_minimal_project(&tmp);
+
+    specsync()
+        .arg("stale")
+        .arg("--root")
+        .arg(&root)
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("not a git repository"))
+        .stdout(predicate::str::contains("\"stale_specs\""));
+}
+
+#[test]
+fn stale_in_fresh_repo_reports_all_up_to_date() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_minimal_project(&tmp);
+
+    // Initialize a repo and commit everything so source and spec share history.
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(&root)
+            .assert()
+            .success();
+    };
+    git(&["init"]);
+    git(&["config", "user.email", "test@test.com"]);
+    git(&["config", "user.name", "Test"]);
+    git(&["config", "commit.gpgsign", "false"]);
+    git(&["add", "-A"]);
+    git(&["commit", "-m", "initial"]);
+
+    specsync()
+        .arg("stale")
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to date"));
+}


### PR DESCRIPTION
## Summary

Triaged all **26** of Jules' code-review suggestions and applied the ones that genuinely need fixing, plus the high-value missing tests. Scope was confirmed with the maintainer as **fixes + tests** — subjective refactors are deferred to keep this PR reviewable.

### ✅ Performance
- **N+1 git subprocess spawns.** `git_commits_between` internally re-ran `git log` to resolve the spec's commit *for every source file*. Added `git_commits_since(root, spec_commit, source_file)` that takes a precomputed hash, and updated all **5** call sites (`stale`, `check`, `report`, `scoring`, `lifecycle`) to resolve the spec commit once per spec. For a spec with N source files this drops `N+1` `git log` calls to `1`.
- **Repeated regex compilation.** `count_placeholder_todos` recompiled two regexes on every spec scored. Now cached via `LazyLock` (no new deps — edition 2024 / MSRV 1.88).

### ✅ Security hardening
- **Token redaction in error messages** (Jira, Confluence, GitHub API in `importer.rs` + `github.rs`). Tokens travel in `Authorization` *headers*, not URLs, so `ureq` errors don't currently include them — but this adds defense-in-depth mirroring the existing `ai.rs` pattern, in case a proxy/redirect echoes them back.
- **git argument-injection hardening.** `git diff` now passes `--end-of-options` so a user-supplied `base` ref starting with `-` can't be misparsed as a git flag.

### ✅ Correctness
- **`print_summary` underflow.** `total - passed` panics on `usize` underflow in debug builds if `passed > total`; switched to `saturating_sub`.

### ✅ Tests (+25)
| Area | Coverage |
|------|----------|
| `git_utils` | hash resolution (tracked/untracked), commit counting (0 / N / invalid ref), repo detection |
| `output` | `print_summary` underflow + coverage color boundaries (0/79/80/99/100) |
| `init` | `ensure_hashes_gitignored` success / idempotent / **error path** |
| `migrate` | `apply_create_directories` creation + idempotency |
| `cli` | `Cli`/`Command` parsing, defaults, comma delimiters, rejection cases |
| integration | `stale` outside a git repo (text + json) and fresh-repo up-to-date path |

### ⏭️ Reviewed but intentionally not changed
- **API-key exposure in OpenAI / Gemini / Anthropic logging** — already mitigated (`if msg.contains(api_key)` at `ai.rs:622/709/785`).
- **"Command Injection" in git/AI execution** — uses `.args([...])` (no shell); the AI `sh -c` path runs an intentional user-configured command. No shell-injection vector introduced by untrusted input.
- **"Hardcoded" Jira/Confluence token leaks** — tokens are env-sourced, not hardcoded, and not present in the error strings; addressed via the redaction hardening above.
- **Refactors** (split `run`/`score_spec`, dedup GitHub issue fetchers, dynamic languages list) — quality items, not bugs; deferred to keep this PR focused.

## Test Plan
- [x] `cargo test` — 607 unit + 129 integration pass
- [x] `cargo clippy --all-targets` — no new warnings (5 pre-existing, unrelated)
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)