### PR TITLE
chore: release v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.4.0] - 2026-06-07
+
 ### Added
 
 - **`openrouter` and `ollama` API providers.** OpenRouter joins the OpenAI-compatible family; Ollama now runs over its OpenAI-compatible HTTP endpoint (local server keyless, or Ollama Cloud via `OLLAMA_API_KEY`) instead of shelling out to `ollama run`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.3.5"
+version = "4.4.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.3.5"
+version = "4.4.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
Release **v4.4.0** — finalizes the corvid-ai AI-provider rework (the #277/#278 work, now on `main`).

### Contents (clean 3-file diff)
- `Cargo.toml` / `Cargo.lock` → **4.4.0** (binary `--version` confirmed; MSRV 1.89)
- `CHANGELOG.md` → `[Unreleased]` finalized as **[4.4.0] - 2026-06-07**

### Why minor (4.4.0)
Behavior changes with a documented migration (`MIGRATION.md` → "AI providers (4.4.0)"), no removed commands: default provider is now Ollama, `claude`→`anthropic` deprecation, `openai`/`together` need an explicit model, MSRV 1.89, new env/flags.

### Highlights (full notes in CHANGELOG)
- AI calls go through the shared **corvid-ai** crate — current model defaults, secret redaction, no hand-rolled HTTP
- **Ollama by default** (local keyless or cloud) → API-first when keyed → **prompt-when-multiple** → never auto-selects a CLI
- `claude` → Anthropic API alias (removes the `sh -c "claude -p"` agentic surface)
- `--model` flag + `SPECSYNC_AI_PROVIDER` / `SPECSYNC_AI_MODEL` env; `flag > env > config` throughout
- Verified end-to-end against real local Ollama; aligned 1:1 with fledge 1.5.0

### After merge
Push the tag to trigger `release.yml` (cross-platform binaries + GitHub Release):
```
git tag v4.4.0 <merge-sha> && git push origin v4.4.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)