### PR TITLE
docs: update README + docs site for the 4.4.0 AI provider model

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,8 @@ specsync [command] [flags]
 | `--strict` | Warnings become errors (recommended for CI) |
 | `--require-coverage N` | Fail if file coverage < N% |
 | `--root <path>` | Project root (default: cwd) |
-| `--provider <name>` | AI provider: `auto`, `anthropic`, `openai`, or `command`. `auto` detects installed provider. Without `--provider`, generate uses templates only. |
+| `--provider <name>` | AI provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, `ollama` (or `auto`; deprecated `claude`/`copilot`). With nothing configured, `generate` is template-only. |
+| `--model <id>` | Model id for `generate` (overrides `SPECSYNC_AI_MODEL` and `aiModel` in config) |
 | `--fix` | Auto-add undocumented exports as stub rows in spec Public API tables |
 | `--force` | Skip hash cache and re-validate all specs |
 | `--create-issues` | Create GitHub issues for specs with validation errors (on `check`) |
@@ -737,9 +738,12 @@ Create `specsync.json` or `.specsync.toml` in your project root (or run `specsyn
 | `excludeDirs` | `string[]` | `["__tests__"]` | Directories excluded from coverage |
 | `excludePatterns` | `string[]` | Common test globs | File patterns excluded from coverage |
 | `sourceExtensions` | `string[]` | All supported | Restrict to specific extensions (e.g., `["ts", "rs"]`) |
-| `aiCommand` | `string?` | — | Custom command for AI generation (reads stdin prompt, writes stdout markdown) |
-| `aiProvider` | `string?` | — | AI provider (`auto`, `claude`, `anthropic`, `openai`, `ollama`, `copilot`, etc.) |
-| `aiTimeout` | `number?` | `120` | Seconds before AI command times out per module |
+| `aiProvider` | `string?` | — | AI provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, `ollama` (deprecated: `claude`/`copilot`) |
+| `aiModel` | `string?` | provider default | Model id (e.g. `claude-sonnet-4-6`; `openai`/`together` require one) |
+| `aiApiKey` | `string?` | env | API key; falls back to `<PROVIDER>_API_KEY`. Never written back to config |
+| `aiBaseUrl` | `string?` | — | Override the provider endpoint (self-hosted / proxy gateways) |
+| `aiCommand` | `string?` | — | Deprecated, trusted shell escape hatch (reads stdin prompt, writes stdout markdown); never auto-selected |
+| `aiTimeout` | `number?` | `120` | Seconds before AI generation times out per module |
 
 ### TOML alternative
 
@@ -763,7 +767,7 @@ ai_provider = "ollama"
 ai_model = "llama3"
 ```
 
-This file is merged on top of the shared config and only supports `ai_*` keys. Alternatively, set the `SPECSYNC_AI_COMMAND` env var or pass `--provider` on the CLI.
+This file is merged on top of the shared config and only supports `ai_*` keys. Alternatively, set `SPECSYNC_AI_PROVIDER` / `SPECSYNC_AI_MODEL` (or `SPECSYNC_AI_COMMAND`) env vars, or pass `--provider` / `--model` on the CLI (`flag > env > config`).
 
 ### Lifecycle Guards
 
@@ -873,23 +877,28 @@ specsync coverage                         # See what's still missing
 
 Uses your custom template (`specs/_template.spec.md`) or the built-in default. Generates frontmatter plus guided starter sections for review.
 
-### AI mode (`--provider`)
+### AI mode (`--provider` or a configured provider)
 
-Reads your source code, sends it to an LLM, and generates specs with real content — Purpose, Public API tables, Invariants, Error Cases, all filled in from the code. No manual filling required.
+Reads your source code, sends it to an LLM, and generates specs with real content — Purpose, Public API tables, Invariants, Error Cases, all filled in from the code. No manual filling required. API calls go through the shared [`corvid-ai`](https://crates.io/crates/corvid-ai) client — plain HTTP, no CLI tool required.
 
-The AI command is resolved in order:
-1. `"aiCommand"` in `specsync.json`
-2. `SPECSYNC_AI_COMMAND` environment variable
-3. `claude -p --output-format text` (default, requires [Claude CLI](https://docs.anthropic.com/en/docs/claude-code))
+**Providers** — set the matching `<PROVIDER>_API_KEY`:
+`anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, and `ollama` (local & **keyless**, or Ollama Cloud via `OLLAMA_API_KEY`). The `claude` and `copilot` providers are **deprecated** — `claude` now warns and routes to the `anthropic` API (no more `claude -p` shell-out).
 
-Any command that reads a prompt from stdin and writes markdown to stdout works:
+**Provider resolution** (`flag > env > config`): `--provider` > `SPECSYNC_AI_PROVIDER` env > `aiProvider` in config. With nothing set, `generate` auto-detects:
 
-```json
-{ "aiCommand": "claude -p --output-format text" }
-{ "aiCommand": "ollama run llama3" }
+- **no key anywhere → local Ollama** (`http://localhost:11434`) — the zero-config default
+- exactly one `<PROVIDER>_API_KEY` set → that provider
+- several keys set → interactive picker (TTY), else a deterministic order
+
+**Model** (`flag > env > config`): `--model` > `SPECSYNC_AI_MODEL` env > `aiModel` in config > the provider's default (`anthropic` → `claude-sonnet-4-6`; `openai`/`together` require an explicit model).
+
+```bash
+specsync generate --model llama3.3                              # local Ollama, zero config
+ANTHROPIC_API_KEY=… specsync generate --provider anthropic     # API provider
+specsync generate --provider openrouter --model anthropic/claude-sonnet-4-6
 ```
 
-Set `"aiTimeout"` in `specsync.json` to control per-module timeout (default: 120 seconds).
+`aiCommand` (and `SPECSYNC_AI_COMMAND`) remain as an explicit, trusted shell escape hatch — any command that reads a prompt on stdin and writes markdown to stdout — but it is never auto-selected. Set `"aiTimeout"` in config to control the per-module timeout (default: 120 seconds).
 
 ### Designed for AI agents
 

--- a/site/src/content/docs/cli.md
+++ b/site/src/content/docs/cli.md
@@ -48,23 +48,32 @@ specsync coverage --json
 Scaffold spec files for modules that don't have one. Uses `specs/_template.spec.md` if present.
 
 ```bash
-specsync generate                       # template mode — guided starter specs
-specsync generate --provider auto       # AI mode — auto-detect provider, writes real content
-specsync generate --provider anthropic  # AI mode — use Anthropic API directly
+specsync generate                          # template mode — guided starter specs
+specsync generate --provider anthropic     # AI mode — use the Anthropic API
+specsync generate --provider openai --model gpt-4o   # AI mode — pick provider + model
+specsync generate --provider ollama        # AI mode — keyless local Ollama
 ```
 
-With `--provider`, source code is sent to an LLM which generates filled-in specs (Purpose, Public API tables, Invariants, etc.). Use `--provider auto` to auto-detect an installed provider, or specify one by name:
+With a provider configured, source code is sent to an LLM which generates filled-in specs (Purpose, Public API tables, Invariants, etc.). AI calls go through the shared [`corvid-ai`](https://crates.io/crates/corvid-ai) crate over plain HTTP — no CLI tool required. Just set `<PROVIDER>_API_KEY` and name the provider:
 
 | Provider | How it works |
 |:---------|:-------------|
-| `auto` | Auto-detect: checks installed CLIs (`claude`, `ollama`, `copilot`), then API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) |
-| `claude` | Shells out to Claude Code CLI (`claude -p --output-format text`) |
-| `anthropic` | Calls Anthropic Messages API directly (requires `ANTHROPIC_API_KEY`) |
-| `openai` | Calls OpenAI Chat Completions API directly (requires `OPENAI_API_KEY`) |
-| `ollama` | Shells out to Ollama CLI (`ollama run <model>`) |
-| `copilot` | Shells out to GitHub Copilot CLI (`gh copilot suggest`) |
+| `anthropic` | Anthropic Messages API (`ANTHROPIC_API_KEY`). Default model `claude-sonnet-4-6` |
+| `openai` | OpenAI Chat Completions API (`OPENAI_API_KEY`). Requires an explicit `--model` |
+| `openrouter` | OpenRouter API (`OPENROUTER_API_KEY`) |
+| `gemini` | Google Gemini API (`GEMINI_API_KEY`) |
+| `deepseek` | DeepSeek API (`DEEPSEEK_API_KEY`) |
+| `groq` | Groq API (`GROQ_API_KEY`) |
+| `mistral` | Mistral API (`MISTRAL_API_KEY`) |
+| `xai` | xAI API (`XAI_API_KEY`) |
+| `together` | Together API (`TOGETHER_API_KEY`). Requires an explicit `--model` |
+| `ollama` | Local Ollama HTTP API (`http://localhost:11434`, keyless) or Ollama Cloud (`OLLAMA_API_KEY`). Default model `llama3.3` |
+| `claude` | **Deprecated** — warns and routes to the `anthropic` API |
+| `copilot`, `cursor` | **Deprecated** |
 
-See [Configuration](configuration.md) for `aiProvider`, `aiModel`, `aiApiKey`, `aiBaseUrl`, and `aiTimeout`.
+With no provider configured, `generate` auto-detects: no key anywhere falls back to keyless local Ollama; exactly one `<PROVIDER>_API_KEY` selects that provider; multiple keys prompt an interactive picker (TTY) or use a deterministic order. Add `--model <id>` to override the provider default.
+
+See [Configuration](configuration.md) for `aiProvider`, `aiModel`, `aiCommand`, `aiApiKey`, `aiBaseUrl`, and `aiTimeout`.
 
 ### `score`
 
@@ -396,7 +405,8 @@ specsync watch
 | `--strict` | Warnings become errors. Recommended for CI. |
 | `--require-coverage N` | Fail if file coverage < N%. |
 | `--root <path>` | Project root directory (default: cwd). |
-| `--provider <name>` | Enable AI-powered generation and select provider: `auto`, `claude`, `anthropic`, `openai`, `ollama`, or `copilot`. Without this flag, `generate` uses templates only. |
+| `--provider <name>` | Enable AI-powered generation and select provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, or `ollama` (deprecated: `claude`→`anthropic`, `copilot`, `cursor`). Without this flag (and no AI config/env), `generate` uses templates only. |
+| `--model <id>` | Override the provider's default model (e.g. `gpt-4o`, `claude-sonnet-4-6`). Resolution is `--model` > `SPECSYNC_AI_MODEL` > `aiModel` config > provider default. |
 | `--format <fmt>` | Output format: `text` (default), `json`, or `markdown`. Markdown produces clean tables suitable for PRs and docs. |
 | `--json` | Shorthand for `--format json`. Structured output, no color codes. |
 | `--fix` | Auto-add undocumented exports as stub rows in spec Public API tables (on `check`). |

--- a/site/src/content/docs/configuration.md
+++ b/site/src/content/docs/configuration.md
@@ -27,7 +27,7 @@ specs_dir = "specs"
 source_dirs = ["src"]
 schema_dir = "db/migrations"
 ai_provider = "anthropic"
-ai_model = "claude-sonnet-4-20250514"
+ai_model = "claude-sonnet-4-6"
 ai_timeout = 120
 export_level = "member"
 required_sections = ["Purpose", "Public API", "Invariants", "Behavioral Examples", "Error Cases", "Dependencies", "Change Log"]
@@ -63,7 +63,7 @@ Config resolution order: `.specsync/config.toml` → `.specsync/config.json` →
   "sourceExtensions": [],
   "exportLevel": "member",
   "aiProvider": "anthropic",
-  "aiModel": "claude-sonnet-4-20250514",
+  "aiModel": "claude-sonnet-4-6",
   "aiCommand": null,
   "aiApiKey": null,
   "aiBaseUrl": null,
@@ -99,11 +99,11 @@ Config resolution order: `.specsync/config.toml` → `.specsync/config.json` →
 | `excludeDirs` | `string[]` | `["__tests__"]` | Directory names skipped during coverage scanning |
 | `excludePatterns` | `string[]` | Common test globs | File patterns excluded from coverage (additive with language-specific test exclusions) |
 | `sourceExtensions` | `string[]` | All supported | Restrict to specific extensions (e.g., `["ts", "rs"]`) |
-| `aiProvider` | `string?` | — | AI provider name: `claude`, `anthropic`, `openai`, `ollama`, `copilot`, or `custom` |
-| `aiModel` | `string?` | Provider default | Model name override (e.g., `"claude-sonnet-4-20250514"`, `"gpt-4o"`, `"mistral"`) |
-| `aiCommand` | `string?` | — | Custom CLI command for AI generation (reads stdin prompt, writes stdout markdown) |
-| `aiApiKey` | `string?` | — | API key for `anthropic` or `openai` providers (prefer env vars `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` instead) |
-| `aiBaseUrl` | `string?` | — | Custom base URL for API providers (e.g., for proxies or self-hosted endpoints) |
+| `aiProvider` | `string?` | — | AI provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, or `ollama`. Deprecated: `claude` (routes to `anthropic`), `copilot`, `cursor`. Overridable via `--provider` / `SPECSYNC_AI_PROVIDER` |
+| `aiModel` | `string?` | Provider default | Model name override (e.g., `"claude-sonnet-4-6"`, `"gpt-4o"`, `"llama3.3"`). Overridable via `--model` / `SPECSYNC_AI_MODEL`. `openai` and `together` require an explicit model |
+| `aiCommand` | `string?` | — | **Deprecated** trusted shell escape hatch — a command that reads a prompt on stdin and writes markdown to stdout. Never auto-selected; prefer the HTTP providers above. Overridable via `SPECSYNC_AI_COMMAND` |
+| `aiApiKey` | `string?` | — | API key for the selected provider (prefer the per-provider env var `<PROVIDER>_API_KEY`, e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_API_KEY`) |
+| `aiBaseUrl` | `string?` | — | Custom base URL for API providers (e.g., proxies, self-hosted endpoints, or a non-default Ollama host via `OLLAMA_HOST`) |
 | `aiTimeout` | `number?` | `120` | Seconds before AI command times out per module |
 | `exportLevel` | `string?` | `"member"` | Export validation depth: `"type"` (classes/structs only) or `"member"` (all public symbols) |
 | `modules` | `object?` | `{}` | Custom module definitions mapping module names to `{ files, depends_on }` |
@@ -115,19 +115,26 @@ Config resolution order: `.specsync/config.toml` → `.specsync/config.json` →
 
 ## AI Provider Resolution
 
-When you run `specsync generate --provider auto`, the provider is resolved in this order:
+AI calls go through the shared [`corvid-ai`](https://crates.io/crates/corvid-ai) crate over plain HTTP — no CLI tool required. The **provider** is resolved `flag > env > config`:
 
-1. `--provider` CLI flag (explicit)
-2. `aiCommand` in config — checked in shared config first, then `.specsync/config.local.toml` (gitignored, per-developer overrides)
-3. `aiProvider` in config (same merge order as above)
-4. `SPECSYNC_AI_COMMAND` env var
-5. Auto-detect: installed CLIs (`claude`, `copilot`, `ollama` — alphabetical), then API keys
+1. `--provider` CLI flag
+2. `SPECSYNC_AI_PROVIDER` env var
+3. `aiProvider`/`ai_provider` in config — shared `config.toml` first, then `.specsync/config.local.toml` (gitignored, per-developer overrides)
+
+With nothing set, `generate` auto-detects:
+- **No `<PROVIDER>_API_KEY` anywhere → keyless local Ollama** (`http://localhost:11434`) — the zero-config default
+- Exactly one `<PROVIDER>_API_KEY` set → that provider
+- Several keys set → an interactive picker on a TTY, otherwise a deterministic order: Ollama, Anthropic, OpenAI, OpenRouter, Gemini, DeepSeek, Groq, Mistral, xAI, Together
+
+The **model** follows the same `flag > env > config` precedence: `--model` > `SPECSYNC_AI_MODEL` > `aiModel`/`ai_model` config > provider default (`anthropic` → `claude-sonnet-4-6`, Ollama → `llama3.3`; `openai` and `together` require an explicit model).
+
+`aiTimeout` (default `120`s) controls the per-module AI timeout. `aiBaseUrl` (or `OLLAMA_HOST` for Ollama) points a provider at a custom endpoint.
 
 > **Multi-agent teams**: Don't put `ai_provider` or `ai_command` in the shared `config.toml`. Instead, each contributor creates `.specsync/config.local.toml` with their preferred AI settings. This file is automatically gitignored.
 
 ### API Providers
 
-The `anthropic` and `openai` providers call their respective APIs directly — no CLI tool needed. Just set the API key:
+Every provider calls its HTTP API directly — no CLI tool needed. Just set the provider and its key:
 
 ```json
 {
@@ -135,7 +142,11 @@ The `anthropic` and `openai` providers call their respective APIs directly — n
 }
 ```
 
-Then set `ANTHROPIC_API_KEY` in your environment (or use `aiApiKey` in config for local use — **not recommended for shared repos**).
+Then set `ANTHROPIC_API_KEY` (or the relevant `<PROVIDER>_API_KEY`) in your environment — or use `aiApiKey` in config for local use (**not recommended for shared repos**). Local Ollama needs no key at all.
+
+### Shell escape hatch (`aiCommand`)
+
+`aiCommand`/`SPECSYNC_AI_COMMAND` remain as an explicit, **trusted shell escape hatch** — a command that reads a prompt on stdin and writes markdown to stdout. It is **deprecated** and **never auto-selected**; prefer the HTTP providers above.
 
 ---
 

--- a/site/src/content/docs/integrations/ai-agents.md
+++ b/site/src/content/docs/integrations/ai-agents.md
@@ -35,16 +35,20 @@ Add to your agent's MCP config (e.g., `claude_desktop_config.json`):
 
 ## AI Providers (`--provider`)
 
-The `--provider` flag enables AI-powered spec generation and selects which provider to use:
+AI calls go through the shared [`corvid-ai`](https://crates.io/crates/corvid-ai) crate — plain HTTP, no CLI tool required. Set `<PROVIDER>_API_KEY` and pick a provider:
 
 ```bash
-specsync generate --provider auto             # auto-detect an installed provider
 specsync generate --provider anthropic        # uses ANTHROPIC_API_KEY
-specsync generate --provider openai           # uses OPENAI_API_KEY
-specsync generate --provider command          # shells out to aiCommand config
+specsync generate --provider openai --model gpt-4o   # uses OPENAI_API_KEY
+specsync generate --provider ollama           # keyless local Ollama (http://localhost:11434)
+specsync generate                             # auto-detect (see resolution ladder below)
 ```
 
-Without `--provider`, `generate` uses templates only (no AI). Using `--provider auto` auto-detects an available provider. Specifying a provider name uses that provider directly — just set the API key.
+Supported providers: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `groq`, `mistral`, `xai`, `together`, and `ollama` (local & keyless, or Ollama Cloud via `OLLAMA_API_KEY`).
+
+**Deprecated:** `claude` now warns and routes to the `anthropic` API (no more `claude -p` shell-out); `copilot` and `cursor` are deprecated too.
+
+`generate` enters AI mode when a provider is configured (`--provider`, `aiProvider`/`aiCommand` config, or any `SPECSYNC_AI_*` env var). With nothing configured it is template-only.
 
 ---
 
@@ -63,10 +67,10 @@ Scores are based on completeness, detail, API coverage, behavioral examples, and
 
 ## AI-Powered Generation (`--provider`)
 
-`specsync generate --provider auto` reads your source code, sends it to an LLM, and generates source-aware specs. Purpose, Public API tables, Invariants, Error Cases — all derived from the code.
+`specsync generate --provider anthropic` reads your source code, sends it to an LLM, and generates source-aware specs. Purpose, Public API tables, Invariants, Error Cases — all derived from the code.
 
 ```bash
-specsync generate --provider auto
+specsync generate --provider anthropic
 #   Generating specs/auth/auth.spec.md with AI...
 #     │ ---
 #     │ module: auth
@@ -74,27 +78,48 @@ specsync generate --provider auto
 #   ✓ Generated specs/auth/auth.spec.md (3 files)
 ```
 
-### Configuring the AI command
+### Choosing a provider and model
 
-The AI command is resolved in order:
-1. `ai_command` in `.specsync/config.toml` (or `.specsync/config.local.toml` for per-developer overrides)
-2. `SPECSYNC_AI_COMMAND` environment variable
-3. `claude -p --output-format text` (default, requires Claude CLI)
+The provider is resolved `flag > env > config`:
+1. `--provider <name>` flag
+2. `SPECSYNC_AI_PROVIDER` environment variable
+3. `aiProvider`/`ai_provider` in config (or `.specsync/config.local.toml` for per-developer overrides)
 
-Any command that reads a prompt from stdin and writes markdown to stdout works:
+With nothing set, `generate` **auto-detects**:
+- **No key anywhere → keyless local Ollama** (`http://localhost:11434`) — the zero-config default
+- Exactly one `<PROVIDER>_API_KEY` set → that provider
+- Several keys set → an interactive picker on a TTY, otherwise a deterministic order: Ollama, Anthropic, OpenAI, OpenRouter, Gemini, DeepSeek, Groq, Mistral, xAI, Together
+
+The model is resolved the same way (`flag > env > config`):
+1. `--model <id>` flag
+2. `SPECSYNC_AI_MODEL` environment variable
+3. `aiModel`/`ai_model` in config
+4. Provider default — `anthropic` → `claude-sonnet-4-6`, Ollama → `llama3.3`. `openai` and `together` require an explicit model.
 
 ```toml
 # .specsync/config.toml (or .specsync/config.local.toml for per-developer overrides)
-ai_command = "claude -p --output-format text"
-ai_timeout = 300
+ai_provider = "anthropic"
+ai_model = "claude-sonnet-4-6"
+ai_timeout = 120
 ```
 
-```toml
-ai_command = "ollama run llama3"
-ai_timeout = 60
+```bash
+export SPECSYNC_AI_PROVIDER=openrouter
+export SPECSYNC_AI_MODEL=anthropic/claude-sonnet-4
+specsync generate
 ```
 
 If AI generation fails for a module, it falls back to template generation automatically.
+
+### Shell escape hatch (`aiCommand`, deprecated)
+
+`aiCommand`/`SPECSYNC_AI_COMMAND` remain as an explicit, **trusted shell escape hatch** — any command that reads a prompt on stdin and writes markdown to stdout. It is **deprecated** and **never auto-selected**; the HTTP providers above are preferred.
+
+```toml
+# .specsync/config.toml — deprecated trusted hatch
+ai_command = "my-llm-wrapper --format markdown"
+ai_timeout = 300
+```
 
 ### Template mode (no `--provider`)
 
@@ -106,7 +131,7 @@ Without `--provider`, `specsync generate` scaffolds template specs with frontmat
 
 ```bash
 # One command: AI reads code, writes specs
-specsync generate --provider auto
+specsync generate --provider anthropic
 
 # Validate the generated specs against code
 specsync check --json
@@ -227,7 +252,7 @@ None
 |---------|---------|-----|
 | **Pre-commit hook** | `specsync check --strict` | Block commits with spec errors |
 | **PR review bot** | `specsync check --json` | Parse output, post as PR comment |
-| **Bootstrap coverage** | `specsync generate --provider auto` | AI writes specs from source code |
+| **Bootstrap coverage** | `specsync generate --provider anthropic` | AI writes specs from source code |
 | **Template scaffold** | `specsync generate` | Scaffold templates after adding new modules |
 | **AI code review** | `specsync check --json` | Feed errors to LLM for spec updates |
 | **Coverage gate** | `specsync check --strict --require-coverage 100` | CI enforces full coverage |


### PR DESCRIPTION
**Answers "is the GitHub page updated too?" — it wasn't, now it is.** Both the README and the GitHub Pages docs site (`site/src/content/docs/`) still documented the pre-4.4.0 AI behavior; this brings them in line with what shipped.

## What was stale
- `claude -p --output-format text` described as the **default** AI command
- Provider list limited to `auto/claude/anthropic/openai/ollama/copilot`
- `ollama run llama3` / `claude -p` config examples
- No mention of corvid-ai, the Ollama-default ladder, `--model`, or `SPECSYNC_AI_PROVIDER`/`SPECSYNC_AI_MODEL`

## Updated (README + 3 site docs)
- **README.md** — AI mode section, `--provider`/`--model` flag rows, the config-field table (`aiProvider`/`aiModel`/`aiApiKey`/`aiBaseUrl`/`aiCommand`/`aiTimeout`), and the local-override/env note.
- **site/src/content/docs/integrations/ai-agents.md** — provider list, resolution ladder, model precedence, deprecated `aiCommand` hatch.
- **site/src/content/docs/cli.md** — provider table (Ollama = HTTP API, not a shell-out; `claude`→anthropic deprecated) + `--provider`/`--model` flags.
- **site/src/content/docs/configuration.md** — AI config fields, resolution order, env vars, current default model (`claude-sonnet-4-6`).

Now documents: full provider set, **Ollama by default** (local keyless or cloud) → API-first when keyed → prompt-when-multiple, `flag > env > config` throughout, and `claude`→`anthropic` (no `sh -c "claude -p"`).

## Verification
- [x] `cd site && bun run build` — 34 pages built, prebuild validation passed
- [x] README scanned — no remaining stale `claude -p` / `ollama run` references
- `site/dist` is gitignored; the Pages workflow rebuilds from these source edits on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)