### PR TITLE
docs(site): bump version badge to v4.4.0 + fix stale CI action refs

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -2,7 +2,7 @@
 import Button from './Button.astro'
 import { base } from '../lib/path'
 const current = Astro.url.pathname.replace(/\/$/, '') || base.replace(/\/$/, '')
-const VERSION = 'v4.3.3'
+const VERSION = 'v4.4.0'
 const links = [
   { href: `${base}languages`, label: 'Languages' },
   { href: `${base}examples`, label: 'Examples' },

--- a/site/src/content/examples/ci-gate.mdx
+++ b/site/src/content/examples/ci-gate.mdx
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/specsync-action@v1
+      - uses: CorvidLabs/spec-sync@v4
 ```
 
 The action installs `spec-sync`, runs `spec-sync check --strict`, and annotates any drift directly in the PR diff view.
@@ -32,7 +32,7 @@ The action installs `spec-sync`, runs `spec-sync check --strict`, and annotates 
 Floating to `@v1` is convenient for early adoption but pins to a release once you're stable so an unintended upstream change doesn't break a Friday-afternoon merge:
 
 ```yaml
-- uses: CorvidLabs/specsync-action@v4.3.2
+- uses: CorvidLabs/spec-sync@v4
 ```
 
 The Action follows the spec-sync release cadence — match the version you `cargo install` locally.
@@ -42,7 +42,7 @@ The Action follows the spec-sync release cadence — match the version you `carg
 By default, `--strict` fails on any warning. For teams onboarding spec-sync incrementally, you can start with errors-only:
 
 ```yaml
-- uses: CorvidLabs/specsync-action@v4.3.2
+- uses: CorvidLabs/spec-sync@v4
   with:
     strict: false        # warnings allowed; errors still fail
     score_threshold: 60  # also fail if any spec scores below 60
@@ -55,7 +55,7 @@ Drop `strict: false` once your team is happy with the warning count, and tighten
 Add `annotations: true` so drift errors render as inline GitHub PR review comments on the source line, not just in the Action log:
 
 ```yaml
-- uses: CorvidLabs/specsync-action@v4.3.2
+- uses: CorvidLabs/spec-sync@v4
   with:
     annotations: true
 ```
@@ -67,7 +67,7 @@ A PR that adds an undocumented export now shows the comment "undocumented export
 When you genuinely need to ship a fix without updating the spec (and you're not lying to yourself), opt out per-PR with a label:
 
 ```yaml
-- uses: CorvidLabs/specsync-action@v4.3.2
+- uses: CorvidLabs/spec-sync@v4
   if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-specsync') }}
 ```
 

--- a/site/src/content/examples/polyglot.mdx
+++ b/site/src/content/examples/polyglot.mdx
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/specsync-action@v1
+      - uses: CorvidLabs/spec-sync@v4
         with:
           strict: true
 ```


### PR DESCRIPTION
Fixes the stale version still showing on the marketing site.

## What you saw
The site header (and thus the homepage) hardcoded `const VERSION = 'v4.3.3'` in `Header.astro` — the release process bumps `Cargo.toml` but not this badge, so the marketing site lagged.

## Fixes
- **`Header.astro`** — version badge `v4.3.3` → **`v4.4.0`** (shown site-wide, including the homepage).
- **CI examples** (`ci-gate.mdx`, `polyglot.mdx`) — `CorvidLabs/specsync-action@v4.3.2` / `@v1` was **doubly wrong** (a non-existent repo name *and* a stale pin). Fixed all 6 to the canonical **`CorvidLabs/spec-sync@v4`** used in `docs/integrations/github-action.md`.

Left intentionally: the historical `blog/v4-3-2-release.mdx` post (a dated release announcement) and the `v3.3.0..v3.4.0` *illustrative* `changelog` command examples in `cli.md`.

## Verification
- [x] `cd site && bun run build` — 34 pages, clean
- [x] Built `dist/index.html` shows `v4.4.0`
- [x] No remaining `4.3` version refs in `site/src` (outside the historical blog post)

Merging redeploys Pages (`pages.yml`) and the live homepage will read **v4.4.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)