### PR TITLE
docs(site): read version badge from Cargo.toml (no more drift)

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -1,8 +1,17 @@
 ---
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import Button from './Button.astro'
 import { base } from '../lib/path'
 const current = Astro.url.pathname.replace(/\/$/, '') || base.replace(/\/$/, '')
-const VERSION = 'v4.4.0'
+// Single source of truth: read the package version from the workspace Cargo.toml
+// at build time so the badge never drifts behind a release.
+const cargoToml = fs.readFileSync(
+  path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../Cargo.toml'),
+  'utf-8',
+)
+const VERSION = `v${cargoToml.match(/^version\s*=\s*"([^"]+)"/m)?.[1] ?? '0.0.0'}`
 const links = [
   { href: `${base}languages`, label: 'Languages' },
   { href: `${base}examples`, label: 'Examples' },


### PR DESCRIPTION
Prevents the marketing-site version badge from drifting behind releases (the issue where the homepage showed `v4.3.3` while `4.4.0` had shipped).

## Change
`site/src/components/Header.astro` now reads the package version from the workspace **`Cargo.toml`** at build time — the canonical source the release process bumps — instead of a hardcoded string:

```js
const cargoToml = fs.readFileSync(
  path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../Cargo.toml'),
  'utf-8',
)
const VERSION = `v${cargoToml.match(/^version\s*=\s*"([^"]+)"/m)?.[1] ?? '0.0.0'}`
```

The regex is line-anchored (`/m`), so it matches the `[package]` `version`, not any dependency's inline `version =`.

## Verified end-to-end
- [x] `bun run build` — 34 pages, clean; homepage badge reads **`v4.4.0`**
- [x] Temporarily bumped `Cargo.toml` to `9.9.9` → rebuilt badge tracked to `v9.9.9` (then restored) — proves the link
- The Pages CI checks out the full repo, so `Cargo.toml` is present at build time.

From now on, a release that bumps `Cargo.toml` auto-updates the site badge on the next Pages deploy — no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)