### PR TITLE
chore: release v4.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.5] - 2026-06-07
+
+### Security
+
+- **Auth tokens redacted from import/GitHub error messages** — Jira, Confluence, and GitHub API request failures now strip any verbatim token from the surfaced error as defense-in-depth, mirroring the AI client's sanitization. Tokens travel in `Authorization` headers (not URLs), so this guards against a misbehaving proxy or redirect echoing them back.
+- **`git diff` hardened against argument injection** — the drift command passes `--end-of-options` so a user-supplied base ref starting with `-` is always parsed as a revision, never as a git flag.
+
+### Performance
+
+- **Eliminated N+1 git subprocess spawns in staleness checks** — `git_commits_between` re-ran `git log` to resolve the spec's commit for *every* source file. Replaced with `git_commits_since`, which takes a precomputed spec commit so callers (`stale`, `check`, `report`, `scoring`, `lifecycle`) spawn one `git rev-list` per source file instead of an extra `git log` each. For a spec with N source files this drops N+1 `git log` calls to 1.
+- **Cached spec-scoring regexes** — `count_placeholder_todos` no longer recompiles its two regexes on every spec scored; they are built once via `LazyLock`.
+
+### Fixed
+
+- **`print_summary` integer underflow** — `total - passed` could panic on `usize` underflow in debug builds when `passed` exceeded `total`; now uses `saturating_sub`.
+
+### Tests
+
+- Added 25 tests covering git utilities (commit resolution and counting edge cases), CLI argument parsing, `ensure_hashes_gitignored` (including the write-failure error path), migration step application, output boundary cases, and the `stale` command outside a git repository.
+
 ## [4.3.4] - 2026-06-07
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.3.4"
+version = "4.3.5"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.3.4"
+version = "4.3.5"
 edition = "2024"
 rust-version = "1.88"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
Release **v4.3.5** — bundles the version bump + curated changelog for the fixes merged in #275.

### Contents
- `Cargo.toml` / `Cargo.lock` → `4.3.5` (binary `--version` confirmed)
- `CHANGELOG.md` → curated `[4.3.5]` section (Security / Performance / Fixed / Tests)

### After merge
Push the `v4.3.5` tag on the merge commit to trigger `release.yml` (cross-platform binaries + GitHub Release). No crates.io publish.

```
git tag v4.3.5 <merge-sha> && git push origin v4.3.5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)