### PR TITLE
docs(specs): groom every spec companion to 5/5 + scorer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Spec scoring no longer false-flags documented HTML-comment syntax** — the `placeholder_free` check strips fenced and inline code before counting `<!-- ... -->`, so a spec that *documents* an HTML-comment directive (e.g. ``a `<!-- specsync-ignore -->` directive``) isn't penalized for showing real syntax.
+
 ## [4.4.0] - 2026-06-07
 
 ### Added

--- a/specs/ai/context.md
+++ b/specs/ai/context.md
@@ -4,21 +4,28 @@ spec: ai.spec.md
 
 ## Key Decisions
 
-- **5-level provider resolution**: CLI flag > config `aiCommand` > config `aiProvider` > env var `SPECSYNC_AI_COMMAND` > auto-detect. This ensures explicit choices always win over implicit detection.
-- **CLI vs API separation**: CLI providers (Claude, Ollama, Copilot) shell out to installed tools; API providers (Anthropic, OpenAI) make direct HTTP calls via ureq. This avoids requiring any CLI tool to be installed if you have an API key.
-- **Cursor explicitly errors**: The Cursor IDE doesn't expose a CLI pipe, so selecting it produces a clear error directing users to use Claude or Copilot instead.
-- **Source truncation**: Files capped at 30KB each, 150KB total, to stay within provider context limits without requiring token counting.
-- **Post-processing**: AI output is stripped of code fences and validated for frontmatter before being written, preventing malformed specs from reaching disk.
+- **corvid-ai owns all HTTP**: Every API provider routes through the shared `corvid-ai` crate via `corvid_ai::complete(&settings, &completion)`. spec-sync no longer hand-rolls Anthropic / OpenAI / Gemini wire shapes; corvid-ai owns the endpoint registry, default models, `<PROVIDER>_API_KEY` resolution, and secret redaction. This keeps spec-sync aligned with fledge.
+- **`ResolvedProvider` has two variants**: `Cli(String)` (legacy shell-out) and `Api(corvid_ai::Settings)`. Its `Debug` impl is hand-written to redact the API key as `[REDACTED]` — the derived `Settings` debug would leak it.
+- **`flag > env > config` resolution (12-factor)**: `--provider` > `SPECSYNC_AI_COMMAND` env > `SPECSYNC_AI_PROVIDER` env > `aiCommand` config > `aiProvider` config > auto-detect. Within env and config tiers, the command hatch outranks the provider name. Model precedence mirrors this: `--model` > `SPECSYNC_AI_MODEL` > `aiModel` > corvid-ai default.
+- **Key-presence auto-detect, no network probe**: none set → keyless local Ollama; exactly one → use it; multiple → interactive prompt (provider + model) when stdin & stderr are TTYs, else the deterministic order `[Ollama, Anthropic, OpenAI, OpenRouter, Gemini, DeepSeek, Groq, Mistral, xAI, Together]`. A set key beats unkeyed local Ollama, and auto-detect never shells out to a CLI.
+- **`claude` → anthropic API**: The deprecated `claude` provider now resolves to the `anthropic` API (with a warning); it no longer shells out to `claude -p`. Removed in spec-sync 5.0.
+- **Ollama host routing**: `OLLAMA_HOST` env > `aiBaseUrl` config > `-cloud` model tag + `OLLAMA_API_KEY` ⇒ `https://ollama.com` > `http://localhost:11434`. corvid-ai speaks to it over the OpenAI-compatible `/v1` endpoint; default model `llama3.3`. The eager key check is skipped for Ollama and whenever `aiBaseUrl` is set (self-hosted/proxy gateways).
+- **Source truncation, not token counting**: 30K chars/file, 150K total, truncated on UTF-8 char boundaries — avoids a tokenizer dependency while staying inside context windows.
+- **Post-processing guards disk writes**: AI output has code fences stripped and frontmatter delimiters validated before it can be written as a spec.
 
 ## Files to Read First
 
-- `src/ai.rs` — Single-file module; provider resolution, prompt building, API calls, and post-processing all live here.
+- `src/ai.rs` — provider resolution (`resolve_ai_provider`), the `ResolvedProvider` enum, prompt building, `corvid-ai` dispatch (`run_provider`), and post-processing all live here.
+- `src/types.rs` — `AiProvider` (with `is_api_provider`, `api_key_env_var`, `detection_order`, `from_str_loose`) and `SpecSyncConfig`.
+- `src/commands/generate.rs` — wires `--provider`/`--model` and the env/config precedence into `resolve_ai_provider`.
+- The `corvid-ai` crate — `Settings`, `Completion`, `complete`, `DEFAULT_PROVIDER`; owns endpoints, default models, and key resolution.
 
 ## Current Status
 
-Fully implemented. All 6 providers work (Claude CLI, Ollama, Copilot, Anthropic API, OpenAI API, Custom command). Auto-detection probes CLI tools first, then checks for API keys.
+Fully implemented and stable. API providers (`anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, `ollama`) all go through corvid-ai. Deprecated paths: `claude` (→ anthropic API), `copilot`, `cursor` (legacy CLI), plus the explicit `aiCommand` shell hatch. Auto-detect defaults to keyless local Ollama. MSRV 1.89.
 
 ## Notes
 
-- The `ureq` crate is the only HTTP dependency in the project — used here and in the registry module for remote fetches.
-- Spinner and live-line output during AI generation provides user feedback without cluttering the terminal.
+- `resolve_ai_command` remains as a thin compatibility alias over `resolve_ai_provider` for older tests; new code uses `resolve_ai_provider`.
+- The CLI shell-out path writes stdin on a background thread to avoid a stdout-pipe deadlock when a child streams tokens, and shows a spinner / live `│`-prefixed lines on stderr.
+- Eager key checks are UX-only "fail fast" — corvid-ai validates again at request time.

--- a/specs/ai/requirements.md
+++ b/specs/ai/requirements.md
@@ -4,36 +4,41 @@ spec: ai.spec.md
 
 ## User Stories
 
-- As a developer, I want spec-sync to auto-detect which AI provider is available on my system so that I don't need to manually configure it
-- As a team lead, I want to specify an AI provider in config so that all team members use the same provider for consistent spec generation
-- As a developer using Claude, I want to generate specs via the CLI binary so that I don't need an API key
-- As a developer with an Anthropic API key, I want spec-sync to call the API directly so that I get faster, more reliable generation without needing the CLI installed
-- As a developer using Ollama, I want local AI generation so that my code never leaves my machine
-- As a CI operator, I want to set the AI provider via environment variable (SPECSYNC_AI_COMMAND) so that I can configure generation in pipelines without modifying project config
+- As a developer with no AI setup, I want spec-sync to default to a local, keyless Ollama server so that I can generate specs with zero configuration and my code never leaves my machine
+- As a developer with a single provider API key set, I want spec-sync to auto-detect and use it so that I don't have to configure anything else
+- As a developer with several provider keys, I want an interactive prompt (provider + model) when running in a terminal, and a deterministic choice in CI, so that resolution is predictable everywhere
+- As a team lead, I want to pin a provider/model in `specsync.json` (`aiProvider`, `aiModel`) so that all contributors generate specs consistently
+- As a CI operator, I want to override the provider and model with environment variables (`SPECSYNC_AI_PROVIDER`, `SPECSYNC_AI_MODEL`, `SPECSYNC_AI_COMMAND`) so that I can configure generation in pipelines without editing project config
+- As a developer using a custom or self-hosted gateway, I want an explicit trusted shell hatch (`aiCommand` / `SPECSYNC_AI_COMMAND`) or a custom `aiBaseUrl` so that I can route to any tool or OpenAI-compatible endpoint
 
 ## Acceptance Criteria
 
-- CLI flag `--provider` overrides all other provider settings
-- Config field `aiCommand` overrides `aiProvider` when both are set
-- Auto-detection tries CLI providers (claude, ollama, copilot) before API providers (anthropic, openai)
-- Cursor provider returns a clear error explaining it cannot be used (no stdin/stdout pipe mode)
-- Source code input is capped at 150KB total and 30KB per individual file
-- AI response has code fences stripped and frontmatter validated before returning
-- Generation times out after configurable `aiTimeout` (default 120s)
-- API providers (Anthropic, OpenAI) use direct HTTP calls, not CLI binaries
-- Missing API key for API providers produces a clear error message naming the expected env var
-- Provider resolution falls back gracefully: CLI flag > aiCommand > aiProvider > env var > auto-detect
+- Provider resolution follows `flag > env > config` (12-factor): `--provider` flag > `SPECSYNC_AI_COMMAND` env > `SPECSYNC_AI_PROVIDER` env > `aiCommand` config > `aiProvider` config > auto-detect
+- Model precedence is the same shape: `--model` flag > `SPECSYNC_AI_MODEL` env > `aiModel` config > corvid-ai provider default
+- All API providers (`anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, `ollama`) route through the shared `corvid-ai` crate (`corvid_ai::complete`) — there are no hand-rolled per-provider HTTP calls
+- Auto-detect uses `<PROVIDER>_API_KEY` presence only, with no network probe: none set → keyless local Ollama; exactly one set → use it; multiple set → interactive prompt when stdin and stderr are TTYs, else the deterministic order `[Ollama, Anthropic, OpenAI, OpenRouter, Gemini, DeepSeek, Groq, Mistral, xAI, Together]`
+- A set API key beats unkeyed local Ollama; auto-detect never selects a CLI shell-out provider
+- The deprecated `claude` provider routes to the `anthropic` API (with a deprecation warning), never shelling out to `claude -p`
+- Deprecated `copilot` and the no-pipe `cursor` providers still resolve via the legacy CLI path with a warning; `cursor` returns a clear "no CLI pipe mode" error with workarounds
+- Ollama host resolves as `OLLAMA_HOST` env > `aiBaseUrl` config > `-cloud` routing (model tag contains `-cloud` and `OLLAMA_API_KEY` set ⇒ `https://ollama.com`) > `http://localhost:11434`; corvid-ai talks to it over the OpenAI-compatible `/v1` endpoint
+- Missing API key for a key-required provider produces a clear error naming the expected env var and `aiApiKey`; the key check is skipped for Ollama and when a custom `aiBaseUrl` is set
+- Source code input is capped at 30K chars per file and 150K chars total before prompting
+- AI output is post-processed: code fences stripped, frontmatter delimiters validated, error if missing
+- Generation times out after `aiTimeout` (default 120s); API timeout is carried into `corvid_ai::Settings`
 
 ## Constraints
 
-- No external crate dependencies for HTTP beyond ureq (already in use)
-- AI prompt must include all relevant source files to produce accurate specs
-- Timeout must be enforced even if the AI provider hangs (channel-based async)
-- Must not panic on provider failure — return Result with actionable error message
+- All HTTP transport is owned by `corvid-ai`; spec-sync carries only user overrides (model/key/base-url/timeout) in `corvid_ai::Settings`
+- `corvid-ai` owns the endpoint registry, default models, `<PROVIDER>_API_KEY` resolution, and secret redaction in error strings
+- `ResolvedProvider`'s `Debug` must redact the API key (`[REDACTED]`), since the derived `corvid_ai::Settings` debug would print it verbatim
+- CLI shell-out (`aiCommand`) must write stdin on a background thread to avoid a stdout-pipe deadlock when the child streams tokens
+- Must not panic on provider failure — every path returns `Result<_, String>` with an actionable message
+- MSRV 1.89; resolution semantics and warning text are kept aligned with fledge
 
 ## Out of Scope
 
-- Streaming token-by-token output to the terminal
+- Streaming token-by-token API output to the terminal (CLI path streams lines; API path does not)
 - Caching AI responses across runs
 - Fine-tuning or training custom models
-- Supporting providers that require OAuth flows
+- Providers requiring OAuth flows
+- `AiProvider::default_model` / `default_base_url` — removed; corvid-ai owns these defaults

--- a/specs/ai/tasks.md
+++ b/specs/ai/tasks.md
@@ -4,25 +4,31 @@ spec: ai.spec.md
 
 ## Tasks
 
-- [ ] Add streaming support for API providers (Anthropic and OpenAI) to show incremental output
-- [ ] Support configurable context window size per provider instead of hardcoded 150KB cap
-- [ ] Add retry logic with backoff for transient API failures (rate limits, timeouts)
-- [ ] Support provider-specific model selection (e.g., `aiModel: "claude-sonnet-4-20250514"`)
+- [ ] Add streaming for API providers (the CLI path streams lines; API responses arrive whole)
+- [ ] Add retry with backoff for transient API failures (rate limits, timeouts) — pending corvid-ai support
+- [ ] Make the context-window cap (30K/file, 150K total) provider-aware instead of fixed char limits
+- [ ] Plan removal of the remaining CLI providers (`copilot`, `cursor`) and the `aiCommand` hatch for spec-sync 5.0
 
 ## Done
 
-- [x] Implement 5-stage provider resolution chain
-- [x] Add CLI providers: Claude, Ollama, GitHub Copilot
-- [x] Add API providers: Anthropic Messages API, OpenAI Chat Completions
-- [x] Add Custom command provider
-- [x] Auto-detect available providers
-- [x] Source truncation (30KB/file, 150KB total)
-- [x] Post-processing: code fence stripping, frontmatter validation
+- [x] Migrate all API HTTP calls to the shared `corvid-ai` crate (`corvid_ai::complete`); remove hand-rolled `call_anthropic_api` / `call_openai_api` / `call_gemini_api`
+- [x] Collapse `ResolvedProvider` to `Cli(String)` | `Api(corvid_ai::Settings)` with key-redacting `Debug`
+- [x] Add API providers `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, and `ollama` (OpenAI-compatible HTTP)
+- [x] Route the deprecated `claude` alias to the `anthropic` API with a warning (no more `claude -p` shell-out)
+- [x] Default to keyless local Ollama (`http://localhost:11434`) when no provider key is configured
+- [x] Implement the `flag > env > config` resolution ladder, adding `SPECSYNC_AI_PROVIDER` env
+- [x] Implement key-presence auto-detection (no network probe): none→Ollama, one→use it, multiple→prompt or deterministic order
+- [x] Add interactive provider + model prompt when multiple keys are set and stdin/stderr are TTYs
+- [x] Implement Ollama host routing: `OLLAMA_HOST` > `aiBaseUrl` > `-cloud`+`OLLAMA_API_KEY` cloud routing > localhost, served over `/v1`
+- [x] Add model precedence `--model` > `SPECSYNC_AI_MODEL` > `aiModel` > corvid-ai default, plus the `generate --model` flag
+- [x] Remove `AiProvider::default_model` / `default_base_url` (corvid-ai owns defaults)
+- [x] Source truncation (30K/file, 150K total) on UTF-8 char boundaries
+- [x] Post-processing: code-fence stripping and frontmatter validation
 
 ## Gaps
 
-- No unit tests for API call paths (would need mocking or integration test infrastructure)
-- Custom command provider has no validation that the command exists before running
+- API completion paths are not exercised by live unit tests (would need a corvid-ai mock or recorded HTTP fixtures); coverage is via resolution/error-path tests plus integration fixtures that fail fast on missing keys
+- The interactive multi-key prompt (`prompt_provider_and_model`) has no automated test — it requires a TTY
 
 ## Review Sign-offs
 

--- a/specs/ai/testing.md
+++ b/specs/ai/testing.md
@@ -4,43 +4,66 @@ spec: ai.spec.md
 
 ## Automated Coverage
 
-| Area | Command | Assertions To Watch |
-|------|---------|---------------------|
-| `src/ai.rs` | cargo test ai:: | `safe_truncate_within_limit`, `safe_truncate_exact_limit`, `safe_truncate_truncates_ascii`, `safe_truncate_respects_utf8_boundary`, `safe_truncate_multibyte_sequence`, `safe_truncate_empty_string` |
-| `tests/integration.rs` | cargo test --test integration provider_flag_unknown_provider_errors | End-to-end fixture: `provider_flag_unknown_provider_errors` |
-| `tests/integration.rs` | cargo test --test integration provider_flag_enables_ai | End-to-end fixture: `provider_flag_enables_ai` |
-| `tests/integration.rs` | cargo test --test integration ai_provider_config_field_is_respected | End-to-end fixture: `ai_provider_config_field_is_respected` |
-| `tests/integration.rs` | cargo test --test integration ai_command_overrides_ai_provider | End-to-end fixture: `ai_command_overrides_ai_provider` |
-| `tests/integration.rs` | cargo test --test integration cli_provider_overrides_config_provider | End-to-end fixture: `cli_provider_overrides_config_provider` |
-| `tests/integration.rs` | cargo test --test integration ai_model_config_used_with_ollama_provider | End-to-end fixture: `ai_model_config_used_with_ollama_provider` |
-| `tests/integration.rs` | cargo test --test integration anthropic_provider_requires_api_key | End-to-end fixture: `anthropic_provider_requires_api_key` |
-| `tests/integration.rs` | cargo test --test integration openai_provider_requires_api_key | End-to-end fixture: `openai_provider_requires_api_key` |
+### Unit tests (`src/ai.rs`, `cargo test ai::`)
 
-## Behavioral Verification
+| Group | Tests | What It Covers |
+|-------|-------|----------------|
+| `safe_truncate` | `safe_truncate_within_limit`, `safe_truncate_exact_limit`, `safe_truncate_truncates_ascii`, `safe_truncate_respects_utf8_boundary`, `safe_truncate_multibyte_sequence`, `safe_truncate_empty_string` | Byte-cap truncation backs up to valid UTF-8 char boundaries |
+| `command_for_provider` | `command_for_claude`, `command_for_copilot`, `command_for_cursor_errors`, `command_for_anthropic_errors`, `command_for_custom_errors` | CLI command strings; API providers and custom error out of this path |
+| Ollama routing | `ollama_is_an_api_provider`, `ollama_resolves_keyless`, `ollama_host_strips_v1_and_trailing_slash_from_config`, `ollama_host_defaults_to_localhost` | Ollama is an API provider, resolves keyless, host normalization |
+| Provider mapping | `openrouter_maps_to_corvid_ai`, `claude_routes_to_anthropic_api_not_cli`, `detection_order_is_api_only_and_ollama_first` | corvid-ai registry names; `claude`→anthropic API; detection order is API-only, Ollama first |
+| `ResolvedProvider` Display/Debug | `display_cli_provider`, `display_anthropic_provider`, `display_openai_provider_no_base_url`, `display_openai_provider_with_base_url`, `debug_api_provider_redacts_key` | Display formatting and API-key redaction in `Debug` |
+| `postprocess_spec` | `postprocess_strips_markdown_fence`, `postprocess_strips_plain_fence`, `postprocess_strips_md_fence`, `postprocess_no_fence_passthrough`, `postprocess_missing_frontmatter_errors`, `postprocess_leading_whitespace_before_frontmatter` | Code-fence stripping and frontmatter validation |
+| `build_prompt` | `build_prompt_contains_module_name`, `build_prompt_truncates_large_files`, `build_prompt_skips_files_over_prompt_limit`, `build_prompt_empty_files` | Prompt assembly, per-file truncation, prompt-size skipping |
+| `build_regen_prompt` | `build_regen_prompt_contains_spec_and_requirements`, `build_regen_prompt_no_source_files`, `build_regen_prompt_truncates_large_sources` | Regeneration prompt content and size budget |
+| `resolve_ai_provider` | `resolve_with_ai_command_in_config`, `resolve_with_env_var`, `resolve_unknown_provider_errors`, `resolve_cursor_provider_errors`, `resolve_ai_command_returns_cli_string` | Resolution ladder, env override, error cases, compat alias |
+| Constants | `constants_are_reasonable` | `MAX_FILE_CHARS`=30K, `MAX_PROMPT_CHARS`=150K, `DEFAULT_AI_TIMEOUT_SECS`=120 |
 
-| Flow | Fixture / Setup | Action | Expected Result |
-|------|-----------------|--------|-----------------|
-| Auto-detect Claude CLI | `claude` binary is on PATH and no config overrides | `resolve_ai_provider(config, None)` is called | returns `ResolvedProvider::Cli("claude -p --output-format text")` |
-| Use Anthropic API key | `ANTHROPIC_API_KEY` is set in environment, no CLI providers installed | `resolve_ai_provider(config, None)` is called | returns `ResolvedProvider::AnthropicApi` with the key and default model |
-| Explicit provider override | user passes `--provider openai` | `resolve_ai_provider(config, Some("openai"))` is called | returns `ResolvedProvider::OpenAiApi` using OPENAI_API_KEY |
-| Generate spec with AI | source files for module "auth" | `generate_spec_with_ai("auth", files, root, config, provider)` is called | returns a complete spec markdown string with frontmatter and all required sections |
+### Integration tests (`tests/integration.rs`, `cargo test --test integration`)
 
-## Regression Matrix
+| Fixture | What It Asserts |
+|---------|-----------------|
+| `provider_flag_unknown_provider_errors` | Unknown `--provider` name errors |
+| `provider_flag_enables_ai` | `--provider` puts `generate` into AI mode |
+| `ai_provider_config_field_is_respected` | `aiProvider` config is honored |
+| `ai_command_overrides_ai_provider` | `aiCommand` outranks `aiProvider` |
+| `cli_provider_overrides_config_provider` | `--provider` outranks config |
+| `config_ai_provider_triggers_ai_without_provider_flag` | Configured `aiProvider` enters AI mode with no flag (fails fast on missing key) |
+| `env_provider_overrides_config_provider` | `SPECSYNC_AI_PROVIDER` env outranks `aiProvider` config |
+| `auto_detect_defaults_to_local_ollama_without_keys` | No keys → defaults to local Ollama, never errors/CLI |
+| `anthropic_provider_requires_api_key`, `openai_provider_requires_api_key` | Missing key errors naming the env var |
+| `provider_flag_anthropic_requires_api_key`, `provider_flag_openai_requires_api_key` | Same via `--provider` flag |
+| `anthropic_api_alias_works`, `openai_api_alias_works` | `anthropic-api` / `openai-api` aliases accepted |
+| `ai_api_key_config_field_used_for_anthropic` | `aiApiKey` config field is used for anthropic |
+| `unknown_provider_lists_api_options` | Unknown-provider error lists `anthropic` and `openai` among options |
 
-| Case | Required Behavior | Test Obligation |
-|------|-------------------|-----------------|
-| No AI provider found | Returns descriptive error listing all options | Keep or add a focused assertion before changing this behavior |
-| Provider binary not installed | Error: "not installed or not on PATH" | Keep or add a focused assertion before changing this behavior |
-| API key missing | Error: "requires an API key. Set ENV_VAR or add aiApiKey" | Keep or add a focused assertion before changing this behavior |
-| Cursor selected as provider | Error explaining no CLI pipe mode, with workarounds | Keep or add a focused assertion before changing this behavior |
-| AI command times out | Error with timeout value and suggestion to increase `aiTimeout` | Keep or add a focused assertion before changing this behavior |
-| AI returns empty output | Error: "AI command returned empty output" | Keep or add a focused assertion before changing this behavior |
-| AI response missing frontmatter | Error: "AI response missing YAML frontmatter delimiters" | Keep or add a focused assertion before changing this behavior |
-| API HTTP error | Error with status code and error message | Keep or add a focused assertion before changing this behavior |
+## Manual Testing
+
+- [ ] No keys set, local Ollama running: `specsync generate` defaults to Ollama (`http://localhost:11434`) over `/v1`
+- [ ] Exactly one `<PROVIDER>_API_KEY` set: auto-detected and used without prompting
+- [ ] Multiple keys set in a terminal: interactive provider + model prompt appears; in CI (non-TTY) the deterministic order is used
+- [ ] `--provider claude`: prints the deprecation warning and calls the anthropic API (verify it does NOT spawn `claude -p`)
+- [ ] `--model` / `SPECSYNC_AI_MODEL` / `aiModel` override the model in the documented precedence
+- [ ] Ollama `-cloud` model tag + `OLLAMA_API_KEY`: routes to `https://ollama.com`
+
+## Edge Cases & Boundary Conditions
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| No AI provider configured and no keys | Defaults to keyless local Ollama, warns on stderr |
+| Key-required provider missing its key (no `aiBaseUrl`) | Fails fast: "requires an API key. Set ENV_VAR or add aiApiKey" |
+| Ollama or custom `aiBaseUrl` with no key | Key check skipped; request proceeds (auth errors surface from corvid-ai) |
+| `cursor` selected | Error: no CLI pipe mode, with workarounds (or "not installed" if absent) |
+| Multibyte content at the truncation boundary | `safe_truncate` backs up to a valid char boundary, never splits a code point |
+| Source files exceed 150K total | Remaining files marked "[skipped: prompt size limit]" |
+| API key in a resolved provider | Never printed: `Debug` shows `[REDACTED]`; corvid-ai redacts keys in error strings |
+| AI returns output without `---` frontmatter | Error: "AI response missing YAML frontmatter delimiters" |
+| CLI command times out | Error with the timeout value and a suggestion to raise `aiTimeout` |
+| CLI command returns empty stdout | Error: "AI command returned empty output" |
 
 ## Reviewer Checklist
 
-- Run the narrow source command above before the full suite when changing `src/ai.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
-- Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`.
+- Run `cargo test ai::` (and the relevant `tests/integration.rs` fixtures) before changing `src/ai.rs`.
+- If an error or warning string changes, update the matching Edge Case row and test assertion in the same commit.
+- Confirm `claude` still routes to the anthropic API (never `claude -p`) and that `Debug`/error output never leaks keys.
+- Run the release checks: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`.

--- a/specs/archive/context.md
+++ b/specs/archive/context.md
@@ -2,12 +2,19 @@
 spec: archive.spec.md
 ---
 
-## Key Files
+## Key Decisions
 
-- `src/archive.rs` - Main implementation
-- `specs/archive/archive.spec.md` - Module specification
-- `specs/archive/requirements.md` - User stories and acceptance criteria
+- Archiving is line-based on `tasks.md` companions: completed items (`- [x]`/`- [X]`) are moved to an `## Archive` section appended at the bottom; everything else keeps its order.
+- An existing `## Archive` section is parsed and preserved — its prior entries are re-emitted before the newly archived ones, so history accumulates rather than being overwritten.
+- Errors are non-fatal: an unreadable/unwritable `tasks.md` prints a red error and processing continues with the next file.
+- `dry_run` computes results without writing, so callers can preview exactly which files would change.
+
+## Files to Read First
+
+- `src/archive.rs` — `archive_tasks`, the `archive_completed_tasks` core, and `count_completed_tasks`
+- `src/validator.rs` — `find_spec_files` (how spec dirs and their companion `tasks.md` are discovered)
+- `src/commands/archive_tasks.rs` — the `archive-tasks` subcommand wiring
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Stable and complete. Core logic is unit-tested in `src/archive.rs` (archive, no-completed, preserve-existing). No CLI-level integration test yet.

--- a/specs/archive/tasks.md
+++ b/specs/archive/tasks.md
@@ -4,4 +4,17 @@ spec: archive.spec.md
 
 ## Tasks
 
+- [ ] Add a CLI integration test for `specsync archive-tasks` (currently only unit-tested in `src/archive.rs`)
+
+## Done
+
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+- [x] Implement `archive_tasks`, `archive_completed_tasks`, and `count_completed_tasks`
+- [x] Unit tests for archive, no-completed, and preserve-existing cases
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/changelog/context.md
+++ b/specs/changelog/context.md
@@ -2,12 +2,21 @@
 spec: changelog.spec.md
 ---
 
-## Key Files
+## Key Decisions
 
-- `src/changelog.rs` - Main implementation
-- `specs/changelog/changelog.spec.md` - Module specification
-- `specs/changelog/requirements.md` - User stories and acceptance criteria
+- Spec state is read from git (`git ls-tree` + `git show`) rather than the working tree, so the changelog never depends on or disturbs uncommitted edits.
+- A spec is only "modified" when raw content differs AND a tracked frontmatter field or `##` section actually changed — identical-content or no-op edits are dropped.
+- Section diffing is coarse: top-level `##` sections are reported as `(added)`/`(removed)`/`(modified)`, never line-by-line, to keep output reviewable.
+- The `ChangelogReport` model is shared by all three formatters (text/JSON/markdown) so analysis and rendering stay decoupled.
+- Output is sorted by module name for deterministic, reviewable diffs.
+
+## Files to Read First
+
+- `src/changelog.rs` — entire module (types, git helpers, `compare_frontmatter`, `compare_sections`, `generate_changelog`, formatters)
+- `src/parser.rs` — `parse_frontmatter` (the parse used at each ref)
+- `src/types.rs` — `Frontmatter` fields that drive field-level diffing
+- `src/commands/changelog.rs` — the CLI wiring that calls `generate_changelog` and selects a formatter
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Stable. Frontmatter and section diffing, range parsing, and all three formatters are implemented and unit-tested (including git-backed `generate_changelog` tests via a temp repo). No CLI-level integration test yet.

--- a/specs/changelog/requirements.md
+++ b/specs/changelog/requirements.md
@@ -1,5 +1,42 @@
-# changelog — Requirements
+---
+spec: changelog.spec.md
+---
 
-- Must produce deterministic output for the same two git refs
-- Must support text, JSON, and markdown output formats
-- Must not modify the working tree or index
+## User Stories
+
+- As a release manager, I want a structured diff of spec changes between two git refs so that I can summarize what changed in a release without reading every spec by hand
+- As a reviewer, I want field-level changes (status, version, files, deps) called out per spec so that I can spot risky metadata drift during review
+- As a CI operator, I want changelog output in text, JSON, and markdown so that I can render it in terminals, parse it programmatically, or paste it into release notes
+- As a developer, I want the changelog computed from git history without touching my working tree so that running it never disturbs uncommitted work
+- As a tooling author, I want a `parse_range` helper that validates `from..to` ranges so that malformed ranges are rejected before any git calls
+
+## Acceptance Criteria
+
+- `generate_changelog(root, specs_dir, from_ref, to_ref)` returns a `ChangelogReport` with `added`, `removed`, and `modified` lists
+- Spec state at each ref is read via `git ls-tree` and `git show` — the working tree and index are never modified
+- Only files ending in `.spec.md` under the specs dir are considered
+- A spec appears in `added` if present at `to_ref` but not `from_ref`; in `removed` if present at `from_ref` but not `to_ref`
+- A spec appears in `modified` only when its raw content differs AND at least one frontmatter field or body section actually changed
+- Frontmatter comparison covers: `status`, `version`, `module`, `files`, `db_tables`, `depends_on`, `agent_policy`, `implements`, `tracks`
+- Body comparison emits `section:<name>` changes marked `(added)`, `(removed)`, or `(modified)` for top-level `##` sections
+- `parse_range` splits on the first `..`, requires both sides non-empty, and returns `None` otherwise (e.g. `v0.1`, `..v0.2`, `v0.1..` all yield `None`)
+- `format_text`, `format_json`, and `format_markdown` all consume the same `ChangelogReport` and report identical add/change/remove counts
+- Empty reports render a "No spec changes detected" message in text and markdown
+- Output is deterministic: added/removed/modified lists are sorted by module name
+
+## Constraints
+
+- Must use `parse_frontmatter` (parser module) and the `Frontmatter` type (types module) — no bespoke YAML parsing
+- Must not modify the working tree or index; all reads go through `git ls-tree`/`git show`
+- `\r\n` line endings in git-read content are normalized to `\n` before parsing
+- A missing or nonexistent git ref yields an empty spec list rather than an error or panic
+- Specs whose frontmatter fails to parse at a ref are silently skipped, not reported as changed
+- Output for the same two refs must be deterministic (sorted by module)
+
+## Out of Scope
+
+- Generating changelogs for source code (non-spec) files
+- Writing the changelog to a CHANGELOG.md file or committing it (caller's responsibility)
+- Diffing line-by-line within a section — section changes are reported only as added/removed/modified
+- Semantic versioning inference or release-tag automation
+- Comparing more than two refs at once or producing a cumulative multi-release log

--- a/specs/changelog/tasks.md
+++ b/specs/changelog/tasks.md
@@ -4,4 +4,18 @@ spec: changelog.spec.md
 
 ## Tasks
 
+- [ ] Add a CLI-level integration test for `specsync changelog <range>` (the `generate_changelog` git path is unit-tested via `setup_git_repo`, but the subcommand wiring is not)
+
+## Done
+
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+- [x] Implement frontmatter diffing (incl. agent_policy/implements/tracks) and section diffing
+- [x] Implement `parse_range` with `..` validation and three formatters (text/JSON/markdown)
+- [x] Git-backed `generate_changelog` tests against a temp repo
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/changelog/testing.md
+++ b/specs/changelog/testing.md
@@ -6,11 +6,15 @@ spec: changelog.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/changelog.rs` | cargo test changelog:: | `test_parse_range_valid`, `test_parse_range_head_tilde`, `test_parse_range_invalid_no_dots`, `test_parse_range_invalid_empty_from`, `test_parse_range_invalid_empty_to`, `test_parse_range_commit_hashes` |
+| `parse_range` | cargo test changelog::tests::test_parse_range | `test_parse_range_valid`, `test_parse_range_head_tilde`, `test_parse_range_invalid_no_dots`, `test_parse_range_invalid_empty_from`, `test_parse_range_invalid_empty_to`, `test_parse_range_commit_hashes` |
+| frontmatter diffing | cargo test changelog::tests::test_compare_frontmatter | `test_compare_frontmatter_no_changes`, `test_compare_frontmatter_status_change`, `test_compare_frontmatter_version_change`, `test_compare_frontmatter_files_change`, `test_compare_frontmatter_depends_on_change`, `test_compare_frontmatter_multiple_changes`, `test_compare_frontmatter_implements_change`, `test_compare_frontmatter_agent_policy_change` |
+| section diffing | cargo test changelog::tests::test_compare_sections | `test_compare_sections_no_changes`, `test_compare_sections_modified`, `test_compare_sections_added`, `test_compare_sections_removed`, `test_extract_sections_basic`, `test_extract_sections_ignores_subsections` |
+| git-backed generation | cargo test changelog::tests::test_generate_changelog | `test_generate_changelog_no_changes`, `test_generate_changelog_added_spec`, `test_generate_changelog_removed_spec`, `test_generate_changelog_modified_spec` (use a real temp git repo via `setup_git_repo`) |
+| formatters | cargo test changelog::tests::test_format | `test_format_text_empty`, `test_format_text_added`, `test_format_text_modified_with_section_changes`, `test_format_json_structure`, `test_format_markdown_empty`, `test_format_markdown_all_sections` |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Generate changelog between two tags" before changing user-visible CLI output, generated files, or error handling in changelog.
+- No CLI-level (`tests/integration.rs`) coverage for `specsync changelog <range>`; the `generate_changelog` git path is covered by the in-module `setup_git_repo` tests. Add a CLI fixture before changing the changelog subcommand's terminal output.
 
 ## Behavioral Verification
 

--- a/specs/cli/context.md
+++ b/specs/cli/context.md
@@ -11,16 +11,20 @@ spec: cli.spec.md
 - **Idempotent init**: Both `init` and `init-registry` check for existing files before writing, preventing accidental overwrites.
 - **No network by default**: `resolve` only performs network calls with `--remote`, keeping default behavior offline and fast.
 - **Hook targets**: When no specific `--claude`/`--cursor`/etc. flags are given, an empty targets vec signals "all targets" to the hooks module.
+- **Panic guard**: `main()` wraps `run()` in `std::panic::catch_unwind` and prints a "please report it" message with the issue tracker URL instead of a raw backtrace.
+- **`generate --model`**: a `--model` flag overrides `SPECSYNC_AI_MODEL` and the `aiModel` config field, letting users pin a specific model per invocation; provider resolution itself routes through the reworked `ai` module.
 
 ## Files to Read First
 
-- `src/main.rs` — CLI dispatcher: arg parsing, subcommand routing, output formatting.
+- `src/cli.rs` — the clap derive structs (`Cli`, `Command`, `LifecycleAction`, `HooksAction`) and their flags/help text; also holds the parser unit tests.
+- `src/main.rs` — `run()` dispatcher: builds `root`, resolves `--json`→format, defaults to `Check`, and matches every `Command` variant to a `commands::*` handler.
 
 ## Current Status
 
-Fully implemented. All 12 subcommands work: check, coverage, generate, init, score, watch, mcp, add-spec, init-registry, resolve, hooks (install/uninstall/status).
+Fully implemented. The CLI exposes the `check` default plus init, coverage, generate, score, watch, mcp, add-spec, scaffold, init-registry, resolve, diff, hooks, compact, archive-tasks, view, merge, issues, new, wizard, deps, import, stale, report, comment, rules, changelog, rehash, migrate, and lifecycle (with promote/demote/set/status/history/guard/auto-promote/enforce sub-actions). `generate` now also takes `--model`.
 
 ## Notes
 
 - Every library module is consumed by the CLI — it's the integration point for the entire tool.
-- `watch` and `mcp` are the only modules that take over the process (long-running server / file watcher).
+- `watch` and `mcp` are the only commands that take over the process (long-running file watcher / stdio server).
+- The clap grammar lives in `src/cli.rs`; `main.rs` is dispatch-only. Parser-level tests live in `src/cli.rs`; exit-code tests live in `src/main.rs`.

--- a/specs/cli/requirements.md
+++ b/specs/cli/requirements.md
@@ -11,6 +11,7 @@ spec: cli.spec.md
 - As a developer, I want `--fix` to auto-add undocumented exports to my specs so that keeping specs current is low-friction
 - As a developer, I want `specsync init` to scaffold a config with auto-detected settings so that getting started takes seconds
 - As a developer, I want `specsync generate` to create specs for all unspecced modules in one command so that I can bootstrap documentation for an existing project
+- As a developer, I want `specsync generate --provider <p> --model <m>` to pick an AI provider and pin a specific model so that I control which LLM writes my specs
 - As a developer, I want `specsync watch` to re-validate on file changes so that I get live feedback while editing
 - As a developer, I want `specsync score` to grade my spec quality so that I know where to focus improvement effort
 - As a team lead, I want `specsync hooks install` to set up agent instructions for Claude, Cursor, and Copilot so that AI assistants respect our specs automatically
@@ -23,16 +24,18 @@ spec: cli.spec.md
 - `--json` suppresses all ANSI color codes and outputs valid JSON
 - `--format markdown` produces output suitable for PR comments
 - `--root <path>` allows running against a different project directory
-- All domain logic is delegated to library modules — main.rs is purely a dispatcher
+- All domain logic is delegated to library modules — `main.rs` is purely a dispatcher and the clap grammar lives in `src/cli.rs`
 - `--fix` only modifies spec files, never source code
 - `init` auto-detects source directories, language, and creates a sensible default config
+- `generate --model <m>` overrides `SPECSYNC_AI_MODEL` and the `aiModel` config field for that run
+- A panic in any subcommand is caught and reported as a "please report it" bug message rather than a raw backtrace
 
 ## Constraints
 
 - Single binary with no runtime dependencies
 - Must work on Linux, macOS, and Windows
 - Colored output must respect `NO_COLOR` environment variable
-- CLI argument parsing via clap with derive macros
+- CLI argument parsing via clap with derive macros; grammar defined in `src/cli.rs`, dispatch in `src/main.rs`
 
 ## Out of Scope
 

--- a/specs/cli/tasks.md
+++ b/specs/cli/tasks.md
@@ -10,11 +10,13 @@ spec: cli.spec.md
 
 ## Done
 
-- [x] Implement all 12 subcommands (check, coverage, generate, init, score, watch, mcp, add-spec, init-registry, resolve, hooks install/uninstall/status)
-- [x] Add `--json` output mode for all reporting commands
-- [x] Add `--strict` and `--require-coverage` global flags
+- [x] Implement the full subcommand surface (check, coverage, generate, init, score, watch, mcp, add-spec, scaffold, init-registry, resolve, diff, hooks, compact, archive-tasks, view, merge, issues, new, wizard, deps, import, stale, report, comment, rules, changelog, rehash, migrate, lifecycle)
+- [x] Add `--json` output mode (shorthand for `--format json`) and `--format text/json/markdown`
+- [x] Add `--strict`, `--require-coverage`, `--enforcement`, `--exclude-status`, `--only-status` global flags
 - [x] Add `--root` flag for non-cwd project roots
 - [x] Make `check` the default subcommand when none is specified
+- [x] Add `generate --model` to pin a model id (overrides `SPECSYNC_AI_MODEL` / `aiModel`)
+- [x] Wrap `run()` in `catch_unwind` so panics surface a friendly bug-report message
 
 ## Gaps
 

--- a/specs/cli/testing.md
+++ b/specs/cli/testing.md
@@ -6,7 +6,8 @@ spec: cli.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/main.rs` | cargo test tests:: | `warn_mode_exits_0_with_no_errors`, `warn_mode_exits_0_even_with_errors`, `warn_mode_exits_0_even_with_strict_flag`, `warn_mode_respects_require_coverage`, `enforce_new_exits_0_when_all_files_specced`, `enforce_new_exits_0_with_errors_if_all_specced` |
+| `src/cli.rs` (clap grammar) | cargo test cli::tests | `no_subcommand_yields_none_and_text_default`, `global_flags_parse_before_subcommand`, `json_format_value_enum_parses`, `check_collects_flags_and_positional_specs`, `stale_threshold_defaults_and_overrides`, `exclude_status_splits_on_commas`, `unknown_subcommand_is_rejected`, `non_numeric_threshold_is_rejected` |
+| `src/main.rs` (exit codes) | cargo test --bin specsync tests:: | `warn_mode_exits_0_with_no_errors`, `warn_mode_exits_0_even_with_errors`, `warn_mode_exits_0_even_with_strict_flag`, `warn_mode_respects_require_coverage`, `enforce_new_exits_0_when_all_files_specced`, `enforce_new_exits_1_when_unspecced_files_exist`, `strict_mode_exits_1_with_warnings_and_strict_flag`, `strict_mode_respects_require_coverage` |
 | `tests/integration.rs` | cargo test --test integration strict_turns_warnings_into_errors | End-to-end fixture: `strict_turns_warnings_into_errors` |
 | `tests/integration.rs` | cargo test --test integration require_coverage_passes_when_met | End-to-end fixture: `require_coverage_passes_when_met` |
 | `tests/integration.rs` | cargo test --test integration require_coverage_fails_when_below_threshold | End-to-end fixture: `require_coverage_fails_when_below_threshold` |
@@ -26,6 +27,8 @@ spec: cli.spec.md
 | Init idempotency | `specsync.json` already exists in the project root | `specsync init` is run | prints "specsync.json already exists" and returns without modifying it |
 | Coverage threshold | file coverage is 80% | `specsync check --require-coverage 90` is run | the process exits with code 1 and prints the unspecced files |
 | Generate with AI | an AI provider is available | `specsync generate --provider auto` is run | auto-detects the provider and generates AI-enhanced specs |
+| Generate with pinned model | an AI provider is available | `specsync generate --provider anthropic --model claude-opus-4-8` is run | the `--model` value is passed through, overriding `SPECSYNC_AI_MODEL`/`aiModel` |
+| Panic is caught | a subcommand panics internally | the binary runs | a "specsync panicked … please report it" message is printed and the process exits 1 (no raw backtrace) |
 | Resolve without network | specs have cross-project `depends_on` refs | `specsync resolve` is run (without `--remote`) | lists the refs but does not verify them against remote registries |
 | Fix auto-adds undocumented exports | a spec's source files have exports not documented in the Public API section | `specsync check --fix` is run | skeleton rows for the missing exports are appended to the Public API section and the spec file is written to disk |
 

--- a/specs/cli_args/context.md
+++ b/specs/cli_args/context.md
@@ -4,17 +4,22 @@ spec: cli_args.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- **Declaration-only module**: `cli.rs` defines the Clap `Cli`/`Command`/`HooksAction`/`LifecycleAction` types and nothing else. Dispatch and behavior live in `src/main.rs` and `src/commands/*`. Keeping parsing separate from logic makes the CLI surface easy to audit and unit-test in isolation.
+- **Global flags via `global = true`**: shared flags are attached to the top-level `Cli` so they parse before or after the subcommand. `--json` is a convenience alias for `--format json`.
+- **Loose provider/model strings**: `--provider` and `--model` are `Option<String>`, not typed enums. Validation is deferred so `resolve_ai_provider` can emit a helpful error that lists the available providers, and so `auto` can act as a sentinel forcing auto-detection.
+- **Provider/model precedence is NOT here (4.4.0)**: the `flag > env > config` resolution (`--provider` > `SPECSYNC_AI_PROVIDER` > `aiProvider`; `--model` > `SPECSYNC_AI_MODEL` > `aiModel`) lives in `src/commands/generate.rs::resolve_provider_for_generate`. The parser just captures the raw flag values.
 
 ## Files to Read First
 
-- `src/cli.rs` — primary source file
+- `src/cli.rs` — the Clap parser: all subcommands, flags, and the inline `#[cfg(test)]` parser tests.
+- `src/commands/generate.rs` — consumes `Generate { provider, model, .. }` and applies the flag/env/config precedence.
+- `src/main.rs` — `Cli::parse()` entry point and command dispatch (no-subcommand defaults to Check).
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable. Updated for the 4.4.0 AI rework: the `Generate` command gained a `--model` flag and the `--provider` help text now lists the API provider family (anthropic, openai, openrouter, gemini, deepseek, groq, mistral, xai, together, ollama) plus the deprecated `claude`/`copilot`.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This module is part of the command layer — it orchestrates nothing itself; it is consumed by `main.rs` (via `Cli::parse()`) and the per-command modules.
+- The deprecated `claude`/`copilot`/`cursor` providers are still accepted as `--provider` strings for backward compatibility; `claude` routes to the anthropic API with a warning downstream.

--- a/specs/cli_args/requirements.md
+++ b/specs/cli_args/requirements.md
@@ -4,21 +4,30 @@ spec: cli_args.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cli_args` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a user of the `specsync` binary, I want every subcommand, flag, and global option declared in one Clap parser so that `--help` and argument validation are consistent across the CLI
+- As a CI operator, I want global flags (`--strict`, `--require-coverage`, `--enforcement`, `--format`/`--json`, `--root`, `--exclude-status`/`--only-status`) to work regardless of where they appear relative to the subcommand
+- As a user generating specs with AI, I want a `--provider` flag and a `--model` flag on `generate` so that I can pick a provider and model id from the command line without editing config
+- As a developer, I want invalid arguments rejected by Clap with usage help so that mistakes fail fast and visibly
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `Cli` exposes global flags: `--strict`, `--require-coverage <N>`, `--root <path>`, `--format <text|json|markdown|github|table|csv>`, `--json`, `--enforcement <warn|enforce-new|strict>`, `--exclude-status <...>`, `--only-status <...>` — all `global = true`
+- `--json` is shorthand for `--format json`; default format is `text`
+- `Command` enum covers all current subcommands (Check, Coverage, Generate, Init, Score, Watch, Mcp, AddSpec, Scaffold, InitRegistry, Resolve, Diff, Hooks, Compact, ArchiveTasks, View, Merge, Issues, New, Wizard, Deps, Import, Stale, Report, Comment, Rules, Changelog, Rehash, Migrate, Lifecycle)
+- The `Generate` command exposes `--provider <PROVIDER>` (or `auto`) and `--model <MODEL>`, plus `--uncovered` and `--batch <MODULE...>`
+- `--provider` accepts the API provider names (anthropic, openai, openrouter, gemini, deepseek, groq, mistral, xai, together, ollama) plus the deprecated `claude`/`copilot`; the actual resolution/precedence lives in `generate.rs`, not the parser
+- Running `specsync` with no subcommand yields `Cli.command == None` (main.rs defaults to Check behavior)
+- `HooksAction` (Install/Uninstall/Status) and `LifecycleAction` (Promote/Demote/Set/Status/History/Guard/AutoPromote/Enforce) are declared as sub-subcommands
+- Invalid enum values for `--format`/`--enforcement` and unknown subcommands are rejected by Clap with usage help
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- This module only *declares* the argument surface — flag/env/config precedence and command behavior live in `commands/`, `ai.rs`, and `main.rs`. Keep parsing free of business logic.
+- `--provider`/`--model` are `Option<String>` (loose strings); validation is deferred to `AiProvider::from_str_loose` and `resolve_ai_provider` so error messages can list available providers.
+- Must compile on MSRV 1.89.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Resolving the effective AI provider/model (precedence `flag > env > config`) — handled in `src/commands/generate.rs`
+- Executing subcommands (handled by `src/commands/*` and `src/main.rs`)
+- GUI or web interface; interactive prompts beyond the `wizard` subcommand

--- a/specs/cli_args/tasks.md
+++ b/specs/cli_args/tasks.md
@@ -4,16 +4,22 @@ spec: cli_args.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add an inline parse test asserting `generate --model <id>` lands in `Command::Generate { model: Some(..) }`
+- [ ] Add a parse test for the `auto` sentinel on `--provider`
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] Top-level `Cli` parser with global flags (`--strict`, `--require-coverage`, `--root`, `--format`, `--json`, `--enforcement`, `--exclude-status`, `--only-status`)
+- [x] Full `Command` subcommand enum (Check … Lifecycle), `HooksAction`, and `LifecycleAction`
+- [x] Inline `#[cfg(test)]` parser tests in `cli.rs` (no-subcommand default, global-flag ordering, json format, check flag collection, stale threshold default/override, comma-split exclude-status, unknown-subcommand/non-numeric rejection)
+- [x] **4.4.0 AI rework — DONE:**
+  - [x] Add `--model <MODEL>` flag to `Generate` (overrides `SPECSYNC_AI_MODEL` env and `aiModel` config)
+  - [x] Reword `--provider` help to list the API providers (anthropic, openai, openrouter, gemini, deepseek, groq, mistral, xai, together, ollama) + deprecated claude/copilot, and document the `auto` sentinel
+- [x] Integration coverage for `--provider` behavior (`provider_flag_unknown_provider_errors`, `provider_flag_enables_ai`, `cli_provider_overrides_config_provider`, `env_provider_overrides_config_provider`)
 
 ## Gaps
 
-- No dedicated test file for this command module
+- No inline parse test specifically pins the `Generate { provider, model }` fields (covered end-to-end via integration tests, but not at the parser level)
 
 ## Review Sign-offs
 

--- a/specs/cli_args/testing.md
+++ b/specs/cli_args/testing.md
@@ -6,15 +6,15 @@ spec: cli_args.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/cli.rs` | cargo test cli | No inline tests found; add focused coverage for `Cli`, `Command`, `HooksAction`, `LifecycleAction` before risky changes |
-| `tests/integration.rs` | cargo test --test integration strict_turns_warnings_into_errors | End-to-end fixture: `strict_turns_warnings_into_errors` |
-| `tests/integration.rs` | cargo test --test integration require_coverage_passes_when_met | End-to-end fixture: `require_coverage_passes_when_met` |
-| `tests/integration.rs` | cargo test --test integration require_coverage_fails_when_below_threshold | End-to-end fixture: `require_coverage_fails_when_below_threshold` |
-| `tests/integration.rs` | cargo test --test integration root_flag_overrides_cwd | End-to-end fixture: `root_flag_overrides_cwd` |
-| `tests/integration.rs` | cargo test --test integration require_coverage_on_coverage_subcommand | End-to-end fixture: `require_coverage_on_coverage_subcommand` |
-| `tests/integration.rs` | cargo test --test integration strict_on_coverage_subcommand | End-to-end fixture: `strict_on_coverage_subcommand` |
-| `tests/integration.rs` | cargo test --test integration provider_flag_unknown_provider_errors | End-to-end fixture: `provider_flag_unknown_provider_errors` |
-| `tests/integration.rs` | cargo test --test integration provider_flag_enables_ai | End-to-end fixture: `provider_flag_enables_ai` |
+| `src/cli.rs` (inline `#[cfg(test)] mod tests`) | cargo test --bin specsync cli:: | 8 parser tests: `no_subcommand_yields_none_and_text_default`, `global_flags_parse_before_subcommand`, `json_format_value_enum_parses`, `check_collects_flags_and_positional_specs`, `stale_threshold_defaults_and_overrides`, `exclude_status_splits_on_commas`, `unknown_subcommand_is_rejected`, `non_numeric_threshold_is_rejected` |
+| `tests/integration.rs` | cargo test --test integration strict_turns_warnings_into_errors | Global `--strict` turns warnings into errors |
+| `tests/integration.rs` | cargo test --test integration require_coverage_fails_when_below_threshold | `--require-coverage` exits non-zero below threshold |
+| `tests/integration.rs` | cargo test --test integration root_flag_overrides_cwd | `--root` overrides the working directory |
+| `tests/integration.rs` | cargo test --test integration provider_flag_unknown_provider_errors | Unknown `--provider` value errors with "Unknown provider" |
+| `tests/integration.rs` | cargo test --test integration provider_flag_enables_ai | `--provider` switches `generate` into AI mode |
+| `tests/integration.rs` | cargo test --test integration cli_provider_overrides_config_provider | `--provider` outranks the `aiProvider` config value |
+| `tests/integration.rs` | cargo test --test integration env_provider_overrides_config_provider | `SPECSYNC_AI_PROVIDER` env outranks `aiProvider` config (flag > env > config) |
+| `tests/integration.rs` | cargo test --test integration unknown_provider_lists_api_options | Unknown-provider error lists the API options |
 
 ## Behavioral Verification
 
@@ -23,6 +23,8 @@ spec: cli_args.spec.md
 | Global strict flag propagates to subcommand | user runs `specsync check --strict` | Clap parses arguments | `Cli.strict == true` is accessible regardless of the `Check` subcommand |
 | Default subcommand | user runs `specsync` with no subcommand | Clap parses arguments | `Cli.command` is `None`, and `main.rs` defaults to Check behavior |
 | Hooks install targets | user runs `specsync hooks install --claude --precommit` | Clap parses arguments | `HooksAction::Install { claude: true, precommit: true, ... }` with all others false |
+| Generate provider + model flags | user runs `specsync generate --provider anthropic --model claude-x` | Clap parses arguments | `Command::Generate { provider: Some("anthropic"), model: Some("claude-x"), .. }` |
+| Auto-detect sentinel | user runs `specsync generate --provider auto` | Clap parses arguments | `provider == Some("auto")`; `generate.rs` treats this as force-auto-detect |
 
 ## Regression Matrix
 
@@ -31,7 +33,9 @@ spec: cli_args.spec.md
 | Unknown subcommand | Clap prints error with usage help and exits non-zero | Keep or add a focused assertion before changing this behavior |
 | Missing required argument (e.g., `new` without name) | Clap prints error listing required args | Keep or add a focused assertion before changing this behavior |
 | Invalid `--enforcement` value | Clap prints accepted values: warn, enforce-new, strict | Keep or add a focused assertion before changing this behavior |
-| Invalid `--format` value | Clap prints accepted values: text, json, markdown | Keep or add a focused assertion before changing this behavior |
+| Invalid `--format` value | Clap prints accepted values: text, json, markdown, github, table, csv | Keep or add a focused assertion before changing this behavior |
+| Unknown `--provider` value | Deferred to `resolve_ai_provider`, which errors and lists available providers (`unknown_provider_lists_api_options`) | Parser stays loose; do not turn `--provider` into a typed enum |
+| Non-numeric `--threshold` / `--require-coverage` | Clap rejects with a parse error | `non_numeric_threshold_is_rejected` pins this |
 
 ## Reviewer Checklist
 

--- a/specs/cmd_archive_tasks/context.md
+++ b/specs/cmd_archive_tasks/context.md
@@ -4,17 +4,20 @@ spec: cmd_archive_tasks.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Thin command wrapper: load config, resolve `specs_dir`, call `archive::archive_tasks`, format output. No domain logic lives here.
+- Dry-run is passed straight through to the delegate; this module only flips the printed verb ("would archive" vs "archived") and prints the banner.
+- Empty result is treated as a success case ("No completed tasks to archive.") with an early return — not an error.
 
 ## Files to Read First
 
-- `src/commands/archive_tasks.rs` — primary source file
+- `src/commands/archive_tasks.rs` — the command wrapper (this module)
+- `src/archive.rs` — `archive_tasks` + `ArchiveResult { tasks_path, archived_count }`, where the real parsing/rewriting lives
+- `src/config.rs` — `load_config` / `specs_dir` resolution
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. The delegate `archive` module is well unit-tested; the wrapper itself has no inline tests (output formatting only).
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- `ArchiveResult.tasks_path` is already a repo-relative string produced by the delegate; the wrapper prints it verbatim.

--- a/specs/cmd_archive_tasks/requirements.md
+++ b/specs/cmd_archive_tasks/requirements.md
@@ -4,21 +4,26 @@ spec: cmd_archive_tasks.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_archive_tasks` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want completed (`- [x]`) tasks moved out of each companion `tasks.md` into a `## Done` section so active task lists stay focused on outstanding work
+- As a maintainer, I want a `--dry-run` preview so I can see which files and how many tasks would be archived before committing to a write
+- As a script author, I want a clear summary line ("Archived N task(s) across M file(s)", or "No completed tasks to archive.") so the result is easy to read or assert on
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_archive_tasks(root, dry_run)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
+- When `dry_run` is true, an informational banner ("Dry run — no files will be modified") prints and no files are written; per-file lines read "would archive"
+- When `dry_run` is false, completed tasks are moved and per-file lines read "archived"
+- When the delegate returns no results, prints "No completed tasks to archive." and returns without a summary
+- Each affected file prints its relative `tasks_path` and `archived_count`; a trailing summary reports the summed task count across the affected file count
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Pure orchestration wrapper: all task-parsing/rewriting logic lives in `archive::archive_tasks`; this module only loads config and formats output
+- Must not panic on missing/unreadable `tasks.md` files — the underlying module skips them gracefully
+- Output uses `colored` for status glyphs (`ℹ`, `✓`)
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- The actual task-parsing/rewriting logic (owned by the `archive` module)
+- Restoring archived tasks back into the active list
+- Interactive prompts or GUI

--- a/specs/cmd_archive_tasks/tasks.md
+++ b/specs/cmd_archive_tasks/tasks.md
@@ -4,16 +4,14 @@ spec: cmd_archive_tasks.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add an integration test that drives `archive-tasks` end-to-end through the CLI (the delegate `archive` module is unit-tested, but the wrapper's output/`--dry-run` formatting is not)
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] Verified wrapper delegates to `archive::archive_tasks` and matches the empty-result / dry-run / write paths
+- [x] Confirmed delegate logic is covered by `archive` inline tests (`test_archive_completed_tasks`, `test_archive_no_completed`, `test_archive_preserves_existing`)
 
 ## Review Sign-offs
 

--- a/specs/cmd_archive_tasks/testing.md
+++ b/specs/cmd_archive_tasks/testing.md
@@ -6,30 +6,31 @@ spec: cmd_archive_tasks.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/archive_tasks.rs` | cargo test commands::archive_tasks | No inline tests found; add focused coverage for `cmd_archive_tasks`, `archive_tasks`, `load_config` before risky changes |
+| `src/commands/archive_tasks.rs` | cargo test commands::archive_tasks | Command wrapper has no inline tests (output formatting only); cover `cmd_archive_tasks` end-to-end before risky changes |
+| `src/archive.rs` (delegate logic) | cargo test archive | `test_archive_completed_tasks`, `test_archive_no_completed`, `test_archive_preserves_existing` |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Tasks archived successfully" before changing user-visible CLI output, generated files, or error handling in cmd_archive_tasks.
+- No end-to-end CLI test asserts the wrapper's stdout (per-file lines, "would archive" vs "archived", the summary line, or the "No completed tasks to archive." path). Add one before changing user-visible output.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Tasks archived successfully | tasks.md has 3 checked items (`- [x]`) | `cmd_archive_tasks(root, false)` is called | checked items move to `## Done` section and count is printed |
-| Dry run | tasks.md has completed items | `cmd_archive_tasks(root, true)` is called | prints what would be archived without modifying files |
+| Tasks archived successfully | a companion `tasks.md` has checked items (`- [x]`) | `cmd_archive_tasks(root, false)` is called | checked items move to `## Done`; per-file line + summary printed |
+| Dry run | `tasks.md` has completed items | `cmd_archive_tasks(root, true)` is called | prints "Dry run" banner and "would archive" lines, modifies no files |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| No tasks.md files found | Prints "nothing to archive" | Keep or add a focused assertion before changing this behavior |
-| No completed tasks | Prints "nothing to archive" | Keep or add a focused assertion before changing this behavior |
+| No `tasks.md` files / no completed tasks (empty result) | Prints "No completed tasks to archive." and returns, no summary | Keep or add a focused assertion before changing this behavior |
+| Multiple affected files | Summary sums `archived_count` across all results and reports the file count | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 
 - Run `cargo run -- archive-tasks --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/archive_tasks.rs`.
+- Run `cargo test archive` when changing the delegate; run `cargo test commands::archive_tasks` when changing the wrapper.
 - Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- If an output string changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_changelog/context.md
+++ b/specs/cmd_changelog/context.md
@@ -4,17 +4,20 @@ spec: cmd_changelog.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Thin command wrapper: parse range, load config, call `changelog::generate_changelog`, then dispatch on `OutputFormat`. No domain logic here.
+- Range validation happens up front via `parse_range`; failure prints the expected `FROM..TO` format and exits 1 before any config is loaded.
+- Format dispatch collapses `Text`/`Github`/`Table`/`Csv` onto `format_text` — only Json and Markdown get dedicated renderers.
 
 ## Files to Read First
 
-- `src/commands/changelog.rs` — primary source file
+- `src/commands/changelog.rs` — the command wrapper (this module)
+- `src/changelog.rs` — `parse_range`, `generate_changelog`, `format_text`/`format_json`/`format_markdown`, and `ChangelogReport`
+- `src/types.rs` — `OutputFormat`
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. The `changelog` delegate is heavily unit-tested (range parsing, frontmatter/section diffing, all three formatters, end-to-end generation). The wrapper itself has no inline tests.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Output is emitted with `print!` for text/markdown so the formatter controls trailing newlines; JSON uses `println!`.

--- a/specs/cmd_changelog/requirements.md
+++ b/specs/cmd_changelog/requirements.md
@@ -4,21 +4,26 @@ spec: cmd_changelog.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_changelog` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a maintainer, I want a changelog of spec changes between two git refs so I can summarize what specs were added, modified, or removed in a release
+- As a release automation author, I want the changelog in text, JSON, or markdown so I can embed it in release notes or feed it to other tooling
+- As a CLI user, I want a clear error and non-zero exit when I pass a malformed range so mistakes fail fast
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_changelog(root, range, format)` parses `range` with `changelog::parse_range`; a valid range is `FROM..TO` (e.g. `v0.1..v0.2`, `HEAD~5..HEAD`)
+- On an invalid range (missing `..`, empty FROM, or empty TO) it prints an error naming the expected format and exits 1
+- On a valid range it loads config and calls `changelog::generate_changelog(root, &config.specs_dir, &from, &to)`
+- `Json` prints `format_json`; `Markdown` prints `format_markdown`; `Text`, `Github`, `Table`, and `Csv` all fall through to `format_text`
+- Markdown and text output use `print!` (no extra command-injected trailing newline); JSON uses `println!`
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Pure orchestration wrapper: range parsing, git diffing, and formatting all live in the `changelog` module
+- Must not panic on an invalid range — print and `process::exit(1)`
+- The underlying git diff requires the refs to exist; invalid refs surface as a git failure from the delegate, not a panic here
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Range parsing, git diff collection, and report formatting (owned by the `changelog` module)
+- Writing the changelog to a file (output goes to stdout)
+- Interactive prompts or GUI

--- a/specs/cmd_changelog/tasks.md
+++ b/specs/cmd_changelog/tasks.md
@@ -4,16 +4,14 @@ spec: cmd_changelog.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add an end-to-end CLI test that runs `changelog FROM..TO` against a throwaway git repo and asserts the rendered output per format (the delegate is unit-tested; the wrapper's format dispatch is not)
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] Verified format dispatch: Json→format_json, Markdown→format_markdown, Text/Github/Table/Csv→format_text
+- [x] Confirmed range parsing + report generation are covered by `changelog` inline tests (`test_parse_range_*`, `test_generate_changelog_*`, `test_format_*`)
 
 ## Review Sign-offs
 

--- a/specs/cmd_changelog/testing.md
+++ b/specs/cmd_changelog/testing.md
@@ -6,29 +6,34 @@ spec: cmd_changelog.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/changelog.rs` | cargo test commands::changelog | No inline tests found; add focused coverage for `cmd_changelog`, `generate_changelog`, `load_config`, `OutputFormat` before risky changes |
+| `src/commands/changelog.rs` | cargo test commands::changelog | Command wrapper has no inline tests (range guard + format dispatch only); cover end-to-end before risky changes |
+| `src/changelog.rs` range parsing | cargo test changelog::tests::test_parse_range | `test_parse_range_valid`, `test_parse_range_head_tilde`, `test_parse_range_invalid_no_dots`, `test_parse_range_invalid_empty_from`, `test_parse_range_invalid_empty_to`, `test_parse_range_commit_hashes` |
+| `src/changelog.rs` generation | cargo test changelog::tests::test_generate_changelog | `test_generate_changelog_no_changes`, `test_generate_changelog_added_spec`, `test_generate_changelog_removed_spec`, `test_generate_changelog_modified_spec` |
+| `src/changelog.rs` formatters | cargo test changelog::tests::test_format | `test_format_text_*`, `test_format_json_structure`, `test_format_markdown_empty`, `test_format_markdown_all_sections` |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Valid range with changes" before changing user-visible CLI output, generated files, or error handling in cmd_changelog.
+- No test drives `cmd_changelog` itself, so the format-dispatch mapping (Text/Github/Table/Csv → format_text) and the invalid-range exit path are unverified at the wrapper level. Add a CLI test before changing dispatch.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Valid range with changes | specs changed between `v3.5.0` and `v3.6.0` | `cmd_changelog(root, "v3.5.0..v3.6.0", Text)` is called | prints list of added, modified, and removed specs |
+| Valid range with changes | specs added/modified/removed between two refs | `cmd_changelog(root, "v0.1..v0.2", Text)` | prints added, modified, and removed specs via `format_text` |
+| Empty range (no spec changes) | refs with no spec diffs | `cmd_changelog(root, "HEAD~1..HEAD", Json)` | `format_json` emits an empty/zeroed report |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Range missing `..` | Prints error and exits 1 | Keep or add a focused assertion before changing this behavior |
-| Invalid git refs | Git command fails, error propagated | Keep or add a focused assertion before changing this behavior |
+| Range missing `..` (or empty side) | Prints "Invalid range format…" and exits 1 | Keep or add a focused assertion before changing this behavior |
+| Invalid git refs | git command in the delegate fails; error surfaces | Keep or add a focused assertion before changing this behavior |
+| Github/Table/Csv format requested | Falls through to `format_text` | Keep or add a focused assertion before changing this mapping |
 
 ## Reviewer Checklist
 
 - Run `cargo run -- changelog --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/changelog.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo test changelog` when changing the delegate; run `cargo test commands::changelog` when changing the wrapper.
+- Reproduce one Behavioral Verification row with a temporary git fixture before changing user-visible output.
+- If the invalid-range message or a format mapping changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_check/context.md
+++ b/specs/cmd_check/context.md
@@ -4,17 +4,27 @@ spec: cmd_check.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- `cmd_check` is the default command and the most feature-dense one: caching, requirements-drift detection, multi-pass `--fix`, git staleness, multiple output formats, and GitHub issue creation all live here.
+- Hash-cache skipping is bypassed whenever correctness demands a full pass: `--force`/`--no-cache`, `--strict`, or explicit spec filters.
+- `--fix` is intentionally ordered: header renames first (so section/export detection sees canonical headings), then undocumented-export insertion, then AI regeneration for requirements-drifted specs.
+- `--backup` aborts the whole `--fix` run on any copy failure rather than risk a partial, unrecoverable rewrite.
+- Git staleness uses `git_commits_since(root, spec_commit, source_file)` — one `rev-list` per source file — replacing the old `git_commits_between` pairwise walk (the N+1 fix).
+- AI for `--fix` regeneration is resolved through the reworked `ai` module (corvid-ai backed): an Ollama-default provider ladder with `claude` aliased to `anthropic`.
+- The cache is only persisted when there are zero errors, so a failing run never "blesses" a broken spec as up-to-date.
 
 ## Files to Read First
 
-- `src/commands/check.rs` — primary source file
+- `src/commands/check.rs` — the full command: caching, drift prompts, `auto_fix_specs`, `fix_near_miss_headers`, `auto_regen_stale_specs`, git-staleness loop, format dispatch
+- `src/commands/mod.rs` — shared `load_and_discover`, `run_validation`, `compute_exit_code`, `exit_with_status`, `create_drift_issues`
+- `src/git_utils.rs` — `is_git_repo`, `git_last_commit_hash`, `git_commits_since` (staleness)
+- `src/ai.rs` — `resolve_ai_provider`, `regenerate_spec_with_ai` (the `--fix` regen path)
+- `src/hash_cache.rs` — `HashCache`, `classify_all_changes`, `update_cache`
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable. Exercised end-to-end by many `tests/integration.rs` fixtures (validation outcomes, `--fix` variants, `--backup`, `--dry-run`, JSON). No inline `#[cfg(test)]` module in `check.rs` itself.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Orchestrates library modules; domain logic (validation, scoring, AI, git) lives elsewhere.
+- `--dry-run` without `--fix` prints a warning and otherwise does nothing.

--- a/specs/cmd_check/requirements.md
+++ b/specs/cmd_check/requirements.md
@@ -4,21 +4,39 @@ spec: cmd_check.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_check` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want `specsync check` to validate every spec against its source so that drift is caught before it ships
+- As a developer on a large repo, I want unchanged specs skipped via a hash cache so that repeated checks stay fast, and `--force`/`--no-cache` to re-validate everything when I need it
+- As a CI operator, I want exit codes driven by enforcement mode, `--strict`, and `--require-coverage` so that pipeline pass/fail is predictable
+- As a developer, I want `--fix` to add undocumented exports, fix near-miss headers, and (when requirements drifted) AI-regenerate the spec so that keeping specs current is low-friction
+- As a cautious developer, I want `--dry-run` to preview `--fix` and `--backup` to snapshot specs before they are rewritten so that I never lose work
+- As a maintainer, I want `--stale [N]` to flag specs that are N+ commits behind their source files so that I can spot quietly-rotting docs
+- As a tool integrator, I want `--format json/markdown/github` so that results render in dashboards, PR bodies, or Actions logs
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- Validates discovered specs, applying `--exclude-status`/`--only-status` and positional `[SPEC...]` filters
+- A hash cache (`.specsync/hashes.json`) skips unchanged specs unless `--force`/`--no-cache`, `--strict`, or explicit spec filters are given; the skipped count is reported in text mode
+- Requirements-drift is detected per spec; in an interactive TTY (no `--fix`) the user is prompted to re-validate, and with `--fix` drifted specs are AI-regenerated
+- `--fix` runs in passes: rename near-miss `## Required` and `### Export` headers, append undocumented exports to the Public API table (with language-aware skeleton rows), then AI-regenerate requirements-drifted specs
+- `--backup` copies specs to `.specsync/backup-fix/` before any `--fix` write, aborting on any copy/dir failure to avoid data loss
+- `--dry-run` previews `--fix` without writing; `--dry-run` without `--fix` prints a warning that it has no effect
+- `--stale [N]` (default N=5) runs only inside a git repo, using `git_last_commit_hash` + `git_commits_since` to count how many commits each source file has advanced past the spec's last commit, flagging specs ≥ N behind
+- `--create-issues` creates one GitHub issue per spec with errors (only when `total_errors > 0`)
+- The hash cache is updated and saved only when `total_errors == 0`
+- JSON output is a single object with `passed`, `errors`, `warnings`, `stale`, and `specs_checked`
+- Exit code comes from `compute_exit_code`/`exit_with_status` (Warn/EnforceNew/Strict + require-coverage)
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — print and exit
+- `--fix` only modifies spec markdown files, never source code
+- AI provider resolution goes through the reworked `ai` module (Ollama-default ladder; `claude` aliases to `anthropic`); when none is configured, drift regeneration is skipped with guidance
+- `--stale` is a no-op outside a git repo (no crash); specs without a `files:` list are skipped
+- Git staleness uses `git_commits_since` (single rev-list per file) — the earlier per-pair `git_commits_between` N+1 walk was removed
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Modifying or generating source code
+- Defining the CLI grammar (lives in `src/cli.rs`)
+- The scoring algorithm itself (lives in the scoring module; check only renders `--explain` breakdowns)
+- Non-git staleness heuristics (filesystem mtimes, etc.)

--- a/specs/cmd_check/tasks.md
+++ b/specs/cmd_check/tasks.md
@@ -4,16 +4,22 @@ spec: cmd_check.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add a CLI integration test for `check --stale` against a temp git repo (current stale-subcommand tests don't cover `check --stale`)
+- [ ] Add an integration test asserting the hash cache skips unchanged specs on a second run
 
 ## Done
 
 - [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] Requirements and acceptance criteria documented (now reflecting cache, `--fix`, `--backup`, `--dry-run`, `--stale`, formats)
+- [x] `--fix` paths covered by integration tests: add/dedupe exports, create Public API section, near-miss header fixes, JSON output, dry-run, backup
+- [x] Validation outcomes covered: valid project, missing source file, undocumented export warn, phantom export error
+- [x] Git staleness migrated to `git_commits_since` (N+1 fix over the old `git_commits_between`)
+- [x] `--fix` AI regeneration routed through the reworked `ai` module (Ollama-default ladder; `claude`→`anthropic`)
 
 ## Gaps
 
-- No dedicated test file for this command module
+- `src/commands/check.rs` has no inline `#[cfg(test)]` module; coverage is via `tests/integration.rs`
+- No integration test directly drives `check --stale` (only the standalone `stale` subcommand is tested)
 
 ## Review Sign-offs
 

--- a/specs/cmd_check/testing.md
+++ b/specs/cmd_check/testing.md
@@ -15,6 +15,8 @@ spec: cmd_check.spec.md
 | `tests/integration.rs` | cargo test --test integration require_coverage_passes_when_met | End-to-end fixture: `require_coverage_passes_when_met` |
 | `tests/integration.rs` | cargo test --test integration require_coverage_fails_when_below_threshold | End-to-end fixture: `require_coverage_fails_when_below_threshold` |
 | `tests/integration.rs` | cargo test --test integration require_coverage_on_coverage_subcommand | End-to-end fixture: `require_coverage_on_coverage_subcommand` |
+| `tests/integration.rs` (--fix) | cargo test --test integration fix_ | `fix_adds_undocumented_exports_to_spec`, `fix_does_not_duplicate_already_documented_exports`, `fix_creates_public_api_section_when_missing`, `fix_with_json_output`, `fix_does_not_duplicate_when_non_export_subsections_present`, `fix_near_miss_handles_levenshtein_typos`, `fix_dry_run_does_not_write_files`, `fix_backup_creates_backup_dir`, `fix_backup_preserves_original_on_success` |
+| `tests/integration.rs` (suggestions/dry-run) | cargo test --test integration check_shows_fix_suggestions dry_run_without_fix_warns | `check_shows_fix_suggestions`, `dry_run_without_fix_warns`, `wildcard_reexport_with_fix_adds_all_symbols` |
 
 ## Behavioral Verification
 
@@ -22,7 +24,9 @@ spec: cmd_check.spec.md
 |------|-----------------|--------|-----------------|
 | Incremental check with cache | 25 specs, 3 have changed since last check | `cmd_check` runs without `--force` | only 3 specs are validated; 22 are skipped via hash cache |
 | Auto-fix undocumented exports | spec is missing export `pub fn new_function()` | `cmd_check` runs with `--fix` | the export is appended to the spec's Public API table with a generated description prompt and the file is rewritten |
-| JSON output format | `--format json` is set | validation completes with errors and warnings | output is a single JSON object with `specs_checked`, `passed`, `errors`, `warnings`, `coverage`, and `exit_code` fields |
+| JSON output format | `--format json` is set | validation completes with errors and warnings | output is a single JSON object with `passed`, `errors`, `warnings`, `stale`, and `specs_checked` fields (verified by `fix_with_json_output`) |
+| Backup before fix | a spec will be rewritten by `--fix` | `specsync check --fix --backup` is run | originals are copied to `.specsync/backup-fix/` before any write (`fix_backup_creates_backup_dir`) |
+| Git staleness | a spec's source is N+ commits ahead of the spec's last commit, inside a git repo | `specsync check --stale N` is run | the spec is flagged "N commits behind source files" with per-file detail (uses `git_commits_since`) |
 
 ## Regression Matrix
 
@@ -32,6 +36,9 @@ spec: cmd_check.spec.md
 | Auto-fix changes a spec but validation still fails | Reports remaining errors, does not loop | Keep or add a focused assertion before changing this behavior |
 | Hash cache file is corrupted | Falls back to full validation (cache miss) | Keep or add a focused assertion before changing this behavior |
 | `--create-issues` with no GitHub repo | Prints error, skips issue creation | Keep or add a focused assertion before changing this behavior |
+| `--stale` outside a git repo | No staleness output, no crash (the `is_git_repo` guard skips it) | Keep or add a focused assertion before changing this behavior |
+| Validation has errors | Hash cache is NOT updated/saved (only saved when `total_errors == 0`) | Keep or add a focused assertion before changing this behavior |
+| `--dry-run` without `--fix` | Prints a warning that dry-run has no effect, makes no changes | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 

--- a/specs/cmd_comment/context.md
+++ b/specs/cmd_comment/context.md
@@ -4,17 +4,23 @@ spec: cmd_comment.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Reuses the `check` pipeline verbatim: `load_and_discover` → `run_validation` (collect mode) → `compute_coverage` → `compute_exit_code`. This guarantees the comment's pass/fail badge matches what `check` would exit with in CI.
+- `render_check_comment` (in `src/comment.rs`) is the single renderer for the markdown body. There is intentionally no second comment-generation path — both the marketplace action and the project CI shell out to `specsync comment`.
+- Posting vs printing is the only branch in this wrapper: with `--pr N` it resolves the repo and shells out to `gh pr comment`; without `--pr` it prints the body to stdout.
+- Enforcement resolution: `--enforcement` overrides config; `--strict` implies strict enforcement; otherwise `config.enforcement` is used.
 
 ## Files to Read First
 
-- `src/commands/comment.rs` — primary source file
+- `src/commands/comment.rs` — the command wrapper (this module)
+- `src/comment.rs` — `render_check_comment`, `detect_branch`, and the suggestion/grouping helpers
+- `src/commands/mod.rs` — `run_validation`, `compute_exit_code`, `load_and_discover`, `build_schema_columns`
+- `src/github.rs` — `detect_repo`, `resolve_repo`
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. The `comment` renderer is extensively unit-tested; the wrapper itself (validation reuse + gh shell-out branch) has no inline tests.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- The `_base` parameter is currently unused (prefixed with `_`); it is reserved for diff-base wiring.
+- `gh pr comment` failures and missing `gh` are handled explicitly with distinct error messages and `process::exit(1)`.

--- a/specs/cmd_comment/requirements.md
+++ b/specs/cmd_comment/requirements.md
@@ -10,10 +10,12 @@ spec: cmd_comment.spec.md
 
 ## Acceptance Criteria
 
-- `cmd_comment` runs full validation and renders the check summary as GitHub-flavored markdown
+- `cmd_comment` runs the same validation pipeline as `check` (`run_validation` in collect mode) and renders the summary via `comment::render_check_comment` as GitHub-flavored markdown
+- The pass/fail status embedded in the comment is derived from `compute_exit_code` using the same inputs as `check`, so the comment status matches CI exactly
+- `--strict`, `--enforcement`, and `--require-coverage` affect the computed status the same way they do for `check`; `--enforcement` overrides config, and `--strict` implies strict enforcement
 - When `--pr` is omitted, markdown is printed to stdout for piping (used by both the marketplace action and CI workflow)
-- When `--pr N` is set, the comment is posted directly to the specified PR via `gh pr comment`
-- Exits 1 if `gh` CLI fails or the GitHub repo cannot be resolved
+- When `--pr N` is set, the repo is resolved via `github::resolve_repo` and the comment is posted via `gh pr comment --repo <repo> --body <body>`
+- Exits 1 if `gh` CLI is missing, `gh pr comment` exits non-zero, or the GitHub repo cannot be resolved
 - The marketplace action (`action.yml`, `comment: true`) and CI workflow (`.github/workflows/ci.yml`) both invoke `specsync comment` in stdout mode — no alternative comment generation paths exist
 
 ## Constraints

--- a/specs/cmd_comment/tasks.md
+++ b/specs/cmd_comment/tasks.md
@@ -4,16 +4,16 @@ spec: cmd_comment.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add an end-to-end CLI test for stdout mode (`comment` without `--pr`) asserting the rendered markdown body on a fixture project
+- [ ] Wire up the currently-unused `_base` parameter (diff base), or remove it if there is no planned use
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] Documented the unified pipeline: marketplace action + CI both use `specsync comment` for identical output
+- [x] Verified the wrapper reuses `check`'s validation + `compute_exit_code` and renders via `comment::render_check_comment`
+- [x] Confirmed the renderer is covered by `comment` inline tests (`test_render_check_comment_*`, `test_suggestion_for_*`)
 
 ## Review Sign-offs
 

--- a/specs/cmd_comment/testing.md
+++ b/specs/cmd_comment/testing.md
@@ -6,31 +6,35 @@ spec: cmd_comment.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/comment.rs` | cargo test commands::comment | No inline tests found; add focused coverage for `cmd_comment`, `build_comment_body`, `resolve_repo` before risky changes |
+| `src/commands/comment.rs` | cargo test commands::comment | Command wrapper has no inline tests (pipeline reuse + gh shell-out branch); cover stdout mode end-to-end before risky changes |
+| `src/comment.rs` rendering | cargo test comment::tests::test_render_check_comment | `test_render_check_comment_passed`, `test_render_check_comment_failed_with_errors`, `test_render_check_comment_has_footer`, `test_render_check_comment_truncates_unspecced_files` |
+| `src/comment.rs` suggestions | cargo test comment::tests::test_suggestion | `test_suggestion_for_missing_section`, `test_suggestion_for_source_file_not_found`, `test_suggestion_for_db_table`, `test_suggestion_for_dependency`, … |
+| `src/comment.rs` grouping/links | cargo test comment::tests | `test_group_by_spec`, `test_split_spec_prefix`, `test_strip_spec_prefix`, `test_spec_link_with_repo`, `test_spec_link_without_repo` |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Print to stdout" before changing user-visible CLI output, generated files, or error handling in cmd_comment.
+- No test drives `cmd_comment` directly, so stdout mode (body printed to stdout) and the `--pr` posting branch (resolve repo + `gh pr comment`) are unverified at the wrapper level. The body content is covered through `comment::render_check_comment`.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Print to stdout | `--pr` is not set | `cmd_comment` runs | prints markdown summary to stdout |
-| Post to PR | `--pr 42` is set | `cmd_comment` runs | posts comment on PR #42 |
-| Marketplace action captures stdout | the marketplace action runs with `comment: true` | `specsync comment` is invoked without `--pr` | the stdout output is identical to what the CI workflow captures via `cargo run -- comment` |
+| Print to stdout | `--pr` is not set | `cmd_comment` runs | prints the `render_check_comment` markdown body to stdout, no `gh` invocation |
+| Post to PR | `--pr 42` is set, repo resolvable | `cmd_comment` runs | resolves repo and runs `gh pr comment 42 --repo … --body …`, prints "Posted spec-sync comment on PR #42" |
+| Status matches `check` | same project, same flags | `cmd_comment` vs `cmd_check` | the comment's pass/fail badge matches `check`'s exit code (both go through `compute_exit_code`) |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| `gh` CLI not installed | Command fails with error | Keep or add a focused assertion before changing this behavior |
-| GitHub repo unresolvable | Exits 1 | Keep or add a focused assertion before changing this behavior |
+| `gh` CLI not installed | Prints "Failed to run gh CLI" + install hint, exits 1 | Keep or add a focused assertion before changing this behavior |
+| `gh pr comment` exits non-zero | Prints the exit code and exits 1 | Keep or add a focused assertion before changing this behavior |
+| GitHub repo unresolvable (`--pr` set) | Prints resolver error and exits 1 | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- comment --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/comment.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
+- Run `cargo run -- comment --help` and confirm the help text still names the documented flags (`--pr`, `--strict`, `--enforcement`, `--require-coverage`).
+- Run `cargo test comment` when changing the renderer; run `cargo test commands::comment` when changing the wrapper.
+- Reproduce the stdout-mode Behavioral Verification row with a temporary project fixture before changing user-visible output.
 - If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_compact/context.md
+++ b/specs/cmd_compact/context.md
@@ -4,17 +4,21 @@ spec: cmd_compact.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Thin command wrapper: load config, resolve `specs_dir`, call `compact::compact_changelogs`, format output. No trimming logic here.
+- `--keep` is passed straight through; the wrapper only flips the printed verb ("would compact" vs "compacted") and prints the banner.
+- Empty result is a success case ("No changelogs need compaction (all within limit).") with an early return — not an error.
+- Per-spec output reports both `removed` and the surviving `compacted_entries` count so reviewers can sanity-check the keep limit.
 
 ## Files to Read First
 
-- `src/commands/compact.rs` — primary source file
+- `src/commands/compact.rs` — the command wrapper (this module)
+- `src/compact.rs` — `compact_changelogs` + `CompactResult { spec_path, compacted_entries, removed }`, where the changelog-table trimming lives
+- `src/config.rs` — `load_config` / `specs_dir` resolution
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. The `compact` delegate is unit-tested (trim, no-op when under limit, three-column tables); the wrapper itself has no inline tests (output formatting only).
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- `CompactResult.spec_path` is already repo-relative; the wrapper prints it verbatim.

--- a/specs/cmd_compact/requirements.md
+++ b/specs/cmd_compact/requirements.md
@@ -4,21 +4,27 @@ spec: cmd_compact.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_compact` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a maintainer, I want old spec changelog entries trimmed so the `## Change Log` table in each spec stays readable and only keeps the most recent N rows
+- As a maintainer, I want a `--dry-run` preview so I can see how many entries would be removed (and from which specs) before writing
+- As a script author, I want a clear summary ("Compacted N entries across M spec(s)", or "No changelogs need compaction (all within limit).") so the result is easy to read or assert on
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_compact(root, keep, dry_run)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
+- `--keep N` controls how many changelog entries to retain per spec
+- When `dry_run` is true, a banner prints, no files are written, and per-spec lines read "would compact"
+- When `dry_run` is false, entries are removed and per-spec lines read "compacted"
+- When the delegate returns no results, prints "No changelogs need compaction (all within limit)." and returns without a summary
+- Each affected spec prints its relative `spec_path`, the `removed` count, and the kept (`compacted_entries`) count; the trailing summary sums removed entries across affected specs
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Pure orchestration wrapper: changelog parsing/trimming lives in `compact::compact_changelogs`; this module only loads config and formats output
+- Must not panic on missing/unreadable specs — the underlying module skips them gracefully
+- Output uses `colored` for status glyphs (`ℹ`, `✓`)
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- The changelog-table parsing/rewriting logic (owned by the `compact` module)
+- Compacting non-changelog content
+- Interactive prompts or GUI

--- a/specs/cmd_compact/tasks.md
+++ b/specs/cmd_compact/tasks.md
@@ -4,16 +4,14 @@ spec: cmd_compact.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add an end-to-end CLI test that runs `compact --keep N` against a fixture spec and asserts the per-spec lines, summary, and `--dry-run` no-write behavior
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] Verified wrapper delegates to `compact::compact_changelogs` and matches the empty-result / dry-run / write paths
+- [x] Confirmed the trimming logic is covered by `compact` inline tests (`test_compact_changelog`, `test_compact_no_change_needed`, `test_compact_three_column_table`)
 
 ## Review Sign-offs
 

--- a/specs/cmd_compact/testing.md
+++ b/specs/cmd_compact/testing.md
@@ -6,29 +6,32 @@ spec: cmd_compact.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/compact.rs` | cargo test commands::compact | No inline tests found; add focused coverage for `cmd_compact`, `compact_changelogs`, `load_config` before risky changes |
+| `src/commands/compact.rs` | cargo test commands::compact | Command wrapper has no inline tests (output formatting only); cover `cmd_compact` end-to-end before risky changes |
+| `src/compact.rs` (delegate logic) | cargo test compact | `test_compact_changelog`, `test_compact_no_change_needed`, `test_compact_three_column_table` |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Compact changelogs" before changing user-visible CLI output, generated files, or error handling in cmd_compact.
+- No end-to-end CLI test asserts the wrapper's stdout (per-spec lines, "would compact" vs "compacted", the summary, or the "No changelogs need compaction…" path). Add one before changing user-visible output.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Compact changelogs | a spec has 25 changelog entries, `--keep 10` | `cmd_compact` runs | 15 oldest entries removed, 10 newest kept |
+| Compact changelogs | a spec's `## Change Log` has 25 entries, `--keep 10` | `cmd_compact(root, 10, false)` | 15 oldest entries removed, 10 newest kept; per-spec line + summary printed |
+| Dry run | a spec exceeds the keep limit | `cmd_compact(root, 10, true)` | prints "Dry run" banner + "would compact" lines, modifies no files |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| No specs with changelogs | Prints "nothing to compact" | Keep or add a focused assertion before changing this behavior |
-| Fewer entries than keep | File unchanged | Keep or add a focused assertion before changing this behavior |
+| No specs need compaction (all within limit) | Prints "No changelogs need compaction (all within limit)." and returns, no summary | Keep or add a focused assertion before changing this behavior |
+| Fewer entries than `--keep` | Spec unchanged, not reported | Keep or add a focused assertion before changing this behavior |
+| Multiple affected specs | Summary sums `removed` across results and reports the spec count | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- compact --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/compact.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo run -- compact --help` and confirm the help text still names the documented flags (`--keep`, `--dry-run`).
+- Run `cargo test compact` when changing the delegate; run `cargo test commands::compact` when changing the wrapper.
+- Reproduce one Behavioral Verification row with a temporary spec fixture before changing user-visible output.
+- If an output string changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_coverage/context.md
+++ b/specs/cmd_coverage/context.md
@@ -4,17 +4,22 @@ spec: cmd_coverage.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Validation runs first (`run_validation`), then `compute_coverage`, so the coverage report and any enforcement gate stay consistent with `check`.
+- Two output paths: JSON (`--format json`) builds a `serde_json` object and always `exit(0)` — it is a metrics dump, not a gate. The non-JSON path prints the report + summary + coverage line and delegates the gate to `exit_with_status`.
+- Percentages are computed inline in the wrapper (file_coverage, loc_coverage), rounded to two decimals, with a zero denominator treated as 100%.
+- This command uses `IgnoreRules::default()` rather than `IgnoreRules::load(root)` — `.specsyncignore` is intentionally not applied to coverage discovery here.
 
 ## Files to Read First
 
-- `src/commands/coverage.rs` — primary source file
+- `src/commands/coverage.rs` — the command wrapper (this module), including the JSON serialization
+- `src/validator.rs` — `compute_coverage` (the `Coverage` struct fields used in the JSON) and `get_schema_table_names`
+- `src/commands/mod.rs` — `run_validation`, `exit_with_status`, `load_and_discover`, `build_schema_columns`
+- `src/output.rs` — `print_coverage_report`, `print_summary`, `print_coverage_line`
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. Well covered by `tests/integration.rs` (8 fixtures spanning full/partial coverage, `--require-coverage`, `--strict`, and the MCP coverage tool). The wrapper has no inline unit tests.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- JSON keys: `file_coverage`, `files_covered`, `files_total`, `loc_coverage`, `loc_covered`, `loc_total`, `modules`, `uncovered_files`.

--- a/specs/cmd_coverage/requirements.md
+++ b/specs/cmd_coverage/requirements.md
@@ -4,21 +4,26 @@ spec: cmd_coverage.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_coverage` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want a file-level and LOC-level spec coverage report so I can see which source files are not yet claimed by any spec
+- As a CI operator, I want `--require-coverage N` (and `--strict`/`--enforcement`) to fail the build when coverage drops below a threshold so coverage regressions are caught
+- As a tooling author, I want `--format json` to emit machine-readable coverage metrics (percentages, counts, uncovered files, unspecced modules) so I can integrate with dashboards
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_coverage(root, strict, enforcement, require_coverage, format)` runs validation (`run_validation`) before computing coverage so results are consistent with `check`
+- Coverage is computed via `compute_coverage`; file-coverage and loc-coverage percentages are derived and rounded to two decimals, treating a zero-denominator as 100%
+- JSON output (`--format json`) emits `file_coverage`, `files_covered`, `files_total`, `loc_coverage`, `loc_covered`, `loc_total`, `modules` (unspecced), and `uncovered_files`, then exits 0
+- Non-JSON output prints the coverage report, the validation summary, and a coverage line, then delegates the exit code to `exit_with_status`
+- `--enforcement` overrides config enforcement; `--strict` implies strict enforcement; `--require-coverage N` fails (exit 1) when coverage is below N
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Coverage computation, validation, and exit-status logic all live in shared modules (`validator`, `commands` helpers); this wrapper orchestrates and formats
+- JSON path always exits 0 regardless of validation status (it is a metrics dump, not a gate)
+- This command uses `IgnoreRules::default()` (no `.specsyncignore` loading), unlike `check`/`comment` which load ignore rules from disk
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- The coverage algorithm itself (owned by `validator::compute_coverage`)
+- Writing the report to a file (output goes to stdout)
+- Interactive prompts or GUI

--- a/specs/cmd_coverage/tasks.md
+++ b/specs/cmd_coverage/tasks.md
@@ -4,16 +4,15 @@ spec: cmd_coverage.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Consider loading `IgnoreRules` from disk (like `check`/`comment`) instead of `IgnoreRules::default()`, or document why coverage intentionally ignores `.specsyncignore`
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] End-to-end CLI behavior is covered by integration fixtures (full/partial coverage, `--require-coverage`, `--strict`, JSON via MCP) — see testing.md
+- [x] Verified JSON output keys and the two-decimal rounding / zero-denominator-as-100% behavior against the source
+- [x] Verified exit-code delegation to `exit_with_status` for the non-JSON path
 
 ## Review Sign-offs
 

--- a/specs/cmd_coverage/testing.md
+++ b/specs/cmd_coverage/testing.md
@@ -6,7 +6,7 @@ spec: cmd_coverage.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/coverage.rs` | cargo test commands::coverage | No inline tests found; add focused coverage for `cmd_coverage`, `IgnoreRules::load`, `compute_coverage` before risky changes |
+| `src/commands/coverage.rs` | cargo test commands::coverage | Command wrapper has no inline tests; exercised end-to-end via the integration fixtures below. Note: this wrapper uses `IgnoreRules::default()`, not `IgnoreRules::load` |
 | `tests/integration.rs` | cargo test --test integration coverage_full_reports_100 | End-to-end fixture: `coverage_full_reports_100` |
 | `tests/integration.rs` | cargo test --test integration coverage_partial_lists_unspecced_files | End-to-end fixture: `coverage_partial_lists_unspecced_files` |
 | `tests/integration.rs` | cargo test --test integration coverage_shows_unspecced_modules | End-to-end fixture: `coverage_shows_unspecced_modules` |
@@ -21,7 +21,8 @@ spec: cmd_coverage.spec.md
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
 | Full coverage | all source files claimed by specs | `cmd_coverage` runs | prints 100% with green check marks |
-| Below threshold | 58% coverage, `--require-coverage 80` | `cmd_coverage` runs | lists uncovered files and exits 1 |
+| Below threshold | partial coverage, `--require-coverage 80` | `cmd_coverage` runs | lists uncovered files and exits 1 |
+| JSON metrics dump | `--format json` | `cmd_coverage` runs | emits coverage keys (`file_coverage`, `loc_coverage`, `uncovered_files`, …) and exits 0 regardless of validation status |
 
 ## Regression Matrix
 

--- a/specs/cmd_deps/context.md
+++ b/specs/cmd_deps/context.md
@@ -4,17 +4,21 @@ spec: cmd_deps.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Two modes: diagram mode (`--mermaid`/`--dot`) builds the graph, prints the diagram, and returns early without validation or an exit-code change; validation mode runs `deps::validate_deps` and renders per `OutputFormat`.
+- `render_mermaid` and `render_dot` are private helpers kept in this wrapper (not the `deps` module) because they are presentation-only; both sort modules and deps for deterministic output and mark missing targets specially (dashed `❌` / dashed red).
+- The text path additionally prints a topological build order via `deps::topological_sort` when there are no cycles and the graph is non-empty.
+- Exit code: the command exits 1 whenever `report.errors` is non-empty, after the report has been printed in whatever format was requested.
 
 ## Files to Read First
 
-- `src/commands/deps.rs` — primary source file
+- `src/commands/deps.rs` — the command wrapper (this module), including `render_mermaid`/`render_dot`
+- `src/deps.rs` — `build_dep_graph`, `validate_deps`, `topological_sort`, `DepNode`, and `DepsReport { module_count, edge_count, errors, warnings, cycles, missing_deps, undeclared_imports }`
+- `src/types.rs` — `OutputFormat`
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. The `deps` delegate is heavily unit-tested; `tests/integration.rs::dependency_spec_not_found_errors` exercises the missing-dependency path end-to-end. The diagram renderers in this wrapper have no direct test.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- The empty-graph hint ("No depends_on relationships found…") is stderr-only and diagram-mode-only.

--- a/specs/cmd_deps/requirements.md
+++ b/specs/cmd_deps/requirements.md
@@ -4,21 +4,27 @@ spec: cmd_deps.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_deps` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want cross-module `depends_on` declarations validated so missing dependency specs, cycles, and undeclared imports are caught
+- As an architect, I want to render the dependency graph as Mermaid or Graphviz DOT so I can visualize module relationships
+- As a CI operator, I want `deps` to exit non-zero when there are dependency errors so broken graphs fail the build
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_deps(root, format, mermaid, dot)` loads config and, when `--mermaid` or `--dot` is set, builds the graph and prints the corresponding diagram, then returns (no validation, no exit code change)
+- In diagram mode, if there are no `depends_on` edges but the graph is non-empty, a hint about adding `depends_on:` is printed to stderr
+- Mermaid renders missing targets as dashed `❌` nodes; DOT renders them as dashed red nodes; both sort modules/deps for deterministic output
+- Without a diagram flag, validation runs via `deps::validate_deps`, producing module/edge counts, errors, warnings, cycles, missing deps, and undeclared imports
+- Output is rendered per `OutputFormat`: Json (full report object), Markdown/Github (headed sections), and Text/Table/Csv (decorated lines plus a topological build order when there are no cycles)
+- Exits 1 if `report.errors` is non-empty (after printing the report in any format)
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Graph building, cycle detection, import analysis, and topological sort all live in the `deps` module; this wrapper formats and decides the exit code
+- `render_mermaid` and `render_dot` are private helpers in this module
+- The empty-graph hint only fires in diagram mode, not in the validation path
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- The dependency analysis algorithms (owned by the `deps` module)
+- Writing diagrams/reports to a file (output goes to stdout)
+- Interactive prompts or GUI

--- a/specs/cmd_deps/tasks.md
+++ b/specs/cmd_deps/tasks.md
@@ -4,16 +4,16 @@ spec: cmd_deps.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add a CLI test asserting `--mermaid`/`--dot` output shape (the renderers are private to the wrapper and have no direct test today)
+- [ ] Add a CLI test asserting the non-zero exit when `report.errors` is non-empty
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] Verified format dispatch (Json / Markdown+Github / Text+Table+Csv) and the topological build-order line for the text path
+- [x] Verified the empty-graph `depends_on` hint fires only in diagram mode
+- [x] Confirmed the delegate is covered by `deps` inline tests (graph build, missing dep, cycle detection, undeclared imports per language, topological sort) and the `dependency_spec_not_found_errors` integration test
 
 ## Review Sign-offs
 

--- a/specs/cmd_deps/testing.md
+++ b/specs/cmd_deps/testing.md
@@ -6,17 +6,23 @@ spec: cmd_deps.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/deps.rs` | cargo test commands::deps | No inline tests found; add focused coverage for `cmd_deps`, `validate_deps`, `load_config`, `OutputFormat` before risky changes |
+| `src/commands/deps.rs` | cargo test commands::deps | Command wrapper has no inline tests (format dispatch + private `render_mermaid`/`render_dot`); cover end-to-end before risky changes |
+| `src/deps.rs` graph + validation | cargo test deps::tests | `test_build_dep_graph_empty`, `test_build_dep_graph_basic`, `test_validate_no_errors`, `test_validate_missing_dep` |
+| `src/deps.rs` cycles + ordering | cargo test deps::tests | `test_detect_circular_deps`, `test_detect_three_node_cycle`, `test_topological_sort_valid`, `test_topological_sort_cycle` |
+| `src/deps.rs` imports | cargo test deps::tests | `test_undeclared_rust_import`, `test_undeclared_ts_import`, `test_undeclared_python_import`, `test_self_import_not_flagged`, `test_declared_import_not_flagged` |
+| `tests/integration.rs` | cargo test --test integration dependency_spec_not_found_errors | End-to-end: a spec's `depends_on` references a nonexistent spec → error |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Mermaid output" before changing user-visible CLI output, generated files, or error handling in cmd_deps.
+- The private `render_mermaid`/`render_dot` diagram output and the wrapper's exit-on-errors path have no direct test. Add a CLI-level assertion before changing diagram syntax or the exit behavior.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Mermaid output | `--mermaid` flag set, clean dep graph | `cmd_deps` runs | outputs valid Mermaid flowchart syntax |
+| Mermaid output | clean dep graph, `--mermaid` | `cmd_deps(root, _, true, false)` | prints `graph LR` with sorted nodes/edges; missing targets shown as dashed `❌` nodes |
+| DOT output | clean dep graph, `--dot` | `cmd_deps(root, _, false, true)` | prints `digraph specs { … }` with sorted nodes/edges |
+| Valid graph, text format | no errors/warnings, no cycles | `cmd_deps(root, Text, false, false)` | prints "All dependency declarations are valid." plus a "Build order: …" line |
 | Cycle detected | A depends on B, B depends on A | `cmd_deps` runs | prints cycle error and exits 1 |
 
 ## Regression Matrix
@@ -24,13 +30,14 @@ spec: cmd_deps.spec.md
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
 | Circular dependency | Error printed, exits 1 | Keep or add a focused assertion before changing this behavior |
-| Missing dependency spec | Error printed, exits 1 | Keep or add a focused assertion before changing this behavior |
-| Empty dep graph | Prints hint about `depends_on` | Keep or add a focused assertion before changing this behavior |
+| Missing dependency spec | Error printed (`missing_deps`), exits 1 (covered by `dependency_spec_not_found_errors`) | Keep or add a focused assertion before changing this behavior |
+| Empty dep graph in diagram mode | Prints `depends_on` hint to stderr (diagram mode only) | Keep or add a focused assertion before changing this behavior |
+| Undeclared import | Reported as a warning (not an error → no exit 1) | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- deps --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/deps.rs`.
+- Run `cargo run -- deps --help` and confirm the help text still names the documented flags (`--format`, `--mermaid`, `--dot`).
+- Run `cargo test deps` when changing the delegate; run `cargo test commands::deps` when changing the wrapper.
 - Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- If an error message or diagram syntax changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_diff/context.md
+++ b/specs/cmd_diff/context.md
@@ -4,17 +4,23 @@ spec: cmd_diff.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Export deltas are computed against the **spec body's documented symbols**, not against the base revision's source tree. `new_exports` = currently-exported symbols missing from the spec; `removed_exports` = spec symbols no longer exported. This keeps the command dependency-free of `git show` and frames drift as "spec vs. reality".
+- The git changed-file scan uses `git diff --name-only --end-of-options <base>`. `--end-of-options` is a deliberate hardening step so a base ref like `--upload-pack=...` can never be interpreted as a git flag.
+- PR base auto-detection: when the caller passes the default `HEAD`, `detect_pr_base()` reads `GITHUB_EVENT_NAME` and `GITHUB_BASE_REF` and rewrites the base to `origin/<base_ref>` for `pull_request`/`pull_request_target` events. An explicit `--base` always wins.
+- A spec is reported when either its tracked files changed or the `.spec.md` itself changed (`spec_modified`), so spec-only edits still surface.
 
 ## Files to Read First
 
-- `` — primary source file
+- `src/commands/diff.rs` — the whole command, including the `DiffEntry` struct and `detect_pr_base()`.
+- `src/output.rs` — `print_diff_markdown`, used for Markdown/Github output.
+- `src/exports.rs` — `get_exported_symbols` / `has_extension`, the source of current exports.
+- `src/parser.rs` — `parse_frontmatter` and `get_spec_symbols` (spec-documented API surface).
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. Covered by five integration tests in `tests/integration.rs`. No inline unit tests in `diff.rs`.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Output formats: Json and Markdown/Github render structured reports; Text/Table/Csv share a human-readable path that, when no specs match, lists changed source files not covered by any spec.
+- This module orchestrates library modules (exports, output, parser) rather than containing domain logic.

--- a/specs/cmd_diff/requirements.md
+++ b/specs/cmd_diff/requirements.md
@@ -4,21 +4,26 @@ spec: cmd_diff.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_diff` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer opening a PR, I want to see which specs are affected by my source changes so that I update the right specs before review.
+- As a reviewer, I want export deltas (new/removed symbols vs. the spec) per affected spec so that I can spot undocumented or stale API surface.
+- As a CI operator, I want the diff to auto-detect the PR base branch and emit Markdown/JSON so that I can post drift reports without configuring a base ref by hand.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_diff` lists every spec whose `files:` frontmatter references a file changed since the base ref, plus specs whose own `.spec.md` file changed.
+- For each affected spec, computes `new_exports` (exported symbols not documented in the spec body) and `removed_exports` (spec-documented symbols no longer exported).
+- When `base == "HEAD"` and running inside a GitHub Actions `pull_request`/`pull_request_target` event with `GITHUB_BASE_REF` set, compares against `origin/<base_ref>` instead of `HEAD`.
+- Supports JSON, Markdown/Github, and Text/Table/Csv output formats; empty changesets render a "no changes" message per format.
+- When no specs are affected, the Text format lists changed source files not covered by any spec (filtered by `config.source_extensions`).
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Invokes `git diff --name-only --end-of-options <base>`; `--end-of-options` guards against a base ref that begins with `-` being parsed as a git flag (argument injection).
+- Must not panic on missing/unreadable spec files or unparseable frontmatter — such specs are skipped.
+- Exits with code 1 only when the `git` process itself fails to spawn.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Computing line-level diffs or rendering patch hunks (only changed-file names and export deltas).
+- Fetching exports from the base revision via `git show` (deltas compare current exports against spec-documented symbols, not against the base tree).
+- Interactive prompts, GUI, or web output.

--- a/specs/cmd_diff/tasks.md
+++ b/specs/cmd_diff/tasks.md
@@ -4,16 +4,16 @@ spec: cmd_diff.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add a fixture that exercises the `--end-of-options` guard (base ref starting with `-`).
+- [ ] Add a fixture for GitHub Actions PR auto-detection (`GITHUB_EVENT_NAME=pull_request` + `GITHUB_BASE_REF`).
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] `cmd_diff` implemented: cross-references `git diff --name-only` with spec `files:` lists and computes export deltas.
+- [x] Hardened git invocation with `--end-of-options` to prevent argument injection from a `-`-prefixed base ref.
+- [x] PR base auto-detection via `GITHUB_BASE_REF` when base is the default `HEAD`.
+- [x] Detection of spec-file-only changes (`spec_modified` flag).
+- [x] Integration coverage: `diff_shows_changes_since_base_ref`, `diff_no_changes_returns_empty`, `diff_detects_removed_exports`, `diff_human_readable_output`, `diff_detects_spec_file_only_changes`.
 
 ## Review Sign-offs
 

--- a/specs/cmd_diff/testing.md
+++ b/specs/cmd_diff/testing.md
@@ -6,31 +6,36 @@ spec: cmd_diff.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/diff.rs` | cargo test commands::diff | No inline tests found; add focused coverage for `cmd_diff`, `load_and_discover`, `get_exported_symbols`, `print_diff_markdown` before risky changes |
-| `tests/integration.rs` | cargo test --test integration diff_shows_changes_since_base_ref | End-to-end fixture: `diff_shows_changes_since_base_ref` |
-| `tests/integration.rs` | cargo test --test integration diff_no_changes_returns_empty | End-to-end fixture: `diff_no_changes_returns_empty` |
-| `tests/integration.rs` | cargo test --test integration diff_detects_removed_exports | End-to-end fixture: `diff_detects_removed_exports` |
-| `tests/integration.rs` | cargo test --test integration diff_human_readable_output | End-to-end fixture: `diff_human_readable_output` |
-| `tests/integration.rs` | cargo test --test integration diff_detects_spec_file_only_changes | End-to-end fixture: `diff_detects_spec_file_only_changes` |
+| `src/commands/diff.rs` | cargo test --test integration diff_ | No inline `#[cfg(test)]` module in `diff.rs`; behavior is covered end-to-end. Add inline coverage for `detect_pr_base` and the `--end-of-options` guard before risky changes. |
+| `tests/integration.rs` | cargo test --test integration diff_shows_changes_since_base_ref | Staged new export `logout` appears in `changes[0].new_exports` (JSON output). |
+| `tests/integration.rs` | cargo test --test integration diff_no_changes_returns_empty | Clean tree against `HEAD` yields `{"changes":[]}`. |
+| `tests/integration.rs` | cargo test --test integration diff_detects_removed_exports | Removed export `logout` (still in spec) appears in `changes[0].removed_exports`. |
+| `tests/integration.rs` | cargo test --test integration diff_human_readable_output | Default Text format prints the `auth` spec and new export `signup`. |
+| `tests/integration.rs` | cargo test --test integration diff_detects_spec_file_only_changes | Spec-only edit reports one change with `spec_modified == true` and empty `changed_files`. |
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| New export added | `src/auth.rs` added `pub fn verify_token()` since HEAD | `cmd_diff --base HEAD~1` runs | shows `auth` spec with "Added: `verify_token`" |
-| No spec-tracked changes | only non-source files changed (e.g., README.md) | `cmd_diff` runs | prints "No spec-tracked source files changed since `{base}`." |
+| New export added | `src/auth/service.ts` gains `export function signup()` after the base commit | `specsync diff --base HEAD` (Text) | Prints the `auth` spec and `+ New exports (not in spec): signup`. |
+| New export added (JSON) | same as above | `specsync diff --base HEAD --json` | `changes[0].new_exports` contains the new symbol. |
+| Spec-only change | only the `.spec.md` is edited; no tracked source files change | `specsync diff --base HEAD --json` | One entry with `spec_modified: true` and empty `changed_files`. |
+| No changes | nothing changed since base | `specsync diff` | JSON: `{"changes":[]}`; Markdown: "No files changed since `<base>`."; Text: "No files changed since <base>". |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| `git diff` fails (bad ref) | Exits with code 1 | Keep or add a focused assertion before changing this behavior |
-| Changed file not in any spec | Listed under "Changed files not covered by any spec" | Keep or add a focused assertion before changing this behavior |
+| `git` fails to spawn | Prints "Failed to run git diff" to stderr and exits 1 | Keep; not currently asserted by a fixture — add before changing the spawn-error path. |
+| Bad/unknown base ref | `git diff` exits non-zero with empty stdout; command treats it as "no changes" (status is not inspected) | Document accurately; add a fixture before adding hard-failure semantics. |
+| Base ref starting with `-` | Parsed as a revision via `--end-of-options`, never as a git flag | Add a fixture before touching the `git diff` argument list. |
+| Changed source file not in any spec (Text format) | Listed under "Changed files not covered by any spec" when no specs matched | Keep or add a focused assertion before changing this behavior. |
+| PR context (`pull_request` + `GITHUB_BASE_REF`) and default `HEAD` base | Compares against `origin/<base_ref>` and logs the detection to stderr | Add a fixture that sets the env vars before changing `detect_pr_base`. |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- diff --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/diff.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo run -- diff --help` and confirm the help text still names the documented flags (`--base`, `--format`/`--json`).
+- Run `cargo test --test integration diff_` before the full suite when changing `src/commands/diff.rs`.
+- Reproduce one Behavioral Verification row with a temporary git fixture before changing user-visible output strings.
+- If an output or error message changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_generate/context.md
+++ b/specs/cmd_generate/context.md
@@ -4,17 +4,25 @@ spec: cmd_generate.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- **Command pattern**: load config + discover specs (`load_and_discover`), compute coverage, resolve a provider, delegate scaffolding to `generator::generate_specs_for_unspecced_modules(_paths)`, recompute coverage/validation, format output, and exit via `exit_with_status`.
+- **Config triggers AI (4.4.0)**: `resolve_provider_for_generate` returns AI mode when a provider is configured *anywhere* — the `--provider` flag, `aiProvider`/`aiCommand` config, or `SPECSYNC_AI_PROVIDER`/`SPECSYNC_AI_COMMAND` env. Previously a configured provider silently fell back to templates unless `--provider` was repeated; that gate is now fixed.
+- **`--provider auto` is special-cased**: `Some("auto")` is mapped to `None` so the auto-detect ladder runs even when a provider is configured; any other explicit name overrides config; an absent flag falls through to config/env/auto. Actual auto-detect (keyless local Ollama → single key → multi-key prompt/deterministic order) lives in `ai::resolve_ai_provider`.
+- **Model precedence inline**: the config is cloned and `ai_model` is overridden as `--model` > `SPECSYNC_AI_MODEL` env > existing `aiModel` config before calling `ai::resolve_ai_provider`.
+- **Fail fast vs. fall back**: provider *resolution* failure (unknown provider, missing key) prints the error and `process::exit(1)`; per-module AI *generation* failure falls back to the template and continues.
+- **JSON mode short-circuits**: `--format json` builds the generated-paths object and exits 0 without the human-readable coverage/validation report.
 
 ## Files to Read First
 
-- `src/commands/generate.rs` — primary source file
+- `src/commands/generate.rs` — primary source file: `cmd_generate`, `cmd_generate_all`, `cmd_generate_batch`, and the `resolve_provider_for_generate` precedence helper.
+- `src/ai.rs` — `resolve_ai_provider`, `ResolvedProvider`, the auto-detect ladder, and `<PROVIDER>_API_KEY`/env precedence this command relies on.
+- `src/cli.rs` (`Generate` variant) — the `provider`, `model`, `uncovered`, `batch` flag definitions and help text.
+- `src/generator.rs` — `generate_specs_for_unspecced_modules(_paths)` that actually writes the spec files.
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented for spec-sync 4.4.0. Aligned with the reworked corvid-ai providers: AI mode is gated by configured provider (flag/config/env), `--model` is supported, and 12-factor flag > env > config precedence holds. Template-only generation remains the zero-config default.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This module is part of the command layer — it orchestrates library modules (`ai`, `generator`, `validator`, `output`) rather than containing domain logic.
+- There are no inline `#[cfg(test)]` tests here; behavior is verified through `tests/integration.rs`.

--- a/specs/cmd_generate/requirements.md
+++ b/specs/cmd_generate/requirements.md
@@ -4,21 +4,37 @@ spec: cmd_generate.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_generate` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want `specsync generate` to scaffold spec files for unspecced modules so that I can reach coverage quickly
+- As a developer with an AI provider configured, I want `generate` to use AI automatically — without re-passing `--provider` — so that a configured provider "just works"
+- As a developer, I want `--provider auto` to force fresh auto-detection even when a provider is configured so that I can override config on the fly
+- As a developer, I want `--model` to override the configured/env model for a single run so that I can experiment without editing config
+- As a developer, I want a template-only fallback when no provider is configured anywhere so that `generate` still works with zero AI setup
+- As a developer, I want `--batch mod1,mod2` to generate only specific modules so that I can target a subset
+- As a CI operator, I want `--format json` machine-readable output and meaningful exit codes so that pipeline steps are actionable
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- AI mode is entered when a provider is configured anywhere: the `--provider` flag, `aiProvider`/`aiCommand` in config, or the `SPECSYNC_AI_PROVIDER`/`SPECSYNC_AI_COMMAND` env vars (`resolve_provider_for_generate` gates on exactly these). Repeating `--provider` is no longer required.
+- With nothing configured anywhere → template-only generation (no AI call).
+- `--provider auto` ignores the configured provider and forces the auto-detect ladder; an explicit `--provider <name>` overrides config; an absent flag falls through to config/env/auto.
+- Model precedence is `--model` > `SPECSYNC_AI_MODEL` env > `aiModel` config > corvid-ai default, applied by cloning the config and overriding `ai_model` before resolution.
+- The header prints "Generating Specs (AI)" when a provider resolved, else "Generating Specs".
+- `--batch` expands comma-separated and space-separated entries; modules already specced are skipped, modules absent from the coverage report are reported as not-found.
+- `--uncovered` is accepted but behaves identically to the default (generate for all unspecced modules).
+- `--format json` prints a `{ "generated": [...] }` object (batch mode also includes `requested`, `skipped_already_specced`, `skipped_not_found`) and exits 0 without the human-readable report.
+- After generation, coverage and validation are recomputed so the summary reflects the new specs.
+- If AI provider resolution fails (unknown provider, missing API key), the process prints the error and exits 1.
+- If AI generation fails for an individual module, generation falls back to template and continues (does not abort the run).
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — print the error and exit, or fall back to templates
+- Must work with the project's Clap-based CLI argument parsing (`Generate { provider, model, uncovered, batch }`)
+- Provider/model resolution must follow 12-factor precedence (flag > env > config), delegating to `ai::resolve_ai_provider`
 
 ## Out of Scope
 
 - GUI or web interface
-- Interactive prompts (except wizard module)
+- Interactive prompts here (the multi-key auto-detect TTY prompt lives in the `ai` module, not `cmd_generate`)
+- Defining the AI providers themselves (owned by the `ai`/corvid-ai layer)
+- Editing or refining specs after scaffolding (that is `score`/`refine`/validation territory)

--- a/specs/cmd_generate/tasks.md
+++ b/specs/cmd_generate/tasks.md
@@ -4,16 +4,27 @@ spec: cmd_generate.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add a focused integration test asserting `--model` reaches the resolved provider (currently only provider resolution is covered end-to-end)
+- [ ] Add a `--format json` batch-mode test asserting the `requested`/`skipped_already_specced`/`skipped_not_found` shape
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
+- [x] `--model` flag added (overrides `SPECSYNC_AI_MODEL` env and `aiModel` config)
+- [x] Config-triggers-AI gate fix — `resolve_provider_for_generate` enters AI mode from `aiProvider`/`aiCommand` config or `SPECSYNC_AI_PROVIDER`/`SPECSYNC_AI_COMMAND` env, no longer requiring `--provider` (regression: `config_ai_provider_triggers_ai_without_provider_flag`)
+- [x] 12-factor env precedence — `SPECSYNC_AI_PROVIDER` outranks configured `aiProvider` (`env_provider_overrides_config_provider`)
+- [x] `--provider auto` forces auto-detect even when a provider is configured
+- [x] Model precedence wired: `--model` > `SPECSYNC_AI_MODEL` env > `aiModel` config
+- [x] `--batch` mode with comma/space expansion, already-specced and not-found reporting
+- [x] `--uncovered` accepted as an explicit alias of default behavior
+- [x] `--format json` output for both default and batch modes; coverage/validation recomputed post-generation
+- [x] Integration coverage for provider resolution (`provider_flag_unknown_provider_errors`, `cli_provider_overrides_config_provider`, `ai_command_overrides_ai_provider`, `auto_detect_defaults_to_local_ollama_without_keys`, etc.)
 
 ## Gaps
 
-- No dedicated test file for this command module
+- No `#[cfg(test)]` unit tests inside `generate.rs`; provider-resolution behavior is exercised only via `tests/integration.rs`
+- `--model` propagation into the AI call is not yet asserted by a dedicated end-to-end test
 
 ## Review Sign-offs
 

--- a/specs/cmd_generate/testing.md
+++ b/specs/cmd_generate/testing.md
@@ -4,35 +4,52 @@ spec: cmd_generate.spec.md
 
 ## Automated Coverage
 
+`src/commands/generate.rs` has no inline `#[cfg(test)]` tests; coverage is end-to-end via `tests/integration.rs`. Provider-resolution semantics also have deterministic unit tests in `src/ai.rs` (e.g. `ollama_is_an_api_provider`, `ollama_resolves_keyless`).
+
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/generate.rs` | cargo test commands::generate | No inline tests found; add focused coverage for `cmd_generate`, `generate_spec_template`, `IgnoreRules::load`, `compute_coverage` before risky changes |
-| `tests/integration.rs` | cargo test --test integration generate_creates_spec_for_unspecced_module | End-to-end fixture: `generate_creates_spec_for_unspecced_module` |
-| `tests/integration.rs` | cargo test --test integration generate_no_op_when_fully_covered | End-to-end fixture: `generate_no_op_when_fully_covered` |
-| `tests/integration.rs` | cargo test --test integration generate_with_multiple_languages | End-to-end fixture: `generate_with_multiple_languages` |
-| `tests/integration.rs` | cargo test --test integration generate_uncovered_flag_accepted | End-to-end fixture: `generate_uncovered_flag_accepted` |
-| `tests/integration.rs` | cargo test --test integration generate_batch_empty_list_skips_gracefully | End-to-end fixture: `generate_batch_empty_list_skips_gracefully` |
-| `tests/integration.rs` | cargo test --test integration generate_creates_companion_files | End-to-end fixture: `generate_creates_companion_files` |
-| `tests/integration.rs` | cargo test --test integration generate_creates_design_md_when_enabled | End-to-end fixture: `generate_creates_design_md_when_enabled` |
+| Scaffolding (templates) | cargo test --test integration generate_creates_spec_for_unspecced_module | `generate_creates_spec_for_unspecced_module` |
+| No-op when covered | cargo test --test integration generate_no_op_when_fully_covered | `generate_no_op_when_fully_covered` |
+| Multi-language | cargo test --test integration generate_with_multiple_languages | `generate_with_multiple_languages` |
+| `--uncovered` alias | cargo test --test integration generate_uncovered_flag_accepted | `generate_uncovered_flag_accepted` |
+| `--batch` empty list | cargo test --test integration generate_batch_empty_list_skips_gracefully | `generate_batch_empty_list_skips_gracefully` |
+| Companion files | cargo test --test integration generate_creates_companion_files | `generate_creates_companion_files` |
+| design.md when enabled | cargo test --test integration generate_creates_design_md_when_enabled | `generate_creates_design_md_when_enabled` |
+| Unknown provider errors | cargo test --test integration provider_flag_unknown_provider_errors | `provider_flag_unknown_provider_errors` (stderr "Unknown provider", exit 1) |
+| `--provider` enables AI | cargo test --test integration provider_flag_enables_ai | `provider_flag_enables_ai` |
+| Config triggers AI | cargo test --test integration config_ai_provider_triggers_ai_without_provider_flag | `config_ai_provider_triggers_ai_without_provider_flag` (no flag, fails on missing `ANTHROPIC_API_KEY`) |
+| Env > config precedence | cargo test --test integration env_provider_overrides_config_provider | `env_provider_overrides_config_provider` (`SPECSYNC_AI_PROVIDER` outranks `aiProvider`) |
+| Flag > config precedence | cargo test --test integration cli_provider_overrides_config_provider | `cli_provider_overrides_config_provider` |
+| `aiCommand` > `aiProvider` | cargo test --test integration ai_command_overrides_ai_provider | `ai_command_overrides_ai_provider` (falls back to template, stderr shows AI attempted) |
+| `--provider auto` honors config | cargo test --test integration ai_provider_config_field_is_respected | `ai_provider_config_field_is_respected` |
+| Keyless auto-detect → Ollama | cargo test --test integration auto_detect_defaults_to_local_ollama_without_keys | `auto_detect_defaults_to_local_ollama_without_keys` |
+| API key required | cargo test --test integration anthropic_provider_requires_api_key | `anthropic_provider_requires_api_key`, `openai_provider_requires_api_key` |
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| AI-assisted generation | `--provider claude` set, 3 unspecced modules | `cmd_generate` runs | generates 3 AI-populated specs |
+| Template-only default | no provider configured anywhere, 1 unspecced module | `specsync generate` | header "Generating Specs", template spec written, no AI call |
+| Config-triggered AI | `aiProvider: "anthropic"` in `specsync.json`, no `--provider`, `ANTHROPIC_API_KEY` unset | `specsync generate` | AI mode selected; fails fast on missing key (exit 1, stderr names `ANTHROPIC_API_KEY`) |
+| Env overrides config | config `aiProvider: "ollama"`, env `SPECSYNC_AI_PROVIDER=anthropic`, no key | `specsync generate` | resolves anthropic (env wins), fails on missing `ANTHROPIC_API_KEY` |
+| `--provider auto` | config sets an installed-only/cursor provider | `specsync generate --provider auto` | auto-detect path runs (does not silently ignore the configured intent) |
+| Batch subset | modules `a` (specced), `b` (unspecced), `c` (absent) | `specsync generate --batch a,b,c` | generates `b`; reports `a` skipped-already-specced, `c` not-found |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| AI provider not found | Exits 1 | Keep or add a focused assertion before changing this behavior |
-| AI fails for one module | Error printed, continues | Keep or add a focused assertion before changing this behavior |
-| All modules already specced | Prints "all covered" | Keep or add a focused assertion before changing this behavior |
+| Unknown provider | Prints error, exits 1 | `provider_flag_unknown_provider_errors` |
+| Configured provider, no flag | Enters AI mode (not template-only) | `config_ai_provider_triggers_ai_without_provider_flag` |
+| `SPECSYNC_AI_PROVIDER` vs config | Env wins | `env_provider_overrides_config_provider` |
+| AI fails for one module | Falls back to template, continues | `ai_command_overrides_ai_provider` |
+| No provider anywhere | Template-only generation | `generate_creates_spec_for_unspecced_module` |
+| All modules already specced | No specs generated, full-coverage line shown | `generate_no_op_when_fully_covered` |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- generate --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/generate.rs`.
+- Run `cargo run -- generate --help` and confirm it still names `--provider`, `--model`, `--uncovered`, `--batch` with current help text.
+- When touching `resolve_provider_for_generate`, re-run the precedence trio: `config_ai_provider_triggers_ai_without_provider_flag`, `env_provider_overrides_config_provider`, `cli_provider_overrides_config_provider`.
 - Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
 - If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_hooks/context.md
+++ b/specs/cmd_hooks/context.md
@@ -4,17 +4,21 @@ spec: cmd_hooks.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- The command is a pure dispatcher. Unlike most commands it does **not** load config or discover specs — it only translates CLI flags into `hooks::HookTarget` values and forwards to the `hooks` library module.
+- "No flags means all targets" is encoded by returning an empty `Vec<HookTarget>` from `collect_hook_targets`; the convention is interpreted downstream in the `hooks` module, not here.
+- Install and uninstall share the exact same flag-collection helper, guaranteeing symmetric target selection.
 
 ## Files to Read First
 
-- `src/commands/hooks.rs` — primary source file
+- `src/commands/hooks.rs` — the dispatcher and `collect_hook_targets`.
+- `src/hooks.rs` — `cmd_install`, `cmd_uninstall`, `cmd_status`, the `HookTarget` enum, and all file/IO logic.
+- `src/cli.rs` (`HooksAction`) — the flag definitions (`--claude`, `--cursor`, `--copilot`, `--agents`, `--precommit`, `--claude-code-hook`).
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. No tests target this file directly; behavior is validated through the `hooks` module.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Targets map to: `Claude` (CLAUDE.md), `Cursor` (.cursorrules), `Copilot` (.github/copilot-instructions.md), `Agents` (AGENTS.md), `Precommit` (git pre-commit hook), `ClaudeCodeHook` (Claude Code settings.json hook).
+- Part of the command layer — orchestrates a library module rather than containing domain logic.

--- a/specs/cmd_hooks/requirements.md
+++ b/specs/cmd_hooks/requirements.md
@@ -4,21 +4,25 @@ spec: cmd_hooks.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_hooks` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want to install spec-sync agent instructions and a git pre-commit hook with one command so that drift is caught before commit and AI agents know the spec conventions.
+- As a developer who only uses one agent, I want to select specific targets (e.g. `--claude --precommit`) so that I don't install files for tools I don't use.
+- As a developer, I want a `status` subcommand so that I can see which hooks/instructions are currently installed.
+- As a developer, I want to cleanly uninstall what I installed so that I can remove spec-sync's footprint.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_hooks` dispatches `Install`, `Uninstall`, and `Status` actions to `hooks::cmd_install`, `hooks::cmd_uninstall`, and `hooks::cmd_status` respectively.
+- Boolean flags `claude`, `cursor`, `copilot`, `agents`, `precommit`, `claude_code_hook` map one-to-one to `hooks::HookTarget` variants in `collect_hook_targets`.
+- When no target flags are set, the collected target vec is empty, which the `hooks` module interprets as "all targets".
+- The same flag-to-target mapping is used for both install and uninstall.
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- This module is a thin dispatcher: it performs no I/O itself and contains no domain logic — all file writes and status reporting live in the `hooks` library module.
+- Must not panic; actual error handling (write failures) is delegated to the `hooks` module.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- The content of generated instruction files and the pre-commit hook script (owned by `hooks`).
+- Validating that the selected agent tooling is actually installed on the machine.
+- Interactive prompts, GUI, or web output.

--- a/specs/cmd_hooks/tasks.md
+++ b/specs/cmd_hooks/tasks.md
@@ -4,16 +4,17 @@ spec: cmd_hooks.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add integration tests covering `hooks install`/`uninstall`/`status` CLI behavior (currently no fixtures exist for this command).
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] `cmd_hooks` dispatcher implemented for `Install`, `Uninstall`, and `Status`.
+- [x] `collect_hook_targets` maps the six boolean flags (claude, cursor, copilot, agents, precommit, claude_code_hook) to `hooks::HookTarget` variants.
+- [x] Empty-target-vec convention ("install/uninstall all") wired through to the `hooks` module.
 
 ## Gaps
 
-- No dedicated test file for this command module
+- No integration or inline unit tests target `src/commands/hooks.rs`. The behavior is exercised only indirectly via the `hooks` library module's own tests.
 
 ## Review Sign-offs
 

--- a/specs/cmd_hooks/testing.md
+++ b/specs/cmd_hooks/testing.md
@@ -6,28 +6,33 @@ spec: cmd_hooks.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/hooks.rs` | cargo test commands::hooks | No inline tests found; add focused coverage for `cmd_hooks` before risky changes |
+| `src/commands/hooks.rs` | (none) | No inline `#[cfg(test)]` module and no integration fixtures target this dispatcher. Coverage is indirect via the `hooks` module. |
+| `src/hooks.rs` | cargo test hooks | The `hooks` library module owns install/uninstall/status tests; verify target-to-file mapping there. |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Install specific hooks" before changing user-visible CLI output, generated files, or error handling in cmd_hooks.
+- No fixture exercises the flag-to-`HookTarget` mapping in `collect_hook_targets`. Add a `hooks install --claude --precommit` integration test that asserts only `CLAUDE.md` and the pre-commit hook are written, and that other targets are absent, before changing the mapping.
+- No fixture asserts the "no flags → all targets" empty-vec convention.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Install specific hooks | `specsync hooks install --claude --precommit` | `cmd_hooks` runs | installs only CLAUDE.md and pre-commit hook |
+| Install specific targets | empty temp project | `specsync hooks install --claude --precommit` | Only `CLAUDE.md` and the git pre-commit hook are installed. |
+| Install all (no flags) | empty temp project | `specsync hooks install` | All targets installed (empty target vec → all). |
+| Status | project with some hooks installed | `specsync hooks status` | Reports installed/not-installed for each target. |
+| Uninstall specific targets | project with hooks installed | `specsync hooks uninstall --claude` | Removes only the CLAUDE.md instructions. |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Hook write fails | Delegated to hooks module | Keep or add a focused assertion before changing this behavior |
+| No target flags on install/uninstall | Empty target vec is passed and treated as "all targets" by `hooks` | Keep; assert via a fixture before changing the empty-vec convention. |
+| Hook write fails | Error reporting is delegated to the `hooks` module | Cover in `hooks` module tests, not here. |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- hooks --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/hooks.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo run -- hooks --help` and confirm the documented flags (`--claude`, `--cursor`, `--copilot`, `--agents`, `--precommit`, `--claude-code-hook`) are present.
+- When changing `collect_hook_targets`, add or update a fixture that asserts the resulting `HookTarget` set.
+- For changes to generated file content or write behavior, run the `hooks` module's tests — that is where the I/O lives.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_import/context.md
+++ b/specs/cmd_import/context.md
@@ -4,17 +4,25 @@ spec: cmd_import.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- `cmd_import` is a router. It inspects its flags first: `--all-issues` and `--from-dir` short-circuit to batch handlers (`cmd_import_all_issues`, `cmd_import_from_dir`) before the single-import path requires `source` + `id`.
+- Single import fails hard (`process::exit(1)`) on any problem; batch modes are resilient — each item that errors increments a counter and the loop continues, ending with a `BatchStats` summary.
+- Repo resolution order is identical for single and batch GitHub imports: `--repo` flag → `config.github.repo` → `github::detect_repo(root)`.
+- Markdown directory items are mapped to `ImportSource::Confluence` as the closest semantic match for a generic "doc", and the module name is derived from the filename via `importer::slugify`.
+- Companion generation always runs after a successful spec write; `design.md` is gated on `config.companions.design`.
 
 ## Files to Read First
 
-- `src/commands/import.rs` — primary source file
+- `src/commands/import.rs` — the router plus `cmd_import_single`, `cmd_import_all_issues`, `cmd_import_from_dir`, and the Markdown parsing helpers.
+- `src/importer.rs` — `import_github_issue` / `import_jira_issue` / `import_confluence_page`, `render_spec`, `ImportedItem`, `slugify`, `extract_requirements_pub`.
+- `src/github.rs` — `detect_repo`, `list_issues`.
+- `src/generator.rs` — `generate_companion_files_for_spec`.
+- `src/config.rs` — `load_config`, `companions.design`.
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. Directory-import and the no-args error path are covered by integration tests; remote GitHub/Jira/Confluence fetches are not exercised in CI (network/mocking required).
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Spec frontmatter in `cmd_import.spec.md` documents the original 4-argument single-import signature; the live signature is 7 arguments to accommodate the `--all-issues`/`--label`/`--from-dir` batch modes. The spec is the scored reference; this companion reflects the current code.
+- Part of the command layer — orchestrates importer/github/generator modules rather than containing domain logic.

--- a/specs/cmd_import/requirements.md
+++ b/specs/cmd_import/requirements.md
@@ -4,21 +4,29 @@ spec: cmd_import.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_import` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want to turn a GitHub/Jira/Confluence item into a spec draft with companions so that I can start specs from existing tracking artifacts instead of from scratch.
+- As a maintainer onboarding a repo, I want to batch-import all open GitHub issues (optionally filtered by label) so that I can seed specs for the whole backlog in one pass.
+- As a writer with a folder of design docs, I want to batch-import a directory of Markdown files so that each doc becomes a spec draft.
+- As a developer, I want the import to tell me to validate and complete the imported details (not fill template markers) so that the next step is clear.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_import` routes to one of three modes: single import (`source` + `id`), batch issues (`--all-issues`), or batch directory (`--from-dir <dir>`).
+- Single import supports sources `github`/`gh`, `jira`, and `confluence`/`wiki`; an unknown source exits 1 with the supported list.
+- GitHub repo is resolved from `--repo`, then `github.repo` in config, then `github::detect_repo(root)`; if none resolve, exits 1.
+- Each created spec lives at `<specsDir>/<module>/<module>.spec.md` and is never overwritten — an existing spec causes exit 1 (single) or a skip (batch).
+- After writing a spec, companions are generated via `generator::generate_companion_files_for_spec` with `companions.design` from config controlling whether `design.md` is created.
+- Batch modes print a `[n/total]` progress line per item and a final summary of imported/skipped/error counts; directory mode scans `.md` files one level deep, sorted.
+- Markdown directory items derive: title from the first `# ` heading (else filename), purpose from the first non-empty paragraph after the title, requirements via `importer::extract_requirements_pub`, and module name via `importer::slugify(filename)`.
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- GitHub issue `id` must parse as `u64`; a non-numeric id exits 1 (single import).
+- Must not panic on unreadable files or fetch failures: single import exits 1; batch modes count the failure and continue.
+- Directory scan is non-recursive (one level deep).
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Two-way sync back to the external system; this is a one-shot import.
+- Filling in the full spec body — imported specs are drafts to be completed and validated with `specsync check`.
+- Recursive directory traversal and non-Markdown source files.

--- a/specs/cmd_import/tasks.md
+++ b/specs/cmd_import/tasks.md
@@ -4,16 +4,17 @@ spec: cmd_import.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add integration coverage for single GitHub import (currently only the no-args error and `--from-dir` flows are tested; GitHub/Jira/Confluence paths require network or mocking).
+- [ ] Add a fixture asserting `companions.design` toggles `design.md` generation on import.
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] Single import for `github`/`gh`, `jira`, `confluence`/`wiki` with repo resolution (flag → config → `detect_repo`).
+- [x] Batch import of open GitHub issues (`--all-issues`, optional `--label`) with per-item progress and summary.
+- [x] Batch import of a Markdown directory (`--from-dir`), non-recursive, sorted, with title/purpose/requirements extraction.
+- [x] Companion generation wired to `companions.design` config flag.
+- [x] Success guidance updated to tell users to validate/complete imported details (not fill template markers).
+- [x] Integration coverage: `import_without_args_or_flags_shows_error`, `import_from_dir_imports_markdown_files`, `import_from_dir_skips_existing_specs`, `import_from_dir_nonexistent_directory_errors`.
 
 ## Review Sign-offs
 

--- a/specs/cmd_import/testing.md
+++ b/specs/cmd_import/testing.md
@@ -6,30 +6,37 @@ spec: cmd_import.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/import.rs` | cargo test commands::import | No inline tests found; add focused coverage for `cmd_import`, `load_config`, `generate_companion_files`, `resolve_repo` before risky changes |
-| `tests/integration.rs` | cargo test --test integration import_without_args_or_flags_shows_error | End-to-end fixture: `import_without_args_or_flags_shows_error` |
-| `tests/integration.rs` | cargo test --test integration import_from_dir_imports_markdown_files | End-to-end fixture: `import_from_dir_imports_markdown_files` |
-| `tests/integration.rs` | cargo test --test integration import_from_dir_skips_existing_specs | End-to-end fixture: `import_from_dir_skips_existing_specs` |
-| `tests/integration.rs` | cargo test --test integration import_from_dir_nonexistent_directory_errors | End-to-end fixture: `import_from_dir_nonexistent_directory_errors` |
+| `src/commands/import.rs` | cargo test --test integration import_ | No inline `#[cfg(test)]` module. Directory-import + no-args paths are covered end-to-end; GitHub/Jira/Confluence fetches are not (network/mocking required). |
+| `tests/integration.rs` | cargo test --test integration import_without_args_or_flags_shows_error | Missing source/id with no batch flag fails with "SOURCE is required". |
+| `tests/integration.rs` | cargo test --test integration import_from_dir_imports_markdown_files | `--from-dir docs` prints "Batch Import" and reports 1 imported for one `.md` file. |
+| `tests/integration.rs` | cargo test --test integration import_from_dir_skips_existing_specs | A pre-existing `my-feature` spec causes the same-named doc to be skipped. |
+| `tests/integration.rs` | cargo test --test integration import_from_dir_nonexistent_directory_errors | `--from-dir nonexistent-dir` fails with "Directory not found". |
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Import GitHub issue | `specsync import github 42` | `cmd_import` runs | fetches issue #42, creates spec from its title and body |
+| Single GitHub import | repo resolvable, issue exists | `specsync import github 42` | Fetches issue #42, writes `specs/<module>/<module>.spec.md` + companions, prints "Imported:" and a `specsync check` tip. |
+| Unknown source | any | `specsync import slack 7` | Exits 1: "Unknown source 'slack'. Supported: github, jira, confluence". |
+| Batch issues | repo resolvable | `specsync import --all-issues --label bug` | Prints "Batch Import: GitHub Issues", per-issue `[n/total]` lines, and an imported/skipped/error summary. |
+| Batch directory | `docs/*.md` present | `specsync import --from-dir docs` | One spec per Markdown file (one level deep, sorted), existing specs skipped. |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Invalid source type | Exits 1 with supported list | Keep or add a focused assertion before changing this behavior |
-| Spec already exists | Exits 1 | Keep or add a focused assertion before changing this behavior |
-| Fetch fails | Exits 1 with error | Keep or add a focused assertion before changing this behavior |
+| Missing source/id, no batch flag | Exits 1 with "SOURCE is required" guidance | Covered by `import_without_args_or_flags_shows_error`. |
+| Unknown source type | Exits 1 with the supported-source list | Keep; add a focused assertion before changing the message. |
+| Non-numeric GitHub issue id | Exits 1 with "Invalid issue number" | Add a fixture before changing id parsing. |
+| Spec already exists (single) | Exits 1 | Add a focused assertion before changing this behavior. |
+| Spec already exists (batch) | Skipped, counted, loop continues | Covered by `import_from_dir_skips_existing_specs`. |
+| `--from-dir` missing directory | Exits 1 with "Directory not found" | Covered by `import_from_dir_nonexistent_directory_errors`. |
+| Fetch fails (single) | Exits 1 with the upstream error | Add a fixture/mocked path before changing error handling. |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- import --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/import.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo run -- import --help` and confirm `--repo`, `--all-issues`, `--label`, and `--from-dir` are present.
+- Run `cargo test --test integration import_` before the full suite when changing `src/commands/import.rs`.
+- Reproduce one Behavioral Verification row with a temp project before changing user-visible output (progress lines, summary, tips).
+- If an error message changes, update the matching Regression Matrix row and assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_init/context.md
+++ b/specs/cmd_init/context.md
@@ -4,17 +4,22 @@ spec: cmd_init.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Both `specsync.json` and `.specsync.toml` are checked before writing; either one means "already initialized" and init no-ops. This avoids clobbering a TOML-configured project.
+- The default config is built as a `serde_json::Value` and pretty-printed with a trailing newline, so the on-disk file is stable and diff-friendly.
+- `ensure_hashes_gitignored` returns `Result<bool, String>` (not `io::Error`) so the caller can print a plain warning; the io error is mapped to a "Failed to update .gitignore" string. A `.gitignore` write failure is intentionally **non-fatal** — the config is already written and the cache being un-ignored is a minor issue.
+- Only the repository-root `.gitignore` is edited (a `# spec-sync hash cache` comment plus the `.specsync/hashes.json` entry). The spec's mention of a `.specsync/.gitignore` does not match the implementation.
 
 ## Files to Read First
 
-- `src/commands/init.rs` — primary source file
+- `src/commands/init.rs` — `cmd_init`, `ensure_hashes_gitignored`, and the three inline unit tests.
+- `src/config.rs` — `detect_source_dirs` (the auto-detection logic exercised heavily by integration tests).
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. Strong coverage: three inline unit tests on the gitignore helper plus several integration tests on config creation and source-dir detection.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- `ensure_hashes_gitignored` is `pub`, so it is callable outside `cmd_init` (e.g. rehash flows) and is unit-tested directly.
+- The spec frontmatter documents the helper's return type as `Result<bool, std::io::Error>`; the live signature is `Result<bool, String>`. The spec is the scored reference; this companion tracks the code.
+- Part of the command layer — orchestrates `config::detect_source_dirs` rather than containing domain logic.

--- a/specs/cmd_init/requirements.md
+++ b/specs/cmd_init/requirements.md
@@ -4,21 +4,26 @@ spec: cmd_init.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_init` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer adopting spec-sync, I want `specsync init` to create a ready-to-use `specsync.json` with my source directories already detected so that I can start validating specs immediately.
+- As a developer, I want init to be safe to re-run so that it never clobbers an existing config.
+- As a developer, I want the local-only hash cache to be gitignored automatically so that I don't accidentally commit `.specsync/hashes.json`.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_init` writes `specsync.json` with `specsDir: "specs"`, auto-detected `sourceDirs` (via `config::detect_source_dirs`), a standard `requiredSections` list, and default `excludeDirs`/`excludePatterns`.
+- If either `specsync.json` or `.specsync.toml` already exists, init prints a message and returns without writing.
+- On success, init prints "Created specsync.json" and the detected source directories.
+- After writing the config, `ensure_hashes_gitignored` adds `.specsync/hashes.json` to the root `.gitignore` (with a comment header) unless it is already present; the result is reported as a success line, a no-op, or a warning.
+- `ensure_hashes_gitignored` is idempotent: re-running never duplicates the entry.
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- `ensure_hashes_gitignored(root) -> Result<bool, String>`: `Ok(true)` when the entry was added, `Ok(false)` when already present, `Err(String)` on write failure (the io error is mapped to a "Failed to update .gitignore: …" message).
+- A failure to write `.gitignore` is non-fatal — it is printed as a `warning:` and init still succeeds; a failure to write `specsync.json` is fatal (exit 1).
+- Must not panic on expected error conditions.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Editing a `.specsync/.gitignore` file (only the repository-root `.gitignore` is touched).
+- Creating the `specs/` directory or any spec files.
+- Interactive prompts, GUI, or web output.

--- a/specs/cmd_init/tasks.md
+++ b/specs/cmd_init/tasks.md
@@ -4,16 +4,15 @@ spec: cmd_init.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- (none open) — module is implemented and well covered.
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
-
-## Gaps
-
-- No dedicated test file for this command module
+- [x] `cmd_init` writes a default `specsync.json` with auto-detected `sourceDirs`.
+- [x] Refuses to overwrite an existing `specsync.json` or `.specsync.toml`.
+- [x] `ensure_hashes_gitignored` adds `.specsync/hashes.json` to root `.gitignore`, idempotently, with non-fatal warning on failure.
+- [x] Inline unit tests for `ensure_hashes_gitignored`: `adds_entry_to_missing_gitignore`, `is_idempotent_when_entry_already_present`, `errors_when_gitignore_path_is_unwritable`.
+- [x] Integration coverage for config creation, no-overwrite, and source-dir auto-detection (src/lib/multi/fallback/node_modules-ignore) plus the MCP `init` tool.
 
 ## Review Sign-offs
 

--- a/specs/cmd_init/testing.md
+++ b/specs/cmd_init/testing.md
@@ -6,34 +6,41 @@ spec: cmd_init.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/init.rs` | cargo test commands::init | No inline tests found; add focused coverage for `cmd_init`, `ensure_hashes_gitignored`, `detect_source_dirs` before risky changes |
-| `tests/integration.rs` | cargo test --test integration init_creates_config_file | End-to-end fixture: `init_creates_config_file` |
-| `tests/integration.rs` | cargo test --test integration init_does_not_overwrite_existing_config | End-to-end fixture: `init_does_not_overwrite_existing_config` |
-| `tests/integration.rs` | cargo test --test integration init_auto_detects_src_dir | End-to-end fixture: `init_auto_detects_src_dir` |
-| `tests/integration.rs` | cargo test --test integration init_auto_detects_lib_dir | End-to-end fixture: `init_auto_detects_lib_dir` |
-| `tests/integration.rs` | cargo test --test integration init_auto_detects_multiple_dirs | End-to-end fixture: `init_auto_detects_multiple_dirs` |
-| `tests/integration.rs` | cargo test --test integration init_ignores_node_modules_and_hidden_dirs | End-to-end fixture: `init_ignores_node_modules_and_hidden_dirs` |
-| `tests/integration.rs` | cargo test --test integration init_falls_back_to_src_when_no_source_files | End-to-end fixture: `init_falls_back_to_src_when_no_source_files` |
-| `tests/integration.rs` | cargo test --test integration mcp_tool_init_creates_config | End-to-end fixture: `mcp_tool_init_creates_config` |
+| `src/commands/init.rs` (inline) | cargo test --lib commands::init | `adds_entry_to_missing_gitignore` — creates `.gitignore` with the entry. |
+| `src/commands/init.rs` (inline) | cargo test --lib commands::init | `is_idempotent_when_entry_already_present` — entry count stays 1, content untouched. |
+| `src/commands/init.rs` (inline) | cargo test --lib commands::init | `errors_when_gitignore_path_is_unwritable` — `.gitignore` made a dir; returns `Err` containing "Failed to update .gitignore". |
+| `tests/integration.rs` | cargo test --test integration init_creates_config_file | Writes `specsync.json` containing `specsDir`/`sourceDirs`/`requiredSections`. |
+| `tests/integration.rs` | cargo test --test integration init_does_not_overwrite_existing_config | Existing `{"specsDir":"custom"}` is preserved; prints "already exists". |
+| `tests/integration.rs` | cargo test --test integration init_auto_detects_src_dir | `sourceDirs == ["src"]`. |
+| `tests/integration.rs` | cargo test --test integration init_auto_detects_lib_dir | `sourceDirs == ["lib"]`. |
+| `tests/integration.rs` | cargo test --test integration init_auto_detects_multiple_dirs | `sourceDirs == ["lib", "src"]` (sorted). |
+| `tests/integration.rs` | cargo test --test integration init_ignores_node_modules_and_hidden_dirs | Only `app` detected; `node_modules`/`.cache` ignored. |
+| `tests/integration.rs` | cargo test --test integration init_falls_back_to_src_when_no_source_files | Empty project falls back to `sourceDirs == ["src"]`. |
+| `tests/integration.rs` | cargo test --test integration mcp_tool_init_creates_config | MCP `init` tool creates the config file. |
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| First init | no `specsync.json` exists | `cmd_init(root)` runs | creates config with detected source dirs |
-| Config exists | `specsync.json` already exists | `cmd_init(root)` runs | prints message and returns without changes |
+| First init | empty temp project | `specsync init` | Writes `specsync.json` with detected dirs; prints "Created specsync.json" and the detected dirs. |
+| Config already exists | `specsync.json` present | `specsync init` | Prints "already exists" and leaves the file untouched. |
+| TOML config exists | `.specsync.toml` present | `specsync init` | Prints ".specsync.toml already exists" and no-ops. |
+| Missing `.gitignore` | no `.gitignore` | `specsync init` | Creates `.gitignore` and prints "Added .specsync/hashes.json to .gitignore". |
+| Entry already gitignored | `.gitignore` already lists the entry | `specsync init` | No duplicate appended (no extra line printed). |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| File write fails | Exits 1 | Keep or add a focused assertion before changing this behavior |
-| No source dirs detected | Creates config with empty `sourceDirs` | Keep or add a focused assertion before changing this behavior |
+| `specsync.json` write fails | Exits 1 | Add a focused assertion before changing the write path. |
+| `.gitignore` write fails | Non-fatal: prints a `warning:` and init still succeeds | Covered indirectly by `errors_when_gitignore_path_is_unwritable` on the helper. |
+| No source files present | Falls back to `sourceDirs == ["src"]` (not empty) | Covered by `init_falls_back_to_src_when_no_source_files`. |
+| Gitignore entry already present | Idempotent — no duplicate | Covered by `is_idempotent_when_entry_already_present`. |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- init --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/init.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo run -- init --help` and confirm the documented behavior is intact.
+- Run `cargo test --lib commands::init` and `cargo test --test integration init_` before the full suite when changing `src/commands/init.rs`.
+- Reproduce one Behavioral Verification row with a temp project before changing user-visible output.
+- If an error/warning message changes, update the matching Regression Matrix row and assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_init_registry/context.md
+++ b/specs/cmd_init_registry/context.md
@@ -4,17 +4,20 @@ spec: cmd_init_registry.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- The command is a thin wrapper around `registry::generate_registry`; all spec discovery and TOML rendering live in the `registry` module. This command only resolves the project name, guards against overwrite, and writes the file.
+- Project name defaults to the root directory's file name (`root.file_name()`), with `"project"` as a last-resort fallback, so the registry is usable even when run from an oddly-named or root path.
+- Like `init`, it refuses to overwrite an existing `specsync-registry.toml` and simply reports that it already exists.
 
 ## Files to Read First
 
-- `src/commands/init_registry.rs` — primary source file
+- `src/commands/init_registry.rs` — the whole command.
+- `src/registry.rs` — `generate_registry(root, project_name, specs_dir)`, which discovers specs and renders the TOML.
+- `src/config.rs` — `load_config` (provides `specs_dir`).
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. No tests target this file directly; the registry-rendering logic is covered by the `registry` module's own tests.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Part of the command layer — orchestrates the `registry` module rather than containing domain logic.

--- a/specs/cmd_init_registry/requirements.md
+++ b/specs/cmd_init_registry/requirements.md
@@ -4,21 +4,24 @@ spec: cmd_init_registry.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_init_registry` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a maintainer of a multi-project workspace, I want `specsync init-registry` to generate a `specsync-registry.toml` listing my specs so that other projects can reference them.
+- As a developer, I want the registry's project name to default to the directory name but be overridable with `--name` so that the registry reads naturally.
+- As a developer, I want init-registry to be safe to re-run so that it never overwrites an existing registry.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_init_registry` writes `specsync-registry.toml` at the project root using `registry::generate_registry(root, project_name, &config.specs_dir)`.
+- The project name is `name` when provided; otherwise the root directory's file name, falling back to `"project"` when that cannot be determined.
+- If `specsync-registry.toml` already exists, the command prints a message and returns without writing.
+- On success, prints "Created specsync-registry.toml".
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Reads configuration via `config::load_config` to obtain `specs_dir`; performs no spec validation itself.
+- Must not panic on expected error conditions; a write failure prints an error and exits 1.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Discovering and rendering registry entries (owned by `registry::generate_registry`).
+- Updating or merging into an existing registry (existing file is left untouched).
+- Interactive prompts, GUI, or web output.

--- a/specs/cmd_init_registry/tasks.md
+++ b/specs/cmd_init_registry/tasks.md
@@ -4,16 +4,18 @@ spec: cmd_init_registry.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add an integration test for `init-registry` (creation, `--name` override, and no-overwrite of an existing registry). No fixtures currently exist.
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] `cmd_init_registry` writes `specsync-registry.toml` via `registry::generate_registry`.
+- [x] Project name resolution: `--name` → root dir name → `"project"`.
+- [x] No-overwrite guard when the registry already exists.
+- [x] Write-failure path prints an error and exits 1.
 
 ## Gaps
 
-- No dedicated test file for this command module
+- No integration or inline unit tests target `src/commands/init_registry.rs`. Registry generation logic itself is covered in the `registry` module's tests.
 
 ## Review Sign-offs
 

--- a/specs/cmd_init_registry/testing.md
+++ b/specs/cmd_init_registry/testing.md
@@ -6,29 +6,34 @@ spec: cmd_init_registry.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/init_registry.rs` | cargo test commands::init_registry | No inline tests found; add focused coverage for `cmd_init_registry`, `load_config`, `generate_registry` before risky changes |
+| `src/commands/init_registry.rs` | (none) | No inline `#[cfg(test)]` module and no integration fixtures target this command. |
+| `src/registry.rs` | cargo test registry | The `registry` module owns tests for `generate_registry`; verify entry discovery and TOML shape there. |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Generate registry" before changing user-visible CLI output, generated files, or error handling in cmd_init_registry.
+- No fixture creates a registry and asserts its contents. Add an integration test that: (1) runs `init-registry` in a project with a few specs and checks `specsync-registry.toml` is written with one entry per spec, (2) verifies `--name` sets the project name, and (3) verifies a second run does not overwrite the existing file.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Generate registry | 25 specs, no existing registry | `cmd_init_registry(root, None)` runs | creates TOML with 25 entries |
+| Generate registry | a project with N specs, no existing registry | `specsync init-registry` | Writes `specsync-registry.toml` (one entry per discovered spec); prints "Created specsync-registry.toml". |
+| Name override | any project | `specsync init-registry --name my-lib` | Registry's project name is `my-lib` instead of the directory name. |
+| Registry exists | `specsync-registry.toml` already present | `specsync init-registry` | Prints "specsync-registry.toml already exists" and writes nothing. |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Registry exists | Early return | Keep or add a focused assertion before changing this behavior |
-| Write fails | Exits 1 | Keep or add a focused assertion before changing this behavior |
+| Registry already exists | Early return, no overwrite | Add a fixture before changing the overwrite guard. |
+| `--name` provided | Used as the project name | Add a fixture before changing name resolution. |
+| Name not provided | Defaults to root dir name, then `"project"` | Add a fixture before changing the fallback chain. |
+| Write fails | Prints error, exits 1 | Add a focused assertion before changing the write path. |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- init-registry --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/init_registry.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo run -- init-registry --help` and confirm `--name` is present.
+- For changes to discovered entries or TOML shape, run the `registry` module's tests — that is where rendering lives.
+- Reproduce one Behavioral Verification row with a temp project before changing user-visible output.
+- If an error message changes, update the matching Regression Matrix row and assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_issues/context.md
+++ b/specs/cmd_issues/context.md
@@ -4,17 +4,23 @@ spec: cmd_issues.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Verification is delegated entirely to `github::verify_spec_issues`, which returns an `IssueVerification { valid, closed, not_found, errors }`. This command's job is to iterate specs, accumulate totals, format output, and choose the exit code.
+- Closed issues are surfaced as warnings, not failures: only `not_found` (404) and `errors` drive the non-zero exit. This avoids breaking CI for legitimately-closed-but-still-referenced issues while still flagging them for review.
+- `--create` reuses the shared validation pipeline (`run_validation`, `build_schema_columns`, `get_schema_table_names`) and `create_drift_issues` from the `commands` module, so drift-issue creation stays consistent with other commands.
+- Specs without `implements` or `tracks` are skipped early so the command only talks to GitHub when there is something to verify.
 
 ## Files to Read First
 
-- `src/commands/issues.rs` — primary source file
+- `src/commands/issues.rs` — the whole command, including format branches and the `--create` block.
+- `src/github.rs` — `resolve_repo`, `verify_spec_issues`, and the `IssueVerification` / `GitHubIssue` types.
+- `src/commands/mod.rs` — `run_validation`, `build_schema_columns`, `create_drift_issues`.
+- `src/parser.rs` — `parse_frontmatter` (source of `implements`/`tracks`).
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Implemented and stable. No tests target this file directly because it depends on the live GitHub API; verification logic is covered in the `github` module's tests.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Output split: Text/Table/Csv share the human-readable path (per-spec detail + summary line); Json and Markdown/Github each have a structured path.
+- Part of the command layer — orchestrates the `github`, `validator`, and `commands` modules rather than containing domain logic.

--- a/specs/cmd_issues/requirements.md
+++ b/specs/cmd_issues/requirements.md
@@ -4,21 +4,28 @@ spec: cmd_issues.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_issues` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a maintainer, I want `specsync issues` to verify every GitHub issue referenced in spec frontmatter so that I catch specs pointing at closed, deleted, or wrong issues.
+- As a CI operator, I want the command to exit non-zero when references are broken so that the pipeline fails on stale links.
+- As a maintainer, I want `--create` to open drift issues for specs that fail validation so that drift gets tracked in the issue tracker.
+- As a developer, I want machine-readable JSON/Markdown output so that I can post results in CI summaries.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- Reads each spec's `implements:` and `tracks:` frontmatter lists; specs with neither are skipped.
+- Resolves the target repo via `github::resolve_repo(config.github.repo, root)`; an unresolvable repo prints an error and exits 1.
+- For each referenced issue, `github::verify_spec_issues` classifies it as valid (open), closed, not found (404), or error (API failure), and the command tallies totals across all specs.
+- Per-format output: Text/Table/Csv print per-spec details and a one-line summary; Json emits totals plus a `specs` array; Markdown/Github emit a metric table.
+- With `--create`, runs validation (`run_validation`) and, when there are errors, calls `create_drift_issues`.
+- Exits 1 when any reference is not found (404) or any verification error occurred; otherwise exits 0.
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Closed issues are reported as a warning ("spec may need updating") but do **not** by themselves cause a non-zero exit.
+- Issue verification depends on the GitHub API (via the `github` module); unavailable `gh`/token surfaces as "error" entries.
+- Must not panic on unreadable specs or unparseable frontmatter — such specs are skipped.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Editing specs to fix stale references (read-only verification).
+- Creating non-drift issues or syncing issue state back into specs.
+- Interactive prompts, GUI, or web output.

--- a/specs/cmd_issues/tasks.md
+++ b/specs/cmd_issues/tasks.md
@@ -4,16 +4,20 @@ spec: cmd_issues.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add coverage for the no-references path (specs without `implements`/`tracks`) — assertable without network.
+- [ ] Add a mocked/recorded GitHub fixture to cover valid/closed/not-found classification and the non-zero exit on 404.
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] Verifies `implements`/`tracks` references via `github::verify_spec_issues`, tallying valid/closed/not-found/error counts.
+- [x] Repo resolution via `github::resolve_repo` with a clear error + exit 1 when unresolvable.
+- [x] Text/Table/Csv, Json, and Markdown/Github output formats.
+- [x] `--create` runs validation and opens drift issues for specs with errors.
+- [x] Non-zero exit when any reference is not found or errored.
 
 ## Gaps
 
-- No dedicated test file for this command module
+- No integration or inline unit tests target `src/commands/issues.rs`. The command depends on the live GitHub API, so end-to-end testing needs recorded fixtures or a mock.
 
 ## Review Sign-offs
 

--- a/specs/cmd_issues/testing.md
+++ b/specs/cmd_issues/testing.md
@@ -6,32 +6,38 @@ spec: cmd_issues.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/issues.rs` | cargo test commands::issues | No inline tests found; add focused coverage for `cmd_issues`, `load_config`, `parse_frontmatter`, `OutputFormat` before risky changes |
+| `src/commands/issues.rs` | (none) | No inline `#[cfg(test)]` module and no integration fixtures — the command depends on the live GitHub API. |
+| `src/github.rs` | cargo test github | `verify_spec_issues`/`resolve_repo` classification and repo resolution are covered in the `github` module's tests. |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "All references valid" before changing user-visible CLI output, generated files, or error handling in cmd_issues.
+- No fixture exercises the verification flow. The most testable, network-free case is "no spec references": a project whose specs have neither `implements` nor `tracks` should print "No issue references found in spec frontmatter." and exit 0 — add that first.
+- Add recorded/mocked GitHub responses to cover the valid/closed/not-found/error classification and the non-zero exit on 404 or error.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| All references valid | specs reference issues #10, #15, #20 — all exist and are open | `cmd_issues` runs | prints "3 valid, 0 closed, 0 not found" and exits 0 |
-| Stale reference | spec references issue #5 which was deleted | `cmd_issues` runs | prints error for issue #5 and exits 1 |
+| No references | specs have no `implements`/`tracks` | `specsync issues` | Prints "No issue references found in spec frontmatter." and exits 0. |
+| All references valid | issues #10, #15, #20 open | `specsync issues` | Prints "3 valid, 0 closed, 0 not found" and exits 0. |
+| Closed reference | a referenced issue is closed | `specsync issues` | Warns "(closed — spec may need updating)"; still exits 0 if nothing is not-found/errored. |
+| Stale reference (404) | spec references a deleted issue | `specsync issues` | Reports it as not found and exits 1. |
+| `--create` with drift | specs that fail validation | `specsync issues --create` | Runs validation and opens drift issues for the failing specs. |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| GitHub repo unresolvable | Exits 1 with error message | Keep or add a focused assertion before changing this behavior |
-| `gh` CLI not available | API calls fail, counted as errors | Keep or add a focused assertion before changing this behavior |
-| Issue returns 404 | Counted as "not found", triggers non-zero exit | Keep or add a focused assertion before changing this behavior |
-| API rate limit | Counted as "error", reported but does not halt | Keep or add a focused assertion before changing this behavior |
+| GitHub repo unresolvable | Prints error, exits 1 | Add a focused assertion before changing repo resolution. |
+| Issue returns 404 (not found) | Counted as not-found; triggers exit 1 | Add a mocked fixture before changing exit logic. |
+| Verification error (e.g. API/auth failure) | Counted as error; **triggers exit 1** (`total_not_found > 0 || total_errors > 0`) | Add a mocked fixture before changing exit logic. |
+| Closed issue only | Warned but does **not** by itself force a non-zero exit | Add a mocked fixture before changing the exit condition. |
+| Spec without `implements`/`tracks` | Skipped (not verified) | Cover with the network-free "no references" fixture. |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- issues --help` and confirm the help text still names the documented flags and behavior.
-- Run the narrow source command above before the full suite when changing `src/commands/issues.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo run -- issues --help` and confirm `--create` and the format flags are present.
+- For changes to verification/classification, run the `github` module's tests — that is where the API logic lives.
+- Confirm the exit-code condition (`not_found > 0 || errors > 0`) still matches the documented Regression Matrix before changing it.
+- If an output or error message changes, update the matching Regression Matrix row and assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_lifecycle/requirements.md
+++ b/specs/cmd_lifecycle/requirements.md
@@ -4,18 +4,32 @@ spec: cmd_lifecycle.spec.md
 
 ## User Stories
 
-- As a developer, I want to manage spec lifecycle statuses so that I can track spec maturity
-- As a CI operator, I want transition guards to enforce quality gates before specs advance
+- As a developer, I want to `promote`/`demote`/`set` a spec's status so that I can track its maturity (draft → review → active → stable → deprecated → archived).
+- As a developer, I want `lifecycle status` to show one or all specs grouped by status so that I can see the project's maturity at a glance.
+- As a developer, I want `lifecycle history` to show a spec's transition log so that I can audit how its status evolved.
+- As a developer, I want `lifecycle guard` to dry-run guard evaluation for a transition so that I know why a promotion would be blocked before attempting it.
+- As a team, we want `auto-promote` to advance every spec that already passes its guards so that maturing specs don't get stuck.
+- As a CI operator, I want `enforce` to fail the build on lifecycle violations (missing status, disallowed status, specs stuck past `max_age`) so that lifecycle policy is enforced automatically.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Transition validation prevents invalid status changes unless --force is used
-- Guard evaluation checks min_score, required sections, and staleness
-- Error conditions produce clear, actionable messages with exit code 1
+- `promote`/`demote` use `SpecStatus::next()`/`prev()`; `set` accepts any valid status; all validate via `can_transition_to()` unless `--force`.
+- Guard evaluation checks `min_score`, `require_sections`, and staleness (`no_stale`/`stale_threshold`), matching both specific (`from→to`) and wildcard (`*→to`) keys in either Unicode (`→`) or ASCII (`->`) form.
+- A blocked transition (invalid jump or failed guard) prints the failures and exits 1; `--force` overrides both.
+- When `track_history` is enabled, successful transitions append a dated `lifecycle_log` entry to the spec frontmatter.
+- `auto-promote` advances only specs whose next transition passes guards (or, with `--dry-run`, reports what would change without writing).
+- `enforce` exits non-zero when any selected check (`require_status`, `check_allowed`, `check_max_age`) finds a violation; `status`, `history`, and `guard` honor JSON output.
+
+## Out of Scope
+
+- Defining the lifecycle graph itself (statuses and allowed transitions live in `types::SpecStatus`).
+- Editing spec body content or any field other than `status:` / `lifecycle_log` in frontmatter.
+- Interactive prompts and any GUI/web interface.
 
 ## Constraints
 
 - Must not panic on expected error conditions — return Results or print and exit
 - Must work with the project's Clap-based CLI argument parsing
-- Guard configuration is loaded from specsync.json lifecycle section
+- Lifecycle/guard configuration (guards, `track_history`, `allowed_statuses`, `max_age`) comes from the `[lifecycle]` section of `.specsync/config.toml` (v4 layout)
+- Status mutations rewrite only the `status:` line inside YAML frontmatter delimiters — never the spec body
+- `lifecycle_log` history may live in frontmatter or, post-`migrate`, in `.specsync/lifecycle/{module}.json`; both are read by `history`/`enforce`

--- a/specs/cmd_lifecycle/testing.md
+++ b/specs/cmd_lifecycle/testing.md
@@ -6,7 +6,10 @@ spec: cmd_lifecycle.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/lifecycle.rs` | cargo test commands::lifecycle:: | `update_status_in_content_replaces_status_line`, `update_status_preserves_rest_of_frontmatter`, `update_status_returns_none_when_no_status_line`, `spec_status_next`, `spec_status_prev`, `spec_status_valid_transitions` |
+| Status mutation | cargo test commands::lifecycle:: | `update_status_in_content_replaces_status_line`, `update_status_preserves_rest_of_frontmatter`, `update_status_returns_none_when_no_status_line` |
+| Lifecycle graph | cargo test commands::lifecycle:: | `spec_status_next`, `spec_status_prev`, `spec_status_valid_transitions`, `spec_status_can_transition_to` |
+| Guard matching | cargo test commands::lifecycle:: | `find_guards_specific_and_wildcard`, `find_guards_ascii_arrow` |
+| History log + age | cargo test commands::lifecycle:: | `append_lifecycle_log_new`, `append_lifecycle_log_existing`, `days_since_date_same_day_is_zero`, `days_since_date_invalid_format_returns_none`, `days_since_date_past_date_is_positive`, `estimate_status_age_from_lifecycle_log`, `estimate_status_age_picks_latest_entry` |
 
 ## Coverage Gaps
 

--- a/specs/cmd_merge/testing.md
+++ b/specs/cmd_merge/testing.md
@@ -23,8 +23,8 @@ spec: cmd_merge.spec.md
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| No conflicts | Prints "no conflicts" | Keep or add a focused assertion before changing this behavior |
-| Complex conflict | Exits 1 with file path | Keep or add a focused assertion before changing this behavior |
+| No conflicts | Prints "No spec files with merge conflicts found." | Keep or add a focused assertion before changing this behavior |
+| Complex conflict | Prints "needs manual merge: <path>" and exits 1 | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 

--- a/specs/cmd_migrate/context.md
+++ b/specs/cmd_migrate/context.md
@@ -9,7 +9,7 @@ spec-sync v4.0.0 is a major version break that restructures how project metadata
 ## Key Terminology
 
 - **3.x layout**: Config at root (`specsync.json`, `specsync-registry.toml`), lifecycle history embedded in spec frontmatter as `lifecycle_log` YAML field
-- **4.0 layout**: All metadata under `.specsync/` directory — `config.json`, `registry.toml`, `lifecycle/{module}.json`, `changes/`, `archive/`
+- **4.0 layout**: All metadata under `.specsync/` directory — `config.toml`, `registry.toml`, `lifecycle/{module}.json`, `changes/`, `archive/`, plus a `version` stamp file and `.gitignore`
 - **Migration step**: An atomic unit of work with a check function (is this done?) and an apply function (do it)
 - **Step status**: `Done` (skip), `Pending` (needs work), `Partial` (previous run crashed mid-step — fix forward)
 
@@ -34,3 +34,13 @@ Frontmatter is for spec metadata (module, version, status, dependencies). Lifecy
 ### Modeled after `cargo fix --edition`
 
 Rust's edition migration is the gold standard: automatic, non-interactive, test-driven validation after migration, clear handling of edge cases that can't be auto-fixed. We adopt the same philosophy: migrate everything possible, flag what can't be migrated, validate the result.
+
+## Files to Read First
+
+- `src/commands/migrate.rs` — the step pipeline (`steps()`), each `check_*`/`apply_*` pair, `cmd_migrate`, and the inline unit tests.
+- `src/config.rs` — `load_config_from_path` and `config_to_toml`, used by the config-relocation step.
+- `tests/integration.rs` — the `specsync migrate` section (`migrate_full_v3_to_v4` and friends) for end-to-end expectations and the 3.x fixture builder.
+
+## Current Status
+
+Implemented and shipped (`status: draft` in the spec frontmatter is a maturity label, not project state). The full v3→v4 flow is covered by integration tests, and `apply_create_directories` now has dedicated unit tests. Remaining work is expanding unit coverage to the other `apply_*` steps.

--- a/specs/cmd_migrate/requirements.md
+++ b/specs/cmd_migrate/requirements.md
@@ -26,7 +26,7 @@ spec: cmd_migrate.spec.md
 - Must work on macOS, Linux, and Windows (no symlinks, no Unix-specific operations)
 - Must handle large projects (100+ specs) without excessive memory usage
 - Backup should be opt-out (`--no-backup`) not opt-in
-- File permissions: directories 0755, files 0644 (explicit, not inherited)
+- Created files and directories use the platform default permissions (`fs::create_dir_all` / `fs::write`); no explicit mode is set
 
 ## Out of Scope
 

--- a/specs/cmd_migrate/tasks.md
+++ b/specs/cmd_migrate/tasks.md
@@ -24,11 +24,22 @@ spec: cmd_migrate.spec.md
 - [x] JSON output mode for migration report
 - [x] TOML config format (decided: TOML, matching registry format)
 - [x] Auto-detection of 3.x layout with migration suggestion in `specsync check`
+- [x] Integration tests for the full v3→v4 flow (`migrate_full_v3_to_v4`, dry-run, idempotency, partial recovery, JSON, `--no-backup`, no-project)
+- [x] Unit tests for migration-step application (`apply_create_directories_creates_v4_layout`, `apply_create_directories_is_idempotent`)
 
-### In Progress
+### Open
 
 - [ ] Test on real 3.x project (dogfood on CorvidLabs repos)
+- [ ] Add unit tests for the remaining `apply_*` steps (config/registry relocation, lifecycle extraction, frontmatter cleanup)
 
 ### Gaps
 
+- Most `apply_*` steps are exercised only through the end-to-end integration flow; only `apply_create_directories` has dedicated unit coverage.
 - Consider: migration for projects using spec-sync as a dependency (cross-project registries)
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/cmd_migrate/testing.md
+++ b/specs/cmd_migrate/testing.md
@@ -6,7 +6,7 @@ spec: cmd_migrate.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/migrate.rs` | cargo test commands::migrate | No inline tests found; add focused coverage for `cmd_migrate`, `MigrationStep`, `StepStatus`, `MigrationContext` before risky changes |
+| `src/commands/migrate.rs` | cargo test commands::migrate | `apply_create_directories_creates_v4_layout`, `apply_create_directories_is_idempotent` (step-apply unit tests). Other `apply_*` steps are exercised only via the integration flow below |
 | `tests/integration.rs` | cargo test --test integration migrate_full_v3_to_v4 | End-to-end fixture: `migrate_full_v3_to_v4` |
 | `tests/integration.rs` | cargo test --test integration migrate_check_passes_after_migration | End-to-end fixture: `migrate_check_passes_after_migration` |
 | `tests/integration.rs` | cargo test --test integration migrate_idempotent_rerun_is_noop | End-to-end fixture: `migrate_idempotent_rerun_is_noop` |

--- a/specs/cmd_new/context.md
+++ b/specs/cmd_new/context.md
@@ -4,17 +4,23 @@ spec: cmd_new.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- **Scaffold, don't author**: `cmd_new` writes frontmatter and section skeletons but leaves prose, invariants, and dependency descriptions to the author. Public API rows are review prompts, not finished docs.
+- **Auto-detect sources two ways**: a `src/<module>/` directory (walked recursively) and a top-level `src/<module>.<ext>` file are both treated as the module's sources, filtered by configured `source_extensions`.
+- **Pre-populate exports**: exported symbols from detected sources are pulled via `exports::get_exported_symbols`, de-duplicated, and seeded into the Public API table so the author starts from the real surface area.
+- **Never clobber**: an existing target spec aborts with exit 1 — creation is non-destructive.
+- **No chrono dependency**: dates come from the in-module `chrono_lite_today()` helper to keep the binary dependency-light and cross-platform.
 
 ## Files to Read First
 
-- `| Dir creation fails | Exits 1 |` — primary source file
+- `src/commands/new.rs` — the command itself: `cmd_new`, `detect_module_sources`, and `chrono_lite_today`.
+- `src/generator.rs` — `generate_companion_files_for_spec`, invoked under `--full`.
+- `src/exports.rs` — `get_exported_symbols` and `has_extension`, used for source/export detection.
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Stable and implemented. Behavior is verified only indirectly (no `#[cfg(test)]` module in `new.rs` and no `specsync new` integration tests yet) — adding focused tests is the main open item.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This is a command-layer module: it orchestrates `config`, `exports`, and `generator` rather than holding domain logic.
+- `depends_on` is always emitted empty; imports are not analyzed to infer dependencies.

--- a/specs/cmd_new/requirements.md
+++ b/specs/cmd_new/requirements.md
@@ -4,21 +4,31 @@ spec: cmd_new.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_new` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer starting a new module, I want `specsync new <module>` to scaffold a spec in one step so that I don't hand-write frontmatter and boilerplate sections.
+- As a developer, I want the new spec to auto-detect the module's source files (a matching `src/<module>/` directory or a `src/<module>.<ext>` file) so that the `files:` list is correct from the start.
+- As a developer, I want the Public API table pre-populated with the module's exported symbols so that I only have to fill in descriptions, not discover the surface area.
+- As a developer, I want `--full` to also create the companion files (tasks, context, requirements, testing — plus design when configured) so that a module's spec set is complete from creation.
+- As a careful user, I want the command to refuse to overwrite an existing spec so that I never lose hand-written content.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `specsync new <module>` creates `<specs_dir>/<module>/<module>.spec.md` with frontmatter (`module`, `version: 1`, `status: draft`, `files:`, `db_tables: []`, `depends_on: []`) and the standard section skeleton (Purpose, Public API, Dependencies, Change Log).
+- Source files are detected by scanning each configured `source_dirs` entry for a directory named `<module>` (recursively) and for a top-level file whose stem equals `<module>`, filtered by `source_extensions`; detected paths are relative, forward-slash, sorted, and de-duplicated.
+- When no source files are found, the spec is still created with `files: []`.
+- Exported symbols from the detected source files are collected via `exports::get_exported_symbols`, de-duplicated, and rendered as Public API rows; each row carries a review prompt to document the export rather than a placeholder marker.
+- `--full` invokes `generator::generate_companion_files_for_spec`, creating `tasks.md`, `context.md`, `requirements.md`, `testing.md`, and `design.md` only when `companions.design` is enabled in config.
+- An existing target spec file causes exit code 1 with an error message; the command never overwrites it.
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — print an error and exit non-zero.
+- Dates are produced by an in-module `chrono_lite_today()` helper (no `chrono` dependency) and must be cross-platform.
+- Path output is normalized to forward slashes so generated specs are stable across Windows and Unix.
+- Honors the project's `specs_dir`, `source_dirs`, `source_extensions`, and `companions.design` config values.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Filling in section prose, invariants, or dependency descriptions (the command scaffolds; the author writes content).
+- Inferring `depends_on` from source imports (emitted as `depends_on: []`).
+- Interactive prompts (see the `wizard` command) and any GUI/web interface.
+- Updating the registry or running validation as part of creation.

--- a/specs/cmd_new/tasks.md
+++ b/specs/cmd_new/tasks.md
@@ -4,16 +4,20 @@ spec: cmd_new.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add integration tests for `specsync new` CLI behavior (quick create, `--full`, refuse-overwrite, empty `files:` when no sources)
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] Implement `cmd_new` with source auto-detection (`detect_module_sources`) and export pre-population
+- [x] Generate frontmatter + Purpose/Public API/Dependencies/Change Log skeleton
+- [x] `--full` companion generation via `generator::generate_companion_files_for_spec`, with conditional `design.md`
+- [x] Refuse to overwrite an existing spec (exit 1)
+- [x] Replace unfinished-marker Public API rows with review prompts
+- [x] In-module `chrono_lite_today()` date helper (no chrono dependency)
 
 ## Gaps
 
-- No dedicated test file for this command module
+- No tests cover `cmd_new`; `src/commands/new.rs` has no `#[cfg(test)]` module and there are no `specsync new` integration tests.
 
 ## Review Sign-offs
 

--- a/specs/cmd_report/context.md
+++ b/specs/cmd_report/context.md
@@ -4,17 +4,24 @@ spec: cmd_report.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- **Read-only health view**: `cmd_report` only reads specs, source files, and git history; it never mutates anything. Specs that fail to read or parse are skipped rather than aborting the run.
+- **Staleness via git, resolved once**: the spec's last commit is looked up once with `git_last_commit_hash`, then `git_commits_since(root, spec_commit, source_file)` is counted per declared source file. This replaced the earlier `git_commits_between` per-file call (an N+1 on `git log`).
+- **Graceful git absence**: outside a git repo, or when a spec has no commit history, the module is simply not flagged stale — no error is raised.
+- **Completeness heuristics**: missing `status`/`module`/`version` frontmatter, or a `Public API`/`Invariants` section that is absent/empty/`TODO`/`TBD`/`N/A`/HTML-comment-only, marks a module incomplete.
+- **Status scoping at the CLI layer**: `--only-status` / `--exclude-status` are global flags applied via `filter_by_status` before the report is built.
 
 ## Files to Read First
 
-- `src/commands/report.rs` — primary source file
+- `src/commands/report.rs` — the whole command, including the `ModuleInfo` aggregation and JSON/text rendering.
+- `src/git_utils.rs` — `git_last_commit_hash` and `git_commits_since`, the staleness primitives.
+- `src/validator.rs` — `compute_coverage`, the source of the overall coverage numbers.
+- `src/commands/mod.rs` — `load_and_discover` and `filter_by_status`.
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Stable and implemented. Behavior is verified only indirectly today — `src/commands/report.rs` has no `#[cfg(test)]` module and there are no `specsync report` integration tests; the underlying git and coverage helpers are tested in their own modules.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This is a command-layer module: it orchestrates `git_utils`, `parser`, and `validator` rather than holding domain logic.
+- Overall coverage comes from `compute_coverage` (project-wide), while per-module coverage is computed locally from each spec's `files:` list — the two can differ.

--- a/specs/cmd_report/requirements.md
+++ b/specs/cmd_report/requirements.md
@@ -4,21 +4,30 @@ spec: cmd_report.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_report` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a maintainer, I want a per-module report of spec coverage, staleness, and completeness so that I can see at a glance which specs need attention.
+- As a developer, I want stale specs flagged by how many commits their source files are ahead so that I can prioritize the most drifted modules.
+- As a reviewer, I want incomplete specs surfaced (missing `version`/`status`/`module`, or empty `Public API`/`Invariants` sections) so that thin specs don't slip through.
+- As a CI operator, I want a JSON output mode with per-module detail so that I can gate or chart spec health programmatically.
+- As a user with a mixed backlog, I want to scope the report to (or away from) certain lifecycle statuses via the global `--only-status` / `--exclude-status` flags.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_report(root, format, stale_threshold, exclude_status, only_status)` discovers specs, applies the status filters, computes coverage, and renders a report sorted by module name.
+- Per-module coverage is the share of that spec's declared `files:` that exist on disk (`existing / max(total, 1) * 100`).
+- A module is **stale** when any existing source file has `>= stale_threshold` commits since the spec's last commit; the largest such count is reported as "commits behind". Default `stale_threshold` is 5.
+- Staleness resolves the spec's last commit once via `git_last_commit_hash`, then calls `git_commits_since(root, spec_commit, source_file)` per source file (no per-file spec `git log`).
+- A module is **incomplete** when it is missing any of `status`/`module`/`version`, or when `## Public API` or `## Invariants` is absent, empty, or only `TODO`/`TBD`/`N/A`/an HTML comment.
+- Text mode prints an overall coverage line, a Module/Coverage/Stale/Incomplete table, and stale/incomplete detail sections; JSON mode emits overall stats plus a `modules` array with `coverage_pct`, `stale`, `commits_behind`, `incomplete`, `missing_fields`, and `empty_sections`.
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — specs that fail to read or parse are skipped, not fatal.
+- Staleness depends on git; outside a git repo or when the spec has no commit, the module is simply not flagged stale (no error).
+- Source files listed in the spec but missing on disk are skipped in the staleness calculation.
+- Output honors `OutputFormat` (text vs JSON) and the project's discovery/config conventions.
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Mutating specs or source files (the report is read-only).
+- Auto-fixing stale or incomplete specs (see `lifecycle`, `generate`, and `check`).
+- Interactive prompts and any GUI/web interface.

--- a/specs/cmd_report/tasks.md
+++ b/specs/cmd_report/tasks.md
@@ -4,16 +4,19 @@ spec: cmd_report.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add integration tests for `specsync report` (text + JSON, stale detection, incomplete detection, status filtering)
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] Implement `cmd_report` with per-module coverage, staleness, and completeness analysis
+- [x] Text table output + stale/incomplete detail sections
+- [x] JSON output with per-module detail arrays
+- [x] Wire global `--exclude-status` / `--only-status` filtering through `filter_by_status`
+- [x] Adopt the resolve-spec-commit-once + `git_commits_since` per-source-file staleness path (N+1 fix)
 
 ## Gaps
 
-- No dedicated test file for this command module
+- No tests cover `cmd_report`; `src/commands/report.rs` has no `#[cfg(test)]` module and there are no `specsync report` integration tests. Staleness logic is only exercised indirectly via `git_utils` tests.
 
 ## Review Sign-offs
 

--- a/specs/cmd_report/testing.md
+++ b/specs/cmd_report/testing.md
@@ -6,11 +6,10 @@ spec: cmd_report.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/report.rs` | cargo test commands::report | No inline tests found; add focused coverage for `cmd_report`, `load_and_discover`, `parse_frontmatter`, `OutputFormat` before risky changes |
-| `tests/integration.rs` | cargo test --test integration coverage_full_reports_100 | End-to-end fixture: `coverage_full_reports_100` |
-| `tests/integration.rs` | cargo test --test integration invalid_frontmatter_reports_error | End-to-end fixture: `invalid_frontmatter_reports_error` |
-| `tests/integration.rs` | cargo test --test integration missing_required_sections_reports_error | End-to-end fixture: `missing_required_sections_reports_error` |
-| `tests/integration.rs` | cargo test --test integration missing_frontmatter_fields_reports_error | End-to-end fixture: `missing_frontmatter_fields_reports_error` |
+| `src/commands/report.rs` | cargo test commands::report | No inline tests and no `specsync report` integration tests exist. Add focused coverage for staleness flagging, incomplete detection, and JSON shape before risky changes |
+| `src/git_utils.rs` (indirect) | cargo test git_utils | Staleness primitives `git_last_commit_hash` / `git_commits_since` are tested here, not in `report` |
+
+> Note: `coverage_full_reports_100`, `invalid_frontmatter_reports_error`, `missing_required_sections_reports_error`, and `missing_frontmatter_fields_reports_error` exercise the `coverage` and `check` commands — **not** `report`. Do not rely on them as `cmd_report` coverage.
 
 ## Behavioral Verification
 
@@ -25,7 +24,7 @@ spec: cmd_report.spec.md
 |------|-------------------|-----------------|
 | Git not available or not a git repo | Staleness detection gracefully returns 0 (not stale) | Keep or add a focused assertion before changing this behavior |
 | Spec references a file that doesn't exist | File is skipped in staleness calculation | Keep or add a focused assertion before changing this behavior |
-| No spec files found | Prints "no specs found" and exits 0 | Keep or add a focused assertion before changing this behavior |
+| No spec files found | Renders an empty report (0/0 files, 100% overall, no module rows) and exits 0 | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 

--- a/specs/cmd_resolve/context.md
+++ b/specs/cmd_resolve/context.md
@@ -4,17 +4,24 @@ spec: cmd_resolve.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- **Network is opt-in**: with no flags the command only checks local file existence and lists cross-project refs. `--remote` enables registry fetches; `--verify` (which implies `--remote` at the CLI) enables deep content checks.
+- **Two-phase remote checks**: phase 1 confirms a module exists in the remote registry; phase 2 (`--verify`) fetches the actual remote spec and inspects status, exports, and bidirectional deps.
+- **Drift vs warning**: deprecated/removed/archived status and missing consumed exports are breaking `DRIFT` (exit 1); non-bidirectional deps, fetch failures, and parse failures are non-fatal `WARN`.
+- **Cache to avoid re-fetching**: remote spec bodies are cached on disk under `.specsync-cache/remote-specs/` with a TTL (default 3600s); repo/path slashes are sanitized into the cache filename. TTL 0 disables caching.
+- **Consumed-export discovery is table-driven**: `find_consumed_exports` scans the local spec's `### Consumes` table for rows whose module column matches the remote module, extracting backtick-wrapped identifiers.
 
 ## Files to Read First
 
-- `src/commands/resolve.rs` — primary source file
+- `src/commands/resolve.rs` — `cmd_resolve`, `verify_remote_specs`, `find_consumed_exports`, the `SpecCache` helper, and the inline unit tests.
+- `src/registry.rs` — `fetch_remote_registry`, `fetch_remote_spec`, `parse_remote_spec`, `RemoteRegistry`, `RemoteSpec`.
+- `src/validator.rs` — `is_cross_project_ref` / `parse_cross_project_ref` for ref classification.
+- `src/main.rs` (Resolve arm) — where `remote || verify` is passed, making `--verify` imply `--remote`.
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Stable and implemented. Unit tests cover the cache, `### Consumes` parsing, and deprecated-status detection; the registry/network orchestration is not yet covered end to end.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This is a command-layer module orchestrating `parser`, `registry`, `validator`, and `github`; it owns the dependency-resolution flow and the on-disk remote cache, but not the HTTP/registry primitives.
+- `DriftIssue` is an internal enum (`#[allow(dead_code)]` on some variants used only for matching); it is not part of the public surface.

--- a/specs/cmd_resolve/requirements.md
+++ b/specs/cmd_resolve/requirements.md
@@ -4,21 +4,31 @@ spec: cmd_resolve.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_resolve` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want `specsync resolve` to list every declared dependency and show which local refs exist on disk so that broken `depends_on` paths are obvious.
+- As a developer with cross-project dependencies, I want `--remote` to fetch each referenced repo's registry and confirm the module is actually published so that I don't ship a dangling cross-project ref.
+- As a maintainer, I want `--verify` to fetch the real remote spec and detect drift — deprecated/removed status and exports I consume that no longer exist — so that breaking upstream changes fail my build.
+- As a maintainer, I want non-bidirectional dependencies surfaced as warnings (not failures) so that I'm informed without being blocked.
+- As a CI operator, I want remote content cached with a configurable TTL so that repeated verify runs don't hammer GitHub.
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_resolve(root, remote, verify, cache_ttl)` scans every spec's `depends_on`, classifying each ref as local (path) or cross-project (`owner/repo@module`).
+- With no flags, local refs are checked by file existence and cross-project refs are listed only — **no network calls** are made.
+- At the CLI, `--verify` implies `--remote` (`main.rs` passes `remote || verify`); registry-level checks always run before deep verification.
+- `--remote` fetches each repo's registry once (de-duplicated per repo) and reports per ref: module present, module not in registry, registry fetch failed, or no registry.
+- `--verify` deep-checks remote specs and reports: `DRIFT` for deprecated/removed/archived remote status, `DRIFT` for a consumed export missing from the remote spec, and `WARN` for non-bidirectional deps, fetch failures, and parse failures.
+- The command exits 1 only on breaking drift (deprecated status or missing export); warnings alone exit 0. Unresolvable/local-missing refs are warnings.
+- Remote spec content is cached under `.specsync-cache/remote-specs/` with the given TTL (default 3600s); cache filenames sanitize `/` in repo and path to `_`.
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — fetch/parse failures degrade to warnings and the scan continues.
+- No network access unless `--remote` or `--verify` is set.
+- Consumed exports are discovered by parsing the local spec's `### Consumes` table rows matching the remote module name; only backtick-wrapped identifiers are extracted.
+- Cache TTL of 0 means entries are always treated as expired (no caching).
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Resolving transitive (multi-hop) dependencies — only directly declared refs are checked.
+- Writing or fixing dependencies (the command is read-only aside from populating the cache).
+- Interactive prompts and any GUI/web interface.

--- a/specs/cmd_resolve/tasks.md
+++ b/specs/cmd_resolve/tasks.md
@@ -4,16 +4,20 @@ spec: cmd_resolve.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add end-to-end CLI tests for `--remote` / `--verify` against a stubbed registry (currently only helper-level unit tests exist)
 
 ## Done
 
-- [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] Implement local vs cross-project dependency classification
+- [x] `--remote` registry fetch + per-repo de-duplication and presence checks
+- [x] `--verify` deep content verification: deprecated-status, missing-export, bidirectional, and fetch/parse drift issues
+- [x] Exit 1 on breaking drift; warnings exit 0
+- [x] File-based remote-spec cache with TTL (`SpecCache`) and slash sanitization
+- [x] Unit tests for cache roundtrip/miss/expired, path sanitization, `### Consumes` parsing, and deprecated-status detection
 
 ## Gaps
 
-- No dedicated test file for this command module
+- Coverage is helper-level only (`find_consumed_exports`, `SpecCache`, `RemoteSpec`); the `cmd_resolve` orchestration and `verify_remote_specs` network paths are not exercised end to end.
 
 ## Review Sign-offs
 

--- a/specs/cmd_resolve/testing.md
+++ b/specs/cmd_resolve/testing.md
@@ -6,7 +6,9 @@ spec: cmd_resolve.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/resolve.rs` | cargo test commands::resolve:: | `test_find_consumed_exports_parses_table`, `test_find_consumed_exports_skips_header_row`, `test_spec_cache_roundtrip`, `test_spec_cache_miss`, `test_spec_cache_expired`, `test_verify_detects_deprecated_status` |
+| `src/commands/resolve.rs` | cargo test commands::resolve:: | `test_find_consumed_exports_parses_table`, `test_find_consumed_exports_skips_header_row`, `test_spec_cache_roundtrip`, `test_spec_cache_miss`, `test_spec_cache_expired`, `test_cache_path_sanitizes_slashes`, `test_verify_detects_deprecated_status` |
+
+> These are helper-level unit tests (`find_consumed_exports`, `SpecCache`, `RemoteSpec` status). The `cmd_resolve` / `verify_remote_specs` network orchestration has no automated coverage yet — verify Behavioral Verification rows manually.
 
 ## Coverage Gaps
 

--- a/specs/cmd_rules/tasks.md
+++ b/specs/cmd_rules/tasks.md
@@ -1,3 +1,20 @@
-# cmd_rules — Tasks
+---
+spec: cmd_rules.spec.md
+---
 
-No open tasks.
+## Tasks
+
+- No open tasks.
+
+## Done
+
+- [x] List all five built-in rules with active/off status
+- [x] List custom rules with name, severity (color-coded), type, and optional filters
+- [x] Integration coverage for custom-rule listing (`rules_command_lists_custom_rules`)
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/cmd_scaffold/context.md
+++ b/specs/cmd_scaffold/context.md
@@ -4,17 +4,24 @@ spec: cmd_scaffold.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Two entry points share one file: `cmd_add_spec` (fixed built-in template, no flags) and `cmd_scaffold` (optional `--dir` and `--template`, plus registry auto-registration).
+- Neither command uses AI — spec bodies come from inline string templates or the generator. AI generation is the separate `generate` command.
+- An existing `*.spec.md` is never overwritten; both commands instead backfill missing companions and return early, so re-running is safe and idempotent for companions.
+- Companion emission is delegated to `generator` (`generate_companion_files_for_spec` / `generate_companion_files_from_template`), keeping template content in one place.
+- Registry auto-registration is opt-in by file presence: it only fires when `specsync-registry.toml` already exists at the repo root.
 
 ## Files to Read First
 
-- `src/commands/scaffold.rs` — primary source file
+- `src/commands/scaffold.rs` — primary source (both `cmd_add_spec` and `cmd_scaffold`)
+- `src/generator.rs` — `find_files_for_module`, `generate_spec`, companion generators
+- `src/registry.rs` — `register_module` for auto-registration
+- `src/exports.rs` — `has_extension` used during source auto-detection
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable. No inline unit tests; companion-generation behavior is covered indirectly by integration tests (`generate_creates_companion_files`, `companion_files_not_overwritten_on_regenerate`).
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Part of the command layer: orchestrates `config`, `generator`, `registry`, and `exports` rather than holding domain logic.
+- Source-file paths in generated frontmatter are normalized to forward slashes for cross-platform manifests.

--- a/specs/cmd_scaffold/requirements.md
+++ b/specs/cmd_scaffold/requirements.md
@@ -4,21 +4,32 @@ spec: cmd_scaffold.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_scaffold` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want `specsync add-spec <module>` to create a ready-to-edit spec from a built-in template with my module's source files already detected so I can start documenting immediately
+- As a developer, I want `specsync scaffold <module>` to support a custom specs directory and a custom template directory so I can match an existing project layout or house style
+- As a team lead, I want scaffolding to auto-register a new module in `specsync-registry.toml` when a registry exists so the module is tracked without a manual edit
+- As any user, I want companion files (tasks/context/requirements/testing, plus design when enabled) generated alongside the spec so the documentation set is complete from the start
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_add_spec` writes `<specs_dir>/<module>/<module>.spec.md` from the built-in template and never uses AI
+- `cmd_scaffold` resolves the target specs directory from the `--dir` argument when provided, otherwise from `config.specs_dir`
+- When a `--template` directory is provided, both the spec body and companions are produced from that template; otherwise the built-in generator is used
+- Both commands auto-detect source files for the module: `cmd_add_spec` walks `<source_dir>/<module>/` matching `source_extensions`; `cmd_scaffold` delegates to `generator::find_files_for_module`
+- If the spec file already exists, neither command overwrites it; both still backfill any missing companion files and return early
+- Companion files always include tasks.md, context.md, requirements.md, testing.md; design.md is generated only when `config.companions.design` is true
+- `cmd_scaffold` registers the new module in `specsync-registry.toml` only when that file already exists at the repo root
+- On success, paths are printed relative to `root` with a checkmark; auto-detected source counts are reported
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — print to stderr and `process::exit(1)`
+- Directory-creation and file-write failures exit with code 1 and a clear message
+- Read-only with respect to existing specs: an existing `*.spec.md` is never modified
+- Source-file paths are normalized to forward slashes (`\` → `/`) for cross-platform manifests
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- AI-assisted spec generation (handled by the `generate` command, not scaffold)
+- Interactive prompts (handled by the `wizard` command)
+- Editing or regenerating an existing spec's body
+- Validation or scoring of the generated spec

--- a/specs/cmd_scaffold/testing.md
+++ b/specs/cmd_scaffold/testing.md
@@ -6,7 +6,9 @@ spec: cmd_scaffold.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/scaffold.rs` | cargo test commands::scaffold | No inline tests found; add focused coverage for `cmd_add_spec`, `cmd_scaffold`, `load_config`, `get_exported_symbols` before risky changes |
+| `src/commands/scaffold.rs` | cargo test commands::scaffold | No inline `#[cfg(test)]` module; add focused coverage for `cmd_add_spec`, `cmd_scaffold`, source auto-detection, and registry auto-registration before risky changes |
+| `tests/integration.rs` | cargo test --test integration generate_creates_companion_files | Exercises the same `generator::generate_companion_files_for_spec` path scaffold uses to emit companions |
+| `tests/integration.rs` | cargo test --test integration companion_files_not_overwritten_on_regenerate | Confirms existing companions are not clobbered when re-running on an existing spec |
 
 ## Coverage Gaps
 

--- a/specs/cmd_score/context.md
+++ b/specs/cmd_score/context.md
@@ -4,17 +4,24 @@ spec: cmd_score.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- `cmd_score` is a pure renderer over the `scoring` module: it scores each discovered spec with `score_spec`, aggregates with `compute_project_score`, then formats per the requested `OutputFormat`.
+- Four output renderers live here — text, table (ASCII), CSV (with a SUMMARY row), and JSON — each driven off the same `ProjectScore`.
+- Scoring is informational: unlike `check`, it never sets a non-zero exit code.
+- "Batch mode" (no filters or `--all`) prints a progress header in text mode only, so CSV/JSON stay clean for piping.
+- `--explain` deepens output: in text it lists every criterion with ✓/✗ and points; in JSON it adds an `explain` array; in table it adds the five sub-score columns.
 
 ## Files to Read First
 
-- `src/commands/score.rs` — primary source file
+- `src/commands/score.rs` — `cmd_score` plus the `print_text_output`, `print_table_output`, `print_csv_output`, and colorize helpers
+- `src/scoring.rs` — `score_spec`, `compute_project_score`, `SpecScore`, `ProjectScore`, and the per-dimension `explain` data
+- `src/commands/mod.rs` — `load_and_discover`, `filter_specs`, `filter_by_status`
+- `src/types.rs` — `OutputFormat`
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable. Covered end-to-end by `tests/integration.rs` (text, JSON, table, CSV, MCP, and with/without `--all`). No inline `#[cfg(test)]` module in `score.rs` itself.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- The live `cmd_score` signature also takes `all: bool`, `exclude_status`, and `only_status` beyond what the spec's API table lists.
+- Orchestrates the scoring module; the grading rubric is defined there, not here.

--- a/specs/cmd_score/requirements.md
+++ b/specs/cmd_score/requirements.md
@@ -4,21 +4,34 @@ spec: cmd_score.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_score` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want `specsync score` to grade each spec 0–100 with a letter grade so that I know which docs need work
+- As a developer, I want `--explain` to break the score into per-dimension, per-criterion lines so that I can see exactly why points were lost
+- As a team lead, I want a project-level average and A–F distribution so that I can track overall spec health at a glance
+- As a dashboard author, I want `--format csv` (with a SUMMARY row) and `--format json` so that I can feed scores into spreadsheets or tooling
+- As a CI user, I want `--format table` for a compact aligned report so that scores read cleanly in logs
+- As a developer, I want to scope scoring with positional spec filters and `--exclude-status`/`--only-status` so that I can focus on relevant specs
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_score` scores discovered specs (after `filter_specs` and `filter_by_status`) using `score_spec`, then aggregates via `compute_project_score`
+- Five dimensions, 20 points each: Frontmatter, Sections, API, Depth, Freshness
+- JSON output includes per-spec objects (`total`, `grade`, the five sub-scores, `suggestions`) and a project object (`average_score` rounded to 1 dp, `grade`, `total_specs`, A–F `distribution`); `--explain` adds an `explain` array per spec
+- `--format table` renders an aligned ASCII table; with `--explain` it adds FM/Sec/API/Depth/Fresh columns
+- `--format csv` prints a header row, one row per spec, and a final `SUMMARY` row with the average, grade, and distribution
+- Default/text output prints each spec's grade and either the 5-subscore line or, with `--explain`, a per-criterion breakdown with ✓/✗ marks and point details, followed by suggestions
+- Batch mode (no filters, or `--all`) prints a "Scoring N spec(s)…" progress header in text mode (suppressed for JSON/CSV)
+- Grades are colorized by band (A/B green, C/D yellow, F red); subscores colorized (20 green, 10–19 yellow, <20 red)
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — print and exit
+- Scoring logic itself lives in the `scoring` module; this command only orchestrates and renders
+- Status filtering reuses `filter_by_status`; unmatched positional filters print a warning via `filter_specs`
+- Output must honor the requested `OutputFormat` (Text/Json/Table/Csv) — anything unrecognized falls through to text
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Defining or tuning the scoring rubric (owned by the scoring module)
+- Failing the build on low scores — `score` is informational and does not set a non-zero exit code
+- Writing scores to a file or committing them
+- Interactive prompts

--- a/specs/cmd_score/tasks.md
+++ b/specs/cmd_score/tasks.md
@@ -4,16 +4,20 @@ spec: cmd_score.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add an integration test asserting `--explain` text output shows per-criterion ✓/✗ lines
 
 ## Done
 
 - [x] Initial spec creation with all required sections
-- [x] Requirements and acceptance criteria documented
+- [x] Requirements and acceptance criteria documented (now covering table/CSV formats, `--all`, batch summary, status filters)
+- [x] Text, JSON, table, and CSV output paths covered by `tests/integration.rs`
+- [x] MCP score tool path covered (`mcp_score_tool_returns_grades`)
+- [x] CSV SUMMARY row and table-without-`--all` behavior covered
 
 ## Gaps
 
-- No dedicated test file for this command module
+- `src/commands/score.rs` has no inline `#[cfg(test)]` module; coverage is via `tests/integration.rs`
+- No focused assertion for the `--explain` per-criterion breakdown rendering
 
 ## Review Sign-offs
 

--- a/specs/cmd_score/testing.md
+++ b/specs/cmd_score/testing.md
@@ -20,12 +20,17 @@ spec: cmd_score.spec.md
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
 | Score with explain | `--explain` set | `cmd_score` runs | each spec shows FM/Sec/API/Depth/Fresh subscores |
+| CSV format | `--format csv --all` | `specsync score` runs | a header row, one row per spec, and a final `SUMMARY` row are printed (`score_all_format_csv_outputs_header_row`, `score_all_format_csv_includes_summary_row`) |
+| Table format | `--format table --all` | `specsync score` runs | an aligned ASCII table with a Spec/Score/Grade header is printed (`score_all_format_table_outputs_headers`) |
+| JSON grades | `--format json` (or `--json`) | `specsync score` runs | JSON includes per-spec `grade`/`total` and a project `average_score`/`distribution` (`score_json_output_has_grades`) |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| No specs match filters | Warning printed | Keep or add a focused assertion before changing this behavior |
+| No specs match filters | Warning printed (via `filter_specs`) | Keep or add a focused assertion before changing this behavior |
+| `--format table` without `--all` | Still renders a valid table (single/filtered spec) | Covered by `score_format_table_without_all_flag_still_works` |
+| Any output format | `score` never sets a non-zero exit code (informational only) | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 

--- a/specs/cmd_stale/context.md
+++ b/specs/cmd_stale/context.md
@@ -5,17 +5,19 @@ spec: cmd_stale.spec.md
 ## Key Decisions
 
 - **Git history as source of truth**: Staleness is based on commits to source files since the spec's last commit, not file modification time.
+- **One spec commit, many source files**: the spec's last commit hash is resolved once via `git_last_commit_hash`, then each source file's divergence is counted with `git_commits_since(root, spec_commit, source_file)` — this is the post-N+1-fix shape (`git_commits_between` was removed).
 - **Most stale first**: Results sort by maximum commits behind so the highest-risk specs appear first.
-- **Skip untracked history**: Files with no usable git history are skipped to avoid false failures during bootstrap.
+- **Skip untracked history**: Specs not yet committed (no commit hash) and specs with empty `files` are counted as fresh to avoid false failures during bootstrap.
+- **Non-zero on drift**: the command exits 1 when any stale spec is found so CI can gate on it.
 
 ## Files to Read First
 
-- `src/commands/stale.rs` — CLI implementation and formatting.
-- `src/git_utils.rs` — Commit hash and commit distance helpers.
+- `src/commands/stale.rs` — CLI implementation, status filtering, and output formatting.
+- `src/git_utils.rs` — `git_last_commit_hash`, `git_commits_since`, `is_git_repo`, and the `StaleInfo` struct.
 
 ## Current Status
 
-Stable. The command is implemented and integrated with common output formats.
+Stable. Implemented across all output formats with integration coverage for non-git and fresh-repo cases.
 
 ## Notes
 

--- a/specs/cmd_stale/requirements.md
+++ b/specs/cmd_stale/requirements.md
@@ -5,18 +5,28 @@ spec: cmd_stale.spec.md
 ## User Stories
 
 - As a developer, I want to know which specs have drifted from their source files so I can update them
-- As a CI operator, I want staleness checks integrated into the validation pipeline so drift is caught early
+- As a CI operator, I want `specsync stale` to fail the build (non-zero exit) when drift is detected so drift is caught early
+- As a maintainer, I want to scope the scan with `--only-status`/`--exclude-status` so I can ignore draft or archived specs
 
 ## Acceptance Criteria
 
-- `specsync stale` lists specs whose source files have changed since the spec was last modified
-- Reports include commit count, changed file list, and last commit details
-- JSON output mode (`--format json`) produces machine-readable staleness data
-- `specsync check --stale` integrates drift warnings into the standard check pipeline
-- Exit code is non-zero when stale specs are detected (for CI usage)
+- `specsync stale` lists specs whose source files have changed since the spec was last committed, sorted most-stale-first
+- A spec is stale when any of its source files has `>= threshold` commits since the spec's last commit (default threshold: 5)
+- Output reports per-spec commit count and the list of drifted source files (each with its own commit count)
+- Honors the global `--exclude-status` / `--only-status` filters when selecting which specs to scan
+- Supports `text`/`table`/`csv` (human), `json` (machine), and `markdown`/`github` output formats
+- Exit code is 1 when any stale specs are detected, 0 when all are fresh (for CI usage)
+- Requires a git repository: errors and exits 1 when `is_git_repo` returns false (JSON mode emits an error object instead of stderr text)
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
+- Must not panic on expected error conditions — print and exit
 - Must work with the project's Clap-based CLI argument parsing
-- Git operations must handle missing git repos gracefully (non-git directories)
+- Git operations must handle missing git repos gracefully (non-git directories error cleanly rather than crashing)
+- Staleness uses `git_commits_since` with one precomputed spec commit hash per spec (no N+1 `git log` calls)
+
+## Out of Scope
+
+- Auto-updating or regenerating stale specs (reporting only)
+- File modification-time heuristics (git history is the sole source of truth)
+- Combining staleness with coverage/validation status (that is the `report` command)

--- a/specs/cmd_stale/tasks.md
+++ b/specs/cmd_stale/tasks.md
@@ -4,13 +4,15 @@ spec: cmd_stale.spec.md
 
 ## Tasks
 
+- No open tasks.
+
+## Done
+
 - [x] Implement git-based stale-spec detection
-- [x] Support text, JSON, markdown, and GitHub-oriented output
-- [ ] Add integration coverage for non-git directory behavior
-
-## Gaps
-
-- Some git failure modes are intentionally treated as fresh/skipped; integration tests should document the CLI behavior for non-git roots.
+- [x] Support text/table/csv, JSON, and markdown/github output
+- [x] Sort results most-stale-first and exit non-zero when stale specs are found
+- [x] Migrate to `git_commits_since` (one spec commit hash per spec) as part of the N+1 fix
+- [x] Add integration coverage for non-git and fresh-repo behavior (`stale_outside_git_repo_fails_with_message`, `stale_outside_git_repo_json_reports_error`, `stale_in_fresh_repo_reports_all_up_to_date`)
 
 ## Review Sign-offs
 

--- a/specs/cmd_stale/testing.md
+++ b/specs/cmd_stale/testing.md
@@ -6,11 +6,15 @@ spec: cmd_stale.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/stale.rs` | cargo test commands::stale | No inline tests found; add focused coverage for `cmd_stale` before risky changes |
+| `src/commands/stale.rs` | cargo test commands::stale | No inline `#[cfg(test)]` module; CLI behavior is covered by the integration tests below |
+| `tests/integration.rs` | cargo test --test integration stale_outside_git_repo_fails_with_message | Non-git root: failure exit, stderr contains "Not a git repository" |
+| `tests/integration.rs` | cargo test --test integration stale_outside_git_repo_json_reports_error | Non-git root, `--format json`: failure exit, stdout has `"not a git repository"` and `"stale_specs"` |
+| `tests/integration.rs` | cargo test --test integration stale_in_fresh_repo_reports_all_up_to_date | Repo where spec and source share history: success exit, stdout contains "up to date" |
+| `src/git_utils.rs` | cargo test git_utils | Underlying commit-distance logic (`commits_since_counts_source_changes_after_spec`, etc.) lives in git_utils tests |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "All specs fresh" before changing user-visible CLI output, generated files, or error handling in cmd_stale.
+- No integration fixture yet exercises a *stale* spec end-to-end (a committed spec followed by N commits to its source). The git-distance counting is covered at the unit level in `src/git_utils.rs`.
 
 ## Behavioral Verification
 
@@ -24,7 +28,7 @@ spec: cmd_stale.spec.md
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Not a git repository | Prints error, exits 1 | Keep or add a focused assertion before changing this behavior |
+| Not a git repository | Prints error, exits 1 | Covered by `stale_outside_git_repo_fails_with_message` / `stale_outside_git_repo_json_reports_error` |
 | Spec file unreadable | Skipped silently | Keep or add a focused assertion before changing this behavior |
 | No frontmatter | Skipped silently | Keep or add a focused assertion before changing this behavior |
 | Source file doesn't exist on disk | Skipped in commit distance check | Keep or add a focused assertion before changing this behavior |

--- a/specs/cmd_view/context.md
+++ b/specs/cmd_view/context.md
@@ -4,17 +4,21 @@ spec: cmd_view.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Thin command wrapper: load config, find spec files, loop and delegate each to `view::view_spec`, print with a `---` separator. All section-filtering logic lives in the `view` library module.
+- Per-file resilience: a render error for one spec is printed to stderr and skipped rather than aborting the whole run.
+- Role validation is delegated: an unknown role surfaces as an error string from `view::view_spec` (valid roles: dev, qa, product, agent).
+- `--spec` filtering matches on module name derived from the file stem with a trailing `.spec` stripped.
 
 ## Files to Read First
 
-- `src/commands/view.rs` — primary source file
+- `src/commands/view.rs` — the command wrapper
+- `src/view.rs` — `view_spec`, `sections_for_role`, `valid_roles` (the actual role-to-section mapping)
+- `src/validator.rs` — `find_spec_files` used for discovery
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable. The command itself has no unit tests; the role/section logic it relies on is unit-tested in `src/view.rs` (e.g. `test_sections_for_role`).
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Part of the command layer — it orchestrates the `view`, `config`, and `validator` modules rather than holding domain logic.

--- a/specs/cmd_view/requirements.md
+++ b/specs/cmd_view/requirements.md
@@ -4,21 +4,30 @@ spec: cmd_view.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_view` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want `specsync view --role dev` to show only the implementation-relevant sections of a spec so I can read its API and invariants without wading through every section
+- As a QA engineer, I want a `qa` role view that surfaces behavioral examples, error cases, and invariants so I can derive test cases
+- As a product owner, I want a `product` role view limited to purpose and change log
+- As an agent/tooling author, I want an `agent` role view that includes status, agent policy, and invariants
+- As a user, I want to optionally narrow the output to a single module with `--spec <module>`
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `cmd_view` discovers spec files under `config.specs_dir` via `find_spec_files`
+- Each spec is rendered through `view::view_spec(path, role)`, which keeps only the sections allowed for the given role
+- When `spec_filter` is provided, only the spec whose module name (file stem minus `.spec`) matches is rendered
+- Rendered specs are separated by a `---` delimiter line
+- A per-file render error is printed to stderr (`error:` prefix) and processing continues to the next spec
+- Exits with code 1 when no spec files are found
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
+- Must not panic on expected error conditions — print and exit
 - Must work with the project's Clap-based CLI argument parsing
+- Read-only: never writes or modifies spec or companion files
+- Unknown role names are rejected by `view::view_spec` with a message listing the valid roles (dev, qa, product, agent)
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Defining which sections belong to each role (owned by the `view` module, not this command)
+- GUI or web rendering
+- Interactive prompts (handled by the `wizard` command)

--- a/specs/cmd_view/testing.md
+++ b/specs/cmd_view/testing.md
@@ -6,11 +6,12 @@ spec: cmd_view.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/view.rs` | cargo test commands::view | No inline tests found; add focused coverage for `cmd_view`, `load_config`, `find_spec_files`, `view_spec` before risky changes |
+| `src/commands/view.rs` | cargo test commands::view | No inline `#[cfg(test)]` module in the command wrapper; add a CLI fixture before risky changes |
+| `src/view.rs` | cargo test view | Role/section logic is unit-tested here (`test_sections_for_role` covers dev/qa/product/agent and rejects unknown roles) |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Dev view" before changing user-visible CLI output, generated files, or error handling in cmd_view.
+- Integration gap: no end-to-end CLI fixture asserts that `specsync view --role <r>` prints only the role's sections or that `--spec <module>` filters correctly. The section mapping itself is covered by `test_sections_for_role` in `src/view.rs`.
 
 ## Behavioral Verification
 

--- a/specs/cmd_wizard/context.md
+++ b/specs/cmd_wizard/context.md
@@ -4,17 +4,22 @@ spec: cmd_wizard.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- Interactive-first: all input is gathered through `dialoguer` (`Input`, `Select`, `Confirm`). Interrupting any prompt maps to a clean `process::exit(0)`.
+- Safety before writing: nothing touches disk until the user confirms the preview; an existing spec aborts the wizard early.
+- Module-type presets are inlined as `(extra_invariants, extra_api_hint)` tuples keyed on the selected template index, so each type seeds appropriate invariants and an API table.
+- The spec body is built as one `format!` string here rather than via the generator, but companion files are still produced through `generator::generate_companion_files_for_spec` (so design.md respects `companions.design`).
 
 ## Files to Read First
 
-- `src/commands/wizard.rs` — primary source file
+- `src/commands/wizard.rs` — the full interactive flow and spec-body template
+- `src/generator.rs` — `generate_companion_files_for_spec` for the companion set
+- `src/config.rs` — `source_dirs`, `source_extensions`, `companions.design`
+- `src/exports.rs` — `has_extension` used during source auto-detection
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable. No automated tests cover the interactive flow (it requires a TTY); the spec-body shape mirrors the `scaffold`/`generate` templates.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- Part of the command layer — orchestrates `config`, `generator`, and `exports`; the only command that depends on interactive prompts.

--- a/specs/cmd_wizard/requirements.md
+++ b/specs/cmd_wizard/requirements.md
@@ -4,21 +4,32 @@ spec: cmd_wizard.spec.md
 
 ## User Stories
 
-- As a developer, I want the `cmd_wizard` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer new to a project, I want an interactive wizard that walks me through creating a spec (name, purpose, type, status, sources, dependencies) so I don't have to remember the frontmatter format
+- As a developer, I want the wizard to auto-detect source files for my module and let me add one manually when nothing is found
+- As a developer, I want a preview and an explicit confirmation before anything is written so I can cancel a mistake
+- As a developer, I want module-type presets (API endpoint, data model, utility, UI component) that seed type-appropriate invariants and API sections
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- Prompts (via `dialoguer`) collect, in order: module name, purpose, module type, initial status, source files, dependencies
+- Module name is trimmed; an empty name prints an error and exits 1
+- If `<specs_dir>/<module>/<module>.spec.md` already exists, the wizard prints a warning and exits 1 (never overwrites)
+- Source files are auto-detected by scanning `config.source_dirs` for files whose stem or parent directory equals the module name and whose extension is in `source_extensions`; when none are found the user may enter one path or skip
+- Status choices are `draft`, `unstable`, `stable`, `locked` (default `draft`); module-type choices add type-specific invariants/API hints
+- Dependencies are parsed from a comma-separated list into `depends_on`
+- A truncated preview (~first 30 lines) is shown, then a write confirmation; declining prints "Cancelled." and returns without writing
+- On confirm, the spec dir is created, the spec is written, and companion files are generated (design.md only when `config.companions.design` is enabled)
+- Cancelling at any prompt (Ctrl-C / interrupt) exits cleanly with code 0
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — print and exit
+- Interactive only: relies on a TTY for `Input`/`Select`/`Confirm` prompts
+- Read-only with respect to existing specs: an existing `*.spec.md` is never modified
+- Source-file paths are normalized to forward slashes in generated frontmatter
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Non-interactive / scripted spec creation (use `scaffold` or `add-spec`)
+- AI-assisted content (use the `generate` command)
+- Editing or re-running against an existing spec

--- a/specs/cmd_wizard/testing.md
+++ b/specs/cmd_wizard/testing.md
@@ -6,11 +6,11 @@ spec: cmd_wizard.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/wizard.rs` | cargo test commands::wizard | No inline tests found; add focused coverage for `cmd_wizard`, `load_config` before risky changes |
+| `src/commands/wizard.rs` | cargo test commands::wizard | No inline `#[cfg(test)]` module; the flow is interactive (TTY-bound via `dialoguer`) so it is not exercised by automated tests |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Create API endpoint spec" before changing user-visible CLI output, generated files, or error handling in cmd_wizard.
+- The interactive wizard cannot be driven by the standard CLI integration harness (it blocks on TTY prompts). The spec-body template and companion generation it relies on are covered indirectly by the `generate`/scaffold companion tests (`generate_creates_companion_files`, `generate_creates_design_md_when_enabled`). Verify the template-specific sections manually before changing them.
 
 ## Behavioral Verification
 

--- a/specs/commands/context.md
+++ b/specs/commands/context.md
@@ -4,17 +4,24 @@ spec: commands.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- This is the shared infrastructure layer: `mod.rs` holds the boilerplate every subcommand reuses (config load, spec discovery, filtering, validation pipeline, exit-code logic, GitHub drift issues) and re-exports each `commands::*` submodule.
+- Discovery skips `_`-prefixed spec files so template/internal specs never get validated.
+- Exit-code logic is split in two: `compute_exit_code` is pure (returns `i32`, easy to unit-test), while `exit_with_status` is the side-effecting twin that prints and calls `process::exit`.
+- `run_validation` owns the full text rendering of check output AND the `collect` path that gathers error/warning strings for JSON/markdown/GitHub formats — both share one validation loop and one ignore-rule filter.
+- `filter_by_status` reads only the frontmatter section (up to the closing `---`) to avoid re-reading full file bodies that callers parse again later.
 
 ## Files to Read First
 
-- `| `build_schema_columns` | `root: &Path, config: &SpecSyncConfig` | `HashMap<String, SchemaTable>` | Build column-level schema from migration files if `schema_dir` is configured |` — primary source file
+- `src/commands/mod.rs` — the module itself (all shared functions + submodule re-exports)
+- `src/main.rs` — dispatches every `Command` variant into these submodules; also home to the `compute_exit_code` unit tests
+- `src/validator.rs` — `find_spec_files`, `validate_spec` (the core called by `run_validation`)
+- `src/config.rs` — `load_config` used by `load_and_discover`
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable. `compute_exit_code` is unit-tested in `src/main.rs`; the surrounding flow is exercised by `tests/integration.rs`. `mod.rs` itself has no `#[cfg(test)]` module.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This module orchestrates library modules rather than containing domain logic.
+- `filter_by_status` warns on unrecognized status strings so typos don't silently filter nothing.

--- a/specs/commands/requirements.md
+++ b/specs/commands/requirements.md
@@ -4,21 +4,34 @@ spec: commands.spec.md
 
 ## User Stories
 
-- As a developer, I want the `commands` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a subcommand author, I want shared config-load, discovery, filtering, and validation helpers so that I don't re-implement boilerplate in every `commands::*` module
+- As a CLI user, I want `--exclude-status` / `--only-status` and positional spec filters honored consistently across commands so that scoping a run behaves the same everywhere
+- As a CI operator, I want exit codes that reflect enforcement mode and coverage thresholds so that pipeline pass/fail is predictable and actionable
+- As a maintainer, I want exit-code logic separated from process exit so that the decision is unit-testable without spawning a process
+- As a team using GitHub, I want validation errors turned into one issue per drifted spec so that drift gets tracked without flooding the tracker
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `load_and_discover` loads config, discovers spec files under the configured specs dir, excludes `_`-prefixed files, and exits 0 with a "run `specsync generate`" hint when empty and `allow_empty` is false
+- `filter_specs` matches a filter against exact path, project-relative path, filename stem, or module name (stem minus `.spec`); empty filters return all specs; unmatched filters print a yellow warning
+- `filter_by_status` supports exclude-list and only-list modes, warns on statuses not in {draft, review, active, stable, deprecated, archived}, and includes specs with no status only when excluding (not when `--only-status` is active)
+- `build_schema_columns` returns an empty map when `schema_dir` is unset, otherwise builds column-level schema from migrations
+- `run_validation` validates each spec, applies global/inline/per-spec ignore rules to warnings, and returns `(errors, warnings, passed, total, error_strings, warning_strings)`; when `collect` is false it renders the full per-spec text report
+- `compute_exit_code` returns: Warn → always 0; EnforceNew → 1 if any unspecced files; Strict → 1 on any error and (with `--strict`) 1 on any warning; and 1 whenever `--require-coverage N` exceeds actual file coverage, regardless of mode
+- `exit_with_status` mirrors `compute_exit_code` but prints the reason and calls `process::exit`
+- `create_drift_issues` groups `"spec/path: message"` errors by spec and creates exactly one GitHub issue per spec using configured drift labels (default `spec-drift`)
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Must not panic on expected error conditions — print and exit, or return Result-like values
+- Must reuse `load_config`, `find_spec_files`, `validate_spec` from the library rather than duplicating logic
+- `\r\n` is normalized to `\n` before frontmatter parsing in status filtering
+- GitHub issue creation must continue past individual `gh` failures, reporting each per-spec error
+- Output rendering must respect the requested `OutputFormat` (text vs collected JSON/markdown/GitHub)
 
 ## Out of Scope
 
 - GUI or web interface
-- Interactive prompts (except wizard module)
+- Interactive prompts (only the wizard and the check `--fix` re-validation prompt live elsewhere)
+- Domain logic for validation/scoring/coverage — those live in their own library modules; this module only orchestrates them
+- Defining the CLI argument grammar (that is the `cli` module's responsibility)

--- a/specs/commands/tasks.md
+++ b/specs/commands/tasks.md
@@ -4,16 +4,18 @@ spec: commands.spec.md
 
 ## Tasks
 
-- [ ] Add integration tests for this command's CLI behavior
+- [ ] Add focused inline tests in `src/commands/mod.rs` for `filter_specs`, `filter_by_status`, and `load_and_discover` (only `compute_exit_code` is currently unit-tested, and it lives in `src/main.rs`)
 
 ## Done
 
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
+- [x] `compute_exit_code` exit-code matrix covered by unit tests in `src/main.rs` (warn/enforce-new/strict + require-coverage)
+- [x] End-to-end enforcement and coverage flows covered in `tests/integration.rs`
 
 ## Gaps
 
-- No dedicated test file for this command module
+- `src/commands/mod.rs` has no `#[cfg(test)]` module; `filter_specs`/`filter_by_status`/`run_validation` are exercised only indirectly via integration tests
 
 ## Review Sign-offs
 

--- a/specs/commands/testing.md
+++ b/specs/commands/testing.md
@@ -6,7 +6,8 @@ spec: commands.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/mod.rs` | cargo test commands::mod | No inline tests found; add focused coverage for `load_and_discover`, `filter_specs`, `filter_by_status`, `build_schema_columns` before risky changes |
+| `src/commands/mod.rs` | cargo test commands::mod | No inline tests in mod.rs; add focused coverage for `load_and_discover`, `filter_specs`, `filter_by_status`, `build_schema_columns` before risky changes |
+| `compute_exit_code` | cargo test --bin specsync | Pure exit-code matrix tested in `src/main.rs`: `warn_mode_exits_0_with_no_errors`, `warn_mode_exits_0_even_with_errors`, `warn_mode_respects_require_coverage`, `enforce_new_exits_1_when_unspecced_files_exist`, `strict_mode_exits_1_with_errors`, `strict_mode_exits_1_with_warnings_and_strict_flag`, `strict_mode_respects_require_coverage`, `strict_mode_exits_0_when_coverage_meets_threshold` (12 cases total) |
 | `tests/integration.rs` | cargo test --test integration strict_turns_warnings_into_errors | End-to-end fixture: `strict_turns_warnings_into_errors` |
 | `tests/integration.rs` | cargo test --test integration require_coverage_passes_when_met | End-to-end fixture: `require_coverage_passes_when_met` |
 | `tests/integration.rs` | cargo test --test integration require_coverage_fails_when_below_threshold | End-to-end fixture: `require_coverage_fails_when_below_threshold` |

--- a/specs/comment/context.md
+++ b/specs/comment/context.md
@@ -2,12 +2,23 @@
 spec: comment.spec.md
 ---
 
-## Key Files
+## Key Decisions
 
-- `src/comment.rs` - Main implementation
-- `specs/comment/comment.spec.md` - Module specification
-- `specs/comment/requirements.md` - User stories and acceptance criteria
+- **Single rendering function**: `render_check_comment` is the only public rendering entry point. The marketplace GitHub Action and the project's own CI workflow both call it (via `specsync comment` / `cargo run -- comment`) so PR comments are byte-identical regardless of invocation.
+- **String-based suggestion classification**: `suggestion_for_error`/`suggestion_for_warning` match on message prefixes (e.g. `"Missing required section: "`, `"Export '"`). This couples the comment module to the validator's message wording — changing a validator message means updating these matchers.
+- **Spec-prefixed messages**: Validator messages arrive as `"spec/path.md: message"`. `group_by_spec` clusters them per spec for the Errors/Warnings sections; `strip_spec_prefix` removes the prefix for the flat Action Items checklist.
+- **Branch detection shells out to git**: `detect_branch` runs `git rev-parse --abbrev-ref HEAD`; failures (not a repo, git missing) return `None` rather than erroring.
+
+## Files to Read First
+
+- `src/comment.rs` — entire module: rendering, suggestion classification, grouping helpers, `detect_branch`.
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Stable and complete. Public API is `render_check_comment` and `detect_branch`. The `#[cfg(test)]` module contains a private `SpecViolation` struct and `render_comment_body` helper used only to exercise the renderer.
+
+## Notes
+
+- Consumed by the `cli` module (and through it, `cmd_comment`).
+- Depends only on `types::CoverageReport`.
+- Unspecced-files list is capped at 15 with an "...and N more" suffix.

--- a/specs/comment/requirements.md
+++ b/specs/comment/requirements.md
@@ -10,9 +10,12 @@ spec: comment.spec.md
 
 ## Acceptance Criteria
 
-- `render_check_comment` produces valid GitHub-flavored markdown with pass/fail header, summary table, coverage metrics, and actionable error suggestions
-- When repo and branch are provided, spec links are full GitHub URLs; otherwise relative markdown links
-- Errors are classified into actionable categories: missing sections, missing source files, DB table issues, frontmatter problems, dependency issues
+- `render_check_comment` produces valid GitHub-flavored markdown with pass/fail header (✅/❌), summary table (specs checked, passed, errors, warnings, file coverage, LOC coverage), grouped error/warning sections, an actionable checklist, an unspecced-files section, and a footer
+- When repo and branch are provided, spec links are full GitHub URLs; otherwise plain inline-code markdown
+- Errors are classified into actionable categories: missing sections, missing source files, DB table issues, frontmatter problems, dependency issues, schema column issues, and stale file references (with a generic "Review and fix" fallback)
+- Warnings are classified into: undocumented export, consumed-by, schema column (with a generic "Review" fallback)
+- Errors and warnings are grouped by spec path (`group_by_spec`), preserving insertion order; messages prefixed with `spec/path: ...` have the prefix stripped for the checklist
+- The unspecced-files list is truncated to 15 entries with an "...and N more" line
 - `detect_branch` returns `Some(branch)` inside a git repo, `None` otherwise
 - Both the marketplace GitHub Action (`action.yml`) and project CI workflow (`.github/workflows/ci.yml`) use `specsync comment` to generate identical PR comment output
 
@@ -24,6 +27,6 @@ spec: comment.spec.md
 
 ## Out of Scope
 
-- Posting comments (handled by `cmd_comment`)
+- Posting comments (handled by `cmd_comment` / the GitHub Action and CI workflow)
 - Interactive or terminal-formatted output
-- Violation-level rendering (`SpecViolation`, `render_comment_body` were removed in the unified pipeline refactor)
+- Public violation-level rendering: the public API is just `render_check_comment` and `detect_branch`. (`SpecViolation` and `render_comment_body` exist only as private test helpers in the `#[cfg(test)]` module, not as part of the module's API.)

--- a/specs/comment/tasks.md
+++ b/specs/comment/tasks.md
@@ -4,4 +4,23 @@ spec: comment.spec.md
 
 ## Tasks
 
+(none open)
+
+## Done
+
+- [x] `render_check_comment`: header, summary table, grouped errors/warnings, action items, unspecced files, footer
+- [x] `spec_link` GitHub URL vs inline-code fallback
+- [x] `suggestion_for_error` classification (missing section, source file, DB table, frontmatter, dependency, schema column, stale file ref, generic fallback)
+- [x] `suggestion_for_warning` classification (export, consumed-by, schema column, generic fallback)
+- [x] `group_by_spec` / `split_spec_prefix` / `strip_spec_prefix` message grouping and prefix handling
+- [x] `detect_branch` via `git rev-parse --abbrev-ref HEAD`
+- [x] Unspecced-files truncation at 15 entries
+- [x] Unified output pipeline shared by the marketplace action and project CI
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/compact/context.md
+++ b/specs/compact/context.md
@@ -2,12 +2,24 @@
 spec: compact.spec.md
 ---
 
-## Key Files
+## Key Decisions
 
-- `src/compact.rs` - Main implementation
-- `specs/compact/compact.spec.md` - Module specification
-- `specs/compact/requirements.md` - User stories and acceptance criteria
+- **String slicing, not markdown parsing**: `compact_spec_changelog` finds the `## Change Log` marker, computes the section end (next `## ` heading or EOF), and rewrites only that slice. The rest of the file is copied byte-for-byte.
+- **First two table lines are structural**: any `|`-prefixed line counts toward the table; the first two are treated as header + separator and always kept, the rest are data rows.
+- **Keep-last semantics**: the most recent `keep` rows survive; older rows collapse into one summary row inserted at the position of the first removed row.
+- **Column-aware summary**: column count comes from the first data row; 3+ column tables get a `—` placeholder for the interior column so the markdown table stays aligned.
+- **No-op filtering**: `compact_spec_changelog` still returns a `CompactResult` when nothing is removed, but `compact_changelogs` drops those (only `removed > 0` is surfaced and written).
+
+## Files to Read First
+
+- `src/compact.rs` — entire module: `compact_changelogs` (driver), `compact_spec_changelog` (core rewrite), `extract_first_cell`, and the `CompactResult` struct.
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Stable and complete. Public API is `compact_changelogs` plus the `CompactResult` struct. Invoked by the `cmd_compact` subcommand.
+
+## Notes
+
+- Depends on `validator::find_spec_files`.
+- `dry_run` short-circuits the `fs::write` only; results are still collected.
+- Summary row format: `| <first> — <last> | Compacted: <N> entries |` (with an extra `—` cell for wider tables).

--- a/specs/compact/requirements.md
+++ b/specs/compact/requirements.md
@@ -3,3 +3,33 @@ spec: compact.spec.md
 ---
 
 ## User Stories
+
+- As a maintainer of long-lived specs, I want old changelog rows collapsed into one summary line so that the `## Change Log` table stays readable
+- As a CI operator, I want a `--dry-run` mode so that I can preview which specs would change before writing anything
+- As a developer, I want compaction to keep the most recent N entries verbatim so that recent history is never lost
+
+## Acceptance Criteria
+
+- `compact_changelogs(root, specs_dir, keep, dry_run)` walks every spec found by `find_spec_files` and compacts each spec's `## Change Log` table
+- The `## Change Log` section ends at the next `## ` heading or EOF; only that slice is rewritten
+- The first two `|`-prefixed lines in the section (header + separator) are always preserved
+- The last `keep` data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
+- The summary row reads `| <first_date> — <last_date> | Compacted: <N> entries |` for 2-column tables, and inserts a `—` placeholder for the middle column(s) on 3+ column tables
+- Column count is detected from the first data row (`| count - 1`)
+- If `total <= keep`, no rows are removed (`removed == 0`) and the spec is not written; such results are filtered out by `compact_changelogs`
+- `dry_run: true` collects `CompactResult` values but never writes files
+- Only results where `removed > 0` are returned from `compact_changelogs`
+
+## Constraints
+
+- Operates on the raw markdown text via string slicing; no markdown AST
+- A spec is only touched if it contains a `## Change Log` marker; otherwise silently skipped
+- Date range is taken from the first cell of the first/last removed rows (`extract_first_cell`)
+- Write failures print a bold-red `error:` line to stderr and continue with the next spec
+
+## Out of Scope
+
+- Compacting any section other than `## Change Log`
+- Parsing or validating individual changelog dates
+- Merging or de-duplicating changelog content beyond counting removed rows
+- Restoring previously compacted entries

--- a/specs/compact/tasks.md
+++ b/specs/compact/tasks.md
@@ -4,4 +4,23 @@ spec: compact.spec.md
 
 ## Tasks
 
+(none open)
+
+## Done
+
+- [x] `compact_changelogs` walks all specs via `find_spec_files`, writes unless `dry_run`
+- [x] `compact_spec_changelog` locates the `## Change Log` section (next `## ` heading or EOF)
+- [x] Preserve header + separator rows; keep last `keep` data rows
+- [x] Build summary row with date range and `Compacted: N entries` count
+- [x] 2-column and 3+ column table summary formats
+- [x] `extract_first_cell` for date-range extraction
+- [x] Filter out results where `removed == 0`
+- [x] Bold-red error on write failure, continue with remaining specs
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/compact/testing.md
+++ b/specs/compact/testing.md
@@ -16,7 +16,7 @@ spec: compact.spec.md
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Compact a long changelog | a spec with 20 changelog entries and `keep = 5` | `compact_changelogs` is called | the first 15 entries are replaced with a single summary row like `\| 2025-01-01 — 2026-03-15 \| 15 entries compacted \|` |
+| Compact a long changelog | a spec with 20 changelog entries and `keep = 5` | `compact_changelogs` is called | the first 15 entries are replaced with a single summary row of the form `\| <first_date> — <last_date> \| Compacted: 15 entries \|` |
 | Short changelog (no compaction needed) | a spec with 3 changelog entries and `keep = 5` | `compact_changelogs` is called | the spec is skipped (not included in results) |
 | Dry run | specs with long changelogs | `compact_changelogs(root, specs_dir, 5, true)` is called | returns `CompactResult` entries but does not modify any files |
 

--- a/specs/config/context.md
+++ b/specs/config/context.md
@@ -4,22 +4,27 @@ spec: config.spec.md
 
 ## Key Decisions
 
-- **JSON-first, TOML fallback**: `specsync.json` is checked first for familiarity with the JS/TS ecosystem; `.specsync.toml` is the alternative for Rust/Go projects. Both produce the same `SpecSyncConfig`.
-- **Zero-dependency TOML**: Rather than pulling in a TOML crate, parsing is done line-by-line with string operations. This keeps the dependency tree minimal and avoids version conflicts.
-- **Auto-detection fallback**: If no config file exists, source directories are detected by scanning for files with recognized extensions up to 3 levels deep. Fallback is `["src"]` if nothing found.
+- **v4 layout precedence**: `load_config` checks `.specsync/config.toml` first, then `.specsync/config.json`, then legacy root `.specsync.toml`, then legacy root `specsync.json`, then auto-detected defaults. The TOML `.specsync/config.toml` is the canonical v4 form; the JSON variants stay supported for back-compat.
+- **Per-developer local overrides**: After the shared config loads, `.specsync/config.local.toml` (gitignored) is merged on top via `merge_local_config`. Only top-level `ai_*` keys are applied — any key inside a `[section]` is skipped, and unknown top-level keys warn "only ai_* keys are supported." This lets contributors set their own `ai_provider`/`ai_command`/`ai_model` without touching committed config.
+- **Zero-dependency TOML**: Rather than pulling in a TOML crate, parsing is done line-by-line with string operations, routed per section (`[rules]`, `[github]`, `[lifecycle]`, `[lifecycle.max_age]`, `[lifecycle.guards."x→y"]`, `[companions]`). This keeps the dependency tree minimal and avoids version conflicts.
+- **AI fields are loose-parsed**: `ai_provider`/`aiProvider` goes through `AiProvider::from_str_loose`, so aliases like `claude` (deprecated → anthropic) and casing variants resolve. The env-precedence layering (`SPECSYNC_AI_PROVIDER`, `SPECSYNC_AI_COMMAND`, `SPECSYNC_AI_MODEL`, `<PROVIDER>_API_KEY`) is handled by the `ai`/`cmd_generate` layers, not here — `config.rs` only reads file values.
+- **API key never written back**: `config_to_toml` intentionally omits `ai_api_key` and prints a warning telling the user to set the `<PROVIDER>_API_KEY` env var instead, so secrets don't land in committed config.
+- **Auto-detection fallback**: If no config file exists (or a file omits source dirs), source directories are detected by scanning for files with recognized extensions up to 3 levels deep. Fallback is `["src"]` if nothing found; root-level source files yield `["."]`.
 - **Manifest-first discovery**: When detecting source dirs, manifest files (Cargo.toml, Package.swift, etc.) are checked before falling back to extension scanning. This gives more accurate module-aware results.
 - **46 hardcoded excludes**: Common build/cache directories (node_modules, target, .git, dist, etc.) are always excluded to prevent scanning generated code.
 
 ## Files to Read First
 
-- `src/config.rs` — Config loading, TOML parsing, source directory detection, and manifest integration.
-- `src/types.rs` — `SpecSyncConfig` struct definition with all field defaults.
+- `src/config.rs` — Config loading, format precedence, `merge_local_config`, TOML/JSON parsing, `config_to_toml`, `is_legacy_layout`, source directory detection, and manifest integration.
+- `src/types.rs` — `SpecSyncConfig`, `AiProvider`, and the per-section config structs (rules, github, lifecycle, companions) with all field defaults.
+- `src/ai.rs` — Where AI env precedence and provider resolution actually happen (config supplies the file-level values they layer on top of).
 
 ## Current Status
 
-Fully implemented. JSON and TOML loading work with unknown-key warnings. Auto-detection covers all 9 supported languages. Manifest-aware discovery delegates to the manifest module.
+Fully implemented for spec-sync 4.4.0. JSON and TOML loading work with unknown-key warnings, v4 layout precedence, and the `config.local.toml` AI override merge. AI config is aligned with the reworked corvid-ai providers (anthropic, openai, openrouter, gemini, deepseek, groq, mistral, xai, together, ollama; deprecated claude/copilot/cursor; plus `ai_command` shell hatch). Auto-detection covers the supported languages and delegates manifest discovery to the manifest module.
 
 ## Notes
 
-- The config module is the bridge between user intent (config file) and the rest of the system — validator, watch, and MCP all depend on it.
+- The config module is the bridge between user intent (config file) and the rest of the system — validator, watch, MCP, and the generate command all depend on it.
 - Unknown keys in config files produce warnings, not errors, for forward compatibility when newer config options are added.
+- `config.rs` does not read env vars itself (except indirectly via callers); the AI env-var precedence ladder lives in `src/ai.rs` and `src/commands/generate.rs`.

--- a/specs/config/requirements.md
+++ b/specs/config/requirements.md
@@ -9,28 +9,38 @@ spec: config.spec.md
 - As a team lead, I want to configure required sections, excluded directories, and source extensions so that validation fits our project's needs
 - As a monorepo maintainer, I want spec-sync to discover source directories from manifest files (Cargo.toml, package.json, etc.) so that complex project structures are handled automatically
 - As a developer, I want missing config fields to fall back to sensible defaults so that I only need to configure what I want to customize
+- As a contributor on a shared repo, I want per-developer AI settings in a gitignored `.specsync/config.local.toml` so that my chosen AI provider/model doesn't conflict with the team's committed config
+- As a developer, I want to pick an AI provider via the flat `aiProvider`/`aiModel`/`aiCommand`/`aiApiKey`/`aiBaseUrl`/`aiTimeout` fields so that `generate` can run AI without re-passing flags
 
 ## Acceptance Criteria
 
-- Config search order: `specsync.json` > `.specsync.toml` > auto-detected defaults
+- Config search order: `.specsync/config.toml` > `.specsync/config.json` > `.specsync.toml` (legacy root) > `specsync.json` (legacy root) > auto-detected defaults
+- After loading the shared config, `.specsync/config.local.toml` is merged on top when present; only top-level `ai_*` keys are honored there (section keys are skipped)
 - Auto-detection scans up to 3 directory levels deep for source files
-- At least 46 common build/cache directories are excluded from auto-detection (node_modules, target, .git, dist, etc.)
+- 46 common build/cache directories are excluded from auto-detection (node_modules, target, .git, dist, etc.)
 - Falls back to `["src"]` if no source files are found anywhere
 - Root-level source files produce `["."]` as the source directory
 - TOML parsing works without external TOML dependencies (zero-dependency line-by-line parser)
-- Auto-detection runs even when config file exists but omits `sourceDirs`
+- Auto-detection runs even when config file exists but omits `sourceDirs`/`source_dirs`
 - `load_config` never panics — always returns a valid config with defaults filled in
 - Manifest-aware discovery (Cargo.toml, package.json, etc.) feeds into source directory detection
+- AI fields are parsed from both JSON (`aiProvider`, `aiModel`, `aiCommand`, `aiApiKey`, `aiBaseUrl`, `aiTimeout`) and TOML (`ai_provider`, `ai_model`, `ai_command`, `ai_api_key`, `ai_base_url`, `ai_timeout`); `ai_provider`/`aiProvider` is parsed loosely via `AiProvider::from_str_loose` (e.g. `claude`, `anthropic`, `ollama`)
+- `config_to_toml` round-trips config back to TOML but deliberately omits `ai_api_key`, printing a warning that the value should live in a `<PROVIDER>_API_KEY` env var instead
+- Inline TOML comments are stripped from `config.local.toml` values, but a `#` inside a quoted string is preserved
+- `is_legacy_layout` reports true when root-level config (`specsync.json`/`.specsync.toml`/`specsync-registry.toml`) exists without a `.specsync/version` stamp
 
 ## Constraints
 
 - Config loading must be fast — no network calls, no AI, no heavy computation
 - TOML parser only needs to handle the subset of TOML used by specsync configs (not full TOML spec)
 - Config schema must be backwards-compatible — new fields must always have defaults
+- `ai_api_key` must never be written back into a committed config file by `config_to_toml`
+- `config.local.toml` overrides are limited to AI fields by design — other keys emit an "only ai_* keys are supported" warning
 
 ## Out of Scope
 
-- Config file validation or linting beyond basic parse errors
-- Config inheritance or merging across directories (monorepo-level config)
+- Config file validation or linting beyond basic parse errors and unknown-key warnings
+- Config inheritance/`extends` across files (only the fixed local-override merge is supported)
 - Remote/shared configuration (config is always local to the project)
-- Environment variable overrides for all config fields (only AI-related env vars supported)
+- Environment variable overrides for non-AI config fields (env precedence for `aiProvider`/`aiModel`/`aiCommand` is resolved in the `ai`/`cmd_generate` layers, not in `config.rs`)
+- Secret management for `ai_api_key` beyond the "use an env var instead" warning

--- a/specs/config/tasks.md
+++ b/specs/config/tasks.md
@@ -10,18 +10,24 @@ spec: config.spec.md
 
 ## Done
 
-- [x] JSON config loading with field defaults
-- [x] TOML config loading (zero-dependency parser)
+- [x] JSON config loading with field defaults (camelCase keys, unknown-key warnings)
+- [x] TOML config loading (zero-dependency parser) incl. `[rules]`, `[github]`, `[lifecycle]`, `[lifecycle.max_age]`, `[lifecycle.guards."x→y"]`, `[companions]` sections
+- [x] v4 layout config precedence: `.specsync/config.toml` > `.specsync/config.json` > `.specsync.toml` > `specsync.json`
+- [x] `.specsync/config.local.toml` per-developer override merge (top-level `ai_*` keys only)
+- [x] AI config fields wired through both formats: `aiProvider`/`ai_provider` (loose-parsed), `aiModel`, `aiCommand`, `aiApiKey`, `aiBaseUrl`, `aiTimeout`
+- [x] `config_to_toml` serializer — round-trips config, omits `ai_api_key` with a "set the env var instead" warning
+- [x] `is_legacy_layout` detection for 3.x root-level layouts
+- [x] Inline-comment stripping in local config that preserves `#` inside quoted strings (`strip_inline_comment`)
 - [x] Auto-detection of source directories by file extension
 - [x] Manifest-aware source directory discovery
 - [x] 46 hardcoded build/cache directory exclusions
-- [x] Unknown key warnings for forward compatibility
-- [x] Module definitions support in config
+- [x] Unknown key warnings for forward compatibility (`KNOWN_JSON_KEYS`, per-section TOML warnings)
 
 ## Gaps
 
-- TOML parsing handles only flat key-value pairs and simple arrays — nested tables would need extension
+- TOML parsing handles flat key-value pairs, simple inline arrays, and known sections only — arbitrary nested tables outside the known sections are skipped silently
 - No schema validation beyond type checking (e.g., invalid `status` values in modules aren't caught at config load time)
+- Non-AI fields cannot be overridden in `config.local.toml` (intentional, but warns rather than supporting it)
 
 ## Review Sign-offs
 

--- a/specs/config/testing.md
+++ b/specs/config/testing.md
@@ -4,24 +4,30 @@ spec: config.spec.md
 
 ## Automated Coverage
 
+Unit tests live in the `#[cfg(test)]` module at the bottom of `src/config.rs`. Run with `cargo test config::`.
+
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/config.rs` | cargo test config:: | `test_parse_toml_string_quoted`, `test_parse_toml_string_unquoted`, `test_parse_toml_string_empty_quotes`, `test_parse_toml_string_with_whitespace`, `test_parse_toml_string_array_basic`, `test_parse_toml_string_array_single` |
-| `tests/integration.rs` | cargo test --test integration init_creates_config_file | End-to-end fixture: `init_creates_config_file` |
-| `tests/integration.rs` | cargo test --test integration init_does_not_overwrite_existing_config | End-to-end fixture: `init_does_not_overwrite_existing_config` |
-| `tests/integration.rs` | cargo test --test integration ai_provider_config_field_is_respected | End-to-end fixture: `ai_provider_config_field_is_respected` |
-| `tests/integration.rs` | cargo test --test integration cli_provider_overrides_config_provider | End-to-end fixture: `cli_provider_overrides_config_provider` |
-| `tests/integration.rs` | cargo test --test integration ai_model_config_used_with_ollama_provider | End-to-end fixture: `ai_model_config_used_with_ollama_provider` |
-| `tests/integration.rs` | cargo test --test integration ai_api_key_config_field_used_for_anthropic | End-to-end fixture: `ai_api_key_config_field_used_for_anthropic` |
-| `tests/integration.rs` | cargo test --test integration check_works_without_config_file | End-to-end fixture: `check_works_without_config_file` |
-| `tests/integration.rs` | cargo test --test integration mcp_tool_init_creates_config | End-to-end fixture: `mcp_tool_init_creates_config` |
+| TOML scalar/array/bool parsing | cargo test config:: | `test_parse_toml_string_quoted`, `test_parse_toml_string_unquoted`, `test_parse_toml_string_empty_quotes`, `test_parse_toml_string_with_whitespace`, `test_parse_toml_string_array_basic`, `test_parse_toml_string_array_single`, `test_parse_toml_string_array_empty`, `test_parse_toml_bool_true_variants`, `test_parse_toml_bool_false_variants` |
+| Load + format precedence | cargo test config:: | `test_load_config_json`, `test_load_config_toml`, `test_load_config_toml_takes_priority_over_json`, `test_load_config_v4_toml_takes_priority`, `test_load_config_no_config_file`, `test_load_config_malformed_json_returns_defaults`, `test_load_config_json_without_source_dirs_auto_detects`, `test_toml_full_config`, `test_toml_comments_and_blank_lines`, `test_toml_without_source_dirs_auto_detects` |
+| `config.local.toml` AI overrides | cargo test config:: | `test_local_config_overrides_ai_provider`, `test_local_config_overrides_ai_command`, `test_local_config_missing_is_fine`, `test_local_config_works_with_legacy_json`, `test_local_config_strips_inline_comments`, `test_strip_inline_comment_preserves_hash_in_quotes` |
+| Source-dir detection | cargo test config:: | `test_detect_source_dirs_empty_project`, `test_detect_source_dirs_with_src_dir`, `test_detect_source_dirs_ignores_node_modules`, `test_detect_source_dirs_root_source_files` |
+| `config_to_toml` round-trip & companions | cargo test config:: | `test_config_to_toml_roundtrips_companions`, `test_toml_companions_design_enabled`, `test_toml_companions_design_default_false` |
+| Schema-pattern default | cargo test config:: | `test_default_schema_pattern_matches_create_table`, `test_default_schema_pattern_captures_table_name` |
+| AI config field (e2e) | cargo test --test integration ai_provider_config_field_is_respected | End-to-end fixture: `ai_provider_config_field_is_respected` |
+| AI key from config (e2e) | cargo test --test integration ai_api_key_config_field_used_for_anthropic | End-to-end fixture: `ai_api_key_config_field_used_for_anthropic` |
+| Config triggers AI (e2e) | cargo test --test integration config_ai_provider_triggers_ai_without_provider_flag | End-to-end fixture: `config_ai_provider_triggers_ai_without_provider_flag` |
+| Env over config (e2e) | cargo test --test integration env_provider_overrides_config_provider | End-to-end fixture: `env_provider_overrides_config_provider` |
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
 | Load JSON config | a `specsync.json` exists at project root with `"specsDir": "docs/specs"` | `load_config(root)` is called | returns a config with `specs_dir = "docs/specs"` |
-| No config file | no `specsync.json` or `.specsync.toml` exists | `load_config(root)` is called | returns default config with auto-detected source dirs |
+| No config file | no config file exists | `load_config(root)` is called | returns default config with auto-detected source dirs |
+| v4 TOML wins | `.specsync/config.toml` and legacy `specsync.json` both present | `load_config(root)` is called | v4 TOML values win over the legacy root file |
+| Local override merge | committed `config.toml` sets `ai_provider = "claude"`, `config.local.toml` sets `ai_provider = "ollama"` and `ai_model = "llama3"` | `load_config(root)` is called | `ai_provider = Ollama`, `ai_model = "llama3"`, non-AI fields unchanged |
+| API key not serialized | a config with `ai_api_key` set | `config_to_toml(&config)` is called | output omits `ai_api_key` and a warning is printed to stderr |
 | Auto-detect source dirs | a project root with `src/` and `lib/` containing `.rs` files | `detect_source_dirs(root)` is called | returns `["lib", "src"]` (sorted alphabetically) |
 
 ## Regression Matrix
@@ -29,8 +35,11 @@ spec: config.spec.md
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
 | Config file unreadable | Falls back to `SpecSyncConfig::default()` | Keep or add a focused assertion before changing this behavior |
-| Malformed JSON config | Prints warning to stderr, falls back to defaults | Keep or add a focused assertion before changing this behavior |
-| Empty project root | Returns `["src"]` as source dirs | Keep or add a focused assertion before changing this behavior |
+| Malformed JSON config | Prints warning to stderr, falls back to defaults | `test_load_config_malformed_json_returns_defaults` |
+| Empty project root | Returns `["src"]` as source dirs | `test_detect_source_dirs_empty_project` |
+| `config.local.toml` only applies AI keys | Section keys and unknown top-level keys are skipped/warned | `test_local_config_overrides_ai_provider` + manual unknown-key check |
+| `#` inside a quoted local-config value | Not treated as a comment | `test_strip_inline_comment_preserves_hash_in_quotes` |
+| `ai_api_key` round-trip | Never written back by `config_to_toml` | Add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 

--- a/specs/deps/context.md
+++ b/specs/deps/context.md
@@ -2,12 +2,22 @@
 spec: deps.spec.md
 ---
 
+## Key Decisions
+
+- **Module-name keyed graph**: nodes are keyed by frontmatter `module`, and `depends_on` paths are reduced to module names via `extract_module_from_dep_path` so cycle/missing checks compare bare names.
+- **DFS coloring for cycles**: `detect_cycles` uses White/Gray/Black coloring; a back-edge to a Gray node yields a reported chain. All cycles are collected, not just the first.
+- **Regex import extraction**: `extract_imports` uses cached `LazyLock<Regex>` patterns per language (Rust `use`/`mod`, TS `import`/`require`, Python `import`/`from .`). It is best-effort, not a real parser.
+- **Conservative warnings**: undeclared-import warnings only fire when the imported name is a known spec module, isn't already declared, and isn't the module itself — keeping false positives low.
+- **Silent skips**: unreadable source files and unparseable frontmatter are skipped, so validation always returns a populated `DepsReport` instead of erroring out.
+- **Cross-project refs skipped**: refs matching `is_cross_project_ref` are dropped before validation so external links aren't reported as missing.
+
 ## Key Files
 
-- `src/deps.rs` - Main implementation
+- `src/deps.rs` - Graph construction, cycle detection, import analysis, topological sort, and inline tests
+- `src/validator.rs` - provides `find_spec_files` and `is_cross_project_ref` used here
+- `src/commands/deps.rs` - wires the `specsync deps` subcommand to `validate_deps`
 - `specs/deps/deps.spec.md` - Module specification
-- `specs/deps/requirements.md` - User stories and acceptance criteria
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Module is stable and complete, with extensive inline unit tests. Validation is exposed via the `specsync deps` subcommand.

--- a/specs/deps/requirements.md
+++ b/specs/deps/requirements.md
@@ -1,5 +1,35 @@
-# deps — Requirements
+---
+spec: deps.spec.md
+---
 
-- Must detect circular dependencies and report all cycles
-- Must support import extraction for Rust, TypeScript, and Python
-- Must skip cross-project refs during local validation
+## User Stories
+
+- As a developer, I want spec-sync to verify that every `depends_on` reference points to a module that actually has a spec so that stale or typo'd dependency links are caught
+- As a maintainer, I want circular dependency chains between specs reported so that I can keep the module graph acyclic
+- As a developer, I want imports in my source code cross-checked against declared `depends_on` so that undeclared cross-module coupling surfaces as a warning
+- As a developer working across projects, I want cross-project dependency refs skipped during local validation so that they aren't flagged as missing
+
+## Acceptance Criteria
+
+- `build_dep_graph` parses every spec's frontmatter, keying nodes by `module` name, recording `depends_on` (as module names via `extract_module_from_dep_path`) and `files`
+- `extract_module_from_dep_path` resolves `specs/<m>/<m>.spec.md` and bare module names to `<m>`, returning `None` for unrelated paths
+- Cross-project refs (those matching `is_cross_project_ref`) are excluded from declared deps and never reported as missing
+- `validate_deps` reports an error for each declared dependency whose target module has no spec, populating both `errors` and `missing_deps`
+- `detect_cycles` finds all circular chains via DFS coloring; each cycle is reported as a `Circular dependency: a -> b -> a` error
+- `extract_imports` extracts imported module names for Rust (`use`/`mod`), TypeScript/JavaScript (`import ... from`/`require`), and Python (`import`/`from .`); unsupported languages return an empty set
+- `check_undeclared_imports` warns only when a source import matches a known spec module, is not already declared, and is not the module's own name (self-imports are never flagged)
+- `topological_sort` returns a deterministic order for a DAG and `None` when the graph contains a cycle
+
+## Constraints
+
+- Import extraction is regex-based (`LazyLock<Regex>`), best-effort, and does not run a real parser
+- Unreadable source files and unparseable spec frontmatter are skipped silently, not treated as errors
+- Only Rust, TypeScript, and Python imports are analyzed; other languages contribute no import edges
+- Must not panic on malformed input — returns a populated `DepsReport` regardless
+
+## Out of Scope
+
+- Resolving or validating cross-project dependency references (skipped locally)
+- Suggesting or auto-adding missing `depends_on` entries
+- Transitive/version-aware dependency resolution
+- Import analysis for languages beyond Rust, TypeScript, and Python

--- a/specs/deps/tasks.md
+++ b/specs/deps/tasks.md
@@ -2,6 +2,26 @@
 spec: deps.spec.md
 ---
 
-## Tasks
+## Done
 
+- [x] `build_dep_graph` / `extract_module_from_dep_path` — build the module graph from spec frontmatter
+- [x] `validate_deps` — report missing dependency targets (errors + `missing_deps`)
+- [x] `detect_cycles` — DFS-coloring cycle detection with full chain reporting
+- [x] `extract_imports` for Rust, TypeScript/JavaScript, and Python (regex-based)
+- [x] `check_undeclared_imports` — warn on undeclared cross-module imports, never flag self-imports
+- [x] `topological_sort` — deterministic DAG ordering, `None` on cycles
+- [x] Skip cross-project refs during local validation
+- [x] Inline unit tests for graph build, validation, cycles, import extraction, and topo sort
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+
+## Open
+
+- [ ] No end-to-end integration fixture asserting `specsync deps` CLI output for missing/circular deps (only inline unit tests exist)
+- [ ] Import extraction is regex-based and may miss aliased/multiline import forms
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/exports/context.md
+++ b/specs/exports/context.md
@@ -4,24 +4,25 @@ spec: exports.spec.md
 
 ## Key Decisions
 
-- **Regex over AST**: All 9 language backends use compiled regexes (`LazyLock<Regex>`) rather than language-specific AST parsers. This keeps the binary small and avoids per-language parser dependencies at the cost of some edge-case accuracy.
+- **Regex by default, AST opt-in**: All 12 language backends use compiled regexes (`LazyLock<Regex>`). `ParseMode::Ast` enables tree-sitter backends for TypeScript, Python, and Rust only; if the AST backend returns nothing (parse failure), `mod.rs` falls back to the regex backend automatically.
 - **Comment stripping first**: Every backend strips string literals then comments before running export regexes, preventing false matches inside strings or commented-out code.
-- **TypeScript wildcard resolution**: `export * from './foo'` is resolved one level deep to prevent infinite re-export loops. Namespace re-exports (`export * as Ns`) produce the namespace name, not the inner symbols.
+- **TypeScript wildcard resolution**: `export * from './foo'` is resolved one level deep via `resolve_ts_import` to prevent infinite re-export loops. Namespace re-exports (`export * as Ns`) produce the namespace name, not the inner symbols. Without a resolver, wildcard lines are skipped.
 - **Python `__all__` precedence**: If `__all__` is defined, it is the sole source of exports. Otherwise, top-level non-underscore functions and classes are extracted.
 - **Go capitalization convention**: Uppercase first letter = exported. Methods are extracted separately from functions.
-- **Two export levels**: `ExportLevel::Type` extracts only top-level type declarations (class, struct, enum, interface); `ExportLevel::Member` extracts all public symbols. This allows specs to document at the right granularity.
+- **Two export levels**: `ExportLevel::Type` (via `filter_type_level_exports`) extracts only top-level type declarations (class, struct, enum, interface); `ExportLevel::Member` extracts all public symbols. This allows specs to document at the right granularity.
 
 ## Files to Read First
 
-- `src/exports/mod.rs` — Router, language detection, `get_exported_symbols()` entry point, and `is_test_file()`/`is_source_file()` helpers.
-- `src/exports/typescript.rs` — Most complex backend (re-exports, wildcards, defaults). Good reference for understanding the pattern.
+- `src/exports/mod.rs` — Router, language detection, `get_exported_symbols()`/`get_exported_symbols_full()` entry points, `filter_type_level_exports`, `resolve_ts_import`, and `is_test_file()`/`is_source_file()`/`has_extension()` helpers.
+- `src/exports/typescript.rs` — Most complex regex backend (re-exports, wildcards, defaults). Good reference for understanding the pattern.
+- `src/exports/ast/tests.rs` — Parity tests asserting AST backends match the regex backends.
 
 ## Current Status
 
-Fully implemented for all 9 languages: TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart. Each backend has compiled regex patterns and handles language-specific idioms.
+Fully implemented for all 12 languages: TypeScript/JS, Rust, Go, Python, Swift, Kotlin, Java, C#, Dart, PHP, Ruby, YAML. Each regex backend has compiled patterns; AST backends exist for TypeScript, Python, and Rust under `src/exports/ast/`.
 
 ## Notes
 
-- This is the only multi-file module in the project (10 source files under `src/exports/`).
+- This is the only multi-file module in the project (~14 source files under `src/exports/`, plus the `ast/` subdirectory).
 - Language detection is purely extension-based — no shebang or content sniffing.
 - The validator uses this module bidirectionally: undocumented exports = warning, documented-but-missing exports = error.

--- a/specs/exports/requirements.md
+++ b/specs/exports/requirements.md
@@ -9,32 +9,35 @@ spec: exports.spec.md
 - As a Rust developer, I want `pub` items extracted including `pub(crate)` visibility so that my module's public API is accurately captured
 - As a Python developer, I want `__all__` respected when present, with fallback to top-level definitions, so that my intended public API is what gets checked
 - As a Go developer, I want uppercase identifiers recognized as exports so that Go's visibility convention is supported
-- As a polyglot team, I want export extraction for all 11 supported languages so that spec-sync works across our entire codebase
+- As a polyglot team, I want export extraction for all 12 supported languages so that spec-sync works across our entire codebase
 - As a developer, I want test files automatically excluded from export extraction so that test helpers don't pollute the public API
+- As a power user, I want an opt-in AST parse mode (`ParseMode::Ast`) for TypeScript, Python, and Rust so that I get higher-fidelity extraction with regex fallback when AST parsing fails
 
 ## Acceptance Criteria
 
-- Supports 11 languages: TypeScript/JS, Python, Rust, Go, Java, Kotlin, Swift, Dart, C#, PHP, Ruby
-- Language detection is purely extension-based (no content sniffing)
+- Supports 12 languages: TypeScript/JS, Python, Rust, Go, Java, Kotlin, Swift, Dart, C#, PHP, Ruby, YAML
+- Language detection is purely extension-based via `Language::from_extension` (no content sniffing)
 - Symbols are deduplicated while preserving declaration order
 - Unreadable files or unknown extensions return empty vector (no errors)
-- TypeScript wildcard re-exports (`export * from`) are followed one level deep via file resolver
+- TypeScript wildcard re-exports (`export * from`) are followed one level deep via `resolve_ts_import` file resolver
 - Ruby visibility tracking correctly handles public/private/protected toggles
 - PHP skips magic methods (`__construct`, `__toString`, etc.) and private members
-- `ExportLevel::Type` filters to only class/struct/enum declarations; `Member` includes all public symbols
-- Test file detection uses language-specific patterns (`.test.ts`, `_test.go`, `test_*.py`, etc.)
+- `ExportLevel::Type` filters (via `filter_type_level_exports`) to only class/struct/enum declarations; `Member` includes all public symbols
+- `ParseMode::Ast` uses tree-sitter for TypeScript, Python, and Rust; falls back to regex for other languages or on empty/failed AST results
+- Test file detection uses language-specific patterns (`.test.ts`, `_test.go`, `test_*.py`, etc.) plus well-known test directory names (`tests`, `__tests__`, `fixtures`, `mocks`, ...)
 - All regex patterns are compiled once via `LazyLock` for performance
 
 ## Constraints
 
-- Regex-based parsing only — no AST parsing or external language toolchains required
-- Must handle malformed or partial source files gracefully (best-effort extraction)
-- Each language backend must be in its own file for maintainability
+- Regex-based parsing is the default; AST parsing (tree-sitter) is opt-in via `ParseMode::Ast` and limited to TS/Python/Rust
+- Must handle malformed or partial source files gracefully (best-effort extraction; never panic)
+- Each language backend lives in its own file under `src/exports/` for maintainability
 - Must strip comments before extracting exports to avoid false positives
+- AST results that come back empty fall back to the regex backend automatically
 
 ## Out of Scope
 
-- Full AST parsing or semantic analysis
+- AST/semantic analysis for languages other than TypeScript, Python, and Rust
 - Extracting function signatures, parameter types, or return types
-- Cross-file dependency resolution (except TypeScript wildcard re-exports)
+- Cross-file dependency resolution (except TypeScript wildcard re-exports, one level deep)
 - Extracting private/internal symbols for any purpose

--- a/specs/exports/tasks.md
+++ b/specs/exports/tasks.md
@@ -6,24 +6,29 @@ spec: exports.spec.md
 
 - [ ] Add support for C/C++ header exports (`.h`/`.hpp` files)
 - [ ] Handle TypeScript `export =` (CommonJS-style default export)
-- [ ] Handle Python conditional exports (platform-specific `__all__` modification)
+- [ ] Add AST backends for Go, Java, Swift, Kotlin, and the remaining languages (currently only TS/Python/Rust)
 - [ ] Add Rust `pub(crate)` visibility filtering — currently all `pub` items are treated as exported
 
 ## Done
 
-- [x] Implement export extraction for all 9 languages
+- [x] Implement regex export extraction for all 12 languages (TS, Python, Rust, Go, Java, Kotlin, Swift, Dart, C#, PHP, Ruby, YAML)
 - [x] TypeScript: declarations, re-exports, wildcards, namespace re-exports, defaults
 - [x] Python: `__all__` precedence, top-level defs fallback
-- [x] Rust: pub fn/struct/enum/trait/type/const/static/mod
+- [x] Rust: pub fn/struct/enum/trait/type/const/static/mod (incl. `pub(crate)`, `pub async/unsafe`)
 - [x] Go: capitalized names, methods, type declarations
-- [x] Swift, Kotlin, Java, C#, Dart: public type and member extraction
+- [x] Swift, Kotlin, Java, C#, Dart, PHP, Ruby: public type and member extraction
+- [x] YAML backend: top-level keys, named entries under well-known parent keys, anchors
 - [x] Comment and string literal stripping across all backends
-- [x] Two-level export granularity (Type vs Member)
-- [x] Test file detection (`is_test_file()`)
+- [x] Two-level export granularity (Type vs Member) via `filter_type_level_exports`
+- [x] Opt-in AST parse mode (`ParseMode::Ast`) for TypeScript, Python, Rust with regex fallback
+- [x] AST parity tests in `src/exports/ast/tests.rs` cross-checking AST vs regex output
+- [x] Test file detection (`is_test_file()`) by filename pattern and test directory name
+- [x] TypeScript wildcard resolver (`resolve_ts_import`) trying .ts/.tsx/.js/.jsx/.mts/.cts and index files
 
 ## Gaps
 
 - Regex-based parsing can miss edge cases: conditional exports, computed property names, decorator-generated exports
+- AST mode is limited to TypeScript, Python, and Rust; all other languages are regex-only
 - No support for re-exports in languages other than TypeScript
 - Dart backend doesn't distinguish `part of` visibility
 

--- a/specs/exports/testing.md
+++ b/specs/exports/testing.md
@@ -6,7 +6,7 @@ spec: exports.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/exports/mod.rs` | cargo test exports::mod | No inline tests found; add focused coverage for `get_exported_symbols`, `get_exported_symbols_with_level`, `is_test_file`, `bool` before risky changes |
+| `src/exports/mod.rs` | cargo test exports:: | No inline tests in `mod.rs` itself; covered indirectly via the per-language backends and `tests/integration.rs`. Add focused coverage for `get_exported_symbols`, `get_exported_symbols_full`, `is_test_file`, `is_source_file`, `has_extension` before risky changes |
 | `src/exports/typescript.rs` | cargo test exports::typescript:: | `test_basic_exports`, `test_comments_stripped`, `test_re_exports`, `test_wildcard_namespace_export`, `test_wildcard_export_with_resolver`, `test_wildcard_export_without_resolver` |
 | `src/exports/python.rs` | cargo test exports::python:: | `test_python_all`, `test_python_no_all`, `test_python_all_single_quotes`, `test_python_all_overrides_conventions`, `test_python_decorators_ignored`, `test_python_nested_not_captured` |
 | `src/exports/rust_lang.rs` | cargo test exports::rust_lang:: | `test_rust_exports`, `test_pub_crate`, `test_ignores_pub_inside_string_literals`, `test_pub_after_raw_string_with_hash_in_content`, `test_real_ai_rs`, `test_real_registry_rs` |
@@ -19,9 +19,9 @@ spec: exports.spec.md
 | `src/exports/php.rs` | cargo test exports::php:: | `test_php_class_and_methods`, `test_php_final_readonly`, `test_php_skips_magic_methods` |
 | `src/exports/ruby.rs` | cargo test exports::ruby:: | `test_ruby_class_and_methods`, `test_ruby_top_level_functions`, `test_ruby_visibility_toggle`, `test_ruby_skips_initialize` |
 | `src/exports/yaml.rs` | cargo test exports::yaml:: | `test_github_actions_workflow`, `test_docker_compose`, `test_anchors`, `test_top_level_only`, `test_four_space_indentation`, `test_four_space_nested_not_extracted` |
-| `src/exports/ast/mod.rs` | cargo test exports::ast::mod | No inline tests found; add focused coverage for `get_exported_symbols`, `get_exported_symbols_with_level`, `is_test_file`, `bool` before risky changes |
-| `src/exports/ast/typescript.rs` | cargo test exports::ast::typescript:: | `test_basic_exports`, `test_re_exports_with_alias`, `test_wildcard_namespace`, `test_wildcard_with_resolver`, `test_default_export`, `test_async_abstract` |
-| `src/exports/ast/python.rs` | cargo test exports::ast::python:: | `test_python_all`, `test_python_no_all`, `test_python_nested_not_captured`, `test_python_dunder_excluded`, `test_python_all_overrides`, `test_decorated_functions` |
+| `src/exports/ast/mod.rs` | cargo test exports::ast::tests:: | Parity tests in `ast/tests.rs` cross-check AST vs regex output: `ts_basic_parity`, `ts_re_exports_with_alias`, `ts_wildcard_with_resolver`, `py_basic_parity`, `py_all_takes_precedence`, `rs_basic_parity`, `rs_pub_crate`, `rs_feature_gated`, `rs_pub_mod` |
+| `src/exports/ast/typescript.rs` | cargo test exports::ast::typescript:: | `test_basic_exports`, `test_re_exports_with_alias`, `test_wildcard_namespace`, `test_wildcard_with_resolver`, `test_default_export`, `test_async_abstract`, `test_conditional_export`, `test_export_type_clause`, `test_comments_not_exported` |
+| `src/exports/ast/python.rs` | cargo test exports::ast::python:: | `test_python_all`, `test_python_no_all`, `test_python_nested_not_captured`, `test_python_dunder_excluded`, `test_python_all_overrides`, `test_decorated_functions`, `test_conditional_import_init` |
 | `src/exports/ast/rust_lang.rs` | cargo test exports::ast::rust_lang:: | `test_rust_exports`, `test_pub_crate`, `test_async_unsafe`, `test_ignores_pub_in_strings`, `test_feature_gated`, `test_pub_mod` |
 | `tests/integration.rs` | cargo test --test integration fix_adds_undocumented_exports_to_spec | End-to-end fixture: `fix_adds_undocumented_exports_to_spec` |
 | `tests/integration.rs` | cargo test --test integration fix_does_not_duplicate_already_documented_exports | End-to-end fixture: `fix_does_not_duplicate_already_documented_exports` |

--- a/specs/generator/context.md
+++ b/specs/generator/context.md
@@ -4,22 +4,28 @@ spec: generator.spec.md
 
 ## Key Decisions
 
-- **Never overwrite**: Existing specs are never overwritten by generation — this prevents accidental loss of hand-tuned documentation.
-- **Custom templates first**: If `_template.spec.md` exists in the specs directory, it's used instead of the built-in default. This lets projects define their own spec structure.
-- **Language-specific templates**: Built-in templates vary by language (Rust, Swift, Kotlin/Java, Go, Python each have tailored Public API table formats). Generic template covers TypeScript, C#, Dart.
-- **AI fallback to template**: If AI generation fails (provider unavailable, timeout, bad output), the template-based generator runs as a fallback so the user always gets something.
-- **Companion file generation**: `tasks.md` and `context.md` are generated alongside specs as empty scaffolds. Only created if they don't already exist.
-- **Flat file detection**: Standalone source files (not in subdirectories) are detected as modules, excluding common entry points like main, lib, mod, index, app, `__init__`.
+- **Never overwrite**: existing specs and existing companion files are never overwritten — this protects hand-tuned documentation.
+- **Template-only is always available**: AI is opt-in. The generator only enters AI mode when a provider is configured; otherwise it scaffolds from templates and makes no network call.
+- **AI delegated to the `ai` module**: the generator passes an `Option<&ResolvedProvider>` straight to `ai::generate_spec_with_ai`. After the 4.4.0 rework, `ResolvedProvider` is `Cli(String) | Api(corvid_ai::Settings)` and all HTTP goes through `corvid-ai` — none of that leaks into the generator, which only orchestrates files and templates.
+- **AI falls back to template**: if AI generation fails (missing key, timeout, bad output), `generate_module_spec` catches the error, warns on stderr, and writes the template version so the user always gets a spec.
+- **Custom templates first**: a `specs/_template.spec.md`, or a custom template directory passed to `generate_spec_from_custom_template` / `generate_companion_files_from_template`, takes precedence over built-ins, with per-file fallback to the defaults.
+- **Language-aware templates**: Rust, Swift, Kotlin/Java, Go, and Python each get tailored Public API sections; TypeScript, C#, Dart, and unknown languages use `DEFAULT_TEMPLATE`. Primary language is the most common source extension.
+- **Module discovery order**: config `modules` definitions → `src/<module>/` subdirectories → flat `src/<module>.<ext>` files; test files are excluded via `is_test_file`.
+- **Companion frontmatter**: each companion keeps a `spec: <module>.spec.md` back-reference; `design.md` additionally carries `sources: []`. This companion-level metadata is not parsed by the spec validation pipeline.
 
 ## Files to Read First
 
-- `src/generator.rs` — Single-file module handling spec generation, template selection, and companion file creation.
+- `src/generator.rs` — template constants, language templates, module discovery (`find_files_for_module`), spec generation, and companion creation all live here.
+- `src/ai.rs` — `generate_spec_with_ai` and `ResolvedProvider`; the generator delegates all LLM work here.
+- `src/exports/mod.rs` — `has_extension` and `is_test_file`, used to filter discovered source files.
+- `src/types.rs` — `SpecSyncConfig` (`modules`, `source_dirs`, `source_extensions`, `companions.design`, `required_sections`) and `CoverageReport`.
 
 ## Current Status
 
-Fully implemented. Template-based and AI-powered generation both work. Companion files are generated as part of the `generate` command and also via `generate_companion_files_for_spec()`.
+Fully implemented and stable. Template-based and AI-powered generation both work; AI generation now flows entirely through the `ai` module's corvid-ai-backed provider. Companion files (tasks/context/requirements/testing, plus opt-in design) are created by `generate_specs_for_unspecced_modules` and exposed via `generate_companion_files_for_spec`.
 
 ## Notes
 
-- Module titles are derived from directory/file names with dash-to-title-case conversion (e.g., "api-gateway" becomes "Api Gateway").
-- The generator consumes the exports module to pre-populate Public API tables in templates.
+- Module titles are dash-to-title-case from the module name ("api-gateway" → "Api Gateway").
+- Frontmatter rewriting is regex-based: it replaces `module`/`status`/`version`/`files`/`db_tables` and the `# Title` line; the `files:` regex handles both `files: []` and an existing multi-line YAML list.
+- `generate_specs_for_unspecced_modules_paths` is the path-returning variant used by the MCP server; the count-returning variant is used by the CLI.

--- a/specs/generator/requirements.md
+++ b/specs/generator/requirements.md
@@ -4,33 +4,40 @@ spec: generator.spec.md
 
 ## User Stories
 
-- As a developer adopting spec-sync on an existing project, I want to generate spec scaffolds for all unspecced modules in one command so that I have a starting point for every module
-- As a developer, I want AI-powered generation to produce specs with real content (not just templates) so that I spend less time writing from scratch
-- As a developer, I want companion files (tasks.md, context.md, requirements.md) generated alongside each spec so that the full documentation structure is ready immediately
-- As a team, I want a custom `_template.spec.md` to be used when it exists so that generated specs match our conventions
+- As a developer adopting spec-sync on an existing project, I want to scaffold spec files for all unspecced modules in one command so that every module has a starting point
+- As a developer with an AI provider configured, I want AI-powered generation to produce real spec content (not just a template) so that I write less from scratch
+- As a developer with nothing configured, I want template-only generation so that I never depend on an AI provider or network call to bootstrap specs
+- As a developer, I want companion files (tasks.md, context.md, requirements.md, testing.md, and design.md when enabled) generated alongside each spec so that the full documentation structure is ready immediately
+- As a team, I want a custom `_template.spec.md` (or a custom template directory) honored when present so that generated specs match our conventions
 - As a developer, I want existing specs and companion files to never be overwritten so that my manual edits are safe
 
 ## Acceptance Criteria
 
-- Specs are never overwritten — modules with existing specs are skipped
-- Companion files (tasks.md, context.md, requirements.md) are only created if they don't already exist
-- Custom template at `specs/_template.spec.md` takes precedence over the built-in default
-- Template fills in module name, version (1), status (draft), and discovered source files
-- Module title is derived from directory name with title case ("api-gateway" -> "Api Gateway")
-- AI generation falls back to template on failure, with a warning to stderr
-- Source file paths in generated specs are relative to the project root
-- `generate_specs_for_unspecced_modules` returns the count of specs created
-- `generate_specs_for_unspecced_modules_paths` returns the file paths of specs created
+- Specs are never overwritten — a module with an existing `<module>.spec.md` is skipped
+- Companion files are only created when absent; existing companions are left untouched
+- `generate` enters AI mode only when a provider is configured (`--provider`, `aiProvider`/`aiCommand`, or `SPECSYNC_AI_PROVIDER`/`SPECSYNC_AI_COMMAND`); with nothing configured it is template-only and makes no network calls
+- AI generation falls back to template generation on any failure, printing a warning to stderr (the spec is still written)
+- A custom `specs/_template.spec.md` takes precedence over the built-in language-aware default; `generate_spec_from_custom_template` / `generate_companion_files_from_template` honor a custom template directory and fall back to built-ins per-file
+- Built-in templates are language-aware: Rust, Swift, Kotlin/Java, Go, and Python each get tailored Public API sections; TypeScript, C#, Dart, and unknown fall back to the default template
+- Templates fill in module name, version (1), status (draft), and discovered source-file paths (relative to root); `db_tables` is reset to `[]`
+- Module title is dash-to-title-case from the module name ("api-gateway" → "Api Gateway")
+- Test files are excluded from module source discovery (via `is_test_file`)
+- Module discovery order: config `modules` definitions first, then `src/<module>/` subdirectories, then flat `src/<module>.<ext>` files
+- `generate_specs_for_unspecced_modules` returns the count of specs created; `generate_specs_for_unspecced_modules_paths` returns their paths
+- `design.md` is generated only when `companions.design` is enabled, and carries its own frontmatter (`spec:` back-reference, `sources: []`)
 
 ## Constraints
 
-- Generator must work without AI (template-only mode is always available)
-- Must not make network calls unless AI generation is explicitly requested
-- Generated specs must pass `specsync check` without errors (valid frontmatter, required sections present)
+- Template-only mode must always be available; the generator must work with no AI provider
+- No network calls unless an AI provider is explicitly configured for the run
+- AI prompt building, truncation, and the LLM call are delegated to the `ai` module (`generate_spec_with_ai`); the generator owns only template scaffolding and file orchestration
+- Generated specs must pass `specsync check` (valid frontmatter, required sections present)
+- Source-file paths written into frontmatter are relative to the project root
 
 ## Out of Scope
 
-- Regenerating or updating existing specs based on code changes
-- Generating specs for individual files (only module-level)
+- Regenerating or updating existing specs from code drift (handled via the `ai` module's `regenerate_spec_with_ai`, driven elsewhere)
+- Per-file specs (generation is module-level only)
 - Interactive prompts asking the developer to complete sections
-- Generating specs from external documentation or API schemas
+- A `--force` overwrite or `--dry-run` preview (not yet implemented)
+- AI-authored companion file bodies (companions are scaffolds; only the `.spec.md` is AI-generated)

--- a/specs/generator/tasks.md
+++ b/specs/generator/tasks.md
@@ -4,24 +4,28 @@ spec: generator.spec.md
 
 ## Tasks
 
-- [ ] Add `--force` flag to overwrite existing specs (with confirmation prompt)
-- [ ] Support interactive mode that asks the user to confirm/edit each generated spec before writing
-- [ ] Populate companion files with source-specific content from AI instead of bare scaffolds
-- [ ] Add `--dry-run` flag to preview what would be generated without writing files
+- [ ] Add a `--force` flag to overwrite existing specs (with a confirmation prompt)
+- [ ] Add a `--dry-run` flag to preview what would be generated without writing files
+- [ ] Support an interactive mode that lets the user confirm/edit each generated spec before writing
+- [ ] Populate companion files (tasks/context/requirements/testing) with AI-authored, source-specific content instead of bare scaffolds
 
 ## Done
 
-- [x] Template-based spec generation with language-specific templates
-- [x] AI-powered spec generation with fallback to template
-- [x] Custom template support (`_template.spec.md`)
-- [x] Companion file generation (tasks.md, context.md)
-- [x] Module detection from config, subdirectories, and flat files
-- [x] Flat file entry point exclusion (main, lib, mod, index, app, `__init__`)
+- [x] Template-based spec generation with language-aware templates (Rust, Swift, Kotlin/Java, Go, Python; default for the rest)
+- [x] AI-powered spec generation delegated to `ai::generate_spec_with_ai`, with fallback to template on failure
+- [x] Carry the new `corvid-ai`-backed `ResolvedProvider` (passed in as `Option<&ResolvedProvider>`) through generation — no provider-specific logic lives in the generator
+- [x] AI mode entered only when a provider is configured; otherwise template-only (no network)
+- [x] Custom `_template.spec.md` support and custom template-directory support with per-file fallback
+- [x] Companion file generation: tasks.md, context.md, requirements.md, testing.md, and opt-in design.md (with `spec:`/`sources:` frontmatter)
+- [x] Module discovery: config `modules` definitions → `src/<module>/` subdirectories → flat `src/<module>.<ext>` files, excluding test files
+- [x] Frontmatter rewriting: module name, version 1, status draft, root-relative file list, reset `db_tables`
+- [x] Replace the old unfinished-marker template bodies with guided starter content
 
 ## Gaps
 
-- Generated specs from templates still need source-specific expansion to score well on the quality rubric
-- No way to regenerate a single spec without deleting the existing one first
+- Template-only specs still need source-specific expansion (AI or hand-editing) to score well on the quality rubric
+- No way to regenerate a single existing spec without deleting it first (`--force` not yet implemented)
+- Companion file bodies are scaffolds, not AI-generated
 
 ## Review Sign-offs
 

--- a/specs/generator/testing.md
+++ b/specs/generator/testing.md
@@ -4,39 +4,56 @@ spec: generator.spec.md
 
 ## Automated Coverage
 
-| Area | Command | Assertions To Watch |
-|------|---------|---------------------|
-| `src/generator.rs` | cargo test generator:: | `detect_language_rust`, `detect_language_typescript`, `detect_language_python`, `detect_language_go`, `detect_language_mixed_majority_wins`, `detect_language_empty` |
-| `tests/integration.rs` | cargo test --test integration generate_creates_spec_for_unspecced_module | End-to-end fixture: `generate_creates_spec_for_unspecced_module` |
-| `tests/integration.rs` | cargo test --test integration generate_no_op_when_fully_covered | End-to-end fixture: `generate_no_op_when_fully_covered` |
-| `tests/integration.rs` | cargo test --test integration generate_with_multiple_languages | End-to-end fixture: `generate_with_multiple_languages` |
-| `tests/integration.rs` | cargo test --test integration generate_uncovered_flag_accepted | End-to-end fixture: `generate_uncovered_flag_accepted` |
-| `tests/integration.rs` | cargo test --test integration generate_batch_empty_list_skips_gracefully | End-to-end fixture: `generate_batch_empty_list_skips_gracefully` |
-| `tests/integration.rs` | cargo test --test integration generate_creates_companion_files | End-to-end fixture: `generate_creates_companion_files` |
-| `tests/integration.rs` | cargo test --test integration generate_creates_design_md_when_enabled | End-to-end fixture: `generate_creates_design_md_when_enabled` |
+### Unit tests (`src/generator.rs`, `cargo test generator::`)
 
-## Behavioral Verification
+| Group | Tests | What It Covers |
+|-------|-------|----------------|
+| `detect_primary_language` | `detect_language_rust`, `detect_language_typescript`, `detect_language_python`, `detect_language_go`, `detect_language_mixed_majority_wins`, `detect_language_empty`, `detect_language_unknown_extensions` | Picks the dominant language by extension; `None` when unknown/empty |
+| `language_template` | `template_rust_has_structs_enums_section`, `template_swift_has_protocols_section`, `template_go_has_package_terminology`, `template_kotlin_has_classes_interfaces`, `template_python_has_classes`, `template_typescript_uses_default` | Per-language Public API sections; TS falls back to the default template |
+| `generate_spec` | `generate_spec_fills_module_name`, `generate_spec_hyphenated_name_title_case`, `generate_spec_uses_custom_template`, `generate_spec_rust_files_use_rust_template` | Frontmatter rewriting, dash-to-title-case, custom-template precedence, language selection |
+| Template content | `tasks_template_has_required_sections`, `requirements_template_has_required_sections`, `context_template_has_required_sections`, `testing_template_has_required_sections`, `design_template_has_required_sections`, `default_template_has_all_required_sections` | Built-in companion/spec templates carry their required sections and `{module}` placeholder |
+| Companion creation | `companion_files_created_when_absent`, `companion_files_created_with_design_enabled`, `companion_files_not_overwritten`, `companion_files_from_template_uses_custom_testing`, `companion_files_from_template_falls_back_for_testing`, `companion_files_from_template_uses_custom_design`, `companion_files_from_template_falls_back_for_design` | Companions created only when absent, design opt-in, custom-template-dir use with per-file fallback |
+| `find_files_for_module` | `find_files_flat_module`, `find_files_subdir_module`, `find_files_excludes_test_files`, `find_files_no_match`, `find_files_user_defined_module` | Discovery via flat files, subdirs, config `modules`; test-file exclusion |
 
-| Flow | Fixture / Setup | Action | Expected Result |
-|------|-----------------|--------|-----------------|
-| Generate spec for unspecced module | a module "auth" with source files in `src/auth/` and no existing spec | `generate_specs_for_unspecced_modules` is called | creates `specs/auth/auth.spec.md`, `specs/auth/tasks.md`, `specs/auth/context.md`, `specs/auth/requirements.md`, `specs/auth/testing.md`, and `specs/auth/design.md` if `companions.design` is enabled in config |
-| Skip existing spec | a module "auth" that already has `specs/auth/auth.spec.md` | `generate_specs_for_unspecced_modules` is called | skips the module, returns 0 |
-| Design companion opt-in | `companions.design` is enabled in config | `generate_companion_files_for_spec` is called for module "dashboard" | creates design.md with YAML frontmatter (`spec: dashboard.spec.md`, `sources: []`) and sections for Layout, Components, Tokens, Assets |
-| Design companion disabled by default | no `companions.design` config (default: false) | `generate_companion_files_for_spec` is called | creates tasks.md, context.md, requirements.md, testing.md but NOT design.md |
-| AI generation fallback | an AI provider that fails with an error | generating a spec for module "auth" | falls back to template-based generation and prints a warning |
+### Integration tests (`tests/integration.rs`, `cargo test --test integration`)
 
-## Regression Matrix
+| Fixture | What It Asserts |
+|---------|-----------------|
+| `generate_creates_spec_for_unspecced_module` | Creates `<module>.spec.md` for an unspecced module |
+| `generate_no_op_when_fully_covered` | No specs generated when coverage is complete |
+| `generate_with_multiple_languages` | Mixed-language project generates per-module specs |
+| `generate_uncovered_flag_accepted` | The uncovered-targeting flag is accepted |
+| `generate_batch_empty_list_skips_gracefully` | Empty module list is a clean no-op |
+| `generate_creates_companion_files` | tasks/context/requirements/testing companions created alongside the spec |
+| `generate_creates_design_md_when_enabled` | `design.md` created only when `companions.design` is enabled |
+| `companion_testing_md_has_correct_structure` | Generated testing.md carries the expected sections and `spec:` back-reference |
+| `companion_files_not_overwritten_on_regenerate` | Re-running generation leaves existing companions untouched |
 
-| Case | Required Behavior | Test Obligation |
-|------|-------------------|-----------------|
-| Cannot create spec directory | Prints error to stderr, skips module | Keep or add a focused assertion before changing this behavior |
-| Cannot write spec file | Prints error to stderr, skips module | Keep or add a focused assertion before changing this behavior |
-| AI generation fails | Falls back to template, prints warning | Keep or add a focused assertion before changing this behavior |
-| No source files found for module | Skips module entirely | Keep or add a focused assertion before changing this behavior |
+## Manual Testing
+
+- [ ] Run `specsync generate` on a project with no AI provider configured — confirm template-only specs are written with no network call
+- [ ] Configure an AI provider and run `generate` — confirm the spec body is AI-authored, then force a failure (bad/missing key) and confirm the warning + template fallback
+- [ ] Place a `specs/_template.spec.md` and confirm it overrides the built-in template
+- [ ] Enable `companions.design` and confirm `design.md` is created with `spec:`/`sources:` frontmatter; disable it and confirm it is not
+- [ ] Re-run `generate` and confirm no existing spec or companion is overwritten
+
+## Edge Cases & Boundary Conditions
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Spec file already exists | Module skipped, not overwritten |
+| Companion file already exists | Left untouched; only missing companions are created |
+| No source files found for module | Module skipped entirely |
+| AI generation fails (missing key, timeout, bad output) | Warns on stderr, falls back to template, still writes the spec |
+| Cannot create the spec directory / write the spec file | Prints an error to stderr, skips the module |
+| Mixed-language module | Template chosen by the most common source extension |
+| Unknown/unsupported language | Falls back to `DEFAULT_TEMPLATE` |
+| Hyphenated module name | Title rendered dash-to-title-case ("api-gateway" → "Api Gateway") |
+| Custom template dir missing a specific companion | Falls back to the built-in template for that file only |
 
 ## Reviewer Checklist
 
-- Run the narrow source command above before the full suite when changing `src/generator.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
-- Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `./target/release/specsync score --all`.
+- Run `cargo test generator::` (and the relevant `tests/integration.rs` generate/companion fixtures) before changing `src/generator.rs`.
+- Reproduce one Manual Testing flow with a temp project fixture before changing user-visible output.
+- If an error/warning string or template section changes, update the matching Edge Case row and test assertion in the same commit.
+- Run the release checks: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`.

--- a/specs/git_utils/context.md
+++ b/specs/git_utils/context.md
@@ -4,18 +4,26 @@ spec: git_utils.spec.md
 
 ## Key Decisions
 
-- **Git CLI wrapper**: The module shells out to `git` rather than linking a git library, keeping dependencies small.
-- **Safe defaults**: Git failures return `None`, `0`, or `false` so callers can decide whether to warn, skip, or fail.
-- **Repository-root execution**: Every command runs with `current_dir(root)` to preserve expected path resolution.
+- **Git CLI wrapper**: shells out to `git` via `std::process::Command` rather than linking libgit2, keeping the dependency tree small.
+- **Safe defaults**: git failures return `None` / `0` / `false` so callers decide whether to warn, skip, or fail.
+- **Repository-root execution**: every command runs with `current_dir(root)`.
+- **N+1 fix (2026-06-07)**: the old `git_commits_between` (which re-resolved the spec commit on every call) was removed. The current shape is: caller resolves the spec's commit once with `git_last_commit_hash`, then calls `git_commits_since(root, spec_commit, source_file)` per source file. `git_commits_since` runs `git rev-list --count {spec_commit}..HEAD -- {source_file}`.
+
+## Public Surface
+
+- `git_last_commit_hash(root, file) -> Option<String>`
+- `git_commits_since(root, spec_commit, source_file) -> usize`
+- `is_git_repo(root) -> bool`
+- `struct StaleInfo { spec_path, module_name, max_commits_behind, source_details }`
 
 ## Files to Read First
 
-- `src/git_utils.rs` — Shared git wrappers.
-- `src/commands/stale.rs` and `src/commands/report.rs` — Main callers.
+- `src/git_utils.rs` — the helpers, `StaleInfo`, and the inline `#[cfg(test)]` module.
+- `src/commands/stale.rs` — the primary caller demonstrating the resolve-once / count-per-file pattern.
 
 ## Current Status
 
-Stable. Used by staleness detection, reports, and spec scoring freshness.
+Stable. Used by staleness detection, reports, check, and scoring freshness. Covered by inline unit tests using `tempfile` + real `git` invocations.
 
 ## Notes
 

--- a/specs/git_utils/requirements.md
+++ b/specs/git_utils/requirements.md
@@ -4,18 +4,27 @@ spec: git_utils.spec.md
 
 ## User Stories
 
-- As a developer, I want git-aware spec tooling so that staleness and freshness are tracked automatically
-- As a module consumer, I want a clean API for git log queries without reimplementing git2 boilerplate
+- As a command author (stale/report/check/scoring), I want a small set of git query helpers so I can measure spec freshness without reimplementing `git` invocations in each command
+- As a maintainer, I want a single source-file's drift to be measured against a precomputed spec commit so iterating a spec's source list does not trigger an N+1 explosion of `git log` calls
+- As a user running outside git, I want these helpers to degrade gracefully (safe defaults) rather than panic
 
 ## Acceptance Criteria
 
-- `commits_since` returns accurate commit counts for files since a given timestamp
-- `last_commit_for_file` returns the most recent commit touching a specific file
-- `changed_files_since` lists files modified since a reference point
-- All functions handle missing repos, untracked files, and shallow clones gracefully
+- `git_last_commit_hash(root, file)` returns `Some(full SHA)` for a tracked file and `None` for an untracked/never-committed file
+- `git_commits_since(root, spec_commit, source_file)` returns the count of commits touching `source_file` in the range `spec_commit..HEAD`, and `0` when the range is empty or the commit ref is invalid
+- `is_git_repo(root)` returns `true` inside a git work tree and `false` otherwise
+- `StaleInfo` carries `spec_path`, `module_name`, `max_commits_behind`, and `source_details: Vec<(String, usize)>`
+- All commands run with `current_dir(root)`
+- Any git command that fails to spawn or returns unparseable output yields the safe default (`None` / `0` / `false`)
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results
-- Must use git2 (libgit2) for git operations, not shell commands
-- Must not hold repository locks longer than necessary
+- Must not panic on expected error conditions (no `unwrap`/`expect` on git output in library paths)
+- Implemented by shelling out to the system `git` binary via `std::process::Command` — no libgit2 / `git2` dependency
+- `git_commits_since` takes a precomputed spec commit hash (resolved once per spec) rather than re-resolving it per source file
+
+## Out of Scope
+
+- Any git mutation (commit, tag, push) — these helpers are read-only
+- Listing the set of changed files (callers iterate their own known source list)
+- Timestamp-based freshness (commit-count distance is the chosen metric)

--- a/specs/git_utils/tasks.md
+++ b/specs/git_utils/tasks.md
@@ -4,13 +4,14 @@ spec: git_utils.spec.md
 
 ## Tasks
 
+- No open tasks.
+
+## Done
+
 - [x] Extract shared git helpers from stale/report behavior
 - [x] Return safe defaults when git is unavailable or files are untracked
-- [ ] Add platform-focused tests for git command failure modes
-
-## Gaps
-
-- Tests cover logical behavior, but not every platform-specific git executable/path failure mode.
+- [x] Replace `git_commits_between` with `git_commits_since` (takes a precomputed spec commit hash) to eliminate N+1 `git log` calls
+- [x] Add a `#[cfg(test)]` module covering hash lookup, commit counting, invalid-commit degradation, and repo detection
 
 ## Review Sign-offs
 

--- a/specs/git_utils/testing.md
+++ b/specs/git_utils/testing.md
@@ -6,30 +6,39 @@ spec: git_utils.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/git_utils.rs` | cargo test git_utils | No inline tests found; add focused coverage for `git_last_commit_hash`, `git_commits_between`, `usize`, `is_git_repo` before risky changes |
+| `src/git_utils.rs` | cargo test git_utils | Inline `#[cfg(test)]` module using `tempfile` + real `git` invocations (see fixtures below) |
 
-## Coverage Gaps
+### Inline test fixtures (all in `src/git_utils.rs`)
 
-- Integration gap: add a fixture for "File not tracked by git" before changing user-visible CLI output, generated files, or error handling in git_utils.
+| Test | Verifies |
+|------|----------|
+| `last_commit_hash_returns_none_for_untracked_file` | `git_last_commit_hash` returns `None` for a never-committed path |
+| `last_commit_hash_returns_hash_for_tracked_file` | Returns a full 40-char hex SHA for a tracked file |
+| `commits_since_is_zero_when_source_unchanged_after_spec` | `git_commits_since` is `0` when source has not changed since the spec commit |
+| `commits_since_counts_source_changes_after_spec` | Counts exactly 3 source commits after the spec; an untouched file reports `0` |
+| `commits_since_returns_zero_for_invalid_commit` | A bogus commit ref degrades to `0` (no panic) |
+| `is_git_repo_detects_repo_and_non_repo` | `true` inside an initialized repo, `false` in a plain temp dir |
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| File not tracked by git | a file that has never been committed | `git_last_commit_hash` is called | returns `None` |
-| Source file changed after spec | a spec last committed at commit A, and a source file with 3 commits after A | `git_commits_between` is called | returns `3` |
+| File not tracked by git | a path that has never been committed | `git_last_commit_hash` is called | returns `None` |
+| Source file changed after spec | a spec last committed at commit A, then 3 commits to a source file | `git_commits_since(root, A, source_file)` is called | returns `3` |
+| Invalid spec commit | a bogus 40-zero commit ref | `git_commits_since` is called | returns `0` (graceful degradation) |
+| Repo detection | initialized repo vs. plain temp dir | `is_git_repo` is called | `true` then `false` |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Not a git repository | `is_git_repo` returns false; other functions return safe defaults | Keep or add a focused assertion before changing this behavior |
-| Git not installed | All functions return None/0/false | Keep or add a focused assertion before changing this behavior |
-| File doesn't exist in git history | Returns None or 0 | Keep or add a focused assertion before changing this behavior |
+| Not a git repository | `is_git_repo` returns false; other functions return safe defaults | Covered by `is_git_repo_detects_repo_and_non_repo` |
+| Invalid / unresolvable commit ref | `git_commits_since` returns 0 | Covered by `commits_since_returns_zero_for_invalid_commit` |
+| File not in git history | `git_last_commit_hash` returns None | Covered by `last_commit_hash_returns_none_for_untracked_file` |
 
 ## Reviewer Checklist
 
-- Run the narrow source command above before the full suite when changing `src/git_utils.rs`.
-- Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- Run `cargo test git_utils` before the full suite when changing `src/git_utils.rs` (the tests shell out to real `git`).
+- If you change the `git_commits_since` range or arguments, update `commits_since_counts_source_changes_after_spec` in the same commit.
+- Keep the resolve-once / count-per-file contract: callers must not re-resolve the spec commit per source file (that was the removed N+1 path).
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`.

--- a/specs/github/context.md
+++ b/specs/github/context.md
@@ -4,12 +4,18 @@ spec: github.spec.md
 
 ## Key Decisions
 
+- **`gh` CLI first, REST fallback**: every read path (`fetch_issue`, `list_issues`) calls `gh_is_available` and prefers the CLI, falling back to direct `ureq` REST calls with `GITHUB_TOKEN`. Issue creation (`create_drift_issue`) is `gh`-only.
+- **Token redaction**: `redact_token` strips any verbatim `GITHUB_TOKEN` occurrence from REST error strings before they surface (added 4.3.5). The token travels in the `Authorization` header, so this is defense-in-depth against a misbehaving proxy/redirect echoing it back.
+- **State normalization**: issue `state` is lowercased (`"open"`/`"closed"`) so callers compare consistently regardless of CLI vs REST casing.
+- **github.com only**: URL parsing handles `git@github.com:`, `https://github.com/`, and `http://github.com/`; GitHub Enterprise hosts are out of scope.
+
 ## Key Files
 
-- `src/github.rs` - Main implementation with GitHub API and CLI integration
+- `src/github.rs` - Main implementation: repo detection, `gh`/REST issue fetch, `list_issues`, `create_drift_issue`, `redact_token`
+- `src/commands/mod.rs` - `create_drift_issues` wires `github.drift_labels` (default `["spec-drift"]`) into `create_drift_issue`
 - `specs/github/github.spec.md` - Module specification
 - `specs/github/requirements.md` - User stories and acceptance criteria
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Module is stable and complete. Only URL parsing is unit-tested; network paths are exercised manually / in integration. All requirements documented.

--- a/specs/github/requirements.md
+++ b/specs/github/requirements.md
@@ -14,7 +14,7 @@ spec: github.spec.md
 
 ## Acceptance Criteria
 
-- `detect_repo` extracts `owner/repo` from both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) remote URLs
+- `detect_repo` extracts `owner/repo` from SSH (`git@github.com:owner/repo.git`), HTTPS (`https://github.com/owner/repo.git`), and `http://github.com/...` remote URLs; the trailing `.git` is optional
 - `resolve_repo` prefers explicit config repo over auto-detected repo; returns error if neither is available
 - `gh_is_available` returns true only when `gh auth status` succeeds (CLI is installed and authenticated)
 - `fetch_issue` tries `gh` CLI first, falls back to REST API only if `gh` is unavailable
@@ -24,14 +24,16 @@ spec: github.spec.md
 - `verify_spec_issues` classifies each issue as valid (open), closed, not_found, or error with detailed messages
 - `create_drift_issue` requires `gh` CLI — no REST API fallback for issue creation
 - `create_drift_issue` creates issue titled "Spec drift detected: {path}" with formatted error list in body
-- Drift issues are created with configurable labels (default: `["spec-drift", "documentation"]`)
+- Drift issues are created with configurable labels (default `["spec-drift"]`, set via `github.drift_labels`)
+- `list_issues` lists open issues (optionally filtered by label), preferring `gh` CLI and falling back to the REST API; the REST path skips pull requests
+- Auth tokens (`GITHUB_TOKEN`) are redacted from REST request error messages via `redact_token` before being surfaced (defense-in-depth)
 
 ## Constraints
 
 - Must support both `gh` CLI (preferred) and direct REST API (fallback) for maximum compatibility
 - Must handle unauthenticated or rate-limited scenarios gracefully with actionable error messages
 - Must not panic on provider failure — return `Result` with descriptive error message
-- HTTP timeout must be enforced even if GitHub API hangs (channel-based async)
+- HTTP timeout must be enforced even if GitHub API hangs (`ureq` global timeout: 10s for single issues, 15s for `list_issues`)
 - Must not require write access to repo for read-only operations (issue verification)
 - SSH and HTTPS remote URL formats must both be supported for auto-detection
 

--- a/specs/github/tasks.md
+++ b/specs/github/tasks.md
@@ -2,6 +2,24 @@
 spec: github.spec.md
 ---
 
-## Tasks
+## Done
 
+- [x] `detect_repo` / `parse_repo_from_url` — auto-detect `owner/repo` from SSH and HTTP(S) git remotes
+- [x] `resolve_repo` — explicit config repo wins over auto-detection, error when neither is available
+- [x] `gh_is_available` gate, with `gh` CLI preferred and `GITHUB_TOKEN` REST fallback
+- [x] `fetch_issue` / `verify_spec_issues` — classify `implements`/`tracks` references as valid/closed/not_found/error
+- [x] `list_issues` (gh + REST, PR filtering on the REST path)
+- [x] `create_drift_issue` — `gh`-only issue creation titled "Spec drift detected: {path}"
+- [x] Token redaction in REST error messages via `redact_token` (4.3.5)
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+
+## Open
+
+- [ ] No automated coverage for the REST/`gh` network paths (only URL parsing is unit-tested); these remain manual/integration-only
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/hash_cache/context.md
+++ b/specs/hash_cache/context.md
@@ -2,12 +2,25 @@
 spec: hash_cache.spec.md
 ---
 
-## Key Files
+## Key Decisions
 
-- `src/hash_cache.rs` - Main implementation
-- `specs/hash_cache/hash_cache.spec.md` - Module specification
-- `specs/hash_cache/requirements.md` - User stories and acceptance criteria
+- **Conservative on uncertainty**: a missing or corrupt `.specsync/hashes.json`, and any unreadable file, are all treated as "changed". The cache can only ever cause *more* validation, never skip a file that genuinely changed.
+- **SHA-256 streamed in 8KB chunks**: `hash_file` reads incrementally so large source files don't blow memory; the digest is stored as a hex string.
+- **Normalized path keys**: `normalize_rel` rewrites separators to `/` so the same cache works across macOS/Linux/Windows checkouts.
+- **Companion classification split**: `requirements.md` is its own `ChangeKind::Requirements`; `context.md`/`tasks.md`/`testing.md`/`design.md` collapse into `ChangeKind::Companion`. Both plain and legacy `{module}.<suffix>` names are probed by `find_companion_files`.
+- **Cheap frontmatter scan**: `extract_frontmatter_files` string-matches the `files:` block instead of invoking the full YAML parser, keeping the change-detection path fast.
+- **Prune on update**: `update_cache` re-hashes everything relevant and then drops entries for files that no longer exist, bounding cache size.
+
+## Files to Read First
+
+- `src/hash_cache.rs` — entire module: `HashCache` (load/save/hash/is_changed/prune), `classify_changes`, `find_companion_files`, `update_cache`, `extract_frontmatter_files`.
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Stable and complete. Used by `cmd_check` for incremental validation. Public API spans the `HashCache` struct, `ChangeKind`/`ChangeClassification`, and the classify/filter/update free functions.
+
+## Notes
+
+- Depends on `sha2` (hashing) and `serde`/`serde_json` (cache serialization); conceptually pairs with `parser` for frontmatter.
+- `ChangeClassification::has` takes `&ChangeKind`; `is_changed(&self)` reports whether any change was recorded.
+- Cache lives under `.specsync/` alongside other spec-sync state.

--- a/specs/hash_cache/requirements.md
+++ b/specs/hash_cache/requirements.md
@@ -3,3 +3,38 @@ spec: hash_cache.spec.md
 ---
 
 ## User Stories
+
+- As a developer on a large spec set, I want `specsync check` to re-validate only the specs that actually changed so that validation stays fast
+- As a developer, I want changes to a spec's backing source files (`files:` in frontmatter) to also trigger re-validation so that drift between code and spec is caught
+- As a developer, I want companion file edits (requirements/context/tasks/testing/design) to mark the parent spec as changed so that companion-aware checks re-run
+- As a CI operator, I want the cache to be self-healing on first run or corruption so that a missing/invalid cache never blocks validation — it just re-checks everything
+- As a maintainer, I want stale cache entries for deleted files pruned automatically so that the cache file does not grow without bound
+
+## Acceptance Criteria
+
+- Cache persists to `{root}/.specsync/hashes.json` (pretty JSON); the `.specsync/` directory is created on `save`
+- `HashCache::load` returns an empty cache when the file is missing or unparseable (treating all files as changed)
+- `hash_file` computes SHA-256 in 8KB chunks and returns a hex digest, or `None` if the file cannot be read
+- `is_changed` returns true when a path is new or its current hash differs from the cached value; unreadable files are treated as changed
+- Path keys are normalized to forward slashes (`normalize_rel`) for cross-platform consistency
+- `classify_changes` reports `ChangeKind::Spec`, `Requirements`, `Companion`, and/or `Source` for one spec; the requirements companion maps to `Requirements`, while context/tasks/testing/design map to `Companion`
+- Companion detection covers both the plain convention (`requirements.md`, `context.md`, `tasks.md`, `testing.md`, `design.md`) and legacy `{module}.<suffix>` prefixed names
+- `classify_all_changes` / `filter_unchanged` return only specs that have detected changes
+- `update_cache` re-hashes every spec, its companions, and its source files after validation, then prunes deleted entries
+- `extract_frontmatter_files` extracts the `files:` list with lightweight string matching, not the full YAML parser
+
+## Constraints
+
+- Hashing must stream in chunks (8KB) to avoid loading large files fully into memory
+- Cache corruption or absence must never error — fall back to "everything changed"
+- Path normalization is mandatory so cache keys are stable across OSes
+- Companion-name detection must support both current and legacy naming without false positives
+- `extract_frontmatter_files` must not pull in the full parser (kept cheap for the hot path)
+
+## Out of Scope
+
+- Hashing strategies other than SHA-256
+- Tracking changes to files not referenced by a spec (spec, its companions, and its `files:` only)
+- Cross-run change history or diffing (only last-known hash is stored)
+- Watching the filesystem for live changes (see the `watch` module)
+- Validating spec content (only change detection lives here)

--- a/specs/hash_cache/tasks.md
+++ b/specs/hash_cache/tasks.md
@@ -4,4 +4,27 @@ spec: hash_cache.spec.md
 
 ## Tasks
 
+(none open)
+
+## Done
+
+- [x] `HashCache` struct with `load`/`save` to `.specsync/hashes.json` (pretty JSON)
+- [x] `hash_file` SHA-256 streaming in 8KB chunks
+- [x] `is_changed` / `update` / `prune` per-path operations
+- [x] Cross-platform path normalization (`normalize_rel`, forward slashes)
+- [x] `ChangeKind` enum (Spec / Requirements / Companion / Source) and `ChangeClassification`
+- [x] `classify_changes`: spec, companions, and frontmatter source files
+- [x] Companion detection for plain names and legacy `{module}.<suffix>` (req/context/tasks/testing/design)
+- [x] `classify_all_changes` / `filter_unchanged` returning only changed specs
+- [x] `update_cache` re-hash + prune after validation
+- [x] `extract_frontmatter_files` lightweight `files:` extraction
+- [x] Empty-cache fallback on missing/corrupt JSON
+- [x] Integration coverage: `check_creates_hash_cache`
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/hash_cache/testing.md
+++ b/specs/hash_cache/testing.md
@@ -6,7 +6,7 @@ spec: hash_cache.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/hash_cache.rs` | cargo test hash_cache:: | `cache_round_trip`, `is_changed_detects_new_file`, `is_changed_detects_modification`, `extract_files_from_frontmatter`, `prune_removes_missing`, `classify_detects_spec_change` |
+| `src/hash_cache.rs` | cargo test hash_cache:: | `cache_round_trip`, `is_changed_detects_new_file`, `is_changed_detects_modification`, `extract_files_from_frontmatter`, `prune_removes_missing`, `classify_detects_spec_change`, `classify_detects_requirements_change`, `classify_detects_companion_change`, `classify_detects_testing_companion_change`, `classify_detects_source_change`, `companion_files_found_with_plain_names`, `update_cache_tracks_plain_companion_files` |
 | `tests/integration.rs` | cargo test --test integration check_creates_hash_cache | End-to-end fixture: `check_creates_hash_cache` |
 
 ## Behavioral Verification

--- a/specs/hooks/context.md
+++ b/specs/hooks/context.md
@@ -16,9 +16,11 @@ spec: hooks.spec.md
 
 ## Current Status
 
-Fully implemented. All 5 hook targets work: CLAUDE.md, .cursorrules, .github/copilot-instructions.md, .git/hooks/pre-commit, and .claude/settings.json.
+Fully implemented. All 6 hook targets work: CLAUDE.md (`Claude`), .cursorrules (`Cursor`), .github/copilot-instructions.md (`Copilot`), AGENTS.md (`Agents`), .git/hooks/pre-commit (`Precommit`), and .claude/settings.json (`ClaudeCodeHook`). `HookTarget::from_str` is case-insensitive and accepts aliases.
 
 ## Notes
 
 - The hook content includes spec-sync CLI commands and instructions for how AI agents should interact with specs.
 - `cmd_status()` reports installed/not-installed for each target, useful for CI verification.
+- `cmd_install` exits with code 1 if any single hook installation fails.
+- Uninstall removes the spec-sync section via `remove_section`, which deletes the file when nothing else remains.

--- a/specs/hooks/testing.md
+++ b/specs/hooks/testing.md
@@ -6,7 +6,9 @@ spec: hooks.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/hooks.rs` | cargo test hooks:: | `hook_target_all_returns_six_targets`, `hook_target_all_contains_all_variants`, `hook_target_name_returns_expected_strings`, `hook_target_description_returns_human_readable`, `from_str_parses_all_targets`, `from_str_is_case_insensitive` |
+| `src/hooks.rs` (enum/parsing) | cargo test hooks:: | `hook_target_all_returns_six_targets`, `hook_target_all_contains_all_variants`, `hook_target_name_returns_expected_strings`, `hook_target_description_returns_human_readable`, `from_str_parses_all_targets`, `from_str_is_case_insensitive`, `from_str_accepts_aliases`, `from_str_returns_none_for_unknown` |
+| `src/hooks.rs` (install/idempotency) | cargo test hooks:: | `install_claude_creates_file`, `install_claude_is_idempotent`, `install_claude_appends_to_existing`, `install_cursor_creates_file`, `install_copilot_creates_github_dir`, `install_agents_creates_file`, `install_precommit_creates_hook_file`, `install_precommit_appends_to_existing_hook`, `install_precommit_sets_executable_permission`, `install_claude_code_hook_creates_settings`, `install_claude_code_hook_merges_into_existing`, `install_claude_code_hook_idempotent` |
+| `src/hooks.rs` (status/uninstall) | cargo test hooks:: | `is_installed_returns_false_for_empty_dir`, `is_installed_claude_detects_marker`, `uninstall_claude_removes_section`, `uninstall_claude_preserves_other_content`, `uninstall_precommit_removes_hook_file`, `uninstall_returns_false_when_not_installed`, `uninstall_claude_code_hook_is_refused`, `remove_section_deletes_file_if_empty_after`, `remove_section_stops_at_next_top_level_heading` |
 
 ## Coverage Gaps
 

--- a/specs/ignore/context.md
+++ b/specs/ignore/context.md
@@ -4,17 +4,22 @@ spec: ignore.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- **Three suppression scopes**: global (bare category in `.specsyncignore`), per-spec (`category:path-prefix`), and inline (`<!-- specsync-ignore: ... -->` in the spec body). `is_suppressed` checks all three.
+- **Classify by message text**: warnings are categorized by matching substrings/prefixes of their text (`WarningCategory::classify`), so the suppression layer stays decoupled from where warnings are emitted. Order matters — `schema-type-mismatch` is checked before the generic `schema-column`.
+- **Forgiving parsing**: `from_str` lowercases input, treats `_`/`-` as equivalent, and accepts short aliases, so users don't have to memorize exact variant names.
+- **Missing file is not an error**: `load` returns empty rules when `.specsyncignore` is absent, so the feature is purely opt-in.
+- **Prefix matching, not globs**: per-spec rules match when the spec's relative path `starts_with` the configured pattern.
 
 ## Files to Read First
 
-- `src/ignore.rs` — primary source file
+- `src/ignore.rs` — `WarningCategory`, `IgnoreRules`, and all inline tests
+- `src/validator.rs` / `src/commands/check.rs` — call `is_suppressed` to filter warnings before reporting
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable, with inline unit tests covering `classify`, `from_str` aliases, `parse_inline`, all three `is_suppressed` scopes, and `load` (present + absent file).
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This is a library module consumed by the validation/check path — it does no config loading or process exit of its own.
+- Each new suppressible warning needs a `WarningCategory` variant plus arms in both `from_str` and `classify`.

--- a/specs/ignore/requirements.md
+++ b/specs/ignore/requirements.md
@@ -4,21 +4,27 @@ spec: ignore.spec.md
 
 ## User Stories
 
-- As a developer, I want the `ignore` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer, I want to suppress specific warning categories globally via a `.specsyncignore` file so that intentional gaps don't create noise on every run
+- As a developer, I want to suppress a category for only a subtree of specs (e.g. `stub-section:specs/legacy/`) so that legacy specs don't block new work while keeping checks strict elsewhere
+- As a spec author, I want to silence a warning for a single spec with an inline `<!-- specsync-ignore: ... -->` comment so that the suppression lives next to the spec it applies to
+- As a developer, I want category names to accept aliases and kebab/snake case so that the ignore syntax is forgiving
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `WarningCategory::from_str` parses category names case-insensitively, treating `_` and `-` as equivalent, and accepts short aliases (`requirements`, `stub`, `undocumented`, `schema-mismatch`, `changelog`, `invariants`, `depends-on`); unknown strings return `None`
+- `WarningCategory::classify` maps a warning's text to a category, checking the more specific `schema-type-mismatch` before the generic `schema-column`
+- `IgnoreRules::load` reads `.specsyncignore` from the project root, skipping blank lines and `#` comments and stripping inline `#` comments; a `category:pattern` line becomes a per-spec rule, a bare `category` becomes a global rule; a missing file yields empty (default) rules, not an error
+- `IgnoreRules::parse_inline` extracts categories from `<!-- specsync-ignore: a, b -->` lines in a spec body; a directive missing the closing `-->` is ignored
+- `is_suppressed` returns true when the warning's category is suppressed globally, inline, or by a per-spec pattern that the spec's relative path `starts_with`; a warning whose text matches no category (`classify` → `None`) is never suppressed
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Pure in-memory rule evaluation — no process exit; only `load` touches the filesystem (read-only)
+- Per-spec patterns match by path prefix (`starts_with`), not glob
+- Adding a new suppressible warning requires a `WarningCategory` variant plus matching arms in both `from_str` and `classify`
 
 ## Out of Scope
 
-- GUI or web interface
-- Interactive prompts (except wizard module)
+- Glob/regex matching for per-spec patterns (prefix matching only)
+- Suppressing errors (only warnings are categorized and suppressible)
+- Configuring ignore rules through `specsync.json` (only `.specsyncignore` and inline comments)

--- a/specs/ignore/tasks.md
+++ b/specs/ignore/tasks.md
@@ -2,18 +2,20 @@
 spec: ignore.spec.md
 ---
 
-## Tasks
-
-- [ ] Add integration tests for this command's CLI behavior
-
 ## Done
 
+- [x] `WarningCategory` enum with `from_str` (aliases, case/`_`-`-` insensitive) and `classify` (text → category)
+- [x] `IgnoreRules::load` for `.specsyncignore` (global + per-spec rules, comment handling, missing-file safe)
+- [x] `IgnoreRules::parse_inline` for `<!-- specsync-ignore: ... -->` directives
+- [x] `is_suppressed` covering global, inline, and per-spec prefix scopes
+- [x] Inline unit tests for classify ordering, aliases, parse_inline, all suppression scopes, and load (present/absent)
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
 
-## Gaps
+## Open
 
-- No dedicated test file for this command module
+- [ ] No end-to-end integration test that asserts a `.specsyncignore` rule actually suppresses a warning in `specsync check` output
+- [ ] Per-spec patterns are prefix-only; glob support is not implemented
 
 ## Review Sign-offs
 

--- a/specs/ignore/testing.md
+++ b/specs/ignore/testing.md
@@ -6,8 +6,9 @@ spec: ignore.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/ignore.rs` | cargo test ignore:: | `test_classify_requirements_companion`, `test_classify_stub_section`, `test_classify_undocumented_export`, `test_classify_schema_type_before_column`, `test_from_str_aliases`, `test_parse_inline` |
-| `tests/integration.rs` | cargo test --test integration init_ignores_node_modules_and_hidden_dirs | End-to-end fixture: `init_ignores_node_modules_and_hidden_dirs` |
+| `src/ignore.rs` (classify) | cargo test ignore:: | `test_classify_requirements_companion`, `test_classify_stub_section`, `test_classify_undocumented_export`, `test_classify_schema_type_before_column` |
+| `src/ignore.rs` (parse/load) | cargo test ignore:: | `test_from_str_aliases`, `test_parse_inline`, `test_load_specsyncignore`, `test_load_no_file` |
+| `src/ignore.rs` (suppression) | cargo test ignore:: | `test_is_suppressed_global`, `test_is_suppressed_inline`, `test_is_suppressed_per_spec` |
 
 ## Behavioral Verification
 

--- a/specs/importer/context.md
+++ b/specs/importer/context.md
@@ -7,13 +7,14 @@ spec: importer.spec.md
 - Reuses existing `github::gh_is_available()` for auth detection rather than duplicating
 - Uses simple regex-free HTML stripping for Confluence — no external HTML parser dependency
 - Base64 encoding is hand-rolled to avoid adding a dependency (only used for Jira/Confluence basic auth)
-- Requirements extraction is heuristic-based: looks for checkboxes, "Acceptance Criteria", and "Definition of Done" sections
+- Requirements extraction is heuristic-based: looks for checkboxes, "Acceptance Criteria"/"Requirements", and "Definition of Done" sections
 - Generated specs always start as `draft` status — user fills in details after import
+- `redact_secret` strips any verbatim auth token from REST error strings before surfacing them (added 4.3.5), mirroring the GitHub module's `redact_token` and the AI provider client's sanitization
 
 ## Files to Read First
 
 - `src/importer.rs` — all importer logic, parsers, and tests
-- `src/main.rs` — `cmd_import` function wires CLI to importers
+- `src/commands/import.rs` — wires the `specsync import` subcommand to the importer functions (dispatched from `src/main.rs`)
 
 ## Current Status
 

--- a/specs/importer/requirements.md
+++ b/specs/importer/requirements.md
@@ -14,8 +14,10 @@ spec: importer.spec.md
 - Jira importer supports both Atlassian Cloud (basic auth) and Server/DC (bearer token)
 - Confluence importer strips HTML and extracts plain text requirements
 - All imported specs have valid frontmatter and all required sections
-- Requirements are automatically extracted from checkboxes and acceptance criteria sections
-- Module names are properly slugified from titles
+- Requirements are automatically extracted from checkboxes and "Acceptance Criteria" / "Requirements" / "Definition of Done" sections
+- Module names are properly slugified from titles (lowercased, non-alphanumerics collapsed to single `-`)
+- `render_spec` emits `implements: [n]` when an issue number is present and `implements: []` otherwise (Jira/Confluence)
+- Auth tokens (`JIRA_TOKEN`, `CONFLUENCE_TOKEN`, `GITHUB_TOKEN`) are redacted from REST error messages via `redact_secret` before being surfaced
 
 ## Constraints
 

--- a/specs/importer/tasks.md
+++ b/specs/importer/tasks.md
@@ -2,13 +2,14 @@
 spec: importer.spec.md
 ---
 
-## Tasks
+## Done
 
 - [x] Implement GitHub Issues importer with `gh` CLI + REST API fallback
 - [x] Implement Jira importer with ADF and plain text description support
 - [x] Implement Confluence importer with HTML stripping
 - [x] Add requirement extraction from checkboxes and criteria sections
-- [x] Add `specsync import` CLI subcommand
+- [x] Add `specsync import` CLI subcommand (`src/commands/import.rs`)
+- [x] Redact auth tokens from REST error messages via `redact_secret` (4.3.5)
 - [x] Write unit tests for all parsers and helpers
 
 ## Gaps

--- a/specs/importer/testing.md
+++ b/specs/importer/testing.md
@@ -6,7 +6,10 @@ spec: importer.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/importer.rs` | cargo test importer:: | `test_slugify_simple`, `test_slugify_special_chars`, `test_slugify_already_slug`, `test_slugify_mixed_case_spaces`, `test_slugify_empty`, `test_extract_requirements_checkboxes` |
+| `src/importer.rs` (slugify) | cargo test importer:: | `test_slugify_simple`, `test_slugify_special_chars`, `test_slugify_already_slug`, `test_slugify_mixed_case_spaces`, `test_slugify_empty` |
+| `src/importer.rs` (requirement extraction) | cargo test importer:: | `test_extract_requirements_checkboxes`, `test_extract_requirements_criteria_section`, `test_extract_requirements_definition_of_done`, `test_extract_requirements_empty_body` |
+| `src/importer.rs` (parsers) | cargo test importer:: | `test_parse_github_json_full`, `test_parse_jira_json_plain_description`, `test_parse_jira_json_adf_description`, `test_parse_confluence_json` |
+| `src/importer.rs` (render/encode) | cargo test importer:: | `test_render_spec_with_issue_number`, `test_render_spec_without_issue_number`, `test_base64_encode`, `test_strip_html_nested` |
 
 ## Coverage Gaps
 
@@ -34,6 +37,7 @@ spec: importer.spec.md
 | Issue/page not found (404) | Each importer returns `Err("{type} not found")` | Keep or add a focused assertion before changing this behavior |
 | Network timeout | Returns `Err` with connection details | Keep or add a focused assertion before changing this behavior |
 | Invalid issue number for GitHub | CLI rejects before calling importer | Keep or add a focused assertion before changing this behavior |
+| Auth token echoed in a REST error | `redact_secret` replaces the verbatim token with `[REDACTED]` before the `Err` is surfaced | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 

--- a/specs/manifest/tasks.md
+++ b/specs/manifest/tasks.md
@@ -21,9 +21,9 @@ spec: manifest.spec.md
 
 ## Gaps
 
-- Gradle settings.gradle `include` directives not parsed (only build.gradle itself)
 - No support for Bazel BUILD files or Meson build definitions
-- Workspace glob expansion not implemented for Cargo
+- Workspace glob expansion not implemented for Cargo `members` (literal paths only; `package.json` workspace globs like `packages/*` are supported, Cargo's are not)
+- Dependency extraction is only wired up for Cargo (`[dependencies]`) and Swift target `dependencies:`; other manifests leave `dependencies` empty
 
 ## Review Sign-offs
 

--- a/specs/mcp/context.md
+++ b/specs/mcp/context.md
@@ -5,15 +5,18 @@ spec: mcp.spec.md
 ## Key Decisions
 
 - **Stdio transport only**: The server reads JSON-RPC from stdin and writes to stdout. No HTTP/WebSocket transport — MCP clients (Claude Code, Cursor, Windsurf) all support stdio.
-- **6 tools exposed**: check, coverage, generate, list_specs, init, score. These cover the core spec-sync workflow without exposing low-level internals.
-- **Errors as tool results**: Tool failures return `isError: true` in the content response, not JSON-RPC error objects. This follows the MCP convention where tool errors are expected outcomes, not protocol errors.
+- **7 tools exposed**: check, coverage, generate, list_specs, init, score, issues. These cover the core spec-sync workflow without exposing low-level internals.
+- **4 resources + 1 template**: `specsync:///specs`, `specsync:///graph`, `specsync:///config`, `specsync:///coverage`, plus the `specsync:///specs/{module}` template that returns a single spec as `text/markdown`. The `initialize` response advertises both `tools` and `resources` capabilities.
+- **AI provider resolution**: `specsync_generate` delegates to `ai::resolve_ai_provider` (the reworked corvid-ai-backed `ai` module) when `ai: true` or a `provider` argument is given; an unresolvable provider surfaces as a tool error.
+- **Errors as tool results**: Tool failures return `isError: true` in the content response, not JSON-RPC error objects. Resource read failures, however, use JSON-RPC error -32602.
 - **Optional `root` parameter**: Every tool accepts an optional `root` override so agents can work on projects outside the current working directory.
 - **Stateless design**: Each tool invocation loads config from scratch. No server-side state is maintained between calls, which simplifies the implementation and avoids stale data.
 - **Notifications ignored**: JSON-RPC requests without an `id` field are treated as notifications and silently dropped.
 
 ## Files to Read First
 
-- `src/mcp.rs` — Single-file module implementing the full MCP server: JSON-RPC parsing, tool dispatch, and response formatting.
+- `src/mcp.rs` — Single-file module implementing the full MCP server: JSON-RPC parsing, tool/resource dispatch, and response formatting.
+- `src/ai.rs` — `resolve_ai_provider`, used by `specsync_generate` for AI-backed generation.
 
 ## Current Status
 

--- a/specs/mcp/requirements.md
+++ b/specs/mcp/requirements.md
@@ -7,18 +7,22 @@ spec: mcp.spec.md
 - As a Claude Code user, I want spec-sync available as an MCP server so that I can check, generate, and score specs directly from my AI assistant
 - As a Cursor user, I want MCP tools for spec-sync so that spec validation is integrated into my AI-powered editing workflow
 - As an AI agent developer, I want programmatic access to spec-sync over JSON-RPC so that I can build spec validation into automated workflows
+- As an AI agent, I want to read specs, the dependency graph, config, and coverage as MCP resources so that I can inspect project state without invoking a tool
 - As a developer, I want the MCP server to run over stdio so that it works with any MCP-compatible client without network configuration
 
 ## Acceptance Criteria
 
 - Implements JSON-RPC 2.0 over stdio
-- Protocol version "2024-11-05" returned in initialize response
-- Six tools exposed: specsync_check, specsync_coverage, specsync_generate, specsync_list_specs, specsync_init, specsync_score
+- Protocol version "2024-11-05" returned in initialize response; `initialize` advertises both `tools` and `resources` capabilities
+- Seven tools exposed: `specsync_check`, `specsync_coverage`, `specsync_generate`, `specsync_list_specs`, `specsync_init`, `specsync_score`, `specsync_issues`
+- Four resources exposed (`specsync:///specs`, `specsync:///graph`, `specsync:///config`, `specsync:///coverage`) plus one resource template (`specsync:///specs/{module}`)
+- `specsync_generate` resolves the AI provider through `ai::resolve_ai_provider` (the corvid-ai-backed `ai` module) when `ai: true` or a `provider` is given; an unresolvable provider returns a tool error
 - Tool errors returned as `isError: true` in result content, not as JSON-RPC error objects (except parse/method-not-found)
+- Resource read errors return JSON-RPC error -32602 (unknown URI, module not found)
 - Malformed JSON returns JSON-RPC error -32700 "Parse error"
 - Unknown method returns JSON-RPC error -32601 "Method not found"
 - Unknown tool name returns tool-level error "Unknown tool: {name}"
-- Notifications (requests without id) receive no response
+- Notifications (requests without id, e.g. `notifications/initialized`) receive no response
 - `ping` method returns empty result
 - Each tool accepts optional `root` parameter to override project directory
 - stdin EOF triggers graceful exit
@@ -31,7 +35,8 @@ spec: mcp.spec.md
 
 ## Out of Scope
 
-- MCP resources or prompts (only tools are implemented)
+- MCP prompts (tools and resources are implemented; prompts are not)
 - HTTP/SSE transport (stdio only)
 - Authentication or authorization
 - Streaming partial results during long operations
+- Server-side state between calls (each invocation reloads config from scratch)

--- a/specs/mcp/tasks.md
+++ b/specs/mcp/tasks.md
@@ -6,25 +6,27 @@ spec: mcp.spec.md
 
 - [ ] Add `specsync_watch` tool that streams validation results on file changes
 - [ ] Add `specsync_hooks` tool for installing/checking hook status via MCP
-- [ ] Add resource support (MCP resources for reading spec files directly)
 - [ ] Add prompt templates for common spec-sync workflows
+- [ ] Add `specsync_resolve` tool for cross-project dependency resolution
 
 ## Done
 
 - [x] JSON-RPC 2.0 stdio transport
-- [x] `specsync_check` tool — validate all specs
+- [x] `specsync_check` tool — validate all specs (with staleness warnings)
 - [x] `specsync_coverage` tool — file/LOC coverage metrics
-- [x] `specsync_generate` tool — create missing specs (with optional AI)
+- [x] `specsync_generate` tool — create missing specs (optional AI via `ai::resolve_ai_provider`)
 - [x] `specsync_list_specs` tool — list specs with metadata
 - [x] `specsync_init` tool — create specsync.json
 - [x] `specsync_score` tool — quality scoring
-- [x] Error handling as `isError: true` responses
+- [x] `specsync_issues` tool — verify GitHub issue references in frontmatter
+- [x] MCP resources: `specsync:///specs`, `:///graph`, `:///config`, `:///coverage` + `:///specs/{module}` template
+- [x] Error handling as `isError: true` for tools, JSON-RPC -32602 for resource reads
 - [x] Optional `root` parameter on all tools
 
 ## Gaps
 
-- No MCP resource support — agents can't read spec files through the protocol, only through tool results
 - No streaming/progress for long-running operations (AI generation)
+- No MCP prompts (tools and resources only)
 - No `specsync_resolve` tool for cross-project dependency resolution
 
 ## Review Sign-offs

--- a/specs/mcp/testing.md
+++ b/specs/mcp/testing.md
@@ -6,7 +6,9 @@ spec: mcp.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/mcp.rs` | cargo test mcp:: | `test_handle_initialize_response_format`, `test_handle_initialize_null_id`, `test_handle_initialize_string_id`, `test_handle_tools_list_returns_all_tools`, `test_handle_tools_list_tool_names`, `test_handle_tools_list_all_have_schemas` |
+| `src/mcp.rs` (protocol) | cargo test mcp:: | `test_handle_initialize_response_format`, `test_handle_tools_list_returns_all_tools` (asserts 7 tools), `test_handle_tools_list_tool_names`, `test_handle_tools_list_all_have_schemas` |
+| `src/mcp.rs` (tools) | cargo test mcp:: | `test_handle_tools_call_unknown_tool`, `test_tool_check_strict_mode`, `test_tool_score_with_spec`, `test_tool_generate_creates_spec`, `test_load_and_discover_filters_private_specs` |
+| `src/mcp.rs` (resources) | cargo test mcp:: | `test_handle_resources_list_returns_resources` (asserts 4 resources), `test_handle_resources_list_has_templates`, `test_resource_specs_list_with_spec`, `test_resource_spec_by_module`, `test_resource_graph_empty`, `test_resource_unknown_uri` |
 | `tests/integration.rs` | cargo test --test integration mcp_initialize_returns_capabilities | End-to-end fixture: `mcp_initialize_returns_capabilities` |
 | `tests/integration.rs` | cargo test --test integration mcp_tools_list_returns_all_tools | End-to-end fixture: `mcp_tools_list_returns_all_tools` |
 | `tests/integration.rs` | cargo test --test integration mcp_tool_check_validates_specs | End-to-end fixture: `mcp_tool_check_validates_specs` |

--- a/specs/merge/context.md
+++ b/specs/merge/context.md
@@ -2,12 +2,24 @@
 spec: merge.spec.md
 ---
 
-## Key Files
+## Key Decisions
 
-- `src/merge.rs` - Main implementation
-- `specs/merge/merge.spec.md` - Module specification
-- `specs/merge/requirements.md` - User stories and acceptance criteria
+- **Section-aware strategies**: `resolve_conflict` dispatches on the enclosing section (last `## ` heading, computed via `detect_section` from text emitted so far). Frontmatter (before any heading) unions lists and takes theirs for scalars; `## Change Log` merges rows chronologically; any section that is *pure table rows* gets a key-based table merge; everything else (prose) is left for manual resolution.
+- **Region parsing, not regex**: `parse_conflict_regions` walks lines, peeling `<<<<<<< / ======= / >>>>>>>` blocks into `ours`/`theirs` strings and a `marker_label`. Clean text between blocks is preserved verbatim.
+- **Zero-dependency YAML**: `parse_yaml_fields` handles the project's simple key/scalar and key/list subset directly rather than pulling in a YAML crate. List keys `files`, `db_tables`, `depends_on` are unioned and sorted.
+- **Theirs-wins precedence**: for scalar frontmatter fields and generic-table row collisions, the incoming (theirs) value overrides ours, treating the merged-in branch as the newer change.
+- **Conservative fallbacks**: when `git diff` fails in git mode, `detect_conflicted_specs` returns an empty list (no specs processed); unreadable files become `Manual`; a still-conflicted result keeps its markers.
+
+## Files to Read First
+
+- `src/merge.rs` — entire module: `merge_specs` (driver), `resolve_spec_conflicts` (orchestrator), `parse_conflict_regions`, `resolve_conflict` and the three strategy functions (`resolve_changelog_conflict`, `resolve_table_conflict`, `resolve_frontmatter_conflict`).
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Stable and complete. Public API: `merge_specs`, `has_conflict_markers`, `print_results`, `results_to_json`, plus `MergeResult`/`MergeStatus`. Invoked by the `cmd_merge` subcommand.
+
+## Notes
+
+- Depends on `parser::parse_frontmatter` (post-resolution validation) and `validator::find_spec_files` (all-files scan).
+- Changelog sorting assumes ISO `YYYY-MM-DD` dates so lexicographic order is chronological.
+- `print_results` skips `Clean` entries; `results_to_json` includes all three statuses.

--- a/specs/merge/requirements.md
+++ b/specs/merge/requirements.md
@@ -24,7 +24,7 @@ spec: merge.spec.md
 - `all_files: true` scans all `.spec.md` files for conflict markers regardless of git state
 - `dry_run: true` returns resolution results without writing any changes to disk
 - Unreadable spec files are marked as `Manual` with the read error included in details
-- If `git diff` fails, the tool falls back to scanning all files for conflict markers
+- If `git diff` fails in git mode (`all_files: false`), `detect_conflicted_specs` returns no files (the run is a safe no-op); explicit `all_files: true` is the way to scan everything
 - Post-resolution frontmatter validation warnings are printed but don't prevent file writes
 - Results include `spec_path`, `status` (`Resolved` | `Manual` | `Clean`), and `details` for each file
 - Human-readable output uses colored formatting to distinguish status types

--- a/specs/merge/tasks.md
+++ b/specs/merge/tasks.md
@@ -4,4 +4,27 @@ spec: merge.spec.md
 
 ## Tasks
 
+(none open)
+
+## Done
+
+- [x] `merge_specs` driver: git-conflicted vs all-files scan, dry-run, write-back
+- [x] `has_conflict_markers` detection of `<<<<<<< ` markers
+- [x] `detect_conflicted_specs` via `git diff --name-only --diff-filter=U`
+- [x] `parse_conflict_regions` splitting content into clean text and ours/theirs conflict blocks
+- [x] `detect_section` context detection (last `## ` heading) to choose a strategy
+- [x] Frontmatter conflict resolution: list union+sort, scalar "theirs wins"
+- [x] Changelog conflict resolution: chronological merge, dedup by full row
+- [x] Generic table conflict resolution: dedup by first cell, "theirs wins"
+- [x] Prose conflicts left as `Manual` with markers preserved
+- [x] Post-resolution frontmatter validation warning
+- [x] `print_results` (colored text) and `results_to_json` output formats
+- [x] Custom zero-dep YAML field parser (`parse_yaml_fields`)
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/merge/testing.md
+++ b/specs/merge/testing.md
@@ -6,7 +6,7 @@ spec: merge.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/merge.rs` | cargo test merge:: | `test_has_conflict_markers`, `test_parse_conflict_regions`, `test_resolve_changelog_conflict`, `test_resolve_table_conflict`, `test_resolve_frontmatter_conflict`, `test_full_spec_conflict_resolution` |
+| `src/merge.rs` | cargo test merge:: | `test_has_conflict_markers`, `test_parse_conflict_regions`, `test_resolve_changelog_conflict`, `test_resolve_table_conflict`, `test_resolve_frontmatter_conflict`, `test_full_spec_conflict_resolution`, `test_manual_fallback_for_prose`, `test_parse_yaml_fields`, `test_is_pure_table_rows` |
 
 ## Coverage Gaps
 
@@ -26,8 +26,8 @@ spec: merge.spec.md
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
 | Spec file unreadable | Marked as `Manual` with read error in details | Keep or add a focused assertion before changing this behavior |
-| `git diff` command fails | Falls back to scanning all files for conflict markers | Keep or add a focused assertion before changing this behavior |
-| Post-resolution frontmatter invalid | Warning printed; file is still written with resolved content | Keep or add a focused assertion before changing this behavior |
+| `git diff` command fails (`all_files: false`) | `detect_conflicted_specs` returns an empty list — no specs are processed (no auto-fallback to scanning all files) | Keep or add a focused assertion before changing this behavior |
+| Post-resolution frontmatter invalid | `"Warning: resolved file has invalid frontmatter"` added to details; file is still written with resolved content | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist
 

--- a/specs/output/context.md
+++ b/specs/output/context.md
@@ -4,17 +4,20 @@ spec: output.spec.md
 
 ## Key Decisions
 
-- Module follows the standard command pattern: load config, discover specs, delegate to library module, format output, exit
-- Spec was created during the 100% coverage push to dogfood spec-sync on its own codebase
+- **Pure presentation layer**: `output` only formats and prints data passed to it. It does no config loading, file I/O, or process exit — those belong to the command layer (`src/commands/`). This keeps formatting testable in isolation.
+- **Color thresholds**: percentages render green at 100, yellow at ≥80, red below 80 (`print_coverage_line`); summary counts color passed green, warnings yellow, failed red. Coloring uses the `colored` crate.
+- **`saturating_sub` for failures**: `print_summary` computes `failed = total.saturating_sub(passed)` after a usize-underflow panic was found when `passed` exceeded `total`. This is regression-guarded by `print_summary_does_not_underflow_when_passed_exceeds_total`.
+- **Markdown vs terminal**: `print_check_markdown` / `print_diff_markdown` emit plain Markdown (no ANSI) for PR comments and CI summaries; the line/report printers use color for interactive terminals.
 
 ## Files to Read First
 
-- `src/output.rs` — primary source file
+- `src/output.rs` — all formatting functions plus inline unit tests
+- `src/commands/check.rs` / `src/commands/diff.rs` — callers that compute the data and own exit codes
 
 ## Current Status
 
-Fully implemented and stable. Spec created to achieve 100% file coverage.
+Fully implemented and stable, with inline unit tests covering `print_summary` (underflow + zero/all-passed) and `print_coverage_line` color boundaries. The `saturating_sub` underflow fix is in place.
 
 ## Notes
 
-- This module is part of the command layer — it orchestrates library modules rather than containing domain logic
+- This module contains no domain logic — it is the rendering layer for `check`, `coverage`, and `diff`.

--- a/specs/output/requirements.md
+++ b/specs/output/requirements.md
@@ -4,21 +4,29 @@ spec: output.spec.md
 
 ## User Stories
 
-- As a developer, I want the `output` module to work reliably so that spec-sync validation and tooling is trustworthy
-- As a CI operator, I want clear exit codes and error messages so that pipeline failures are actionable
+- As a developer running `specsync check`, I want a colored one-line summary of passed/warning/failed counts so that I can see project health at a glance
+- As a developer, I want file and LOC coverage printed with color thresholds (green at 100%, yellow ≥80%, red below) so that gaps stand out
+- As a CI operator, I want check results and drift reports rendered as Markdown so that they can be posted to PR comments and job summaries
+- As a developer, I want the coverage report to list unspecced modules and files (with uncovered LOC) so that I know exactly what to document next
 
 ## Acceptance Criteria
 
-- All exported functions perform their documented purpose
-- Error conditions produce clear, actionable messages
-- Module follows the project's established patterns for config loading and output formatting
+- `print_summary(total, passed, warnings, errors)` prints `{total} specs checked: {passed} passed, {warnings} warning(s), {failed} failed`, where `failed = total.saturating_sub(passed)` (never underflows)
+- `passed` is colored green, `warnings` yellow, and `failed` red when nonzero (otherwise `0`)
+- `print_coverage_line` colors both file and LOC percentages green at 100, yellow at ≥80, red below 80
+- `print_coverage_report` prints a "✓ All source modules have spec directories" / "✓ All source files referenced by specs" success line when nothing is unspecced, otherwise lists each unspecced module (`name/`) and file (with per-file LOC and an uncovered-LOC total)
+- `print_check_markdown` emits a `## SpecSync Check Results` block with a ✅/❌ status line, optional Errors/Warnings sections, and a Coverage section
+- `print_diff_markdown` emits a `## SpecSync Drift Report`; with no drift entries it reports either "No spec-tracked source files changed since `{base}`." or lists changed files not covered by any spec; with entries it tabulates added/removed exports per spec and flags spec-file-only modifications
 
 ## Constraints
 
-- Must not panic on expected error conditions — return Results or print and exit
-- Must work with the project's Clap-based CLI argument parsing
+- Pure presentation layer — formats data passed in, no config loading, file I/O, or process exit
+- Uses the `colored` crate for ANSI coloring; must not panic on any count combination (including `passed > total`)
+- Markdown output must be plain (no ANSI) so it renders correctly in PR comments and CI summaries
 
 ## Out of Scope
 
 - GUI or web interface
-- Interactive prompts (except wizard module)
+- Interactive prompts
+- Deciding pass/fail or exit codes (callers in the command layer own that)
+- Computing coverage or diff data (this module only renders it)

--- a/specs/output/tasks.md
+++ b/specs/output/tasks.md
@@ -2,18 +2,18 @@
 spec: output.spec.md
 ---
 
-## Tasks
-
-- [ ] Add integration tests for this command's CLI behavior
-
 ## Done
 
+- [x] `print_summary` / `print_coverage_line` / `print_coverage_report` colored terminal output
+- [x] `print_check_markdown` and `print_diff_markdown` for PR comments and CI summaries
+- [x] `saturating_sub` underflow fix in `print_summary` (`passed > total` no longer panics)
+- [x] Inline unit tests for `print_summary` (underflow, zero/all-passed) and `print_coverage_line` color boundaries
 - [x] Initial spec creation with all required sections
 - [x] Requirements and acceptance criteria documented
 
-## Gaps
+## Open
 
-- No dedicated test file for this command module
+- [ ] No direct unit tests for `print_coverage_report` / `print_check_markdown` / `print_diff_markdown` — covered only indirectly via integration fixtures (`diff_human_readable_output`, `score_*`)
 
 ## Review Sign-offs
 

--- a/specs/output/testing.md
+++ b/specs/output/testing.md
@@ -6,7 +6,7 @@ spec: output.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/output.rs` | cargo test output | No inline tests found; add focused coverage for `print_summary`, `print_coverage_line`, `print_coverage_report`, `print_check_markdown` before risky changes |
+| `src/output.rs` | cargo test output:: | `print_summary_does_not_underflow_when_passed_exceeds_total`, `print_summary_handles_zero_and_all_passed`, `print_coverage_line_handles_color_threshold_boundaries` |
 | `tests/integration.rs` | cargo test --test integration score_command_outputs_quality_grades | End-to-end fixture: `score_command_outputs_quality_grades` |
 | `tests/integration.rs` | cargo test --test integration score_json_output_has_grades | End-to-end fixture: `score_json_output_has_grades` |
 | `tests/integration.rs` | cargo test --test integration fix_with_json_output | End-to-end fixture: `fix_with_json_output` |
@@ -28,6 +28,7 @@ spec: output.spec.md
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
 | Empty spec list | `print_summary` shows "0 passed, 0 failed" | Keep or add a focused assertion before changing this behavior |
+| `passed` exceeds `total` | `print_summary` does not panic; `failed` is `saturating_sub` (0) | `print_summary_does_not_underflow_when_passed_exceeds_total` |
 | Coverage report with no unspecced files | Shows "✓ All source files referenced by specs" | Keep or add a focused assertion before changing this behavior |
 | Diff with changed files not in any spec | Lists them under "Changed files not covered by any spec" | Keep or add a focused assertion before changing this behavior |
 

--- a/specs/parser/context.md
+++ b/specs/parser/context.md
@@ -6,7 +6,7 @@ spec: parser.spec.md
 
 - **Zero-dependency YAML**: Frontmatter is parsed line-by-line with regex instead of using a YAML library. This handles the subset of YAML actually used in specs (flat key-value pairs and simple lists) without pulling in a full YAML parser.
 - **First backtick per row**: Only the first backtick-quoted identifier in each markdown table row is extracted as a symbol. This matches the spec convention where the function/type name is always in the first column.
-- **Sub-table skipping**: `### Methods`, `### Constructor`, `### Properties` headings inside the Public API section are skipped when extracting symbols to avoid double-counting members of a documented type.
+- **Sub-table skipping**: `####` headings containing `Methods`, `Constructor`, or `Properties` inside the Public API section are skipped when extracting symbols to avoid double-counting members of a documented type. In addition, `###` subsections that are not export headers (e.g. `### API Endpoints`, `### Route Handlers`, `### Configuration`) are skipped via an `is_export_header` allowlist.
 - **Deduplication with order preservation**: Extracted symbols are deduplicated while maintaining their order of appearance in the spec.
 - **Case-sensitive section matching**: Required section names are matched exactly (e.g., `## Public API` won't match `## public api`), enforcing consistent spec formatting.
 

--- a/specs/registry/tasks.md
+++ b/specs/registry/tasks.md
@@ -17,7 +17,9 @@ spec: registry.spec.md
 - [x] Template file exclusion
 - [x] Module name extraction from frontmatter
 - [x] Alphabetically sorted output
-- [x] `RemoteRegistry` struct with `has_spec()` lookup
+- [x] `RemoteRegistry` struct with `has_spec()` and `spec_path()` lookup
+- [x] `register_module` — idempotent append of a module entry to an existing registry
+- [x] Cross-repo content verification: `fetch_remote_spec`, `parse_remote_spec`, `RemoteSpec`
 
 ## Gaps
 

--- a/specs/rehash/requirements.md
+++ b/specs/rehash/requirements.md
@@ -4,11 +4,26 @@ spec: rehash.spec.md
 
 ## User Stories
 
-- As a developer, I want to regenerate my hash cache after switching branches so that `specsync check` works without `--force`
-- As a CI operator, I want clear exit codes so that cache failures are actionable
+- As a developer, I want to regenerate my hash cache after switching branches or pulling so that `specsync check` reflects the current files without needing `--force`
+- As a developer who gitignores `.specsync/hashes.json`, I want a single command to rebuild it from scratch
+- As a CI operator, I want a non-zero exit on cache write failure so the problem is actionable
 
 ## Acceptance Criteria
 
-- `cmd_rehash` rebuilds hashes.json from scratch for all discovered specs
-- Exits with code 1 on save failure with a clear error message
-- Prints the number of specs hashed on success
+- `cmd_rehash` discovers all specs via `load_and_discover(root, false)` and rebuilds a fresh `HashCache` from scratch (not incremental)
+- The rebuilt cache is written to `.specsync/hashes.json`
+- On success, prints a confirmation including the number of specs hashed
+- On `cache.save` failure, prints an `error:` message to stderr and exits with code 1
+
+## Constraints
+
+- Must not panic on expected error conditions — print and exit
+- Full rebuild only: the command does not merge with or trust any existing cache contents
+- Deterministic and offline: reflects files on disk only; no git or network dependency
+- Writes a local artifact (`.specsync/hashes.json`) expected to be gitignored
+
+## Out of Scope
+
+- Incremental / partial cache updates (that path lives in `check`, not `rehash`)
+- Validating or scoring specs
+- Reading or honoring a pre-existing cache state

--- a/specs/scoring/context.md
+++ b/specs/scoring/context.md
@@ -6,7 +6,7 @@ spec: scoring.spec.md
 
 - **5 equal components**: Each dimension (frontmatter, sections, API coverage, content depth, freshness) is worth exactly 20 points for a total of 100. Equal weighting keeps the rubric simple and predictable.
 - **Letter grades**: A (90+), B (80-89), C (70-79), D (60-69), F (<60). These map to intuitive quality tiers.
-- **Unfinished-work marker counting ignores code blocks**: Incomplete-content markers and HTML-only notes are counted only outside fenced code blocks, preventing code examples from penalizing the score.
+- **Unfinished-work marker counting ignores code blocks**: Standalone `TODO` lines and unfilled `<!-- ... -->` HTML comments are counted only outside fenced code blocks. For the HTML-comment check, inline code spans (`` `...` ``) are also stripped first, so a spec that *documents* `<!-- -->` syntax inside a code span isn't falsely flagged as a placeholder.
 - **No-exports = full API score**: Modules with no extractable exports (e.g., config-only, types-only) receive full API coverage points rather than being penalized for having nothing to document.
 - **Stale reference penalties**: Missing source files cost 5 points each (max 15), missing dependency specs cost 3 points each. This encourages keeping specs in sync with code changes.
 - **Actionable suggestions**: Each score includes specific improvement suggestions (e.g., "Add version field to frontmatter") so users know exactly what to fix.

--- a/specs/scoring/testing.md
+++ b/specs/scoring/testing.md
@@ -6,7 +6,7 @@ spec: scoring.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/scoring.rs` | cargo test scoring:: | `test_count_placeholder_todos`, `test_count_placeholder_todos_in_code_blocks`, `test_count_placeholder_todos_zero`, `test_count_sections_with_content`, `test_count_sections_with_content_empty`, `test_compute_project_score_empty` |
+| `src/scoring.rs` | cargo test scoring:: | `test_count_placeholder_todos`, `test_count_placeholder_todos_in_code_blocks`, `test_count_placeholder_todos_zero`, `test_placeholder_comments_count_prose_only`, `test_count_sections_with_content`, `test_count_sections_with_content_stubs_not_counted`, `test_compute_project_score_distribution`, `test_score_spec_complete`, `test_score_spec_stub_sections_penalized`, `test_explain_has_all_dimensions` |
 
 ## Coverage Gaps
 

--- a/specs/types/context.md
+++ b/specs/types/context.md
@@ -5,20 +5,24 @@ spec: types.spec.md
 ## Key Decisions
 
 - **Central type definitions**: All shared types live in `types.rs` rather than being scattered across modules. This creates a single source of truth and prevents circular dependencies.
-- **Loose string parsing for AI providers**: `AiProvider::from_str_loose()` accepts case-insensitive input with common aliases (e.g., "gh-copilot" → Copilot, "gpt" → OpenAI). This makes CLI input forgiving without sacrificing type safety internally.
-- **CLI providers before API providers**: The auto-detection order checks for installed CLI tools (Claude, Ollama, Copilot) before checking for API keys (Anthropic, OpenAI), preferring the simpler integration path.
-- **Sensible defaults everywhere**: `SpecSyncConfig::default()` provides working values for all fields (specs_dir="specs", source_dirs=["src"], required sections, etc.) so the tool works without any config file.
-- **Never panics**: All defaults are always provided, and the type system ensures no field access can cause a panic from missing data.
+- **Loose string parsing for AI providers**: `AiProvider::from_str_loose()` accepts case-insensitive input with common aliases (e.g., "gh-copilot" → Copilot, "grok"/"x-ai" → XAi, "google" → Gemini, "open-router" → OpenRouter). This makes CLI/config input forgiving without sacrificing type safety internally.
+- **API-first, CLI deprecated (4.4.0)**: The AI provider layer was reworked to be API-centric. `detection_order()` is now **API-only** and never shells out — it probes `<PROVIDER>_API_KEY` env vars in a deterministic order (Ollama first, then Anthropic, OpenAi, OpenRouter, Gemini, DeepSeek, Groq, Mistral, XAi, Together). The legacy CLI providers (`claude`, `copilot`, `cursor`) are kept only for explicit selection; `claude` routes to the anthropic API with a deprecation warning.
+- **Ollama is an API provider**: As of 4.4.0, Ollama talks to its OpenAI-compatible HTTP endpoint (cloud uses `OLLAMA_API_KEY`; a local server runs keyless). It is no longer a CLI shell-out and `is_api_provider()` returns true for it.
+- **Endpoint/default-model registry lives in `corvid-ai`, not here**: `AiProvider::default_model` and `default_base_url` were **removed**. This crate only knows provider identity, the API-key env var name, and (for legacy CLI providers) the binary name. The `corvid-ai` crate — shared with the fledge tool — owns base URLs and default model ids. Keeps this module a thin enum and avoids drift between two endpoint tables.
+- **Sensible defaults everywhere**: `SpecSyncConfig::default()` provides working values for all fields so the tool works without any config file.
 
 ## Files to Read First
 
-- `src/types.rs` — Single-file module defining all enums, structs, and their `Default`/`Display`/`FromStr` implementations.
+- `src/types.rs` — Single-file module defining all enums, structs, and their `Default`/`Display` implementations.
+- `src/ai.rs` — Consumer of `AiProvider`; `resolve_ai_provider` and the Ollama-as-API tests (`ollama_is_an_api_provider`, `ollama_resolves_keyless`) show how these types are used at runtime.
+- `src/commands/generate.rs` — Reads `ai_model`/`ai_provider` and applies the `flag > env > config` precedence.
 
 ## Current Status
 
-Fully implemented. The types module is stable and consumed by every other module in the project. Changes here have the widest blast radius.
+Fully implemented and stable. The types module is consumed by every other module in the project, so changes here have the widest blast radius. The 4.4.0 AI rework (OpenRouter + the OpenAI-compatible family, Ollama-as-API, removal of `default_model`/`default_base_url`, API-only `detection_order`) is complete.
 
 ## Notes
 
-- `ModuleDefinition` in config allows users to explicitly define modules with their source files, overriding auto-detection. This is the escape hatch for projects with non-standard layouts.
-- The `OutputFormat` enum (Text, Json, Markdown) determines CLI output formatting across all reporting commands.
+- `ModuleDefinition` in config allows users to explicitly define modules with their source files, overriding auto-detection — the escape hatch for non-standard layouts.
+- The `OutputFormat` enum (Text, Json, Markdown, Github, Table, Csv) determines CLI output formatting across all reporting commands.
+- `SpecSyncConfig` carries `ai_model` and `ai_base_url`; `ai_base_url` overrides the OpenAI-compatible endpoint for local proxies.

--- a/specs/types/requirements.md
+++ b/specs/types/requirements.md
@@ -5,32 +5,38 @@ spec: types.spec.md
 ## User Stories
 
 - As a spec-sync contributor, I want all shared types defined in one module so that other modules import from a single source of truth
-- As a developer adding a new AI provider, I want the AiProvider enum to be extensible with clear methods (default_command, binary_name, api_key_env_var) so that adding a provider is straightforward
+- As a developer adding a new AI provider, I want the AiProvider enum to expose clear, minimal helpers (`binary_name`, `is_api_provider`, `api_key_env_var`, `from_str_loose`, `detection_order`) so that adding an API provider is a small, local change and the endpoint/default-model registry stays out of this crate
 - As a developer adding a new language, I want the Language enum to map extensions to languages and provide test patterns so that language support is consistent
 - As an integrator consuming spec-sync output, I want ValidationResult and CoverageReport to be well-structured so that I can process results programmatically
 
 ## Acceptance Criteria
 
-- AiProvider enum includes: Claude, Cursor, Copilot, Ollama, Anthropic, OpenAi, Custom
-- `AiProvider::from_str_loose` is case-insensitive and supports common aliases
-- `AiProvider::detection_order` returns CLI providers before API providers
-- Language enum covers all 11 supported languages with correct extension mappings
+- AiProvider enum includes, in declaration order: Claude, Cursor, Copilot, Ollama, Anthropic, OpenAi, OpenRouter, Gemini, DeepSeek, Groq, Mistral, XAi, Together, Custom
+- `AiProvider::is_api_provider()` is true for anthropic, openai, openrouter, gemini, deepseek, groq, mistral, xai, together, and **ollama** (Ollama is an OpenAI-compatible HTTP API provider, not a CLI shell-out)
+- `AiProvider::from_str_loose` is case-insensitive and supports common aliases ("gh-copilot" → Copilot, "grok"/"x-ai" → XAi, "google" → Gemini, "open-router" → OpenRouter, "together-ai" → Together)
+- `AiProvider::api_key_env_var` returns the `<PROVIDER>_API_KEY` name for every API provider, including `OLLAMA_API_KEY` and `OPENROUTER_API_KEY`
+- `AiProvider::detection_order` is **API-only** (never returns CLI providers), ordered Ollama, Anthropic, OpenAi, OpenRouter, Gemini, DeepSeek, Groq, Mistral, XAi, Together
+- AiProvider does NOT carry endpoint or default-model knowledge — `default_model`/`default_base_url` were removed; the `corvid-ai` crate owns that registry now
+- The deprecated CLI variants (Claude, Copilot, Cursor) remain in the enum but are reachable only by explicit selection; `claude` routes to the anthropic API with a deprecation warning
+- Language enum covers all 12 supported languages (incl. Yaml) with correct extension mappings
 - `Language::from_extension` returns None for unsupported extensions (no panic)
 - `Language::test_patterns` returns language-appropriate test file patterns
-- OutputFormat enum includes Text, Json, and Markdown variants
-- ExportLevel enum has Type (class/struct/enum only) and Member (all public symbols, default) variants
-- `SpecSyncConfig::default()` provides sensible defaults for all fields
+- OutputFormat enum includes Text (default), Json, Markdown, Github, Table, and Csv variants
+- ExportLevel enum has Type (top-level declarations only) and Member (all public symbols, default) variants
+- `SpecSyncConfig::default()` provides sensible defaults for all fields (incl. `ai_model`, `ai_base_url`)
 - `ValidationResult::new()` initializes with empty error/warning/fix vectors
-- All types derive necessary serde traits for JSON serialization where needed
+- All config types derive `serde::Deserialize` for JSON config parsing where needed
 
 ## Constraints
 
 - Types module must have zero dependencies on other spec-sync modules (it's the foundation)
-- All enums must be exhaustive — no catch-all variants that hide missing match arms
+- AI endpoint URLs and default model ids must NOT live here — that registry belongs to `corvid-ai` (the crate shared with the fledge tool); this module only knows provider identity, API-key env var, and CLI binary name
 - Default implementations must produce valid, usable values
+- MSRV 1.89 — no APIs newer than the pinned toolchain
 
 ## Out of Scope
 
+- AI endpoint resolution and default model selection (owned by `corvid-ai`)
+- Actually calling any provider (lives in `src/ai.rs`)
 - Runtime type validation (types are validated at compile time via Rust's type system)
-- Serialization format negotiation (JSON is the only serialized format)
 - Backwards-compatible type versioning

--- a/specs/types/tasks.md
+++ b/specs/types/tasks.md
@@ -4,24 +4,35 @@ spec: types.spec.md
 
 ## Tasks
 
-- [ ] Add `SpecStatus` enum to replace raw string for `status` field validation
 - [ ] Add builder pattern for `SpecSyncConfig` to simplify test construction
 - [ ] Consider splitting large enums into sub-modules if type count grows significantly
+- [ ] Add inline `#[cfg(test)]` unit tests in `types.rs` for `AiProvider`/`Language`/`SpecStatus` (currently only covered indirectly via `ai.rs` and integration tests)
 
 ## Done
 
-- [x] Core enums: AiProvider, Language, OutputFormat, ExportLevel
+- [x] Core enums: AiProvider, Language, OutputFormat, ExportLevel, ParseMode, EnforcementMode
 - [x] Core structs: Frontmatter, ValidationResult, CoverageReport, SpecSyncConfig
+- [x] `SpecStatus` lifecycle enum (draft→review→active→stable→deprecated→archived) with ordinal/next/prev/valid_transitions/can_transition_to
 - [x] Loose string parsing for AiProvider with aliases
-- [x] Language detection from file extensions
+- [x] Language detection from file extensions (12 languages incl. Yaml)
 - [x] Default implementations for all config types
 - [x] ModuleDefinition for explicit module configuration
 - [x] RegistryEntry for cross-project registry
+- [x] CustomRule / CustomRuleType / RuleSeverity / RuleFilter for declarative validation rules
+- [x] LifecycleConfig / TransitionGuard / CompanionConfig / GitHubConfig config structs
+- [x] **4.4.0 AI rework — DONE:**
+  - [x] Add `OpenRouter`, `Gemini`, `DeepSeek`, `Groq`, `Mistral`, `XAi`, `Together` API providers
+  - [x] Reclassify `Ollama` as an API provider (OpenAI-compatible HTTP, `OLLAMA_API_KEY`) — no CLI shell-out
+  - [x] Remove `AiProvider::default_model` and `default_base_url` (endpoint/default-model registry now owned by `corvid-ai`)
+  - [x] Make `detection_order()` API-only, Ollama-first, with no CLI providers
+  - [x] Add `OLLAMA_API_KEY` / `OPENROUTER_API_KEY` to `api_key_env_var`
+  - [x] Mark `claude`/`copilot`/`cursor` as deprecated CLI variants (`claude` routes to anthropic API + warning)
+  - [x] Add `ai_model` / `ai_base_url` fields to `SpecSyncConfig` (consumed by the `--model` flag in `cli_args`)
 
 ## Gaps
 
-- `status` field is a raw String — no type-level enforcement of valid values (draft, review, stable, deprecated)
-- No validation of `version` field type at the type level (accepts any integer)
+- `version` field in `Frontmatter` is typed `Option<String>` — no semver validation at the type level
+- `AiProvider::Custom` carries no command itself; the command comes from `SpecSyncConfig::ai_command`
 
 ## Review Sign-offs
 

--- a/specs/types/testing.md
+++ b/specs/types/testing.md
@@ -6,14 +6,21 @@ spec: types.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/types.rs` | cargo test types | No inline tests found; add focused coverage for `AiProvider`, `Language`, `OutputFormat`, `ExportLevel` before risky changes |
-| `tests/integration.rs` | cargo test --test integration multi_lang_typescript | End-to-end fixture: `multi_lang_typescript` |
+| `src/types.rs` | cargo test types | No inline `#[cfg(test)]` tests in this file; `AiProvider`/`Language`/`SpecStatus` are exercised indirectly. Add focused unit coverage before risky changes. |
+| `src/ai.rs` | cargo test --lib ollama_is_an_api_provider | Asserts `AiProvider::Ollama.is_api_provider()` is true (Ollama reclassified as API in 4.4.0) |
+| `src/ai.rs` | cargo test --lib ollama_resolves_keyless | Local Ollama resolves without an API key |
+| `tests/integration.rs` | cargo test --test integration provider_flag_unknown_provider_errors | Unknown `--provider` value errors with "Unknown provider" |
+| `tests/integration.rs` | cargo test --test integration auto_detect_defaults_to_local_ollama_without_keys | With no `<PROVIDER>_API_KEY` set, auto-detect falls back to local Ollama (detection_order is Ollama-first) |
+| `tests/integration.rs` | cargo test --test integration generate_with_multiple_languages | End-to-end multi-language export/coverage exercising the `Language` enum |
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
 | Parse AI provider from string | the string "anthropic-api" | `AiProvider::from_str_loose("anthropic-api")` is called | returns `Some(AiProvider::Anthropic)` |
+| Parse aliased provider | the string "grok" | `AiProvider::from_str_loose("grok")` is called | returns `Some(AiProvider::XAi)` |
+| Ollama is an API provider | the variant `AiProvider::Ollama` | `is_api_provider()` is called | returns `true` |
+| Detection order is API-only | `AiProvider::detection_order()` | inspect the slice | first element is `Ollama`; no Claude/Copilot/Cursor present |
 | Detect language from file extension | a file with extension "tsx" | `Language::from_extension("tsx")` is called | returns `Some(Language::TypeScript)` |
 | Detect Ruby from file extension | a file with extension "rb" | `Language::from_extension("rb")` is called | returns `Some(Language::Ruby)` |
 | Unknown file extension | a file with extension "haskell" | `Language::from_extension("haskell")` is called | returns `None` |
@@ -23,6 +30,8 @@ spec: types.spec.md
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
 | Unknown provider string | `AiProvider::from_str_loose` returns `None` | Keep or add a focused assertion before changing this behavior |
+| Ollama classified as API | `is_api_provider()` true and `detection_order` is API-only/Ollama-first | Covered by `ollama_is_an_api_provider`; do not regress to a CLI shell-out |
+| No default_model/default_base_url on AiProvider | Endpoint/default-model registry stays in `corvid-ai`, not `types.rs` | Do not re-add these methods here |
 | Unsupported file extension | `Language::from_extension` returns `None` | Keep or add a focused assertion before changing this behavior |
 | Invalid JSON config | `SpecSyncConfig` deserialization fails at the caller level | Keep or add a focused assertion before changing this behavior |
 

--- a/specs/validator/context.md
+++ b/specs/validator/context.md
@@ -23,5 +23,7 @@ Fully implemented. The validator is the heart of spec-sync — it powers `specsy
 
 ## Notes
 
-- SQL schema table extraction (`get_schema_table_names()`) supports `CREATE TABLE` statements for validating `db_tables` frontmatter fields.
+- SQL schema table extraction (`get_schema_table_names()`) supports `CREATE TABLE` statements for validating `db_tables` frontmatter fields. When `schema_columns` are supplied, `validate_spec` also cross-checks documented `### Schema:` column tables against migrations: a documented column absent from migrations is an ERROR, a migration column absent from the spec is a WARNING, and a type mismatch is a WARNING.
+- Status gates validation depth: `archived` specs skip all checks; `draft` specs check structure only; `review` specs check sections but skip Public API and API-surface validation; `active`/`stable`/`deprecated` get the full pass.
+- Non-draft, non-review specs also warn when inline `## Requirements`/`## Acceptance Criteria` appear in the spec body or when the companion `requirements.md` is missing.
 - Exclude patterns use a simplified glob syntax: `**/dir/**` for directory exclusion, `**/*.ext` for extension exclusion.

--- a/specs/view/context.md
+++ b/specs/view/context.md
@@ -2,12 +2,24 @@
 spec: view.spec.md
 ---
 
-## Key Files
+## Key Decisions
 
-- `src/view.rs` - Main implementation
-- `specs/view/view.spec.md` - Module specification
-- `specs/view/requirements.md` - User stories and acceptance criteria
+- **Hardcoded role → section map**: `sections_for_role` returns a fixed list of visible section names per role. Sections are matched with `heading.contains(allowed)` against `## ` headings split out by `split_sections`, so a visible parent section carries its `###` subsections along with it.
+- **Fail fast on bad role**: role validation happens before the file is read; an unknown role returns an `Err` listing `valid_roles()` rather than defaulting.
+- **Role-specific header**: emitted as `# {module} (view: {role})` only when the frontmatter has a module name.
+- **Agent extras**: the `agent` role additionally emits `**Status:**` and `**Agent Policy:**` lines; a missing `agent_policy` renders the literal `not set (default: full-access)`.
+- **Product companion inclusion**: the `product` role appends the sibling `requirements.md` (with its own frontmatter stripped via `strip_frontmatter`) under a `## Requirements` heading, if the file exists and is non-empty.
+
+## Files to Read First
+
+- `src/view.rs` — entire module: `sections_for_role`, `view_spec`, `split_sections`, `strip_frontmatter`.
 
 ## Current Status
 
-Module is stable and complete. All requirements documented.
+Stable and complete. Public API is `view_spec` and `valid_roles`. Invoked by the `cmd_view` subcommand.
+
+## Notes
+
+- Depends on `parser::parse_frontmatter` for module name, status, and `agent_policy`.
+- Output is always a markdown `String`; no alternative formats.
+- `split_sections` only recognizes `## ` (level-2) headings as section boundaries.

--- a/specs/view/requirements.md
+++ b/specs/view/requirements.md
@@ -21,9 +21,9 @@ spec: view.spec.md
 - QA view includes: Behavioral Examples, Error Cases, and Invariants sections
 - Product view includes: Purpose and Change Log sections, plus requirements.md content if present in the same directory
 - Agent view includes: Purpose, Public API, Invariants, Behavioral Examples, and Error Cases sections
-- Agent view header includes `status` and `agent_policy` extracted from frontmatter
-- Output includes a role-specific header line formatted as `# ModuleName (role view)`
-- `agent_policy` defaults to `"full-access"` if not specified in frontmatter
+- Agent view header includes `status` and `agent_policy` extracted from frontmatter (rendered as `**Status:** ...` and `**Agent Policy:** ...` lines)
+- Output includes a role-specific header line formatted as `# {module} (view: {role})` when the module name is present in frontmatter
+- `agent_policy` defaults to the literal `"not set (default: full-access)"` line if not specified in frontmatter
 - Section filtering matches against `## ` heading prefixes
 - `valid_roles()` returns a static slice of the four supported role strings
 - `view_spec()` returns `Result<String, String>` with filtered markdown on success or error message on failure

--- a/specs/view/tasks.md
+++ b/specs/view/tasks.md
@@ -4,4 +4,24 @@ spec: view.spec.md
 
 ## Tasks
 
+(none open)
+
+## Done
+
+- [x] `sections_for_role` visibility map for dev / qa / product / agent
+- [x] `valid_roles` static role list
+- [x] `view_spec`: role validation, frontmatter parse, section filtering
+- [x] Role-specific header `# {module} (view: {role})`
+- [x] Agent role: emit `**Status:**` and `**Agent Policy:**` (default "not set (default: full-access)")
+- [x] Product role: append companion `requirements.md` body (frontmatter stripped)
+- [x] `split_sections` splitting body on `## ` headings
+- [x] `strip_frontmatter` helper for the appended requirements body
+- [x] Error paths: unknown role, unreadable file, unparseable frontmatter
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/view/testing.md
+++ b/specs/view/testing.md
@@ -17,7 +17,7 @@ spec: view.spec.md
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
 | Dev view | a spec with all standard sections | `view_spec(path, "dev")` is called | returns Purpose, Public API, Invariants, Dependencies, and Change Log sections only |
-| Agent view with policy | a spec with `agent_policy: read-only` in frontmatter | `view_spec(path, "agent")` is called | output header includes `Status: stable` and `Agent Policy: read-only` |
+| Agent view with policy | a spec with `agent_policy: read-only` in frontmatter | `view_spec(path, "agent")` is called | output header includes `**Status:** stable` and `**Agent Policy:** read-only` lines |
 | Product view with requirements | a spec at `specs/auth/auth.spec.md` with a companion `specs/auth/requirements.md` | `view_spec(path, "product")` is called | returns Purpose, Change Log, and appended requirements.md content |
 | Invalid role | role string `"manager"` | `view_spec(path, "manager")` is called | returns `Err` with descriptive message listing valid roles |
 

--- a/specs/watch/testing.md
+++ b/specs/watch/testing.md
@@ -6,7 +6,9 @@ spec: watch.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/watch.rs` | cargo test watch:: | `test_is_relevant_event_create`, `test_is_relevant_event_modify`, `test_is_relevant_event_remove`, `test_is_relevant_event_rejects_access`, `test_is_relevant_event_rejects_other`, `test_is_relevant_event_create_any` |
+| `src/watch.rs` (event filtering) | cargo test watch:: | `test_is_relevant_event_create`, `test_is_relevant_event_modify`, `test_is_relevant_event_remove`, `test_is_relevant_event_rejects_access`, `test_is_relevant_event_rejects_other`, `test_is_relevant_event_create_any` |
+| `src/watch.rs` (check args) | cargo test watch:: | `test_build_check_args_basic`, `test_build_check_args_strict`, `test_build_check_args_force`, `test_build_check_args_require_coverage`, `test_build_check_args_all_flags` |
+| `src/watch.rs` (watch dirs / event path) | cargo test watch:: | `test_run_watch_collects_watch_dirs`, `test_run_watch_empty_dirs_detected`, `test_event_path_extraction`, `test_event_path_extraction_no_paths` |
 
 ## Coverage Gaps
 

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -373,7 +373,7 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
     // ─── Content Depth (0-20) ────────────────────────────────────────
     let mut depth_points = 0u32;
     let todo_count = count_placeholder_todos(body);
-    let placeholder_count = body.matches("<!-- ").count();
+    let placeholder_count = count_placeholder_comments(body);
 
     // Check each required section has meaningful content (stubs don't count)
     let sections_with_content = count_sections_with_content(body, &config.required_sections);
@@ -667,6 +667,26 @@ fn count_placeholder_todos(body: &str) -> usize {
     count
 }
 
+/// Count unfilled HTML-comment placeholders (`<!-- ... -->`) in prose.
+///
+/// Fenced code blocks and inline code spans are stripped first, so a spec that
+/// *documents* an HTML-comment directive (e.g. ``a `<!-- specsync-ignore -->`
+/// directive``) isn't penalized for showing real syntax. Mirrors the
+/// code-stripping that [`count_placeholder_todos`] already does for TODOs.
+fn count_placeholder_comments(body: &str) -> usize {
+    use regex::Regex;
+    use std::sync::LazyLock;
+
+    static CODE_BLOCK_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?s)```[^\n]*\n.*?```").expect("valid code-block regex"));
+    static INLINE_CODE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"`[^`]*`").expect("valid inline-code regex"));
+
+    let no_fenced = CODE_BLOCK_RE.replace_all(body, "");
+    let stripped = INLINE_CODE_RE.replace_all(&no_fenced, "");
+    stripped.matches("<!-- ").count()
+}
+
 /// Count how many required sections have meaningful content (more than just a heading).
 fn count_sections_with_content(body: &str, required_sections: &[String]) -> usize {
     let mut count = 0;
@@ -747,6 +767,22 @@ mod tests {
     fn test_count_placeholder_todos_zero() {
         let body = "## Purpose\nAll sections filled in with real content.\n";
         assert_eq!(count_placeholder_todos(body), 0);
+    }
+
+    #[test]
+    fn test_placeholder_comments_count_prose_only() {
+        // A real un-filled HTML comment in prose counts.
+        assert_eq!(count_placeholder_comments("Body with <!-- fill me --> here"), 1);
+        // The same syntax shown as documentation in inline code or a fenced
+        // block does NOT count — it's real content, not a placeholder.
+        assert_eq!(
+            count_placeholder_comments("Use a `<!-- specsync-ignore: x -->` directive"),
+            0
+        );
+        assert_eq!(
+            count_placeholder_comments("```\n<!-- specsync-ignore: x -->\n```\n"),
+            0
+        );
     }
 
     #[test]

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -772,7 +772,10 @@ mod tests {
     #[test]
     fn test_placeholder_comments_count_prose_only() {
         // A real un-filled HTML comment in prose counts.
-        assert_eq!(count_placeholder_comments("Body with <!-- fill me --> here"), 1);
+        assert_eq!(
+            count_placeholder_comments("Body with <!-- fill me --> here"),
+            1
+        );
         // The same syntax shown as documentation in inline code or a fenced
         // block does NOT count — it's real content, not a placeholder.
         assert_eq!(


### PR DESCRIPTION
A full review-and-groom pass over **all 58 modules** — every spec is now **100/100 (A)** and every companion (`requirements`/`tasks`/`context`/`testing`.md, 232 files) was verified against the *current* source code.

## Scorer fix (the one code change)
- **`placeholder_free` no longer false-flags documented HTML-comment syntax.** It now strips fenced + inline code before counting `<!-- ... -->`, so a spec that *documents* a directive (e.g. ``a `<!-- specsync-ignore -->` directive``) isn't penalized. This brought `ignore.spec.md` from 97 → 100. Can only raise scores; added a unit test.

## Companion grooming (232 files, all 58 modules)
Done in three waves (AI-rework modules, then libs/core, then commands). Every companion was checked against the real code and **every referenced test name verified to exist**. Representative fixes:
- **AI-rework modules** (ai, types, cli_args, config, cmd_generate, generator): rewritten for the 4.4.0 corvid-ai ladder, `flag > env > config` precedence, `--model`, `claude`→anthropic, Ollama-as-API.
- **Wrong counts corrected**: 12 languages (not 9/11), 7 MCP tools (not 6), 6 hook targets (not 5), ~30 subcommands (not 12).
- **Fictional/stale test references removed**: e.g. `build_comment_body`, `get_exported_symbols`, `git_commits_between`, `ai_model_config_used_with_ollama_provider` — replaced with real fixtures.
- **Empty/boilerplate `requirements.md` files** rewritten with real stories/criteria.
- **Wrong claims fixed**: false "no inline tests" (cli/output/init/migrate/resolve had tests), wrong return types/exit-code semantics, stale config terminology (`config.json`→`config.toml`).

## Verification
- [x] `specsync score --all` — **58/58 at 100/100 (A)**, avg 100.0
- [x] `specsync check --strict --require-coverage 100 --force` — 58 passed, 0 warnings
- [x] `cargo test` — 614 unit + 131 integration
- [x] `cargo clippy -- -D warnings` + `cargo fmt --check` — clean

No `.spec.md` exports or source behavior changed except the scoring fix. A few `.spec.md` prose-drift notes the agents surfaced (cmd_comment/cmd_import/cmd_init) are flagged in those companions' context.md for a future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)