### PR TITLE
docs(specs): fix stale signatures/symbols in 3 spec prose tables

### DIFF
--- a/specs/cmd_comment/cmd_comment.spec.md
+++ b/specs/cmd_comment/cmd_comment.spec.md
@@ -71,7 +71,7 @@ Implements the `specsync comment` command. Generates a spec-sync check summary a
 | Module | What is used |
 |--------|-------------|
 | commands | `load_and_discover`, `build_schema_columns` |
-| comment | `build_comment_body` |
+| comment | `render_check_comment` |
 | github | `resolve_repo` |
 | validator | `validate_spec`, `compute_coverage` |
 

--- a/specs/cmd_import/cmd_import.spec.md
+++ b/specs/cmd_import/cmd_import.spec.md
@@ -25,7 +25,7 @@ Implements the `specsync import` command. Imports specs from external systems (G
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `cmd_import` | `root: &Path, source: &str, id: &str, repo_override: Option<&str>` | `()` | Fetch external data and create a new spec from it |
+| `cmd_import` | `root: &Path, source: Option<&str>, id: Option<&str>, repo_override: Option<&str>, all_issues: bool, label: Option<&str>, from_dir: Option<&Path>` | `()` | Route external data into specs: a single GitHub/Jira/Confluence item, all open issues (`all_issues`/`label`), or a directory of files (`from_dir`) |
 
 ## Invariants
 

--- a/specs/cmd_import/context.md
+++ b/specs/cmd_import/context.md
@@ -24,5 +24,5 @@ Implemented and stable. Directory-import and the no-args error path are covered 
 
 ## Notes
 
-- Spec frontmatter in `cmd_import.spec.md` documents the original 4-argument single-import signature; the live signature is 7 arguments to accommodate the `--all-issues`/`--label`/`--from-dir` batch modes. The spec is the scored reference; this companion reflects the current code.
+- `cmd_import` routes over three modes from its 7-argument signature: a single GitHub/Jira/Confluence item, all open issues (`all_issues`/`label`), or a directory of files (`from_dir`); `source`/`id` are optional accordingly.
 - Part of the command layer — orchestrates importer/github/generator modules rather than containing domain logic.

--- a/specs/cmd_init/cmd_init.spec.md
+++ b/specs/cmd_init/cmd_init.spec.md
@@ -23,7 +23,7 @@ Implements the `specsync init` command. Creates a `specsync.json` configuration 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `cmd_init` | `root: &Path` | `()` | Create specsync.json with auto-detected source dirs |
-| `ensure_hashes_gitignored` | `root: &Path` | `Result<bool, std::io::Error>` | Add hashes.json to .specsync/.gitignore and .specsync/hashes.json to root .gitignore; returns Ok(true) if changes were made |
+| `ensure_hashes_gitignored` | `root: &Path` | `Result<bool, String>` | Add `.specsync/hashes.json` to the root `.gitignore` (idempotent); returns `Ok(true)` if the entry was added, `Ok(false)` if already present, `Err` if the write fails |
 
 ## Invariants
 

--- a/specs/cmd_init/context.md
+++ b/specs/cmd_init/context.md
@@ -7,7 +7,7 @@ spec: cmd_init.spec.md
 - Both `specsync.json` and `.specsync.toml` are checked before writing; either one means "already initialized" and init no-ops. This avoids clobbering a TOML-configured project.
 - The default config is built as a `serde_json::Value` and pretty-printed with a trailing newline, so the on-disk file is stable and diff-friendly.
 - `ensure_hashes_gitignored` returns `Result<bool, String>` (not `io::Error`) so the caller can print a plain warning; the io error is mapped to a "Failed to update .gitignore" string. A `.gitignore` write failure is intentionally **non-fatal** — the config is already written and the cache being un-ignored is a minor issue.
-- Only the repository-root `.gitignore` is edited (a `# spec-sync hash cache` comment plus the `.specsync/hashes.json` entry). The spec's mention of a `.specsync/.gitignore` does not match the implementation.
+- Only the repository-root `.gitignore` is edited (a `# spec-sync hash cache` comment plus the `.specsync/hashes.json` entry).
 
 ## Files to Read First
 
@@ -21,5 +21,4 @@ Implemented and stable. Strong coverage: three inline unit tests on the gitignor
 ## Notes
 
 - `ensure_hashes_gitignored` is `pub`, so it is callable outside `cmd_init` (e.g. rehash flows) and is unit-tested directly.
-- The spec frontmatter documents the helper's return type as `Result<bool, std::io::Error>`; the live signature is `Result<bool, String>`. The spec is the scored reference; this companion tracks the code.
 - Part of the command layer — orchestrates `config::detect_source_dirs` rather than containing domain logic.


### PR DESCRIPTION
Closes the last accuracy nits the grooming sweep (#280) surfaced — three spec `.md` files had stale signatures/symbol names in their tables. The export *names* matched source (so `check` passed and they scored 100), but the parameters/return types/consumed-symbols were out of date.

## Fixes
- **cmd_comment** — Consumed symbol `build_comment_body` → `render_check_comment` (the actual renderer in `comment.rs`).
- **cmd_import** — `cmd_import` signature updated from the old 4-arg form to the real 7-arg router (`source`/`id` optional; `all_issues`/`label`/`from_dir` for the batch + directory modes).
- **cmd_init** — `ensure_hashes_gitignored` returns `Result<bool, String>` (not `std::io::Error`); description corrected to "edits only the root `.gitignore`".
- Removed the now-resolved "the spec is stale" notes the grooming agents had added to those modules' `context.md`.

(Note: the agents over-flagged `github::resolve_repo` and `validator::validate_spec` — both verified to exist in source, left unchanged.)

## Verification
- [x] `specsync score --all` — 58/58 at 100/100
- [x] `specsync check --strict --require-coverage 100 --force` — 58 passed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)