### PR TITLE
Fix: merge no longer corrupts specs by dropping frontmatter fences (Critical: data loss)

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -380,29 +380,45 @@ fn resolve_table_conflict(ours: &str, theirs: &str) -> Resolution {
     Resolution::Auto(format!("{merged}\n"))
 }
 
-/// Whether a conflict-hunk side is ONLY interior frontmatter fields — every
-/// non-blank line is a YAML `key: value` (spaceless key) or `- item` list line.
+/// Whether a conflict-hunk side is ONLY interior frontmatter fields that
+/// [`parse_yaml_fields`] can round-trip WITHOUT dropping anything.
 ///
-/// Deliberately strict: a `---` fence, a `##` heading, a table row, or any prose
-/// line disqualifies it. We only auto-merge a frontmatter conflict when BOTH sides
-/// are pure fields with the `---` fences left in the surrounding clean regions
-/// (the common "two branches bumped `version`" case). Reconstructing fences that a
-/// hunk swallowed is not attempted — a hunk carrying a fence or body is left for
-/// manual resolution rather than risk deleting body content or emitting a broken
-/// or doubled fence.
+/// It must mirror the parser's keep/drop rules exactly, or a hunk it accepts could
+/// still lose content on merge:
+/// - a `---` fence, `##` heading, table row, or prose line ⇒ reject (not a field);
+/// - a `- item` list line is kept by the parser only while it follows a key with an
+///   empty/`[]` value (a list key). A `- item` before any such key — its owning key
+///   sits in the surrounding clean region — is silently dropped by the parser, so
+///   reject it here and defer to manual resolution instead of losing list items.
+///
+/// The upshot: we only auto-merge conflicts whose fences stay in the clean regions
+/// (the common "two branches bumped `version`" / "diverging `files:` list" case);
+/// anything else is left for the human.
 fn is_frontmatter_only(text: &str) -> bool {
+    let mut under_list_key = false;
     text.lines().all(|line| {
         let t = line.trim();
-        if t.is_empty() || t.starts_with("- ") {
+        if t.is_empty() {
             return true;
         }
-        // A `---` fence has no colon and is rejected here (find(':') → None).
-        line.find(':')
-            .map(|c| {
+        if t.starts_with("- ") {
+            // Only safe when an owning list key was opened earlier in THIS hunk.
+            return under_list_key;
+        }
+        // `key: value` with a spaceless key (a `---` fence has no colon → rejected).
+        match line.find(':') {
+            Some(c) => {
                 let key = line[..c].trim();
-                !key.is_empty() && !key.contains(' ')
-            })
-            .unwrap_or(false)
+                if key.is_empty() || key.contains(' ') {
+                    return false;
+                }
+                let value = line[c + 1..].trim();
+                // An empty (or `[]`) value opens a list the parser attaches items to.
+                under_list_key = value.is_empty() || value == "[]";
+                true
+            }
+            None => false,
+        }
     })
 }
 
@@ -1000,6 +1016,48 @@ The module.
         assert!(resolved.contains("- step one"), "bullets must survive");
         assert!(resolved.contains("- step two"));
         assert!(resolved.contains("- step three"));
+    }
+
+    #[test]
+    fn frontmatter_orphan_list_items_hunk_falls_to_manual() {
+        // Regression: a real `git merge` of two branches that both extended `files:`
+        // (and another field) yields a hunk that STARTS with orphan `- item` lines
+        // (their `files:` key is in the clean region) then continues into
+        // `db_tables:`. The parser drops the orphan items while the trailing field
+        // keeps the result non-empty — silently losing both branches' new files.
+        // Must fall to Manual with the items preserved.
+        let content = "\
+---
+module: m
+version: 1
+status: active
+files:
+  - src/a.ts
+<<<<<<< HEAD
+  - src/b.ts
+db_tables:
+  - users
+=======
+  - src/c.ts
+db_tables:
+  - accounts
+>>>>>>> theirs
+depends_on: []
+---
+# M
+";
+        let (resolved, result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        assert_eq!(
+            result.status,
+            MergeStatus::Manual,
+            "orphan leading list items must not be field-merged: {:?}",
+            result.details
+        );
+        assert!(has_conflict_markers(&resolved));
+        assert!(
+            resolved.contains("- src/b.ts") && resolved.contains("- src/c.ts"),
+            "list items from both sides must survive:\n{resolved}"
+        );
     }
 
     #[test]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -581,12 +581,27 @@ fn parse_table_rows(text: &str) -> Vec<&str> {
     text.lines()
         .filter(|l| {
             let t = l.trim();
-            t.starts_with('|')
-                && !t.starts_with("| -")
-                && !t.starts_with("|--")
-                && !t.starts_with("|-")
+            // Keep every `|`-row EXCEPT the GFM separator row. Match the separator
+            // structurally (all cells are dashes/colons), not by a `| -` prefix —
+            // otherwise a data row whose first cell legitimately starts with `-`
+            // (a CLI flag like `| --debug |`, a negative number) is dropped.
+            t.starts_with('|') && !is_table_separator_row(t)
         })
         .collect()
+}
+
+/// Whether a `|`-delimited row is a GFM header/body separator (`|---|:--:|`),
+/// i.e. every cell contains only dashes, colons, and spaces (with at least one
+/// dash). Data rows — even ones whose first cell starts with `-` — are not.
+fn is_table_separator_row(row: &str) -> bool {
+    let inner = row.trim();
+    if !inner.contains('-') {
+        return false;
+    }
+    inner.trim_matches('|').split('|').all(|cell| {
+        let c = cell.trim();
+        !c.is_empty() && c.chars().all(|ch| ch == '-' || ch == ':')
+    })
 }
 
 /// Extract the first cell value from a markdown table row.
@@ -1107,6 +1122,56 @@ Run it after.
             resolved.contains("## Migration Notes") && resolved.contains("migration script"),
             "the swallowed following section must not be deleted:\n{resolved}"
         );
+    }
+
+    #[test]
+    fn separator_row_detection_excludes_dash_leading_data_rows() {
+        assert!(is_table_separator_row("|------|------|"));
+        assert!(is_table_separator_row("| :--- | ---: |"));
+        assert!(!is_table_separator_row("| --debug | Enable debug |"));
+        assert!(!is_table_separator_row("| Flag | Description |"));
+        assert!(!is_table_separator_row("| -5 | a negative number |"));
+    }
+
+    #[test]
+    fn table_conflict_preserves_dash_leading_row() {
+        // Regression: a generic table hunk mixing a normal row with a `--flag` row
+        // used to DROP the flag row (misread as a `|---|` separator) and write the
+        // result as Resolved — content loss. The flag rows must survive the merge.
+        let content = "\
+---
+module: m
+version: 1
+status: active
+files:
+  - src/m.ts
+db_tables: []
+depends_on: []
+---
+# M
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+<<<<<<< HEAD
+| newFlag | A new flag |
+| --debug | Enable debug |
+=======
+| newFlag | A new flag |
+| --quiet | Quiet mode |
+>>>>>>> feature
+";
+        let (resolved, _result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        assert!(
+            !has_conflict_markers(&resolved),
+            "should auto-resolve:\n{resolved}"
+        );
+        assert!(
+            resolved.contains("--debug") && resolved.contains("--quiet"),
+            "dash-leading rows must not be dropped:\n{resolved}"
+        );
+        assert!(resolved.contains("newFlag"));
     }
 
     #[test]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -131,10 +131,13 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
                 theirs,
                 marker_label,
             } => {
-                // Determine what section this conflict is in
+                // Determine what section this conflict is in. We are still inside
+                // the leading frontmatter block until its closing `---` — i.e.
+                // fewer than two fence lines have been emitted so far.
                 let section = detect_section(&output);
+                let in_frontmatter = output.lines().filter(|l| l.trim() == "---").count() < 2;
 
-                match resolve_conflict(ours, theirs, &section) {
+                match resolve_conflict(ours, theirs, &section, in_frontmatter) {
                     Resolution::Auto(merged) => {
                         details.push(format!(
                             "Auto-resolved in {}: {}",
@@ -160,12 +163,12 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
         }
     }
 
-    // Safety net (shape-independent): never write back a spec we just made invalid
-    // or empty. If the input had frontmatter but the assembled output either does
-    // not parse as frontmatter OR parses to one that lost its `module` (fields
-    // demoted into the body, fences mis-nested, etc.), refuse — downgrade to Manual
-    // so the caller (which writes only on `Resolved`) leaves the ORIGINAL file
-    // untouched instead of silently corrupting it while reporting success.
+    // Safety net for frontmatter validity: if the input had frontmatter but the
+    // assembled output no longer parses as frontmatter OR parses to one that lost
+    // its `module`, refuse — downgrade to Manual so the caller (which writes only
+    // on `Resolved`) leaves the ORIGINAL file untouched. (This guards frontmatter
+    // structure; body/row preservation is handled upstream by only auto-merging
+    // pure field/table hunks, never prose- or section-carrying ones.)
     let had_frontmatter = content.lines().any(|l| l.trim() == "---");
     let resolved_frontmatter_ok = parse_frontmatter(&output)
         .map(|parsed| parsed.frontmatter.module.is_some())
@@ -274,24 +277,35 @@ enum Resolution {
 }
 
 /// Try to auto-resolve a conflict based on section context.
-fn resolve_conflict(ours: &str, theirs: &str, section: &Option<String>) -> Resolution {
+///
+/// `in_frontmatter` is true only while the cursor is still inside the leading
+/// `---…---` frontmatter block. A `None` section (no `## ` heading seen yet) can
+/// mean either the frontmatter OR a pre-first-heading body region (a `# Title` /
+/// intro); only the former may use the field resolver — routing intro prose to it
+/// would silently drop bullet lists and non-winning text.
+fn resolve_conflict(
+    ours: &str,
+    theirs: &str,
+    section: &Option<String>,
+    in_frontmatter: bool,
+) -> Resolution {
     let section_name = section.as_deref().unwrap_or("");
 
+    // Frontmatter fields — only when genuinely inside the frontmatter block.
+    if section_name.is_empty() && in_frontmatter {
+        return resolve_frontmatter_conflict(ours, theirs);
+    }
+
+    // Every remaining auto-merge requires the hunk to be PURE table rows. A hunk
+    // that also carries prose/headings (e.g. a Change Log conflict that swallowed
+    // the following section) is NOT pure, so the row merge — which keeps only
+    // `|`-rows and would delete everything else — is refused and left for manual
+    // resolution instead.
+    let pure_rows = is_pure_table_rows(ours) && is_pure_table_rows(theirs);
     match section_name {
-        // Changelog: merge rows chronologically
+        _ if !pure_rows => Resolution::Manual,
         "Change Log" => resolve_changelog_conflict(ours, theirs),
-
-        // Frontmatter region (before any ## heading): merge frontmatter
-        "" => resolve_frontmatter_conflict(ours, theirs),
-
-        // Any section with only table rows: try table merge
-        _ => {
-            if is_pure_table_rows(ours) && is_pure_table_rows(theirs) {
-                resolve_table_conflict(ours, theirs)
-            } else {
-                Resolution::Manual
-            }
-        }
+        _ => resolve_table_conflict(ours, theirs),
     }
 }
 
@@ -942,6 +956,99 @@ Theirs purpose.
         );
         assert!(resolved.contains("Ours purpose."));
         assert!(resolved.contains("Theirs purpose."));
+    }
+
+    #[test]
+    fn pre_heading_body_field_hunk_falls_to_manual() {
+        // Regression: a conflict in a pre-first-`##` intro (a `# Notes` region,
+        // AFTER the frontmatter) has no `## ` heading, so it used to route to the
+        // frontmatter field resolver, which drops bullet lists and non-winning
+        // prose. It must fall to Manual — bullets and both sides preserved.
+        let content = "\
+---
+module: m
+version: 1
+status: active
+files:
+  - src/m.ts
+db_tables: []
+depends_on: []
+---
+# Notes
+
+<<<<<<< HEAD
+TODO: fix the auth flow
+- step one
+- step two
+=======
+TODO: rewrite the auth flow
+- step three
+>>>>>>> feature
+
+## Purpose
+
+The module.
+";
+        let (resolved, result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        assert_eq!(
+            result.status,
+            MergeStatus::Manual,
+            "pre-heading body hunk must not be field-merged: {:?}",
+            result.details
+        );
+        assert!(has_conflict_markers(&resolved));
+        assert!(resolved.contains("- step one"), "bullets must survive");
+        assert!(resolved.contains("- step two"));
+        assert!(resolved.contains("- step three"));
+    }
+
+    #[test]
+    fn changelog_hunk_swallowing_next_section_falls_to_manual() {
+        // Regression: a Change Log conflict whose hunk runs past the table into the
+        // following section previously deleted that section (the row resolver keeps
+        // only `|`-rows). Impure changelog hunks now fall to Manual.
+        let content = "\
+---
+module: m
+version: 1
+status: active
+files:
+  - src/m.ts
+db_tables: []
+depends_on: []
+---
+# M
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+<<<<<<< HEAD
+| 2026-01-01 | a |
+
+## Migration Notes
+
+Run the migration script before deploying.
+=======
+| 2026-01-02 | b |
+
+## Migration Notes
+
+Run it after.
+>>>>>>> feature
+";
+        let (resolved, result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        assert_eq!(
+            result.status,
+            MergeStatus::Manual,
+            "impure changelog hunk must not be row-merged: {:?}",
+            result.details
+        );
+        assert!(has_conflict_markers(&resolved));
+        assert!(
+            resolved.contains("## Migration Notes") && resolved.contains("migration script"),
+            "the swallowed following section must not be deleted:\n{resolved}"
+        );
     }
 
     #[test]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -161,19 +161,22 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
     }
 
     // Safety net: never write back a spec we just made invalid. If the assembled
-    // output no longer has parseable frontmatter (e.g. a resolution dropped the
-    // `---` fences), refuse to auto-resolve — downgrade to Manual so the caller
-    // leaves the ORIGINAL file untouched (it only writes on `Resolved`) instead of
+    // output no longer has parseable frontmatter, or collapsed to an empty
+    // `---\n---` block (a resolution that dropped the fields/body between the
+    // fences), refuse to auto-resolve — downgrade to Manual so the caller leaves
+    // the ORIGINAL file untouched (it only writes on `Resolved`) instead of
     // silently corrupting it while reporting success.
+    let had_frontmatter = content.lines().any(|l| l.trim() == "---");
+    let doubled_fence = output.trim_start().starts_with("---\n---")
+        || output.trim_start().starts_with("---\r\n---");
     if all_resolved
         && !output.is_empty()
-        && content.contains("---\n")
-        && parse_frontmatter(&output).is_none()
+        && ((had_frontmatter && parse_frontmatter(&output).is_none()) || doubled_fence)
     {
         all_resolved = false;
         details.push(
-            "Resolved content would have invalid frontmatter — left for manual \
-             resolution; the original file was not modified"
+            "Resolved content would have invalid or empty frontmatter — left for \
+             manual resolution; the original file was not modified"
                 .to_string(),
         );
     }
@@ -365,10 +368,52 @@ fn resolve_table_conflict(ours: &str, theirs: &str) -> Resolution {
     Resolution::Auto(format!("{merged}\n"))
 }
 
+/// Whether a conflict-hunk side contains ONLY frontmatter — YAML `key: value` /
+/// `- item` lines, optionally wrapped in `---` fences — and no body content.
+///
+/// Rejected if any non-blank line follows the last `---` fence (a swallowed body),
+/// or if any non-blank, non-fence line is not a field/list line (a heading, prose,
+/// or table — body the field parser would silently drop). Guards the frontmatter
+/// resolver against auto-merging a hunk that spans into the spec body.
+fn is_frontmatter_only(text: &str) -> bool {
+    let lines: Vec<&str> = text.lines().collect();
+
+    // Nothing but blanks may follow a closing fence.
+    if let Some(last_fence) = lines.iter().rposition(|l| l.trim() == "---")
+        && lines[last_fence + 1..].iter().any(|l| !l.trim().is_empty())
+    {
+        return false;
+    }
+
+    // Every non-blank, non-fence line must look like a frontmatter field or list item.
+    lines.iter().all(|line| {
+        let t = line.trim();
+        if t.is_empty() || t == "---" || t.starts_with("- ") {
+            return true;
+        }
+        line.find(':')
+            .map(|c| {
+                let key = line[..c].trim();
+                !key.is_empty() && !key.contains(' ')
+            })
+            .unwrap_or(false)
+    })
+}
+
 /// Merge frontmatter YAML fields.
 /// Lists (files, depends_on, db_tables) are unioned.
 /// Scalars: theirs wins if different.
 fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
+    // Only auto-merge when BOTH sides are genuinely frontmatter-only. A plain
+    // `git merge` of two specs whose content differs right after the frontmatter
+    // produces a hunk that swallows the closing `---` and the body/headings; since
+    // this resolver rebuilds the block from parsed `key: value` fields alone, any
+    // such body content would be silently discarded. Refuse those — leave the
+    // conflict markers for manual resolution rather than delete a spec body.
+    if !is_frontmatter_only(ours) || !is_frontmatter_only(theirs) {
+        return Resolution::Manual;
+    }
+
     // Parse both sides as YAML-like key-value pairs
     let our_fields = parse_yaml_fields(ours);
     let their_fields = parse_yaml_fields(theirs);
@@ -828,6 +873,63 @@ depends_on: []
             parse_frontmatter(&resolved).is_some(),
             "resolved frontmatter must parse, got:\n{resolved}"
         );
+    }
+
+    #[test]
+    fn frontmatter_conflict_swallowing_body_falls_to_manual() {
+        // Regression (CRITICAL): a plain `git merge` of two specs whose content
+        // differs right after the frontmatter yields a hunk that spans the closing
+        // `---` AND the body. The field-only resolver would silently DELETE that
+        // body; it must instead fall to Manual — markers preserved, body intact.
+        let content = "\
+---
+<<<<<<< HEAD
+module: alpha
+version: 2
+status: active
+files:
+  - src/a.ts
+db_tables: []
+depends_on: []
+---
+# Alpha
+
+## Purpose
+
+Ours purpose.
+=======
+module: alpha
+version: 3
+status: active
+files:
+  - src/a.ts
+db_tables: []
+depends_on: []
+---
+# Alpha
+
+## Purpose
+
+Theirs purpose.
+>>>>>>> feature
+";
+        let (resolved, result) = resolve_spec_conflicts(content, "specs/alpha/alpha.spec.md");
+        assert_eq!(
+            result.status,
+            MergeStatus::Manual,
+            "a body-swallowing frontmatter conflict must NOT auto-resolve: {:?}",
+            result.details
+        );
+        assert!(
+            has_conflict_markers(&resolved),
+            "conflict markers must be preserved for manual resolution"
+        );
+        assert!(
+            resolved.contains("## Purpose"),
+            "spec body must not be deleted, got:\n{resolved}"
+        );
+        assert!(resolved.contains("Ours purpose."));
+        assert!(resolved.contains("Theirs purpose."));
     }
 
     #[test]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -160,19 +160,17 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
         }
     }
 
-    // Safety net: never write back a spec we just made invalid. If the assembled
-    // output no longer has parseable frontmatter, or collapsed to an empty
-    // `---\n---` block (a resolution that dropped the fields/body between the
-    // fences), refuse to auto-resolve — downgrade to Manual so the caller leaves
-    // the ORIGINAL file untouched (it only writes on `Resolved`) instead of
-    // silently corrupting it while reporting success.
+    // Safety net (shape-independent): never write back a spec we just made invalid
+    // or empty. If the input had frontmatter but the assembled output either does
+    // not parse as frontmatter OR parses to one that lost its `module` (fields
+    // demoted into the body, fences mis-nested, etc.), refuse — downgrade to Manual
+    // so the caller (which writes only on `Resolved`) leaves the ORIGINAL file
+    // untouched instead of silently corrupting it while reporting success.
     let had_frontmatter = content.lines().any(|l| l.trim() == "---");
-    let doubled_fence = output.trim_start().starts_with("---\n---")
-        || output.trim_start().starts_with("---\r\n---");
-    if all_resolved
-        && !output.is_empty()
-        && ((had_frontmatter && parse_frontmatter(&output).is_none()) || doubled_fence)
-    {
+    let resolved_frontmatter_ok = parse_frontmatter(&output)
+        .map(|parsed| parsed.frontmatter.module.is_some())
+        .unwrap_or(false);
+    if all_resolved && !output.is_empty() && had_frontmatter && !resolved_frontmatter_ok {
         all_resolved = false;
         details.push(
             "Resolved content would have invalid or empty frontmatter — left for \
@@ -368,29 +366,23 @@ fn resolve_table_conflict(ours: &str, theirs: &str) -> Resolution {
     Resolution::Auto(format!("{merged}\n"))
 }
 
-/// Whether a conflict-hunk side contains ONLY frontmatter — YAML `key: value` /
-/// `- item` lines, optionally wrapped in `---` fences — and no body content.
+/// Whether a conflict-hunk side is ONLY interior frontmatter fields — every
+/// non-blank line is a YAML `key: value` (spaceless key) or `- item` list line.
 ///
-/// Rejected if any non-blank line follows the last `---` fence (a swallowed body),
-/// or if any non-blank, non-fence line is not a field/list line (a heading, prose,
-/// or table — body the field parser would silently drop). Guards the frontmatter
-/// resolver against auto-merging a hunk that spans into the spec body.
+/// Deliberately strict: a `---` fence, a `##` heading, a table row, or any prose
+/// line disqualifies it. We only auto-merge a frontmatter conflict when BOTH sides
+/// are pure fields with the `---` fences left in the surrounding clean regions
+/// (the common "two branches bumped `version`" case). Reconstructing fences that a
+/// hunk swallowed is not attempted — a hunk carrying a fence or body is left for
+/// manual resolution rather than risk deleting body content or emitting a broken
+/// or doubled fence.
 fn is_frontmatter_only(text: &str) -> bool {
-    let lines: Vec<&str> = text.lines().collect();
-
-    // Nothing but blanks may follow a closing fence.
-    if let Some(last_fence) = lines.iter().rposition(|l| l.trim() == "---")
-        && lines[last_fence + 1..].iter().any(|l| !l.trim().is_empty())
-    {
-        return false;
-    }
-
-    // Every non-blank, non-fence line must look like a frontmatter field or list item.
-    lines.iter().all(|line| {
+    text.lines().all(|line| {
         let t = line.trim();
-        if t.is_empty() || t == "---" || t.starts_with("- ") {
+        if t.is_empty() || t.starts_with("- ") {
             return true;
         }
+        // A `---` fence has no colon and is rejected here (find(':') → None).
         line.find(':')
             .map(|c| {
                 let key = line[..c].trim();
@@ -404,12 +396,12 @@ fn is_frontmatter_only(text: &str) -> bool {
 /// Lists (files, depends_on, db_tables) are unioned.
 /// Scalars: theirs wins if different.
 fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
-    // Only auto-merge when BOTH sides are genuinely frontmatter-only. A plain
-    // `git merge` of two specs whose content differs right after the frontmatter
-    // produces a hunk that swallows the closing `---` and the body/headings; since
-    // this resolver rebuilds the block from parsed `key: value` fields alone, any
-    // such body content would be silently discarded. Refuse those — leave the
-    // conflict markers for manual resolution rather than delete a spec body.
+    // Only auto-merge when BOTH sides are pure interior frontmatter fields (no
+    // `---` fence, heading, or body in the hunk). A plain `git merge` of specs
+    // whose content differs right after the frontmatter swallows the closing `---`
+    // and body into the hunk; since this resolver rebuilds from parsed `key: value`
+    // fields alone, reconstructing those fences is error-prone (dropped body,
+    // doubled fences). So we don't try — such hunks are left for manual resolution.
     if !is_frontmatter_only(ours) || !is_frontmatter_only(theirs) {
         return Resolution::Manual;
     }
@@ -484,23 +476,11 @@ fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
         }
     }
 
+    // Emit only the merged interior fields. The `---` fences come from the
+    // surrounding clean regions (guaranteed: `is_frontmatter_only` rejects any hunk
+    // that contains a fence), so we never reconstruct or double a delimiter.
     let body = merged_lines.join("\n");
-    // If the conflict hunk swallowed the frontmatter `---` fences — i.e. each side
-    // carried its own full `---\n…\n---` block rather than just the interior fields
-    // — then parsing to fields dropped the delimiters. Re-emit them so the resolved
-    // spec is valid frontmatter instead of loose `key: value` lines. (In the common
-    // interior conflict the fences live in the surrounding clean regions and this is
-    // a no-op.)
-    let had_fences = ours
-        .lines()
-        .chain(theirs.lines())
-        .any(|l| l.trim() == "---");
-    let result = if had_fences {
-        format!("---\n{body}\n---\n")
-    } else {
-        format!("{body}\n")
-    };
-    Resolution::Auto(result)
+    Resolution::Auto(format!("{body}\n"))
 }
 
 #[derive(Clone, Debug)]
@@ -829,12 +809,12 @@ Auth module.
     }
 
     #[test]
-    fn frontmatter_conflict_spanning_fences_stays_valid() {
-        // Regression (CRITICAL): a conflict hunk that swallows the entire
-        // `---\n…\n---` frontmatter block — each side carrying its own fences —
-        // previously auto-resolved to loose `key: value` lines with NO delimiters,
-        // writing a corrupt spec (`check` → "Frontmatter invalid") while reporting
-        // "✓ resolved". The resolved output must remain valid frontmatter.
+    fn frontmatter_conflict_with_fences_in_hunk_falls_to_manual() {
+        // Regression (CRITICAL): a conflict hunk that swallows the `---` fences was
+        // the original corruption source (it resolved to loose `key: value` lines
+        // with the delimiters dropped, or a doubled/empty fence, written as
+        // "✓ resolved"). We no longer try to reconstruct fences — any hunk carrying
+        // a `---` fence falls to Manual with the file left UNTOUCHED (no data loss).
         let content = "\
 <<<<<<< HEAD
 ---
@@ -858,21 +838,53 @@ depends_on: []
 # Minimal
 ";
         let (resolved, result) = resolve_spec_conflicts(content, "specs/minimal/minimal.spec.md");
-        assert!(
-            matches!(result.status, MergeStatus::Resolved),
-            "should auto-resolve, got {:?}: {:?}",
+        assert_eq!(
             result.status,
+            MergeStatus::Manual,
+            "a fence-carrying frontmatter hunk must not auto-resolve: {:?}",
             result.details
         );
-        assert!(!has_conflict_markers(&resolved));
         assert!(
-            resolved.starts_with("---\n"),
-            "resolved spec must re-emit the opening frontmatter fence, got:\n{resolved}"
+            has_conflict_markers(&resolved),
+            "conflict markers must be preserved for manual resolution"
         );
-        assert!(
-            parse_frontmatter(&resolved).is_some(),
-            "resolved frontmatter must parse, got:\n{resolved}"
+        // No data loss: both sides' fields survive verbatim in the preserved hunk.
+        assert!(resolved.contains("version: 2"));
+        assert!(resolved.contains("version: 1"));
+        assert!(resolved.contains("# Minimal"));
+    }
+
+    #[test]
+    fn frontmatter_conflict_with_separator_before_fence_falls_to_manual() {
+        // Regression: a blank/whitespace line between the clean opening `---` and a
+        // fence-swallowing hunk previously defeated the re-wrap + backstop and wrote
+        // an empty-frontmatter spec as "✓ resolved". The hunk carries a `---`, so it
+        // must fall to Manual — file untouched, fields preserved.
+        let content = "\
+---
+
+<<<<<<< HEAD
+module: a
+version: 2
+---
+=======
+module: a
+version: 3
+---
+>>>>>>> feature
+# Body
+";
+        let (resolved, result) = resolve_spec_conflicts(content, "specs/a/a.spec.md");
+        assert_eq!(
+            result.status,
+            MergeStatus::Manual,
+            "separator-before-fence hunk must fall to Manual: {:?}",
+            result.details
         );
+        assert!(has_conflict_markers(&resolved));
+        assert!(resolved.contains("version: 2"));
+        assert!(resolved.contains("version: 3"));
+        assert!(resolved.contains("# Body"));
     }
 
     #[test]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -14,6 +14,7 @@ pub struct MergeResult {
     pub details: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MergeStatus {
     /// File had conflicts and they were resolved automatically.
     Resolved,
@@ -159,13 +160,22 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
         }
     }
 
-    // If everything was resolved, validate the result parses
+    // Safety net: never write back a spec we just made invalid. If the assembled
+    // output no longer has parseable frontmatter (e.g. a resolution dropped the
+    // `---` fences), refuse to auto-resolve — downgrade to Manual so the caller
+    // leaves the ORIGINAL file untouched (it only writes on `Resolved`) instead of
+    // silently corrupting it while reporting success.
     if all_resolved
         && !output.is_empty()
-        && parse_frontmatter(&output).is_none()
         && content.contains("---\n")
+        && parse_frontmatter(&output).is_none()
     {
-        details.push("Warning: resolved file has invalid frontmatter".to_string());
+        all_resolved = false;
+        details.push(
+            "Resolved content would have invalid frontmatter — left for manual \
+             resolution; the original file was not modified"
+                .to_string(),
+        );
     }
 
     let status = if !all_resolved {
@@ -429,8 +439,23 @@ fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
         }
     }
 
-    let result = merged_lines.join("\n");
-    Resolution::Auto(format!("{result}\n"))
+    let body = merged_lines.join("\n");
+    // If the conflict hunk swallowed the frontmatter `---` fences — i.e. each side
+    // carried its own full `---\n…\n---` block rather than just the interior fields
+    // — then parsing to fields dropped the delimiters. Re-emit them so the resolved
+    // spec is valid frontmatter instead of loose `key: value` lines. (In the common
+    // interior conflict the fences live in the surrounding clean regions and this is
+    // a no-op.)
+    let had_fences = ours
+        .lines()
+        .chain(theirs.lines())
+        .any(|l| l.trim() == "---");
+    let result = if had_fences {
+        format!("---\n{body}\n---\n")
+    } else {
+        format!("{body}\n")
+    };
+    Resolution::Auto(result)
 }
 
 #[derive(Clone, Debug)]
@@ -756,6 +781,53 @@ Auth module.
         // Changelog: all entries merged chronologically
         assert!(resolved.contains("Added login"));
         assert!(resolved.contains("Added signup"));
+    }
+
+    #[test]
+    fn frontmatter_conflict_spanning_fences_stays_valid() {
+        // Regression (CRITICAL): a conflict hunk that swallows the entire
+        // `---\n…\n---` frontmatter block — each side carrying its own fences —
+        // previously auto-resolved to loose `key: value` lines with NO delimiters,
+        // writing a corrupt spec (`check` → "Frontmatter invalid") while reporting
+        // "✓ resolved". The resolved output must remain valid frontmatter.
+        let content = "\
+<<<<<<< HEAD
+---
+module: minimal
+version: 2
+status: active
+files:
+  - src/minimal.ts
+depends_on: []
+---
+=======
+---
+module: minimal
+version: 1
+status: review
+files:
+  - src/minimal.ts
+depends_on: []
+---
+>>>>>>> branch
+# Minimal
+";
+        let (resolved, result) = resolve_spec_conflicts(content, "specs/minimal/minimal.spec.md");
+        assert!(
+            matches!(result.status, MergeStatus::Resolved),
+            "should auto-resolve, got {:?}: {:?}",
+            result.status,
+            result.details
+        );
+        assert!(!has_conflict_markers(&resolved));
+        assert!(
+            resolved.starts_with("---\n"),
+            "resolved spec must re-emit the opening frontmatter fence, got:\n{resolved}"
+        );
+        assert!(
+            parse_frontmatter(&resolved).is_some(),
+            "resolved frontmatter must parse, got:\n{resolved}"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5706,3 +5706,128 @@ None
         ))
         .stdout(predicate::str::contains("nothing to validate").not());
 }
+
+// ─── specsync merge ─────────────────────────────────────────────────────
+
+/// Regression (CRITICAL): `merge` must never write a spec with corrupt
+/// frontmatter. A conflict hunk spanning the whole `---…---` block previously
+/// resolved to loose `key: value` lines (fences dropped), so the next `check`
+/// failed with "Frontmatter invalid" — data loss reported as "✓ resolved".
+#[test]
+fn merge_frontmatter_spanning_conflict_stays_valid() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/minimal.ts"),
+        "export function doThing() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/minimal")).unwrap();
+
+    // Each side of the conflict carries its own `---` frontmatter fences.
+    let conflicted = "\
+<<<<<<< HEAD
+---
+module: minimal
+version: 2
+status: active
+files:
+  - src/minimal.ts
+db_tables: []
+depends_on: []
+---
+=======
+---
+module: minimal
+version: 1
+status: active
+files:
+  - src/minimal.ts
+db_tables: []
+depends_on: []
+---
+>>>>>>> branch
+# Minimal
+
+## Purpose
+
+Minimal module.
+
+## Public API
+
+### Exported Functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `doThing` | none | void | Does the thing |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+
+## Invariants
+
+1. None.
+
+## Behavioral Examples
+
+### Scenario: call
+
+- **Given** nothing
+- **When** doThing
+- **Then** ok
+
+## Error Cases
+
+| Condition | Behavior |
+|-----------|----------|
+
+## Dependencies
+
+### Consumes
+
+| Module | What is used |
+|--------|-------------|
+
+### Consumed By
+
+| Module | What is used |
+|--------|-------------|
+
+## Change Log
+
+| Date | Author | Change |
+|------|--------|--------|
+";
+    let spec_path = root.join("specs/minimal/minimal.spec.md");
+    fs::write(&spec_path, conflicted).unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["merge", "--all"])
+        .assert()
+        .success();
+
+    // The written spec must be valid frontmatter with no leftover conflict markers.
+    let resolved = fs::read_to_string(&spec_path).unwrap();
+    assert!(
+        resolved.starts_with("---\n"),
+        "merge must re-emit the opening frontmatter fence, got:\n{resolved}"
+    );
+    assert!(
+        !resolved.contains("<<<<<<<"),
+        "conflict markers must be gone, got:\n{resolved}"
+    );
+
+    // And `check` must accept it — the corruption made this say "Frontmatter invalid".
+    specsync()
+        .current_dir(root)
+        .arg("check")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Frontmatter valid"))
+        .stdout(predicate::str::contains("Frontmatter invalid").not());
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5709,12 +5709,13 @@ None
 
 // ─── specsync merge ─────────────────────────────────────────────────────
 
-/// Regression (CRITICAL): `merge` must never write a spec with corrupt
-/// frontmatter. A conflict hunk spanning the whole `---…---` block previously
-/// resolved to loose `key: value` lines (fences dropped), so the next `check`
-/// failed with "Frontmatter invalid" — data loss reported as "✓ resolved".
+/// Regression (CRITICAL): `merge` must never write a corrupt spec. A conflict
+/// hunk that swallows the `---` fences previously resolved to loose/doubled/empty
+/// frontmatter written as "✓ resolved". We now leave such hunks for manual
+/// resolution — the invariant: a marker-free result is always valid frontmatter,
+/// and the body is never deleted.
 #[test]
-fn merge_frontmatter_spanning_conflict_stays_valid() {
+fn merge_never_writes_corrupt_spec_for_fence_hunk() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();
     write_config(root, "specs", &["src"]);
@@ -5754,53 +5755,64 @@ depends_on: []
 ## Purpose
 
 Minimal module.
+";
+    let spec_path = root.join("specs/minimal/minimal.spec.md");
+    fs::write(&spec_path, conflicted).unwrap();
 
-## Public API
+    // May resolve or defer to manual — but must never corrupt or delete the body.
+    specsync()
+        .current_dir(root)
+        .args(["merge", "--all"])
+        .assert();
 
-### Exported Functions
+    let after = fs::read_to_string(&spec_path).unwrap();
+    if !after.contains("<<<<<<<") {
+        assert!(
+            after.starts_with("---\n") && after.contains("module: minimal"),
+            "merge produced a corrupt, marker-free spec:\n{after}"
+        );
+    }
+    assert!(
+        after.contains("## Purpose") && after.contains("Minimal module."),
+        "spec body must never be deleted:\n{after}"
+    );
+}
 
-| Function | Parameters | Returns | Description |
-|----------|-----------|---------|-------------|
-| `doThing` | none | void | Does the thing |
+/// The common case must still auto-resolve: two branches bumped `version`, with
+/// the `---` fences left in the surrounding clean regions.
+#[test]
+fn merge_resolves_interior_field_conflict() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/minimal.ts"),
+        "export function doThing() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/minimal")).unwrap();
 
-### Exported Types
+    // The conflict is purely the `version` line; fences stay in clean regions.
+    let conflicted = "\
+---
+module: minimal
+<<<<<<< HEAD
+version: 2
+=======
+version: 3
+>>>>>>> branch
+status: active
+files:
+  - src/minimal.ts
+db_tables: []
+depends_on: []
+---
+# Minimal
 
-| Type | Description |
-|------|-------------|
+## Purpose
 
-## Invariants
-
-1. None.
-
-## Behavioral Examples
-
-### Scenario: call
-
-- **Given** nothing
-- **When** doThing
-- **Then** ok
-
-## Error Cases
-
-| Condition | Behavior |
-|-----------|----------|
-
-## Dependencies
-
-### Consumes
-
-| Module | What is used |
-|--------|-------------|
-
-### Consumed By
-
-| Module | What is used |
-|--------|-------------|
-
-## Change Log
-
-| Date | Author | Change |
-|------|--------|--------|
+Minimal module.
 ";
     let spec_path = root.join("specs/minimal/minimal.spec.md");
     fs::write(&spec_path, conflicted).unwrap();
@@ -5811,23 +5823,19 @@ Minimal module.
         .assert()
         .success();
 
-    // The written spec must be valid frontmatter with no leftover conflict markers.
     let resolved = fs::read_to_string(&spec_path).unwrap();
     assert!(
-        resolved.starts_with("---\n"),
-        "merge must re-emit the opening frontmatter fence, got:\n{resolved}"
+        !resolved.contains("<<<<<<<"),
+        "interior field conflict should auto-resolve, got:\n{resolved}"
     );
     assert!(
-        !resolved.contains("<<<<<<<"),
-        "conflict markers must be gone, got:\n{resolved}"
+        resolved.starts_with("---\n") && resolved.contains("version: 3"),
+        "resolved spec must be valid frontmatter with theirs' version, got:\n{resolved}"
     );
-
-    // And `check` must accept it — the corruption made this say "Frontmatter invalid".
+    // No "Frontmatter invalid" — the resolved spec parses.
     specsync()
         .current_dir(root)
         .arg("check")
         .assert()
-        .success()
-        .stdout(predicate::str::contains("Frontmatter valid"))
         .stdout(predicate::str::contains("Frontmatter invalid").not());
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5760,7 +5760,7 @@ Minimal module.
     fs::write(&spec_path, conflicted).unwrap();
 
     // May resolve or defer to manual — but must never corrupt or delete the body.
-    specsync()
+    let _ = specsync()
         .current_dir(root)
         .args(["merge", "--all"])
         .assert();


### PR DESCRIPTION
## Summary
Fixes a **Critical data-loss bug** found while dogfooding, and — after adversarial review probed deeper — several related **pre-existing** content-loss bugs in `specsync merge` (the flagship auto-resolve-conflicts command). The unifying fix: **only auto-resolve a conflict hunk when it can be merged losslessly; otherwise leave it for manual resolution with the file untouched.**

## What was corrupting / losing content (all now closed)
1. **Dropped frontmatter fences** — a hunk holding the whole `---…---` block resolved to loose/doubled/empty frontmatter → `check` says "Frontmatter invalid".
2. **Deleted spec body** — an add/add hunk spanning the closing `---` + body was rebuilt from parsed fields alone, deleting the body.
3. **Separator-before-fence** — a blank/whitespace/comment line between the clean opening `---` and a fence-carrying hunk produced an empty-frontmatter spec.
4. **Pre-`##` body hunk** — a `# Notes`/intro conflict (no `##` heading) was routed to the frontmatter field resolver, dropping bullet lists and prose.
5. **Impure Change Log hunk** — a changelog conflict spanning into the next section deleted that section (the row merge kept only `|`-rows).

## Fix
- **No fence reconstruction.** The field resolver runs only for *pure interior field conflicts* (`is_frontmatter_only`: every line a `key: value`/`- item`) while genuinely inside the frontmatter (`in_frontmatter`: <2 fence lines emitted). Any hunk carrying a `---`, heading, or body → Manual.
- **All row merges gated on `is_pure_table_rows`** (changelog + generic table), so a hunk that swallowed prose/section → Manual.
- **Shape-independent backstop** — if the input had frontmatter but the output doesn't parse or lost its `module`, downgrade to Manual. `merge` writes only on `Resolved`, so a risky resolution never overwrites the original.

## Not in scope (deferred, by-design)
- Generic table resolver unions rows by first cell, so two distinct rows sharing a first cell (e.g. a class name with two method rows) collapse. Union-by-key is intended for symbol-keyed API tables; tracked as a follow-up.
- Scalar "theirs wins" for a genuine frontmatter field conflict (a version/status difference resolves to the incoming side) — not data loss.

## Verified
- All prior repros (fence-in-hunk, body-swallow, separator, pre-heading body, impure changelog) fall to Manual with the file byte-identical (markers + body + fields preserved), confirmed end-to-end on the real CLI.
- Common cases still auto-resolve: interior `version` bump → valid frontmatter (theirs wins); pure changelog rows → unioned chronologically.
- 14 merge unit tests + 2 integration tests; full suite (660 unit + 151 integration), self-check 60/60 at 100%. CI clippy (bin) + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)