### PR TITLE
chore: release v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.6.0] - 2026-07-01
+
 ### Added
 
-- **`specsync agents install`/`uninstall`/`status`** — native skill and slash-command integrations for Claude Code, Cursor, Codex, and Gemini CLI, distinct from the prose-instruction-file mechanism `specsync hooks install` already provides. Installs a `SKILL.md` the tool auto-discovers (all four tools) and a `/specsync:create-spec` slash command (`/specsync-create-spec` on Cursor; Claude, Cursor, and Gemini — Codex's command mechanism is deprecated and global-only, so it gets the skill only). `create-spec` accepts either a bare module name or a natural-language feature description (e.g. `/specsync:create-spec "I want a feature that lets users export their data as CSV"`), defaults to a full scaffold (spec + companion files), and supports `--minimal` to create a spec-only draft instead.
+- **`specsync agents install`/`uninstall`/`status`** — native skill and slash-command integrations for Claude Code, Cursor, Codex, and Gemini CLI, distinct from the prose-instruction-file mechanism `specsync hooks install` already provides. Installs a `SKILL.md` the tool auto-discovers (all four tools) and a `/specsync:create-spec` slash command (`/specsync-create-spec` on Cursor; Claude, Cursor, and Gemini — Codex's command mechanism is deprecated and global-only, so it gets the skill only). `create-spec` accepts either a bare module name or a natural-language feature description (e.g. `/specsync:create-spec "I want a feature that lets users export their data as CSV"`), defaults to a full scaffold (spec + companion files), and supports `--minimal` to create a spec-only draft instead. Re-running `install` also refreshes any already-installed skill/command file whose content has drifted from the current template, so upgrading spec-sync updates existing installations instead of leaving them stale.
 
 ## [4.5.0] - 2026-06-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.5.0"
+version = "4.6.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.5.0"
+version = "4.6.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
## Summary

- Version bump for the release that includes #291 (`specsync agents` — native skill/slash-command installation for Claude Code, Cursor, Codex, Gemini CLI).
- `4.5.0` → `4.6.0` (minor bump — purely additive, backward-compatible feature, matching this project's own precedent for v4.4.0).

## Changes

- `Cargo.toml` — version bump
- `Cargo.lock` — regenerated for the version bump
- `CHANGELOG.md` — moved the `[Unreleased]` entry into a new `## [4.6.0] - 2026-07-01` section

## Checklist

- [x] `cargo test` passes (800/800)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied
- [x] `specsync check --strict` passes (60/60 specs, 0 warnings, 100% coverage)

## Testing

Ran the full local verification suite after the version/changelog edit: `cargo build`, `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`, `specsync check --strict` — all clean.

Once this merges, I'll create and push the `v4.6.0` tag, which triggers `.github/workflows/release.yml` to build the release binaries and publish the GitHub Release.


---
_Generated by [Claude Code](https://claude.ai/code/session_016dHgbYX28UMtQTRVFJiRgW)_