### PR TITLE
Add native agent skills and slash commands (specsync agents)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Enforcement is **strict** — CI and pre-commit hooks will block on any spec vio
 | `specsync scaffold <name>` | Full scaffold: spec + companions + registry entry + source detection |
 | `specsync add-spec <name>` | Scaffold a spec with companion files (tasks.md, context.md) |
 | `specsync hooks install` | Install git pre-commit hooks and IDE agent snippets |
-| `specsync agents install` | Install native Claude/Cursor/Codex skills and `/specsync:create-spec` slash commands (Gemini CLI too) |
+| `specsync agents install` | Install native Claude/Cursor/Codex/Gemini skills and `/specsync:create-spec` slash commands (Claude/Cursor/Gemini) |
 | `specsync resolve --remote` | Resolve cross-project spec references |
 | `specsync diff --base <ref>` | Show export changes since a git ref (useful for CI/PR reviews) |
 | `specsync report` | Per-module coverage report with stale/incomplete detection |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Enforcement is **strict** — CI and pre-commit hooks will block on any spec vio
 | `specsync scaffold <name>` | Full scaffold: spec + companions + registry entry + source detection |
 | `specsync add-spec <name>` | Scaffold a spec with companion files (tasks.md, context.md) |
 | `specsync hooks install` | Install git pre-commit hooks and IDE agent snippets |
+| `specsync agents install` | Install native Claude/Cursor/Codex skills and `/specsync:create-spec` slash commands (Gemini CLI too) |
 | `specsync resolve --remote` | Resolve cross-project spec references |
 | `specsync diff --base <ref>` | Show export changes since a git ref (useful for CI/PR reviews) |
 | `specsync report` | Per-module coverage report with stale/incomplete detection |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`specsync agents install`/`uninstall`/`status`** — native skill and slash-command integrations for Claude Code, Cursor, Codex, and Gemini CLI, distinct from the prose-instruction-file mechanism `specsync hooks install` already provides. Installs a `SKILL.md` the tool auto-discovers (all four tools) and a `/specsync:create-spec` slash command (`/specsync-create-spec` on Cursor; Claude, Cursor, and Gemini — Codex's command mechanism is deprecated and global-only, so it gets the skill only). `create-spec` accepts either a bare module name or a natural-language feature description (e.g. `/specsync:create-spec "I want a feature that lets users export their data as CSV"`), defaults to a full scaffold (spec + companion files), and supports `--minimal` to create a spec-only draft instead.
+
 ## [4.5.0] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ specsync lifecycle auto-promote            # Promote all specs that pass guards
 specsync lifecycle enforce --all           # CI: validate lifecycle rules
 specsync hooks install                    # Install agent instructions + git hooks
 specsync hooks status                     # Check what's installed
+specsync agents install                   # Install native skills + /specsync:create-spec commands
+specsync agents status                    # Check what's installed
 specsync mcp                               # Start MCP server for AI agent integration
 specsync watch                             # Re-validate on every file change
 ```
@@ -373,6 +375,7 @@ specsync [command] [flags]
 | `lifecycle enforce` | CI enforcement — validate lifecycle rules, exit non-zero on violations. `--all` for all checks |
 | `issues` | Verify GitHub issue references in spec frontmatter. `--create` to create missing issues |
 | `hooks` | Install/uninstall agent instructions and git hooks (`install`, `uninstall`, `status`) |
+| `agents` | Install/uninstall native AI-tool skills and slash commands for Claude Code, Cursor, Codex, and Gemini CLI (`install`, `uninstall`, `status`) |
 | `mcp` | Start MCP server for AI agent integration (Claude Code, Cursor, etc.) |
 | `init` | Create default `specsync.json` |
 | `watch` | Live validation on file changes (500ms debounce) |
@@ -902,6 +905,8 @@ specsync generate --provider openrouter --model anthropic/claude-sonnet-4-6
 
 ### Designed for AI agents
 
+For Claude Code, Cursor, Codex, and Gemini CLI, `specsync agents install` ships native integrations — a `SKILL.md` the tool auto-discovers (Claude/Cursor/Codex) and a `/specsync:create-spec` slash command (Claude/Cursor/Gemini) that scaffolds a spec, optionally with companion files, from either a module name or a natural-language feature description. This is separate from `specsync hooks install`, which remains the prose-instruction-file mechanism (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, Copilot instructions) for tools without native skill/command support — run both, or whichever applies to your setup.
+
 The generate command is the entry point for LLM-powered spec workflows:
 
 ```bash
@@ -963,6 +968,7 @@ Shows exports added and removed per spec file since the given git ref. Useful fo
 ```
 src/
 ├── main.rs            CLI entry + output formatting
+├── agents.rs          Native skill/slash-command installation (Claude Code, Cursor, Codex, Gemini CLI)
 ├── ai.rs              AI-powered spec generation (prompt builder + command runner)
 ├── archive.rs         Task archival from companion tasks.md files
 ├── changelog.rs       Changelog generation between git refs

--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ specsync generate --provider openrouter --model anthropic/claude-sonnet-4-6
 
 ### Designed for AI agents
 
-For Claude Code, Cursor, Codex, and Gemini CLI, `specsync agents install` ships native integrations — a `SKILL.md` the tool auto-discovers (Claude/Cursor/Codex) and a `/specsync:create-spec` slash command (Claude/Cursor/Gemini) that scaffolds a spec, optionally with companion files, from either a module name or a natural-language feature description. This is separate from `specsync hooks install`, which remains the prose-instruction-file mechanism (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, Copilot instructions) for tools without native skill/command support — run both, or whichever applies to your setup.
+For Claude Code, Cursor, Codex, and Gemini CLI, `specsync agents install` ships native integrations — a `SKILL.md` the tool auto-discovers (all four) and a `/specsync:create-spec` slash command (Claude/Cursor/Gemini — Codex's command mechanism is deprecated and global-only, so it gets the skill only) that scaffolds a spec, optionally with companion files, from either a module name or a natural-language feature description. This is separate from `specsync hooks install`, which remains the prose-instruction-file mechanism (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, Copilot instructions) for tools without native skill/command support — run both, or whichever applies to your setup.
 
 The generate command is the entry point for LLM-powered spec workflows:
 

--- a/specs/agents/agents.spec.md
+++ b/specs/agents/agents.spec.md
@@ -1,0 +1,108 @@
+---
+module: agents
+version: 1
+status: stable
+files:
+  - src/agents.rs
+db_tables: []
+depends_on: []
+---
+
+# Agents
+
+## Purpose
+
+Installs native, tool-owned skill and slash-command files for AI coding agents (Claude Code, Cursor, Codex, Gemini CLI), distinct from the prose-instruction-file mechanism in `hooks.rs`. Ships a `SKILL.md` each tool auto-discovers and a `/specsync:create-spec` (or tool-equivalent) slash command that scaffolds a spec from a module name or a natural-language feature description.
+
+## Public API
+
+### Exported Enums
+
+| Type | Description |
+|------|-------------|
+| `AgentTool` | AI coding tools that receive native skill/command installation: Claude, Cursor, Codex, Gemini |
+
+### Exported AgentTool Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `all` | — | `&'static [AgentTool]` | Returns slice of all four agent tools |
+| `name` | `&self` | `&'static str` | Short name string for this tool (e.g. "claude", "gemini") |
+| `description` | `&self` | `&'static str` | Human-readable description of what gets installed for this tool |
+| `from_str` | `s: &str` | `Option<Self>` | Parse an agent tool from string (case-insensitive) |
+
+### Exported Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `is_installed` | `(root: &Path, tool: AgentTool) -> bool` | True if every artifact this tool should have (skill dir and/or command file) already exists |
+| `install_agent` | `(root: &Path, tool: AgentTool) -> Result<bool, String>` | Install skill + command files for one tool; `Ok(false)` if everything was already present |
+| `uninstall_agent` | `(root: &Path, tool: AgentTool) -> Result<bool, String>` | Remove a tool's skill dir and/or command file; `Ok(false)` if nothing was present |
+| `cmd_install` | `(root: &Path, targets: &[AgentTool])` | CLI handler: install specified tools (or all if empty) |
+| `cmd_uninstall` | `(root: &Path, targets: &[AgentTool])` | CLI handler: uninstall specified tools (or all if empty) |
+| `cmd_status` | `(root: &Path)` | CLI handler: show installation status of all agent tools |
+
+## Invariants
+
+1. Each `AgentTool` variant owns zero, one, or two artifacts: a skill directory (`<tool-dir>/skills/spec-sync/SKILL.md`) and/or a `create-spec` command file — Codex has skill only (its command mechanism is deprecated and global-only, outside any project root), all others have both.
+2. Installation is idempotent per-artifact — `install_agent` only writes an artifact that's missing, and returns `Ok(false)` when everything already exists.
+3. Every artifact spec-sync writes lives inside a `spec-sync/`-named skill folder or a `specsync`-namespaced command file/directory that spec-sync fully owns — no marker-string surgery on shared files is needed (unlike `hooks.rs`).
+4. `uninstall_agent` removes the skill directory wholesale (`remove_dir_all`) and the command file, then removes the command file's immediate parent directory only if that parent is named `specsync` and is now empty — it never removes a tool's shared `commands/` directory (e.g. `.claude/commands/`, `.cursor/commands/`), which may hold unrelated user commands.
+5. Cursor's command file is flat (`.cursor/commands/specsync-create-spec.md`, no namespaced subdirectory, no YAML frontmatter) since Cursor's command mechanism doesn't support either.
+6. Claude and Gemini's commands live in a namespaced subdirectory (`.claude/commands/specsync/create-spec.md`, `.gemini/commands/specsync/create-spec.toml`) so they're invoked as `/specsync:create-spec`.
+7. Gemini's command file is TOML (`description`/`prompt` keys, `{{args}}` placeholder), hand-built as a string template since no `toml` crate dependency exists in this project.
+8. Empty targets list means "all tools", matching the `hooks` module's convention.
+9. `cmd_install` exits with code 1 if any tool installation fails.
+
+## Behavioral Examples
+
+### Scenario: Install all agent tools
+
+- **Given** a project with no agent integrations installed
+- **When** `cmd_install(root, &[])` is called
+- **Then** installs Claude's skill + command, Cursor's skill + command, Codex's skill, and Gemini's skill + command
+
+### Scenario: Already installed
+
+- **Given** `.claude/skills/spec-sync/SKILL.md` and `.claude/commands/specsync/create-spec.md` both exist
+- **When** `install_agent(root, AgentTool::Claude)` is called
+- **Then** returns `Ok(false)` without modifying either file
+
+### Scenario: Uninstall preserves sibling commands
+
+- **Given** `.claude/commands/specsync/create-spec.md` and an unrelated `.claude/commands/other-command.md` both exist
+- **When** `uninstall_agent(root, AgentTool::Claude)` is called
+- **Then** removes `.claude/commands/specsync/` entirely, but `.claude/commands/other-command.md` and `.claude/commands/` itself are untouched
+
+### Scenario: Codex gets a skill only
+
+- **Given** `install_agent(root, AgentTool::Codex)` is called
+- **Then** `.codex/skills/spec-sync/SKILL.md` is created and no `.codex/commands/` directory is created at all
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Cannot create skill/command directory | Returns `Err` with descriptive message |
+| Cannot write skill/command file | Returns `Err` with descriptive message |
+| Cannot remove skill directory or command file | Returns `Err` with descriptive message |
+
+## Dependencies
+
+### Consumes
+
+| Crate/Module | What is used |
+|-------------|-------------|
+| colored | Terminal output formatting |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| cmd_agents | `cmd_install`, `cmd_uninstall`, `cmd_status`, `AgentTool` |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-01 | claude | Initial spec — native skill/command installation for Claude Code, Cursor, Codex, Gemini CLI |

--- a/specs/agents/agents.spec.md
+++ b/specs/agents/agents.spec.md
@@ -1,6 +1,6 @@
 ---
 module: agents
-version: 1
+version: 2
 status: stable
 files:
   - src/agents.rs
@@ -45,7 +45,7 @@ Installs native, tool-owned skill and slash-command files for AI coding agents (
 ## Invariants
 
 1. Each `AgentTool` variant owns zero, one, or two artifacts: a skill directory (`<tool-dir>/skills/spec-sync/SKILL.md`) and/or a `create-spec` command file — Codex has skill only (its command mechanism is deprecated and global-only, outside any project root), all others have both.
-2. Installation is idempotent per-artifact — `install_agent` only writes an artifact that's missing, and returns `Ok(false)` when everything already exists.
+2. Installation is idempotent per-artifact and content-aware — `install_agent` writes an artifact when it's missing *or* when its existing content differs from the current template (so upgrading spec-sync refreshes stale installations), and returns `Ok(false)` only when every artifact already matches the current template exactly.
 3. Every artifact spec-sync writes lives inside a `spec-sync/`-named skill folder or a `specsync`-namespaced command file/directory that spec-sync fully owns — no marker-string surgery on shared files is needed (unlike `hooks.rs`).
 4. `uninstall_agent` removes the skill directory wholesale (`remove_dir_all`) and the command file, then removes the command file's immediate parent directory only if that parent is named `specsync` and is now empty — it never removes a tool's shared `commands/` directory (e.g. `.claude/commands/`, `.cursor/commands/`), which may hold unrelated user commands.
 5. Cursor's command file is flat (`.cursor/commands/specsync-create-spec.md`, no namespaced subdirectory, no YAML frontmatter) since Cursor's command mechanism doesn't support either.
@@ -79,6 +79,12 @@ Installs native, tool-owned skill and slash-command files for AI coding agents (
 - **Given** `install_agent(root, AgentTool::Codex)` is called
 - **Then** `.codex/skills/spec-sync/SKILL.md` is created and no `.codex/commands/` directory is created at all
 
+### Scenario: Upgrading spec-sync refreshes stale content
+
+- **Given** `.claude/skills/spec-sync/SKILL.md` exists but contains content written by an older spec-sync version
+- **When** `install_agent(root, AgentTool::Claude)` is called
+- **Then** the file is overwritten with the current template content and `Ok(true)` is returned
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -105,4 +111,5 @@ Installs native, tool-owned skill and slash-command files for AI coding agents (
 
 | Date | Author | Change |
 |------|--------|--------|
+| 2026-07-01 | claude | v2: `install_agent` overwrites artifacts whose existing content differs from the current template (content-aware upgrade), instead of only writing missing files |
 | 2026-07-01 | claude | Initial spec — native skill/command installation for Claude Code, Cursor, Codex, Gemini CLI |

--- a/specs/agents/context.md
+++ b/specs/agents/context.md
@@ -1,0 +1,27 @@
+---
+spec: agents.spec.md
+---
+
+## Key Decisions
+
+- **Sibling to `hooks.rs`, not a variant of it**: `hooks.rs` appends prose instructions to shared files a user may already have content in (CLAUDE.md, .cursorrules, AGENTS.md), requiring marker-string detection and surgical section removal. This module writes brand-new files/directories spec-sync fully owns, so install/uninstall are plain existence checks and whole-directory/file operations — a meaningfully simpler ownership model, done deliberately rather than forced into `HookTarget`'s shape.
+- **Per-tool capability matrix, not one enum arm per artifact**: `AgentTool` has 4 variants (not `ClaudeSkill`/`ClaudeCommand`/... as separate variants) because the natural unit of user control is "the tool", e.g. `--claude` should install both its skill and command in one shot. `skill_dir()`/`command_path()` return `Option<PathBuf>` per tool since Codex has no command and (originally) Gemini had no skill.
+- **Gemini skill added after initial ship**: Gemini CLI added stable `SKILL.md` support in 2026 — verified against `geminicli.com` docs and the `google-gemini/gemini-cli` repo — after this module's PR was already up. Gemini went from command-only to skill+command in a follow-up commit.
+- **Codex stays project-scoped, diverging from OpenSpec**: OpenSpec's own adapter (`Fission-AI/OpenSpec`, `src/core/command-generation/adapters/codex.ts`) writes Codex's command globally to `$CODEX_HOME/prompts/opsx-<id>.md` (outside any project). This module deliberately does not — Codex gets a project-local skill only, consistent with every other spec-sync integration never writing outside the project root, and consistent with OpenAI's own guidance that the global prompts mechanism is deprecated in favor of skills.
+- **Cursor has no command frontmatter, verified independently**: OpenSpec's own `cursorAdapter` writes YAML frontmatter (`name`/`id`/`category`/`description`) into Cursor command files, but independent web research confirmed Cursor's command mechanism has no frontmatter support at all — the filename alone determines the command name. This module's Cursor command is plain markdown, no frontmatter block.
+- **SKILL_BODY is a standalone copy, not shared with `hooks.rs`**: `hooks.rs`'s four instruction snippets (CLAUDE_MD_SNIPPET, CURSORRULES_SNIPPET, COPILOT_INSTRUCTIONS_SNIPPET, AGENTS_MD_SNIPPET) aren't identical to each other, so unifying all of them with this module's `SKILL_BODY` was left out of scope to avoid changing already-shipped, tested output for an unrelated reason.
+
+## Files to Read First
+
+- `src/agents.rs` — the whole module: `AgentTool` enum, path routing, install/uninstall/status, skill and command content builders.
+- `src/hooks.rs` — the sibling prose-instruction system this module is distinct from; useful for contrast, not reuse.
+- `src/commands/agents.rs` — thin CLI dispatcher (see `cmd_agents` spec).
+
+## Current Status
+
+Fully implemented and shipped. All four `AgentTool` variants work: Claude (skill + command), Cursor (skill + flat command, no frontmatter), Codex (skill only, project-scoped), Gemini (skill + TOML command). 22 unit tests cover path correctness, idempotency, and safe uninstall (verified sibling files/dirs in shared `commands/` folders survive uninstall).
+
+## Notes
+
+- The `create-spec` command's prompt body instructs the agent to parse either a bare module name or a natural-language feature description out of its arguments — that parsing happens in the agent's own reasoning, not in Rust code, since these are prompt files, not real CLI arg parsers.
+- No `toml` crate dependency exists in this project, so Gemini's `.toml` command file is a hand-built string template (`gemini_create_spec_toml()`), not a serialized struct.

--- a/specs/agents/requirements.md
+++ b/specs/agents/requirements.md
@@ -1,0 +1,36 @@
+---
+spec: agents.spec.md
+---
+
+## User Stories
+
+- As a developer using Claude Code, I want `specsync agents install --claude` to add a `SKILL.md` and a `/specsync:create-spec` command so Claude auto-discovers spec-sync's workflow and I get a native slash command instead of relying on prose in CLAUDE.md
+- As a developer using Cursor, I want the same skill + `/specsync-create-spec` command installed in Cursor's own conventions (flat filename, no frontmatter)
+- As a developer using Codex CLI, I want a project-scoped `SKILL.md` installed without spec-sync writing anything outside my project directory
+- As a developer using Gemini CLI, I want both a skill and a `/specsync:create-spec` TOML command installed
+- As a developer, I want `/specsync:create-spec <name>` to scaffold a full spec (with companion files) by default, and `--minimal` to opt out
+- As a developer, I want to pass a natural-language feature description instead of a bare module name (e.g. `/specsync:create-spec "I want a feature that lets users export their data as CSV"`) and have the agent pick a module name and draft the spec's Purpose/Requirements from it
+- As a developer, I want `specsync agents install` with no target flags to install all four tools at once
+- As a developer, I want `specsync agents status` to show which tools are installed
+- As a developer, I want `specsync agents uninstall` to cleanly remove only spec-sync's own files, never touching unrelated commands a tool's shared directory might contain
+
+## Acceptance Criteria
+
+- Four tools supported: Claude, Cursor, Codex, Gemini
+- Claude, Cursor, and Gemini each get a skill and a `create-spec` command; Codex gets a skill only
+- Installation is idempotent per-artifact — re-installing an already-installed artifact is a no-op
+- Uninstall never removes a tool's shared `commands/` directory, only spec-sync's own namespaced subdirectory/file within it
+- Empty targets list means "all tools"
+- `cmd_install` exits with code 1 if any tool installation fails
+
+## Constraints
+
+- Must never write outside the project root (no `~/.codex/prompts/`-style global writes), even where other ecosystem tools (e.g. OpenSpec) do
+- No `toml` crate dependency exists in this project — Gemini's TOML command file must be a hand-built string template
+- Must not assume undocumented behavior of a tool's command/skill format — verify against the tool's actual documented mechanics before implementing
+
+## Out of Scope
+
+- Additional slash commands beyond `create-spec` (e.g. native `check`/`coverage`/`score` commands) — deferred until real usage of `create-spec` shows a need
+- Extending native skill/command installation to Copilot or the generic `AGENTS.md` fallback — those remain served by `hooks.rs`'s prose-instruction mechanism
+- Persisting which tools were selected in config so a bare `specsync agents install` remembers prior choices

--- a/specs/agents/tasks.md
+++ b/specs/agents/tasks.md
@@ -1,0 +1,33 @@
+---
+spec: agents.spec.md
+---
+
+## Tasks
+
+- [ ] Verify inside a real Claude Code / Cursor / Codex / Gemini CLI session that the installed artifacts are actually auto-discovered/listed as documented
+- [ ] Consider native `check`/`coverage`/`score` slash commands if `create-spec` sees real usage and demand shows up
+- [ ] Consider persisting selected tools in `.specsync/config.toml` so a bare `specsync agents install` remembers prior choices
+
+## Done
+
+- [x] Claude Code skill + `/specsync:create-spec` command install/uninstall/status
+- [x] Cursor skill + `/specsync-create-spec` command install/uninstall/status (flat filename, no frontmatter)
+- [x] Codex CLI skill install/uninstall/status (project-scoped, no command)
+- [x] Gemini CLI skill + `/specsync:create-spec` TOML command install/uninstall/status
+- [x] `create-spec` command accepts a bare module name or a natural-language feature description
+- [x] `--minimal` flag support (spec-only via `specsync new`, vs. full scaffold via `specsync scaffold`)
+- [x] Idempotent per-artifact installation
+- [x] Safe uninstall — never touches a tool's shared `commands/` directory or unrelated sibling files
+- [x] All-tools default when no flags specified
+
+## Gaps
+
+- No artifact content versioning — if the built-in SKILL.md/command body text changes, existing installations won't know they're outdated (same known gap as `hooks.rs`)
+- Cannot verify real-world auto-discovery behavior inside actual Claude Code/Cursor/Codex/Gemini CLI sessions from this environment
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/agents/tasks.md
+++ b/specs/agents/tasks.md
@@ -17,12 +17,12 @@ spec: agents.spec.md
 - [x] `create-spec` command accepts a bare module name or a natural-language feature description
 - [x] `--minimal` flag support (spec-only via `specsync new`, vs. full scaffold via `specsync scaffold`)
 - [x] Idempotent per-artifact installation
+- [x] Content-aware reinstall — `install_agent` overwrites artifacts whose content has drifted from the current template, so upgrading spec-sync refreshes stale installations instead of leaving them outdated
 - [x] Safe uninstall — never touches a tool's shared `commands/` directory or unrelated sibling files
 - [x] All-tools default when no flags specified
 
 ## Gaps
 
-- No artifact content versioning — if the built-in SKILL.md/command body text changes, existing installations won't know they're outdated (same known gap as `hooks.rs`)
 - Cannot verify real-world auto-discovery behavior inside actual Claude Code/Cursor/Codex/Gemini CLI sessions from this environment
 
 ## Review Sign-offs

--- a/specs/agents/testing.md
+++ b/specs/agents/testing.md
@@ -1,0 +1,29 @@
+---
+spec: agents.spec.md
+---
+
+## Automated Testing
+
+| Test File | Type | What It Covers |
+|-----------|------|----------------|
+| `src/agents.rs` (enum/parsing) | cargo test agents:: | `agent_tool_all_returns_four_targets`, `agent_tool_all_contains_all_variants`, `agent_tool_name_returns_expected_strings`, `from_str_parses_all_targets`, `from_str_is_case_insensitive`, `from_str_returns_none_for_unknown` |
+| `src/agents.rs` (path correctness) | cargo test agents:: | `claude_paths_are_correct`, `cursor_command_path_is_flat`, `codex_has_no_command_path`, `gemini_has_both_skill_and_command_paths` |
+| `src/agents.rs` (install/idempotency) | cargo test agents:: | `install_claude_creates_skill_and_command`, `install_cursor_command_has_no_frontmatter`, `install_codex_creates_skill_only`, `install_gemini_creates_skill_and_command`, `install_is_idempotent` |
+| `src/agents.rs` (status/uninstall) | cargo test agents:: | `is_installed_returns_false_for_empty_dir`, `uninstall_returns_false_when_not_installed`, `uninstall_claude_removes_skill_and_command`, `uninstall_preserves_sibling_commands`, `uninstall_cursor_flat_file_does_not_touch_commands_dir`, `uninstall_gemini_removes_skill_and_command`, `uninstall_codex_removes_skill_only` |
+
+## Manual Testing
+
+- [x] `specsync agents install` on a clean project creates all 8 artifacts (skill + command for Claude/Cursor/Gemini, skill only for Codex)
+- [x] `specsync agents status` correctly reflects installed/not-installed state before and after install
+- [x] Simulated the `create-spec` command's own instructions end-to-end — `specsync scaffold csv-export` (full) and `specsync new billing` (`--minimal` path) both produce the expected files
+- [x] `specsync agents uninstall` with an unrelated `.claude/commands/other-command.md` present — sibling file survives, only spec-sync's namespaced subdirectory is removed
+- [ ] Confirm inside a real Claude Code / Cursor / Codex / Gemini CLI session that the installed `SKILL.md` is actually auto-discovered and the slash command actually appears — not verifiable in this sandboxed environment, rests on cross-checked external documentation and OpenSpec's own adapter source
+
+## Edge Cases & Boundary Conditions
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Uninstall when a tool's shared `commands/` directory holds other user commands | Only the spec-sync-owned namespaced subdirectory/file is removed; the shared directory and its other contents survive |
+| Re-running `agents install` after a partial install (e.g. skill written, command missing) | Fills in only the missing artifact; does not error or duplicate the existing one |
+| Cursor's flat command file is the only file in `.cursor/commands/` | Uninstall removes the file but does not remove `.cursor/commands/` itself (only namespaced `specsync/` subdirectories are cleaned up when empty) |
+| Gemini's TOML `prompt` value spans multiple lines with embedded backticks/quotes in the body text | Triple-quoted TOML string (`"""..."""`) must remain balanced — verified via `content.matches("\"\"\"").count() == 2` |

--- a/specs/agents/testing.md
+++ b/specs/agents/testing.md
@@ -8,7 +8,8 @@ spec: agents.spec.md
 |-----------|------|----------------|
 | `src/agents.rs` (enum/parsing) | cargo test agents:: | `agent_tool_all_returns_four_targets`, `agent_tool_all_contains_all_variants`, `agent_tool_name_returns_expected_strings`, `from_str_parses_all_targets`, `from_str_is_case_insensitive`, `from_str_returns_none_for_unknown` |
 | `src/agents.rs` (path correctness) | cargo test agents:: | `claude_paths_are_correct`, `cursor_command_path_is_flat`, `codex_has_no_command_path`, `gemini_has_both_skill_and_command_paths` |
-| `src/agents.rs` (install/idempotency) | cargo test agents:: | `install_claude_creates_skill_and_command`, `install_cursor_command_has_no_frontmatter`, `install_codex_creates_skill_only`, `install_gemini_creates_skill_and_command`, `install_is_idempotent` |
+| `src/agents.rs` (install/idempotency) | cargo test agents:: | `install_claude_creates_skill_and_command`, `install_cursor_command_has_no_frontmatter`, `install_codex_creates_skill_only`, `install_gemini_creates_skill_and_command`, `install_is_idempotent`, `install_does_not_rewrite_unchanged_content` |
+| `src/agents.rs` (content-aware reinstall) | cargo test agents:: | `install_overwrites_stale_skill_content`, `install_overwrites_stale_command_content` |
 | `src/agents.rs` (status/uninstall) | cargo test agents:: | `is_installed_returns_false_for_empty_dir`, `uninstall_returns_false_when_not_installed`, `uninstall_claude_removes_skill_and_command`, `uninstall_preserves_sibling_commands`, `uninstall_cursor_flat_file_does_not_touch_commands_dir`, `uninstall_gemini_removes_skill_and_command`, `uninstall_codex_removes_skill_only` |
 
 ## Manual Testing
@@ -25,5 +26,6 @@ spec: agents.spec.md
 |----------|-------------------|
 | Uninstall when a tool's shared `commands/` directory holds other user commands | Only the spec-sync-owned namespaced subdirectory/file is removed; the shared directory and its other contents survive |
 | Re-running `agents install` after a partial install (e.g. skill written, command missing) | Fills in only the missing artifact; does not error or duplicate the existing one |
+| Re-running `agents install` after upgrading spec-sync (template content changed) | Overwrites the stale artifact with current content and returns `Ok(true)`; unchanged artifacts are left alone and return `Ok(false)` |
 | Cursor's flat command file is the only file in `.cursor/commands/` | Uninstall removes the file but does not remove `.cursor/commands/` itself (only namespaced `specsync/` subdirectories are cleaned up when empty) |
 | Gemini's TOML `prompt` value spans multiple lines with embedded backticks/quotes in the body text | Triple-quoted TOML string (`"""..."""`) must remain balanced — verified via `content.matches("\"\"\"").count() == 2` |

--- a/specs/cli_args/cli_args.spec.md
+++ b/specs/cli_args/cli_args.spec.md
@@ -28,8 +28,9 @@ Defines the CLI argument parser using Clap derive macros. Declares all subcomman
 
 | Type | Description |
 |------|-------------|
-| `Command` | Subcommand enum with 29 variants: Check, Coverage, Generate, Init, Score, Watch, Mcp, AddSpec, Scaffold, InitRegistry, Resolve, Diff, Hooks, Compact, ArchiveTasks, View, Merge, Issues, New, Wizard, Deps, Import, Stale, Report, Comment, Rules, Changelog, Migrate, Lifecycle |
+| `Command` | Subcommand enum with 30 variants: Check, Coverage, Generate, Init, Score, Watch, Mcp, AddSpec, Scaffold, InitRegistry, Resolve, Diff, Hooks, Agents, Compact, ArchiveTasks, View, Merge, Issues, New, Wizard, Deps, Import, Stale, Report, Comment, Rules, Changelog, Migrate, Lifecycle |
 | `HooksAction` | Sub-subcommand for `Hooks`: Install, Uninstall, Status — each with boolean flags for target selection (claude, cursor, copilot, agents, precommit, claude_code_hook) |
+| `AgentsAction` | Sub-subcommand for `Agents`: Install, Uninstall, Status — each with boolean flags for target selection (claude, cursor, codex, gemini) |
 | `LifecycleAction` | Sub-subcommand for `Lifecycle`: Promote, Demote, Set, Status, History, Guard, AutoPromote, Enforce — manages spec lifecycle transitions |
 
 ## Invariants
@@ -40,6 +41,7 @@ Defines the CLI argument parser using Clap derive macros. Declares all subcomman
 4. Default output format is `text` when neither `--json` nor `--format` is specified
 5. The `Command` enum is optional — running `specsync` with no subcommand defaults to `Check`
 6. Each `HooksAction::Install` / `Uninstall` variant carries identical boolean flags for symmetric install/uninstall
+7. Each `AgentsAction::Install` / `Uninstall` variant carries identical boolean flags for symmetric install/uninstall, mirroring `HooksAction`
 
 ## Behavioral Examples
 
@@ -60,6 +62,12 @@ Defines the CLI argument parser using Clap derive macros. Declares all subcomman
 - **Given** user runs `specsync hooks install --claude --precommit`
 - **When** Clap parses arguments
 - **Then** `HooksAction::Install { claude: true, precommit: true, ... }` with all others false
+
+### Scenario: Agents install targets
+
+- **Given** user runs `specsync agents install --claude --gemini`
+- **When** Clap parses arguments
+- **Then** `AgentsAction::Install { claude: true, gemini: true, cursor: false, codex: false }`
 
 ## Error Cases
 
@@ -84,6 +92,7 @@ Defines the CLI argument parser using Clap derive macros. Declares all subcomman
 |--------|-------------|
 | cli (main.rs) | `Cli::parse()` to drive the entire application |
 | cmd_hooks | `HooksAction` enum for hooks subcommand dispatch |
+| cmd_agents | `AgentsAction` enum for agents subcommand dispatch |
 
 ## Change Log
 
@@ -91,3 +100,4 @@ Defines the CLI argument parser using Clap derive macros. Declares all subcomman
 |------|--------|
 | 2026-04-09 | Initial spec |
 | 2026-04-11 | Add LifecycleAction enum and Lifecycle command variant |
+| 2026-07-01 | Add AgentsAction enum and Agents command variant |

--- a/specs/cmd_agents/cmd_agents.spec.md
+++ b/specs/cmd_agents/cmd_agents.spec.md
@@ -1,0 +1,71 @@
+---
+module: cmd_agents
+version: 1
+status: stable
+files:
+  - src/commands/agents.rs
+db_tables: []
+depends_on:
+  - specs/agents/agents.spec.md
+  - specs/cli_args/cli_args.spec.md
+---
+
+# Cmd Agents
+
+## Purpose
+
+Implements the `specsync agents` command. Routes install/uninstall/status subcommands to the `agents` library module, translating boolean CLI flags into agent tool lists.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `cmd_agents` | `root: &Path, action: AgentsAction` | `()` | Dispatch agents action to library module |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+
+## Invariants
+
+1. Maps `AgentsAction` variants to `agents::cmd_install`, `cmd_uninstall`, `cmd_status`
+2. Private `collect_agent_targets()` converts boolean flags (`--claude`/`--cursor`/`--codex`/`--gemini`) to a target vec
+3. When no target flags are set, installs/uninstalls all tools
+
+## Behavioral Examples
+
+### Scenario: Install specific tools
+
+- **Given** `specsync agents install --claude --gemini`
+- **When** `cmd_agents` runs
+- **Then** installs only Claude Code's and Gemini CLI's integrations
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+| Skill/command write fails | Delegated to `agents` module |
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+| agents | `cmd_install`, `cmd_uninstall`, `cmd_status`, `AgentTool` |
+| cli_args | `AgentsAction` enum |
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+| cli (main.rs) | Entry point for `specsync agents` |
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-01 | claude | Initial spec |

--- a/specs/cmd_agents/context.md
+++ b/specs/cmd_agents/context.md
@@ -1,0 +1,24 @@
+---
+spec: cmd_agents.spec.md
+---
+
+## Key Decisions
+
+- The command is a pure dispatcher, mirroring `cmd_hooks`. It performs no I/O itself — it only translates CLI flags into `agents::AgentTool` values and forwards to the `agents` library module.
+- "No flags means all tools" is encoded by returning an empty `Vec<AgentTool>` from `collect_agent_targets`; the convention is interpreted downstream in the `agents` module, matching `cmd_hooks`'s existing pattern.
+- Install and uninstall share the exact same flag-collection helper, guaranteeing symmetric target selection.
+
+## Files to Read First
+
+- `src/commands/agents.rs` — the dispatcher and `collect_agent_targets`.
+- `src/agents.rs` — `cmd_install`, `cmd_uninstall`, `cmd_status`, the `AgentTool` enum, and all file/IO logic.
+- `src/cli.rs` (`AgentsAction`) — the flag definitions (`--claude`, `--cursor`, `--codex`, `--gemini`).
+
+## Current Status
+
+Implemented and stable. No tests target this file directly; behavior is validated through the `agents` module.
+
+## Notes
+
+- Targets map to: `Claude` (skill + `/specsync:create-spec`), `Cursor` (skill + `/specsync-create-spec`), `Codex` (skill only), `Gemini` (skill + `/specsync:create-spec` TOML command).
+- Part of the command layer — orchestrates a library module rather than containing domain logic, same shape as `cmd_hooks`.

--- a/specs/cmd_agents/requirements.md
+++ b/specs/cmd_agents/requirements.md
@@ -1,0 +1,28 @@
+---
+spec: cmd_agents.spec.md
+---
+
+## User Stories
+
+- As a developer, I want to install spec-sync's native agent skills and slash commands with one command so that Claude/Cursor/Codex/Gemini all get set up without one command per tool.
+- As a developer who only uses one agent, I want to select specific targets (e.g. `--claude --gemini`) so that I don't install files for tools I don't use.
+- As a developer, I want a `status` subcommand so that I can see which tool integrations are currently installed.
+- As a developer, I want to cleanly uninstall what I installed so that I can remove spec-sync's footprint from a tool.
+
+## Acceptance Criteria
+
+- `cmd_agents` dispatches `Install`, `Uninstall`, and `Status` actions to `agents::cmd_install`, `agents::cmd_uninstall`, and `agents::cmd_status` respectively.
+- Boolean flags `claude`, `cursor`, `codex`, `gemini` map one-to-one to `agents::AgentTool` variants in `collect_agent_targets`.
+- When no target flags are set, the collected target vec is empty, which the `agents` module interprets as "all tools".
+- The same flag-to-target mapping is used for both install and uninstall.
+
+## Constraints
+
+- This module is a thin dispatcher: it performs no I/O itself and contains no domain logic — all file writes and status reporting live in the `agents` library module.
+- Must not panic; actual error handling (write failures) is delegated to the `agents` module.
+
+## Out of Scope
+
+- The content of generated skill/command files (owned by `agents`).
+- Validating that the selected agent tooling is actually installed on the machine.
+- Interactive prompts, GUI, or web output.

--- a/specs/cmd_agents/tasks.md
+++ b/specs/cmd_agents/tasks.md
@@ -1,0 +1,24 @@
+---
+spec: cmd_agents.spec.md
+---
+
+## Tasks
+
+- [ ] Add integration tests covering `agents install`/`uninstall`/`status` CLI behavior (currently no fixtures exist for this command, matching `cmd_hooks`'s same known gap).
+
+## Done
+
+- [x] `cmd_agents` dispatcher implemented for `Install`, `Uninstall`, and `Status`.
+- [x] `collect_agent_targets` maps the four boolean flags (claude, cursor, codex, gemini) to `agents::AgentTool` variants.
+- [x] Empty-target-vec convention ("install/uninstall all") wired through to the `agents` module.
+
+## Gaps
+
+No integration or inline unit tests target `src/commands/agents.rs`. The behavior is exercised only indirectly via the `agents` library module's own tests.
+
+## Review Sign-offs
+
+- **Product**: pending
+- **QA**: pending
+- **Design**: n/a
+- **Dev**: pending

--- a/specs/cmd_agents/testing.md
+++ b/specs/cmd_agents/testing.md
@@ -1,0 +1,22 @@
+---
+spec: cmd_agents.spec.md
+---
+
+## Automated Testing
+
+| Test File | Type | What It Covers |
+|-----------|------|----------------|
+| `src/commands/agents.rs` | (none) | No inline `#[cfg(test)]` module and no integration fixtures target this dispatcher. Coverage is indirect via the `agents` module. |
+| `src/agents.rs` | cargo test agents | The `agents` library module owns install/uninstall/status tests; verify target-to-artifact mapping there. |
+
+## Manual Testing
+
+- [x] `specsync agents install --claude --gemini` on a clean project installs only Claude's and Gemini's artifacts
+- [x] `specsync agents install` (no flags) installs all four tools
+
+## Edge Cases & Boundary Conditions
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| No target flags on install/uninstall | Empty target vec is passed and treated as "all tools" by `agents`, matching `cmd_hooks`'s convention |
+| Skill/command write fails inside `agents` | Error reporting is delegated to the `agents` module; this dispatcher does not catch or wrap errors |

--- a/specs/commands/commands.spec.md
+++ b/specs/commands/commands.spec.md
@@ -1,6 +1,6 @@
 ---
 module: commands
-version: 3
+version: 4
 status: stable
 files:
   - src/commands/mod.rs
@@ -41,6 +41,7 @@ Shared command infrastructure used by all CLI subcommands. Provides config loadi
 
 | Module | Description |
 |--------|-------------|
+| `agents` | Native AI-tool skill/slash-command installation dispatch (Claude Code, Cursor, Codex, Gemini CLI) |
 | `archive_tasks` | Archive completed tasks from companion files |
 | `changelog` | Generate spec changelog between git refs |
 | `check` | Main validation command |
@@ -143,6 +144,7 @@ Shared command infrastructure used by all CLI subcommands. Provides config loadi
 
 | Date | Change |
 |------|--------|
+| 2026-07-01 | v4: Add `agents` submodule (native AI-tool skill/slash-command installation) |
 | 2026-06-11 | v3: Partial export-coverage summary ("N/M exports documented") prints as ⚠ — it is counted as a warning, so the summary's warning count now matches the printed ⚠ lines |
 | 2026-06-11 | v2: Draft specs report skipped section/export validation explicitly; failing frontmatter renders a negated label |
 | 2026-04-09 | Initial spec |

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -161,7 +161,7 @@ impl AgentTool {
             AgentTool::Claude => "Claude Code skill + /specsync:create-spec command",
             AgentTool::Cursor => "Cursor skill + /specsync-create-spec command",
             AgentTool::Codex => "Codex CLI skill (project-scoped)",
-            AgentTool::Gemini => "Gemini CLI /specsync:create-spec command",
+            AgentTool::Gemini => "Gemini CLI skill + /specsync:create-spec command",
         }
     }
 
@@ -177,14 +177,13 @@ impl AgentTool {
     }
 
     /// Directory (relative to project root) containing this tool's skill
-    /// folder, e.g. `.claude/skills/spec-sync/`. `None` if this tool has no
-    /// skill mechanism (Gemini).
+    /// folder, e.g. `.claude/skills/spec-sync/`.
     fn skill_dir(&self, root: &Path) -> Option<PathBuf> {
         match self {
             AgentTool::Claude => Some(root.join(".claude").join("skills").join("spec-sync")),
             AgentTool::Cursor => Some(root.join(".cursor").join("skills").join("spec-sync")),
             AgentTool::Codex => Some(root.join(".codex").join("skills").join("spec-sync")),
-            AgentTool::Gemini => None,
+            AgentTool::Gemini => Some(root.join(".gemini").join("skills").join("spec-sync")),
         }
     }
 
@@ -540,9 +539,9 @@ mod tests {
     }
 
     #[test]
-    fn gemini_has_no_skill_path() {
+    fn gemini_has_both_skill_and_command_paths() {
         let tmp = setup();
-        assert!(AgentTool::Gemini.skill_dir(tmp.path()).is_none());
+        assert!(AgentTool::Gemini.skill_dir(tmp.path()).is_some());
         assert!(AgentTool::Gemini.command_path(tmp.path()).is_some());
     }
 
@@ -601,10 +600,14 @@ mod tests {
     }
 
     #[test]
-    fn install_gemini_creates_command_only() {
+    fn install_gemini_creates_skill_and_command() {
         let tmp = setup();
         assert!(install_agent(tmp.path(), AgentTool::Gemini).unwrap());
-        assert!(!tmp.path().join(".gemini/skills").exists());
+        assert!(
+            tmp.path()
+                .join(".gemini/skills/spec-sync/SKILL.md")
+                .exists()
+        );
 
         let path = tmp
             .path()
@@ -677,11 +680,12 @@ mod tests {
     }
 
     #[test]
-    fn uninstall_gemini_removes_command_only() {
+    fn uninstall_gemini_removes_skill_and_command() {
         let tmp = setup();
         install_agent(tmp.path(), AgentTool::Gemini).unwrap();
         assert!(uninstall_agent(tmp.path(), AgentTool::Gemini).unwrap());
         assert!(!tmp.path().join(".gemini/commands/specsync").exists());
+        assert!(!tmp.path().join(".gemini/skills/spec-sync").exists());
     }
 
     #[test]

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -128,7 +128,7 @@ const SKILL_TRIGGER_DESCRIPTION: &str = "Keep markdown module specs in specs/<mo
 
 /// AI coding tools that receive native skill/command file installation, as
 /// opposed to the prose-instruction-file hooks in `hooks.rs`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentTool {
     Claude,
     Cursor,
@@ -228,31 +228,45 @@ pub fn is_installed(root: &Path, tool: AgentTool) -> bool {
 }
 
 /// Install skill + command files for one tool. Returns Ok(true) if anything
-/// was written, Ok(false) if everything was already present.
+/// was written, Ok(false) if everything was already present and up to date.
+///
+/// Re-running on an already-installed project upgrades stale content: if a
+/// newer spec-sync ships revised skill/command text, the existing file is
+/// overwritten to match rather than being silently left outdated because it
+/// already exists. Safe because these files are fully spec-sync-owned (see
+/// `uninstall_agent`'s doc comment) — there's no user content to preserve.
 pub fn install_agent(root: &Path, tool: AgentTool) -> Result<bool, String> {
     let mut changed = false;
 
     if let Some(dir) = tool.skill_dir(root) {
         let skill_path = dir.join("SKILL.md");
-        if !skill_path.exists() {
+        let skill_content = skill_md_content(tool);
+        let needs_write = fs::read_to_string(&skill_path)
+            .map(|existing| existing != skill_content)
+            .unwrap_or(true);
+        if needs_write {
             fs::create_dir_all(&dir)
                 .map_err(|e| format!("Failed to create {}: {e}", dir.display()))?;
-            fs::write(&skill_path, skill_md_content(tool))
+            fs::write(&skill_path, skill_content)
                 .map_err(|e| format!("Failed to write {}: {e}", skill_path.display()))?;
             changed = true;
         }
     }
 
-    if let Some(path) = tool.command_path(root)
-        && !path.exists()
-    {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+    if let Some(path) = tool.command_path(root) {
+        let command_content = create_spec_command_content(tool);
+        let needs_write = fs::read_to_string(&path)
+            .map(|existing| existing != command_content)
+            .unwrap_or(true);
+        if needs_write {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+            }
+            fs::write(&path, command_content)
+                .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+            changed = true;
         }
-        fs::write(&path, create_spec_command_content(tool))
-            .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
-        changed = true;
     }
 
     Ok(changed)
@@ -630,6 +644,42 @@ mod tests {
             assert!(install_agent(tmp.path(), *target).unwrap());
             assert!(!install_agent(tmp.path(), *target).unwrap());
         }
+    }
+
+    #[test]
+    fn install_overwrites_stale_skill_content() {
+        let tmp = setup();
+        let skill_path = tmp.path().join(".claude/skills/spec-sync/SKILL.md");
+        fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+        fs::write(&skill_path, "stale content from an older spec-sync version").unwrap();
+
+        assert!(install_agent(tmp.path(), AgentTool::Claude).unwrap());
+
+        let content = fs::read_to_string(&skill_path).unwrap();
+        assert!(content.starts_with("---\nname: spec-sync"));
+        assert!(!content.contains("stale content"));
+    }
+
+    #[test]
+    fn install_overwrites_stale_command_content() {
+        let tmp = setup();
+        let command_path = tmp.path().join(".claude/commands/specsync/create-spec.md");
+        fs::create_dir_all(command_path.parent().unwrap()).unwrap();
+        fs::write(&command_path, "stale command body").unwrap();
+
+        assert!(install_agent(tmp.path(), AgentTool::Claude).unwrap());
+
+        let content = fs::read_to_string(&command_path).unwrap();
+        assert!(content.contains("$ARGUMENTS"));
+        assert!(!content.contains("stale command body"));
+    }
+
+    #[test]
+    fn install_does_not_rewrite_unchanged_content() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Claude).unwrap();
+        // Second install: content is identical, so nothing should be rewritten.
+        assert!(!install_agent(tmp.path(), AgentTool::Claude).unwrap());
     }
 
     // ── uninstall_agent ──────────────────────────────────────────────

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,0 +1,694 @@
+use colored::Colorize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// ─── Shared instruction body ─────────────────────────────────────────────────
+//
+// This is a standalone copy of the workflow prose also found (in slightly
+// different phrasing) in hooks.rs's CLAUDE_MD_SNIPPET/AGENTS_MD_SNIPPET. It is
+// duplicated rather than shared because hooks.rs's four snippets are not
+// identical to each other (Cursor/Copilot use a terser style) and unifying
+// them is out of scope here — this body is purely for the new SKILL.md files.
+
+const SKILL_BODY: &str = r#"## Companion files
+
+Each spec in `specs/<module>/` has companion files — read them before working, update them after:
+
+- **`tasks.md`** — Work items for this module. Check off tasks (`- [x]`) as you complete them. Add new tasks if you discover work needed.
+- **`requirements.md`** — Acceptance criteria and user stories. These are permanent invariants, not tasks — do not check them off. Update if requirements change.
+- **`context.md`** — Architectural decisions, key files, and current status. Update when you make design decisions or change what's in progress.
+- **`testing.md`** — Test strategy: automated test locations, manual QA checklists, and edge cases/boundary conditions.
+- **`design.md`** *(opt-in)* — Layout, component hierarchy, design tokens, and asset references. Present when `companions.design` is enabled in config.
+
+## Before modifying any module
+
+1. Read the relevant spec in `specs/<module>/<module>.spec.md`
+2. Read companion files: `tasks.md`, `requirements.md`, `context.md`, `testing.md`, and `design.md` (if present)
+3. After changes, run `specsync check` to verify specs still pass
+
+## After completing work
+
+1. Mark completed items in `tasks.md` — check off finished tasks, add new ones discovered
+2. Update `context.md` — record decisions made, update current status
+3. If requirements changed, update `requirements.md` acceptance criteria
+4. If test coverage changed, update `testing.md` with new test files or edge cases
+5. If UI/layout changed, update `design.md` with revised layout, components, or tokens
+
+## Before creating a PR
+
+Run `specsync check --strict` — all specs must pass with zero warnings.
+
+## When adding new modules
+
+Run `specsync scaffold <module-name>` to create a spec, companion files, a registry
+entry, and auto-detected source files — or `specsync new <module-name>` for a
+minimal spec-only draft. Complete the spec before writing code. The
+`/specsync:create-spec` command (or tool-equivalent) runs this for you, and
+accepts either a bare module name or a natural-language feature description
+(e.g. `/specsync:create-spec "I want a feature that lets users export their
+data as CSV"`) — pass a description and it will pick a module name and use
+the description to draft the spec's Purpose and Requirements.
+
+## Key commands
+
+- `specsync check` — validate all specs against source code
+- `specsync check --json` — machine-readable validation output
+- `specsync coverage` — show which modules lack specs
+- `specsync score` — quality score for each spec (0-100)
+- `specsync scaffold <name>` — full scaffold: spec + companions + registry entry + source detection
+- `specsync new <name>` — quick-create a minimal spec (add `--full` for companions)
+- `specsync resolve --remote` — verify cross-project dependencies
+"#;
+
+// ─── Create-spec command body (shared prose, per-tool argument syntax) ───────
+
+const CREATE_SPEC_STEPS_MD: &str = r#"1. Parse the arguments above: the first whitespace-separated token is the
+   module name. If the arguments also contain `--minimal` (in any position),
+   remove it and remember that minimal mode was requested.
+2. Look at whatever text remains. It will be one of:
+   - **A bare module name** — a short identifier like `auth-service` or
+     `billing`. Use it as-is.
+   - **A free-text feature description** — a sentence or phrase describing
+     what to build, e.g. `"I want a feature that lets users export their
+     data as CSV"`. In this case, invent a short, kebab-case module name that
+     captures the idea (e.g. `csv-export`). If the right name is ambiguous,
+     ask the user to confirm or rename it before continuing. Keep the full
+     description at hand — you'll use it in step 5.
+3. If minimal mode was requested, run:
+   ```
+   specsync new <module-name>
+   ```
+   This creates a minimal spec only (no companion files).
+4. Otherwise (default), run:
+   ```
+   specsync scaffold <module-name>
+   ```
+   This creates the spec, companion files (`tasks.md`, `requirements.md`,
+   `context.md`, `testing.md`, and `design.md` if `companions.design` is
+   enabled), a registry entry, and auto-detects related source files.
+5. Open the newly created `specs/<module-name>/<module-name>.spec.md` and fill
+   in the `Purpose`, `Requirements`, and `Public API` sections. If a free-text
+   description was given in step 2, use it directly to draft these sections —
+   ask clarifying questions if it's underspecified, but do not leave the
+   sections as unfilled placeholder text. Do the same for `requirements.md`
+   (acceptance criteria) and `tasks.md` (initial task breakdown), if present.
+6. Run `specsync check` to confirm the new spec passes validation."#;
+
+const CREATE_SPEC_STEPS_TOML: &str = r#"1. Parse the arguments above: the first whitespace-separated token is the
+   module name. If the arguments also contain --minimal (in any position),
+   remove it and remember that minimal mode was requested.
+2. Look at whatever text remains. It will be one of:
+   - A bare module name - a short identifier like auth-service or billing.
+     Use it as-is.
+   - A free-text feature description - a sentence or phrase describing what
+     to build, e.g. "I want a feature that lets users export their data as
+     CSV". In this case, invent a short, kebab-case module name that captures
+     the idea (e.g. csv-export). If the right name is ambiguous, ask the user
+     to confirm or rename it before continuing. Keep the full description at
+     hand - you'll use it in step 5.
+3. If minimal mode was requested, run:
+   specsync new <module-name>
+   This creates a minimal spec only (no companion files).
+4. Otherwise (default), run:
+   specsync scaffold <module-name>
+   This creates the spec, companion files (tasks.md, requirements.md,
+   context.md, testing.md, and design.md if companions.design is enabled),
+   a registry entry, and auto-detects related source files.
+5. Open the newly created specs/<module-name>/<module-name>.spec.md and fill
+   in the Purpose, Requirements, and Public API sections. If a free-text
+   description was given in step 2, use it directly to draft these sections -
+   ask clarifying questions if it's underspecified, but do not leave the
+   sections as unfilled placeholder text. Do the same for requirements.md
+   (acceptance criteria) and tasks.md (initial task breakdown), if present.
+6. Run specsync check to confirm the new spec passes validation."#;
+
+const CREATE_SPEC_DESCRIPTION: &str = "Scaffold a new spec-sync module spec from a module name or a natural-language feature description (full scaffold by default, or minimal with --minimal)";
+
+const SKILL_TRIGGER_DESCRIPTION: &str = "Keep markdown module specs in specs/<module>/ synchronized with source code using spec-sync. Use this whenever creating, editing, or reviewing code in a module that has (or should have) a spec, or whenever the user mentions specs, spec-sync, companion files (tasks.md/requirements.md/context.md/testing.md/design.md), or asks to add/update a module's documentation.";
+
+/// AI coding tools that receive native skill/command file installation, as
+/// opposed to the prose-instruction-file hooks in `hooks.rs`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AgentTool {
+    Claude,
+    Cursor,
+    Codex,
+    Gemini,
+}
+
+impl AgentTool {
+    pub fn all() -> &'static [AgentTool] {
+        &[
+            AgentTool::Claude,
+            AgentTool::Cursor,
+            AgentTool::Codex,
+            AgentTool::Gemini,
+        ]
+    }
+
+    #[allow(dead_code)]
+    pub fn name(&self) -> &'static str {
+        match self {
+            AgentTool::Claude => "claude",
+            AgentTool::Cursor => "cursor",
+            AgentTool::Codex => "codex",
+            AgentTool::Gemini => "gemini",
+        }
+    }
+
+    pub fn description(&self) -> &'static str {
+        match self {
+            AgentTool::Claude => "Claude Code skill + /specsync:create-spec command",
+            AgentTool::Cursor => "Cursor skill + /specsync-create-spec command",
+            AgentTool::Codex => "Codex CLI skill (project-scoped)",
+            AgentTool::Gemini => "Gemini CLI /specsync:create-spec command",
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "claude" => Some(AgentTool::Claude),
+            "cursor" => Some(AgentTool::Cursor),
+            "codex" => Some(AgentTool::Codex),
+            "gemini" => Some(AgentTool::Gemini),
+            _ => None,
+        }
+    }
+
+    /// Directory (relative to project root) containing this tool's skill
+    /// folder, e.g. `.claude/skills/spec-sync/`. `None` if this tool has no
+    /// skill mechanism (Gemini).
+    fn skill_dir(&self, root: &Path) -> Option<PathBuf> {
+        match self {
+            AgentTool::Claude => Some(root.join(".claude").join("skills").join("spec-sync")),
+            AgentTool::Cursor => Some(root.join(".cursor").join("skills").join("spec-sync")),
+            AgentTool::Codex => Some(root.join(".codex").join("skills").join("spec-sync")),
+            AgentTool::Gemini => None,
+        }
+    }
+
+    /// Full path to this tool's `create-spec` command file. `None` if this
+    /// tool has no project-local command mechanism (Codex).
+    fn command_path(&self, root: &Path) -> Option<PathBuf> {
+        match self {
+            AgentTool::Claude => Some(
+                root.join(".claude")
+                    .join("commands")
+                    .join("specsync")
+                    .join("create-spec.md"),
+            ),
+            AgentTool::Cursor => Some(
+                root.join(".cursor")
+                    .join("commands")
+                    .join("specsync-create-spec.md"),
+            ),
+            AgentTool::Gemini => Some(
+                root.join(".gemini")
+                    .join("commands")
+                    .join("specsync")
+                    .join("create-spec.toml"),
+            ),
+            AgentTool::Codex => None,
+        }
+    }
+}
+
+/// True if every artifact this tool should have (skill dir and/or command
+/// file) already exists.
+pub fn is_installed(root: &Path, tool: AgentTool) -> bool {
+    let skill_ok = match tool.skill_dir(root) {
+        Some(dir) => dir.join("SKILL.md").exists(),
+        None => true,
+    };
+    let command_ok = match tool.command_path(root) {
+        Some(path) => path.exists(),
+        None => true,
+    };
+    skill_ok && command_ok
+}
+
+/// Install skill + command files for one tool. Returns Ok(true) if anything
+/// was written, Ok(false) if everything was already present.
+pub fn install_agent(root: &Path, tool: AgentTool) -> Result<bool, String> {
+    let mut changed = false;
+
+    if let Some(dir) = tool.skill_dir(root) {
+        let skill_path = dir.join("SKILL.md");
+        if !skill_path.exists() {
+            fs::create_dir_all(&dir)
+                .map_err(|e| format!("Failed to create {}: {e}", dir.display()))?;
+            fs::write(&skill_path, skill_md_content(tool))
+                .map_err(|e| format!("Failed to write {}: {e}", skill_path.display()))?;
+            changed = true;
+        }
+    }
+
+    if let Some(path) = tool.command_path(root)
+        && !path.exists()
+    {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+        }
+        fs::write(&path, create_spec_command_content(tool))
+            .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+        changed = true;
+    }
+
+    Ok(changed)
+}
+
+/// Uninstall a tool's skill dir and/or command file. Returns Ok(true) if
+/// anything was removed, Ok(false) if nothing was present.
+///
+/// Safe by construction: these paths are dedicated files/directories that
+/// spec-sync fully owns (a `spec-sync/`-named skill folder, a
+/// `specsync`-namespaced command file), so removal never risks clobbering
+/// unrelated user content the way editing a shared file like CLAUDE.md would.
+pub fn uninstall_agent(root: &Path, tool: AgentTool) -> Result<bool, String> {
+    let mut removed = false;
+
+    if let Some(dir) = tool.skill_dir(root)
+        && dir.exists()
+    {
+        fs::remove_dir_all(&dir).map_err(|e| format!("Failed to remove {}: {e}", dir.display()))?;
+        removed = true;
+    }
+
+    if let Some(path) = tool.command_path(root)
+        && path.exists()
+    {
+        fs::remove_file(&path).map_err(|e| format!("Failed to remove {}: {e}", path.display()))?;
+        removed = true;
+
+        // Clean up the now-empty namespaced parent dir (e.g.
+        // .claude/commands/specsync/), but never touch a shared commands
+        // directory — Cursor's command is flat (directly inside
+        // .cursor/commands/, alongside any unrelated user commands), so
+        // only remove the parent when it's our own "specsync" namespace
+        // folder, not the tool's shared commands directory.
+        if let Some(parent) = path.parent() {
+            let is_our_namespace_dir =
+                parent.file_name().and_then(|n| n.to_str()) == Some("specsync");
+            if is_our_namespace_dir
+                && fs::read_dir(parent)
+                    .map(|mut it| it.next().is_none())
+                    .unwrap_or(false)
+            {
+                let _ = fs::remove_dir(parent);
+            }
+        }
+    }
+
+    Ok(removed)
+}
+
+// ─── Content builders ─────────────────────────────────────────────────────
+
+fn skill_md_content(_tool: AgentTool) -> String {
+    format!(
+        "---\nname: spec-sync\ndescription: {SKILL_TRIGGER_DESCRIPTION}\n---\n\n# Spec-Sync Workflow\n\nThis project uses [spec-sync](https://github.com/CorvidLabs/spec-sync) for bidirectional spec-to-code validation. Specs live in `specs/<module>/<module>.spec.md`.\n\n{SKILL_BODY}",
+    )
+}
+
+fn create_spec_command_content(tool: AgentTool) -> String {
+    match tool {
+        AgentTool::Claude => claude_create_spec_md(),
+        AgentTool::Cursor => cursor_create_spec_md(),
+        AgentTool::Gemini => gemini_create_spec_toml(),
+        AgentTool::Codex => unreachable!("Codex has no command file"),
+    }
+}
+
+fn claude_create_spec_md() -> String {
+    format!(
+        "---\ndescription: {CREATE_SPEC_DESCRIPTION}\nargument-hint: <module-name-or-description> [--minimal]\n---\n\nCreate a new spec-sync module spec.\n\nArguments: `$ARGUMENTS`\n\n{CREATE_SPEC_STEPS_MD}\n",
+    )
+}
+
+fn cursor_create_spec_md() -> String {
+    format!(
+        "Create a new spec-sync module spec.\n\nArguments: $ARGUMENTS\n\n{CREATE_SPEC_STEPS_MD}\n",
+    )
+}
+
+fn gemini_create_spec_toml() -> String {
+    format!(
+        "description = \"{CREATE_SPEC_DESCRIPTION}\"\n\nprompt = \"\"\"\nCreate a new spec-sync module spec.\n\nArguments: {{{{args}}}}\n\n{CREATE_SPEC_STEPS_TOML}\n\"\"\"\n",
+    )
+}
+
+// ─── CLI command handlers ────────────────────────────────────────────────────
+
+/// Install agent integrations for the specified tools (or all if empty).
+pub fn cmd_install(root: &Path, targets: &[AgentTool]) {
+    let targets = if targets.is_empty() {
+        AgentTool::all().to_vec()
+    } else {
+        targets.to_vec()
+    };
+
+    println!(
+        "\n--- {} ------------------------------------------------",
+        "Installing Agent Integrations".bold()
+    );
+
+    let mut installed = 0;
+    let mut skipped = 0;
+    let mut errors = 0;
+
+    for target in &targets {
+        match install_agent(root, *target) {
+            Ok(true) => {
+                println!("  {} Installed {}", "✓".green(), target.description());
+                installed += 1;
+            }
+            Ok(false) => {
+                println!(
+                    "  {} Already installed: {}",
+                    "·".dimmed(),
+                    target.description()
+                );
+                skipped += 1;
+            }
+            Err(e) => {
+                println!("  {} {}: {e}", "✗".red(), target.description());
+                errors += 1;
+            }
+        }
+    }
+
+    println!();
+    if installed > 0 {
+        println!("{installed} tool(s) installed.");
+    }
+    if skipped > 0 {
+        println!("{skipped} tool(s) already present.");
+    }
+    if errors > 0 {
+        println!("{errors} tool(s) failed.");
+        std::process::exit(1);
+    }
+}
+
+/// Uninstall agent integrations for the specified tools (or all if empty).
+pub fn cmd_uninstall(root: &Path, targets: &[AgentTool]) {
+    let targets = if targets.is_empty() {
+        AgentTool::all().to_vec()
+    } else {
+        targets.to_vec()
+    };
+
+    println!(
+        "\n--- {} ------------------------------------------------",
+        "Uninstalling Agent Integrations".bold()
+    );
+
+    let mut removed = 0;
+
+    for target in &targets {
+        match uninstall_agent(root, *target) {
+            Ok(true) => {
+                println!("  {} Removed {}", "✓".green(), target.description());
+                removed += 1;
+            }
+            Ok(false) => {
+                println!("  {} Not installed: {}", "·".dimmed(), target.description());
+            }
+            Err(e) => {
+                println!("  {} {}: {e}", "!".yellow(), target.description());
+            }
+        }
+    }
+
+    println!();
+    if removed > 0 {
+        println!("{removed} tool(s) removed.");
+    } else {
+        println!("No agent integrations to remove.");
+    }
+}
+
+/// Show installation status of all agent tools.
+pub fn cmd_status(root: &Path) {
+    println!(
+        "\n--- {} ------------------------------------------------",
+        "Agent Integration Status".bold()
+    );
+
+    for target in AgentTool::all() {
+        let installed = is_installed(root, *target);
+        let status = if installed {
+            "installed".green().to_string()
+        } else {
+            "not installed".dimmed().to_string()
+        };
+        println!("  {:45} {}", target.description(), status);
+    }
+
+    println!();
+    println!("Install all: specsync agents install");
+    println!("Install one: specsync agents install --claude --gemini");
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    // ── AgentTool::all / name / from_str ───────────────────────────
+
+    #[test]
+    fn agent_tool_all_returns_four_targets() {
+        assert_eq!(AgentTool::all().len(), 4);
+    }
+
+    #[test]
+    fn agent_tool_all_contains_all_variants() {
+        let all = AgentTool::all();
+        assert!(all.contains(&AgentTool::Claude));
+        assert!(all.contains(&AgentTool::Cursor));
+        assert!(all.contains(&AgentTool::Codex));
+        assert!(all.contains(&AgentTool::Gemini));
+    }
+
+    #[test]
+    fn agent_tool_name_returns_expected_strings() {
+        assert_eq!(AgentTool::Claude.name(), "claude");
+        assert_eq!(AgentTool::Cursor.name(), "cursor");
+        assert_eq!(AgentTool::Codex.name(), "codex");
+        assert_eq!(AgentTool::Gemini.name(), "gemini");
+    }
+
+    #[test]
+    fn from_str_parses_all_targets() {
+        assert_eq!(AgentTool::from_str("claude"), Some(AgentTool::Claude));
+        assert_eq!(AgentTool::from_str("cursor"), Some(AgentTool::Cursor));
+        assert_eq!(AgentTool::from_str("codex"), Some(AgentTool::Codex));
+        assert_eq!(AgentTool::from_str("gemini"), Some(AgentTool::Gemini));
+    }
+
+    #[test]
+    fn from_str_is_case_insensitive() {
+        assert_eq!(AgentTool::from_str("CLAUDE"), Some(AgentTool::Claude));
+        assert_eq!(AgentTool::from_str("Gemini"), Some(AgentTool::Gemini));
+    }
+
+    #[test]
+    fn from_str_returns_none_for_unknown() {
+        assert_eq!(AgentTool::from_str("unknown"), None);
+        assert_eq!(AgentTool::from_str(""), None);
+        assert_eq!(AgentTool::from_str("windsurf"), None);
+    }
+
+    // ── path correctness ────────────────────────────────────────────
+
+    #[test]
+    fn claude_paths_are_correct() {
+        let tmp = setup();
+        assert_eq!(
+            AgentTool::Claude.skill_dir(tmp.path()).unwrap(),
+            tmp.path().join(".claude/skills/spec-sync")
+        );
+        assert_eq!(
+            AgentTool::Claude.command_path(tmp.path()).unwrap(),
+            tmp.path().join(".claude/commands/specsync/create-spec.md")
+        );
+    }
+
+    #[test]
+    fn cursor_command_path_is_flat() {
+        let tmp = setup();
+        assert_eq!(
+            AgentTool::Cursor.command_path(tmp.path()).unwrap(),
+            tmp.path().join(".cursor/commands/specsync-create-spec.md")
+        );
+    }
+
+    #[test]
+    fn codex_has_no_command_path() {
+        let tmp = setup();
+        assert!(AgentTool::Codex.command_path(tmp.path()).is_none());
+        assert!(AgentTool::Codex.skill_dir(tmp.path()).is_some());
+    }
+
+    #[test]
+    fn gemini_has_no_skill_path() {
+        let tmp = setup();
+        assert!(AgentTool::Gemini.skill_dir(tmp.path()).is_none());
+        assert!(AgentTool::Gemini.command_path(tmp.path()).is_some());
+    }
+
+    // ── is_installed ───────────────────────────────────────────────
+
+    #[test]
+    fn is_installed_returns_false_for_empty_dir() {
+        let tmp = setup();
+        for target in AgentTool::all() {
+            assert!(!is_installed(tmp.path(), *target));
+        }
+    }
+
+    // ── install_agent ───────────────────────────────────────────────
+
+    #[test]
+    fn install_claude_creates_skill_and_command() {
+        let tmp = setup();
+        assert!(install_agent(tmp.path(), AgentTool::Claude).unwrap());
+
+        let skill =
+            fs::read_to_string(tmp.path().join(".claude/skills/spec-sync/SKILL.md")).unwrap();
+        assert!(skill.starts_with("---\nname: spec-sync"));
+        assert!(skill.contains("tasks.md"));
+        assert!(skill.contains("specsync check"));
+
+        let command =
+            fs::read_to_string(tmp.path().join(".claude/commands/specsync/create-spec.md"))
+                .unwrap();
+        assert!(command.starts_with("---\ndescription:"));
+        assert!(command.contains("$ARGUMENTS"));
+        assert!(command.contains("specsync scaffold"));
+        assert!(command.contains("specsync new"));
+
+        assert!(is_installed(tmp.path(), AgentTool::Claude));
+    }
+
+    #[test]
+    fn install_cursor_command_has_no_frontmatter() {
+        let tmp = setup();
+        assert!(install_agent(tmp.path(), AgentTool::Cursor).unwrap());
+        let command =
+            fs::read_to_string(tmp.path().join(".cursor/commands/specsync-create-spec.md"))
+                .unwrap();
+        assert!(!command.starts_with("---"));
+        assert!(command.contains("$ARGUMENTS"));
+    }
+
+    #[test]
+    fn install_codex_creates_skill_only() {
+        let tmp = setup();
+        assert!(install_agent(tmp.path(), AgentTool::Codex).unwrap());
+        assert!(tmp.path().join(".codex/skills/spec-sync/SKILL.md").exists());
+        assert!(!tmp.path().join(".codex/commands").exists());
+        assert!(is_installed(tmp.path(), AgentTool::Codex));
+    }
+
+    #[test]
+    fn install_gemini_creates_command_only() {
+        let tmp = setup();
+        assert!(install_agent(tmp.path(), AgentTool::Gemini).unwrap());
+        assert!(!tmp.path().join(".gemini/skills").exists());
+
+        let path = tmp
+            .path()
+            .join(".gemini/commands/specsync/create-spec.toml");
+        assert!(path.exists());
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("prompt = \"\"\""));
+        assert!(content.contains("description ="));
+        assert!(content.contains("{{args}}"));
+        // Triple-quoted block must be balanced.
+        assert_eq!(content.matches("\"\"\"").count(), 2);
+
+        assert!(is_installed(tmp.path(), AgentTool::Gemini));
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        let tmp = setup();
+        for target in AgentTool::all() {
+            assert!(install_agent(tmp.path(), *target).unwrap());
+            assert!(!install_agent(tmp.path(), *target).unwrap());
+        }
+    }
+
+    // ── uninstall_agent ──────────────────────────────────────────────
+
+    #[test]
+    fn uninstall_returns_false_when_not_installed() {
+        let tmp = setup();
+        for target in AgentTool::all() {
+            assert!(!uninstall_agent(tmp.path(), *target).unwrap());
+        }
+    }
+
+    #[test]
+    fn uninstall_claude_removes_skill_and_command() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Claude).unwrap();
+        assert!(uninstall_agent(tmp.path(), AgentTool::Claude).unwrap());
+        assert!(!tmp.path().join(".claude/skills/spec-sync").exists());
+        assert!(!tmp.path().join(".claude/commands/specsync").exists());
+        assert!(!is_installed(tmp.path(), AgentTool::Claude));
+    }
+
+    #[test]
+    fn uninstall_preserves_sibling_commands() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Claude).unwrap();
+        let sibling = tmp.path().join(".claude/commands/other-command.md");
+        fs::write(&sibling, "unrelated command").unwrap();
+
+        assert!(uninstall_agent(tmp.path(), AgentTool::Claude).unwrap());
+
+        assert!(!tmp.path().join(".claude/commands/specsync").exists());
+        assert!(tmp.path().join(".claude/commands").exists());
+        assert!(sibling.exists());
+    }
+
+    #[test]
+    fn uninstall_cursor_flat_file_does_not_touch_commands_dir() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Cursor).unwrap();
+        assert!(uninstall_agent(tmp.path(), AgentTool::Cursor).unwrap());
+        assert!(
+            !tmp.path()
+                .join(".cursor/commands/specsync-create-spec.md")
+                .exists()
+        );
+        assert!(tmp.path().join(".cursor/commands").exists());
+    }
+
+    #[test]
+    fn uninstall_gemini_removes_command_only() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Gemini).unwrap();
+        assert!(uninstall_agent(tmp.path(), AgentTool::Gemini).unwrap());
+        assert!(!tmp.path().join(".gemini/commands/specsync").exists());
+    }
+
+    #[test]
+    fn uninstall_codex_removes_skill_only() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Codex).unwrap();
+        assert!(uninstall_agent(tmp.path(), AgentTool::Codex).unwrap());
+        assert!(!tmp.path().join(".codex/skills/spec-sync").exists());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,6 +170,11 @@ pub enum Command {
         #[command(subcommand)]
         action: HooksAction,
     },
+    /// Manage native skill/slash-command files for AI coding tools (Claude Code, Cursor, Codex, Gemini CLI)
+    Agents {
+        #[command(subcommand)]
+        action: AgentsAction,
+    },
     /// Compact changelog entries in spec files to prevent unbounded growth
     Compact {
         /// Keep the last N changelog entries (default: 10)
@@ -410,6 +415,42 @@ pub enum HooksAction {
         claude_code_hook: bool,
     },
     /// Show installation status of all hooks
+    Status,
+}
+
+#[derive(Subcommand)]
+pub enum AgentsAction {
+    /// Install native skill/command files for AI coding tools
+    Install {
+        /// Install Claude Code skill + /specsync:create-spec command
+        #[arg(long)]
+        claude: bool,
+        /// Install Cursor skill + /specsync-create-spec command
+        #[arg(long)]
+        cursor: bool,
+        /// Install Codex CLI skill (project-scoped, .codex/skills/)
+        #[arg(long)]
+        codex: bool,
+        /// Install Gemini CLI /specsync:create-spec command
+        #[arg(long)]
+        gemini: bool,
+    },
+    /// Remove previously installed skill/command files
+    Uninstall {
+        /// Remove Claude Code skill + command
+        #[arg(long)]
+        claude: bool,
+        /// Remove Cursor skill + command
+        #[arg(long)]
+        cursor: bool,
+        /// Remove Codex CLI skill
+        #[arg(long)]
+        codex: bool,
+        /// Remove Gemini CLI command
+        #[arg(long)]
+        gemini: bool,
+    },
+    /// Show installation status of all agent tools
     Status,
 }
 

--- a/src/commands/agents.rs
+++ b/src/commands/agents.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use crate::agents;
+use crate::cli::AgentsAction;
+
+pub fn cmd_agents(root: &Path, action: AgentsAction) {
+    match action {
+        AgentsAction::Install {
+            claude,
+            cursor,
+            codex,
+            gemini,
+        } => {
+            let targets = collect_agent_targets(claude, cursor, codex, gemini);
+            agents::cmd_install(root, &targets);
+        }
+        AgentsAction::Uninstall {
+            claude,
+            cursor,
+            codex,
+            gemini,
+        } => {
+            let targets = collect_agent_targets(claude, cursor, codex, gemini);
+            agents::cmd_uninstall(root, &targets);
+        }
+        AgentsAction::Status => agents::cmd_status(root),
+    }
+}
+
+fn collect_agent_targets(
+    claude: bool,
+    cursor: bool,
+    codex: bool,
+    gemini: bool,
+) -> Vec<agents::AgentTool> {
+    let mut targets = Vec::new();
+    if claude {
+        targets.push(agents::AgentTool::Claude);
+    }
+    if cursor {
+        targets.push(agents::AgentTool::Cursor);
+    }
+    if codex {
+        targets.push(agents::AgentTool::Codex);
+    }
+    if gemini {
+        targets.push(agents::AgentTool::Gemini);
+    }
+    // If no specific targets, empty vec means "all"
+    targets
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agents;
 pub mod archive_tasks;
 pub mod changelog;
 pub mod check;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agents;
 mod ai;
 mod archive;
 mod changelog;
@@ -169,6 +170,7 @@ fn run() {
         } => commands::resolve::cmd_resolve(&root, remote || verify, verify, cache_ttl),
         Command::Diff { base } => commands::diff::cmd_diff(&root, &base, format),
         Command::Hooks { action } => commands::hooks::cmd_hooks(&root, action),
+        Command::Agents { action } => commands::agents::cmd_agents(&root, action),
         Command::Compact { keep, dry_run } => commands::compact::cmd_compact(&root, keep, dry_run),
         Command::ArchiveTasks { dry_run } => {
             commands::archive_tasks::cmd_archive_tasks(&root, dry_run)


### PR DESCRIPTION
## Summary

- Adds `specsync agents install`/`uninstall`/`status` — native, tool-owned integrations for Claude Code, Cursor, Codex, and Gemini CLI, distinct from the prose-instruction-file mechanism `specsync hooks install` already provides for `CLAUDE.md`/`.cursorrules`/`AGENTS.md`/Copilot.
- Ships a `SKILL.md` each tool auto-discovers (Claude, Cursor, Codex, Gemini) and a `/specsync:create-spec` slash command (`/specsync-create-spec` on Cursor) for Claude, Cursor, and Gemini — Codex's command mechanism is deprecated and global-only (`~/.codex/prompts/`), so it gets the skill only, keeping spec-sync's existing rule of never writing outside the project root.
- `create-spec` accepts either a bare module name or a natural-language feature description (e.g. `/specsync:create-spec "I want a feature that lets users export their data as CSV"`), defaults to a full scaffold (spec + companion files via `specsync scaffold`), and supports `--minimal` for a spec-only draft via `specsync new`.
- Per-tool mechanics were verified against each tool's actual behavior rather than assumed: OpenSpec's real adapter source (`Fission-AI/OpenSpec`) was pulled directly to cross-check the design, which caught that Gemini CLI now ships real `SKILL.md` support (added in 2026) — Gemini gets a skill, not just a command. Cursor's lack of command frontmatter was independently confirmed against Cursor's own docs (Cursor commands don't support YAML frontmatter, unlike what OpenSpec's own adapter writes).
- Dogfoods spec-sync on itself: added `specs/agents/` and `specs/cmd_agents/` (spec + companion files, both score A/100) and updated the `cli_args`/`commands` specs for the new CLI surface — `specsync check --strict` passes clean (60/60 specs, 0 warnings, 100% file/LOC coverage).

## Changes

- `src/agents.rs` (new) — `AgentTool` enum, per-tool skill/command path routing, install/uninstall/status logic, content builders, 22 unit tests
- `src/commands/agents.rs` (new) — CLI dispatcher, mirrors `src/commands/hooks.rs`
- `src/cli.rs` — new `Command::Agents` variant + `AgentsAction` enum (`Install`/`Uninstall`/`Status`, one bool flag per tool, mirrors `HooksAction`)
- `src/main.rs`, `src/commands/mod.rs` — module registration and routing
- `specs/agents/`, `specs/cmd_agents/` (new), `specs/cli_args/cli_args.spec.md`, `specs/commands/commands.spec.md` — spec coverage for the new modules
- `AGENTS.md`, `README.md`, `CHANGELOG.md` — documentation

## Checklist

- [x] `cargo test` passes (797/797, including 22 new tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] Documentation updated (`AGENTS.md`, `README.md`, `CHANGELOG.md`)
- [x] Spec files updated — `specs/agents/`, `specs/cmd_agents/` added; `cli_args`/`commands` specs updated; `specsync check --strict` passes clean
- [x] Added/updated tests for new functionality

## Testing

Manual smoke test in a scratch directory (see PR discussion/session for full transcript):
- `specsync agents install` on a clean dir creates all 8 artifacts (skill + command for Claude/Cursor/Gemini, skill only for Codex)
- Simulated the `create-spec` command's instructions end-to-end: `specsync scaffold csv-export` (full) and `specsync new billing` (`--minimal` path) both produce the expected files
- `specsync agents uninstall` removes only spec-sync-owned files/dirs, verified a sibling `.claude/commands/other-command.md` survives
- `specsync agents status` correctly reflects installed/not-installed state before and after
- `specsync check --strict` — 60/60 specs pass, 0 warnings, 100% file/LOC coverage
- `specsync score agents cmd_agents` — both A/100
- Re-ran `cargo build --release`, `cargo clippy -- -D warnings`, `cargo fmt --check`, and the full test suite clean after each round of changes
