### PR TITLE
Fix: incremental check re-validates on schema/config change (High: false-PASS)

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -22,6 +22,37 @@ use super::{
     filter_by_status, filter_specs, load_and_discover, run_validation,
 };
 
+/// Files whose contents affect validation globally rather than through a single
+/// spec's frontmatter: the resolved config file and every file in the schema
+/// directory. A change to any of these must invalidate the unchanged-skip —
+/// otherwise a migration that drops a documented column, or a newly-added
+/// custom rule, is silently skipped on the default incremental `check` path
+/// (a false-PASS) and only surfaces under `--force`.
+fn global_validation_inputs(root: &Path, config: &types::SpecSyncConfig) -> Vec<String> {
+    let normalize = |p: &Path| -> String {
+        p.strip_prefix(root)
+            .unwrap_or(p)
+            .to_string_lossy()
+            .replace('\\', "/")
+    };
+    let mut inputs: Vec<String> = Vec::new();
+    if let Some(cfg) = &config.config_path {
+        inputs.push(normalize(cfg));
+    }
+    if let Some(dir) = &config.schema_dir
+        && let Ok(entries) = fs::read_dir(root.join(dir))
+    {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                inputs.push(normalize(&path));
+            }
+        }
+    }
+    inputs.sort();
+    inputs
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_check(
     root: &Path,
@@ -124,6 +155,9 @@ pub fn cmd_check(
 
     // Load hash cache and classify changes for each spec.
     let mut cache = hash_cache::HashCache::load(root);
+    // Config + schema files affect validation globally (not via one spec's
+    // frontmatter), so track them separately from per-spec hashes.
+    let global_inputs = global_validation_inputs(root, &config);
     let (specs_to_validate, change_classifications) = if force || strict || !spec_filters.is_empty()
     {
         (spec_files.clone(), Vec::new())
@@ -136,10 +170,19 @@ pub fn cmd_check(
         (spec_files.clone(), classifications)
     } else {
         let classifications = hash_cache::classify_all_changes(root, &spec_files, &cache);
-        let changed: Vec<PathBuf> = classifications
-            .iter()
-            .map(|c| c.spec_path.clone())
-            .collect();
+        let global_changed = global_inputs.iter().any(|p| cache.is_changed(root, p));
+        let changed: Vec<PathBuf> = if global_changed {
+            // A schema or config file changed since the cache was written — a
+            // spec whose own files are unchanged may still now be stale (e.g. a
+            // migration dropped a documented column, or a new custom rule was
+            // added). Re-validate everything rather than trust the stale skip.
+            spec_files.clone()
+        } else {
+            classifications
+                .iter()
+                .map(|c| c.spec_path.clone())
+                .collect()
+        };
         (changed, classifications)
     };
 
@@ -422,6 +465,11 @@ pub fn cmd_check(
     // run must never trust hashes recorded by a run that had findings.
     if total_errors == 0 {
         hash_cache::update_cache(root, &specs_to_validate, &mut cache);
+        // Record global inputs (config + schema files) so a later unchanged run
+        // can skip, and a future schema/config edit is detected as a change.
+        for input in &global_inputs {
+            cache.update(root, input);
+        }
         let _ = cache.save(root);
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5585,3 +5585,117 @@ fn warning_count_matches_printed_warning_lines() {
         "warning count must match printed ⚠ lines, got:\n{stdout}"
     );
 }
+
+#[test]
+fn incremental_check_detects_schema_drift_after_migration_edit() {
+    // Regression (H2): the default incremental `check` must re-validate when a
+    // schema/migration file changes, even if no spec's own files changed.
+    // Previously a migration that dropped a documented column was silently
+    // skipped ("nothing to validate") — a false-PASS only `--force` caught.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    // schemaDir + strict enforcement: a schema-column ERROR gates the exit code
+    // WITHOUT the --strict flag (which would itself bypass the cache we test).
+    fs::write(
+        root.join("specsync.json"),
+        r#"{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "schemaDir": "db/migrations",
+  "enforcement": "strict",
+  "requiredSections": ["Purpose", "Public API", "Invariants", "Behavioral Examples", "Error Cases", "Dependencies", "Change Log"],
+  "excludeDirs": ["__tests__"]
+}"#,
+    )
+    .unwrap();
+
+    // Source with no exports keeps Public API validation trivially clean.
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/msg.ts"), "const internal = 1;\n").unwrap();
+
+    // Migration initially defines both columns.
+    fs::create_dir_all(root.join("db/migrations")).unwrap();
+    let migration = root.join("db/migrations/001_init.sql");
+    fs::write(
+        &migration,
+        "CREATE TABLE messages (\n  id INTEGER PRIMARY KEY,\n  content TEXT NOT NULL\n);\n",
+    )
+    .unwrap();
+
+    // Spec documents both columns, so the first run is clean.
+    fs::create_dir_all(root.join("specs/msg")).unwrap();
+    fs::write(
+        root.join("specs/msg/msg.spec.md"),
+        r#"---
+module: msg
+version: 1
+status: active
+files:
+  - src/msg.ts
+db_tables:
+  - messages
+depends_on: []
+---
+
+# Msg
+
+## Purpose
+Messaging.
+
+## Public API
+
+### Schema: messages
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `id` | INTEGER | PRIMARY KEY |
+| `content` | TEXT | NOT NULL |
+
+## Invariants
+1. Valid.
+
+## Behavioral Examples
+### Scenario: Basic
+- **Given** x
+- **When** y
+- **Then** z
+
+## Error Cases
+| Condition | Behavior |
+|-----------|----------|
+
+## Dependencies
+None
+
+## Change Log
+| Date | Author | Change |
+|------|--------|--------|
+"#,
+    )
+    .unwrap();
+
+    // First run: clean, and it writes the hash cache (incl. the migration file).
+    specsync().arg("check").arg("--root").arg(&root).assert().success();
+
+    // Drop the documented `content` column. The spec's own files are unchanged,
+    // so the naive incremental skip would (wrongly) pass.
+    fs::write(
+        &migration,
+        "CREATE TABLE messages (\n  id INTEGER PRIMARY KEY\n);\n",
+    )
+    .unwrap();
+
+    // Second run on the default path (no --force / no --strict flag) must catch
+    // the drift instead of reporting "nothing to validate".
+    specsync()
+        .arg("check")
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "documented in spec but not found in migrations",
+        ))
+        .stdout(predicate::str::contains("nothing to validate").not());
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5676,7 +5676,12 @@ None
     .unwrap();
 
     // First run: clean, and it writes the hash cache (incl. the migration file).
-    specsync().arg("check").arg("--root").arg(&root).assert().success();
+    specsync()
+        .arg("check")
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .success();
 
     // Drop the documented `content` column. The spec's own files are unchanged,
     // so the naive incremental skip would (wrongly) pass.


### PR DESCRIPTION
## Summary
Fixes **H2 (High)** from the staff-engineer review: a silent false-PASS on the default (and pre-commit-hook) `check` path.

The incremental skip in `cmd_check` only re-validates specs that `classify_all_changes` flags, and that function hashes only each spec, its companions, and its frontmatter `files:` — it never hashes the **schema/migration files** (`config.schema_dir`) or the **config file** itself (`src/hash_cache.rs:266-286`, `:221-229`). So:

- Editing a migration to drop a documented column left every spec "unchanged" → `check` printed *"All specs unchanged — nothing to validate"* and exited 0, silently bypassing the Level-1.5 schema-column ERROR (`src/validator.rs:319-330`).
- Adding a new `custom_rule` / `required_section` in config likewise never ran against unchanged specs.

`--force` caught it; the default path — which the **installed pre-commit hook** (`src/hooks.rs:161`) uses — did not. Reproduced against the built binary.

## Fix
`check.rs` now treats the config file and every file in `schema_dir` as **global validation inputs**:
- On the incremental path, if any global input changed since the cache was written, it re-validates **all** specs instead of trusting the stale skip.
- On a clean run it records those inputs in the cache, so later genuinely-unchanged runs still skip (the incremental optimization is preserved).

Safe by construction: on first run after upgrade the global inputs are "new" → one full revalidation establishes the baseline; the cache is still only saved when `total_errors == 0`, so a stale run never records hashes. `--force`/`--strict`/`--fix` paths are unchanged.

## Test plan
- [x] New end-to-end regression test `incremental_check_detects_schema_drift_after_migration_edit`: clean first run caches the migration; dropping the documented column makes the **default** `check` catch the drift (exit 1, prints the schema error, no "nothing to validate") — it would fail without this change
- [x] `cargo test` — 652 unit + 149 integration pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo run -- check --strict --require-coverage 100 --force` — 60/60 specs pass

## Note
Uses `enforcement: "strict"` in config (not the `--strict` flag) in the test, because the `--strict` flag itself bypasses the incremental cache — so exercising the skip requires config-level strictness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)