### PR TITLE
Fix: reject files: paths that escape the project root (High: info disclosure)

### DIFF
--- a/specs/validator/validator.spec.md
+++ b/specs/validator/validator.spec.md
@@ -1,6 +1,6 @@
 ---
 module: validator
-version: 3
+version: 4
 status: stable
 files:
   - src/validator.rs
@@ -32,6 +32,7 @@ Core validation engine for spec-sync. Validates individual spec files against so
 | `get_schema_table_names` | `root, config` | `HashSet<String>` | Extract table names from SQL schema files using configurable regex |
 | `is_cross_project_ref` | `dep: &str` | `bool` | Check if a dependency string is a cross-project ref (`owner/repo@module`) |
 | `parse_cross_project_ref` | `dep: &str` | `Option<(&str, &str)>` | Parse cross-project ref into (owner/repo, module) tuple |
+| `source_within_root` | `root: &Path, file: &str` | `bool` | Whether a `files:` entry resolves inside the project root (rejects absolute/`..`/symlink escapes); shared guard for every export-extraction site |
 
 ## Invariants
 
@@ -109,6 +110,7 @@ Core validation engine for spec-sync. Validates individual spec files against so
 
 | Date | Change |
 |------|--------|
+| 2026-07-02 | v4: add `source_within_root` — shared guard rejecting `files:` paths that escape the project root (absolute/`..`/symlink); applied in `validate_spec` and every export-extraction site (score, check --fix, diff, new) to close an out-of-root identifier-disclosure vector |
 | 2026-06-11 | v3: `validate_spec` populates `ValidationResult.status` with the parsed lifecycle status so callers can report draft skips |
 | 2026-06-07 | Update draft-only section warning wording |
 | 2026-03-25 | Initial spec |

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -764,6 +764,11 @@ pub fn regenerate_spec_with_ai(
     let files = crate::hash_cache::extract_frontmatter_files(&current_spec);
     let mut source_contents = Vec::new();
     for file in &files {
+        // Never feed an out-of-root `files:` entry's full content into the AI
+        // prompt — a hostile spec could exfiltrate arbitrary host files that way.
+        if !crate::validator::source_within_root(root, file) {
+            continue;
+        }
         let full_path = root.join(file);
         if let Ok(content) = fs::read_to_string(&full_path) {
             source_contents.push((file.clone(), content));

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -868,6 +868,12 @@ fn auto_fix_specs(
         // Collect all exports from source files
         let mut all_exports: Vec<String> = Vec::new();
         for file in &parsed.frontmatter.files {
+            // Never read (or --fix persist) exports from a `files:` entry that
+            // escapes the project root — it would write arbitrary host-file
+            // identifiers into the spec. `check` reports such entries as errors.
+            if !crate::validator::source_within_root(root, file) {
+                continue;
+            }
             let full_path = root.join(file);
             all_exports.extend(get_exported_symbols_full(
                 &full_path,
@@ -914,6 +920,9 @@ fn auto_fix_specs(
         // an "Exported Types" table.
         let mut type_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         for file in &parsed.frontmatter.files {
+            if !crate::validator::source_within_root(root, file) {
+                continue;
+            }
             let full_path = root.join(file);
             type_names.extend(get_exported_symbols_full(
                 &full_path,

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -101,6 +101,11 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
         // Get current exports from changed files
         let mut current_exports: Vec<String> = Vec::new();
         for file in &parsed.frontmatter.files {
+            // Skip `files:` entries that escape the project root (out-of-root
+            // identifier leak); `check` reports them as errors.
+            if !crate::validator::source_within_root(root, file) {
+                continue;
+            }
             let full_path = root.join(file);
             current_exports.extend(get_exported_symbols(&full_path));
         }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -52,6 +52,11 @@ pub fn cmd_new(root: &Path, module_name: &str, full: bool) {
     // Auto-detect exports from source files
     let mut all_exports: Vec<String> = Vec::new();
     for file in &source_files {
+        // Consistency with validate/score/diff: never extract from a path that
+        // escapes the project root.
+        if !crate::validator::source_within_root(root, file) {
+            continue;
+        }
         let full_path = root.join(file);
         all_exports.extend(exports::get_exported_symbols(&full_path));
     }

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -318,6 +318,11 @@ fn check_undeclared_imports(
         let mut actual_imports: HashSet<String> = HashSet::new();
 
         for file in &node.files {
+            // Skip `files:` entries that escape the project root — reading their
+            // imports would probe arbitrary host files (see validator::source_within_root).
+            if !crate::validator::source_within_root(root, file) {
+                continue;
+            }
             let full_path = root.join(file);
             let content = match fs::read_to_string(&full_path) {
                 Ok(c) => c,

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -282,6 +282,12 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
     if !fm.files.is_empty() {
         let mut all_exports: Vec<String> = Vec::new();
         for file in &fm.files {
+            // Never read a `files:` entry that escapes the project root — it would
+            // leak arbitrary host-file identifiers into score suggestions (and the
+            // MCP score tool). validate/check reports such entries as errors.
+            if !crate::validator::source_within_root(root, file) {
+                continue;
+            }
             let full_path = root.join(file);
             all_exports.extend(get_exported_symbols(&full_path));
         }
@@ -927,6 +933,41 @@ None.
             score.total
         );
         assert!(score.grade == "A" || score.grade == "B");
+    }
+
+    #[test]
+    fn test_score_spec_out_of_root_file_does_not_leak_identifiers() {
+        // Security regression: a spec whose `files:` resolves outside the project
+        // root (here an absolute path) must not have that file's exported
+        // identifiers read and surfaced in `score` suggestions (incl. MCP score).
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(
+            outside.path().join("secret.ts"),
+            "export const AWS_SECRET_ACCESS_KEY = \"leak\";\n",
+        )
+        .unwrap();
+
+        let spec_dir = root.path().join("specs").join("s");
+        std::fs::create_dir_all(&spec_dir).unwrap();
+        let spec_content = format!(
+            "---\nmodule: s\nversion: 1\nstatus: active\nfiles:\n  - {}\ndb_tables: []\ndepends_on: []\n---\n\n# S\n\n## Purpose\nx\n\n## Public API\n| Export | Description |\n|--------|-------------|\n\n## Invariants\n1. x\n\n## Behavioral Examples\n### Scenario: a\n- **Given** a **When** b **Then** c\n\n## Error Cases\n| Condition | Behavior |\n|-----------|----------|\n\n## Dependencies\nNone.\n\n## Change Log\n| Date | Change |\n|------|--------|\n| 2024-01-01 | Initial |\n",
+            outside.path().join("secret.ts").display()
+        );
+        let spec_file = spec_dir.join("s.spec.md");
+        std::fs::write(&spec_file, spec_content).unwrap();
+
+        let config = SpecSyncConfig::default();
+        let score = score_spec(&spec_file, root.path(), &config);
+
+        assert!(
+            !score
+                .suggestions
+                .iter()
+                .any(|s| s.contains("AWS_SECRET_ACCESS_KEY")),
+            "out-of-root identifier leaked into score suggestions: {:?}",
+            score.suggestions
+        );
     }
 
     #[test]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -821,7 +821,11 @@ fn suggest_similar_file(root: &Path, missing_file: &str) -> Option<String> {
 /// Returns `true` when the path does not yet resolve (nonexistent/unreadable) so
 /// the existence check reports those instead; containment is only enforced for
 /// paths that actually resolve on disk (which is where a leak could occur).
-fn source_within_root(root: &Path, file: &str) -> bool {
+///
+/// Shared: every site that reads a `files:` entry's CONTENT (export extraction in
+/// `score`, `check --fix`, `diff`, `new`, …) must gate on this, or the out-of-root
+/// identifier leak reopens through that command.
+pub(crate) fn source_within_root(root: &Path, file: &str) -> bool {
     let full = root.join(file);
     match (root.canonicalize(), full.canonicalize()) {
         (Ok(canon_root), Ok(canon_full)) => canon_full.starts_with(&canon_root),

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -290,6 +290,13 @@ pub fn validate_spec(
                     "Remove `{file}` from files list or create the source file"
                 ));
             }
+        } else if !source_within_root(root, file) {
+            result.errors.push(format!(
+                "Source file `{file}` resolves outside the project root and is ignored for security"
+            ));
+            result.fixes.push(format!(
+                "Use a path inside the project (no absolute paths, `..` escapes, or symlinks that leave the project), or remove `{file}` from the files list"
+            ));
         } else if full_path.is_file()
             && let Err(err) = fs::read_to_string(&full_path)
         {
@@ -430,6 +437,12 @@ pub fn validate_spec(
         let mut exports_by_file: Vec<(String, String)> = Vec::new(); // (symbol, file)
         let mut all_exports: Vec<String> = Vec::new();
         for file in &fm.files {
+            // Never extract exports from a path that escapes the project root — it
+            // would leak arbitrary host-file identifiers. The files-exist check
+            // above already reports such entries as errors.
+            if !source_within_root(root, file) {
+                continue;
+            }
             let full_path = root.join(file);
             let exports =
                 get_exported_symbols_full(&full_path, config.export_level, config.parse_mode);
@@ -796,6 +809,26 @@ fn suggest_similar_file(root: &Path, missing_file: &str) -> Option<String> {
     best.map(|(s, _)| s)
 }
 
+/// Whether a spec `files:` entry resolves to a real path INSIDE the project root.
+///
+/// Source files a spec validates must live within the project. An entry that
+/// escapes — an absolute path, `..` traversal, or a symlink pointing outside the
+/// project — is rejected by the caller: reading it would count arbitrary host
+/// files as covered and leak their exported identifiers into coverage output and
+/// PR comments (a hostile-repo info-disclosure vector, the same threat model as a
+/// committed `ai_command`).
+///
+/// Returns `true` when the path does not yet resolve (nonexistent/unreadable) so
+/// the existence check reports those instead; containment is only enforced for
+/// paths that actually resolve on disk (which is where a leak could occur).
+fn source_within_root(root: &Path, file: &str) -> bool {
+    let full = root.join(file);
+    match (root.canonicalize(), full.canonicalize()) {
+        (Ok(canon_root), Ok(canon_full)) => canon_full.starts_with(&canon_root),
+        _ => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -931,6 +964,85 @@ mod tests {
                 .any(|e| e.contains("could not be read as UTF-8")),
             "expected a UTF-8 read error, got: {:?}",
             result.errors
+        );
+    }
+
+    #[test]
+    fn test_validate_spec_absolute_path_source_is_rejected() {
+        // Security: a `files:` entry resolving OUTSIDE the project root (here an
+        // absolute path into a different directory) must be rejected, and its
+        // exported identifiers must never leak into the report.
+        let root_tmp = tempfile::tempdir().unwrap();
+        let outside_tmp = tempfile::tempdir().unwrap();
+        let secret = outside_tmp.path().join("secret.ts");
+        fs::write(&secret, "export const AWS_SECRET_ACCESS_KEY = \"leak\";\n").unwrap();
+
+        let spec = root_tmp.path().join("s.spec.md");
+        let body = format!(
+            "---\nmodule: s\nversion: 1\nstatus: active\nfiles:\n  - {}\n---\n\n## Purpose\nx\n## Public API\n## Invariants\n## Behavioral Examples\n## Error Cases\n## Dependencies\n## Change Log\n",
+            secret.display()
+        );
+        fs::write(&spec, body).unwrap();
+
+        let tables = HashSet::new();
+        let schema_cols = HashMap::new();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(&spec, root_tmp.path(), &tables, &schema_cols, &config);
+
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("outside the project root")),
+            "expected an out-of-root rejection, got: {:?}",
+            result.errors
+        );
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("AWS_SECRET_ACCESS_KEY")),
+            "out-of-root export leaked into warnings: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_validate_spec_parent_escape_source_is_rejected() {
+        // Security: `..` traversal that leaves the project root is rejected.
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("project");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            parent.path().join("outside.ts"),
+            "export function leakMe() {}\n",
+        )
+        .unwrap();
+
+        let spec = root.join("s.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: s\nversion: 1\nstatus: active\nfiles:\n  - ../outside.ts\n---\n\n## Purpose\nx\n## Public API\n## Invariants\n## Behavioral Examples\n## Error Cases\n## Dependencies\n## Change Log\n",
+        )
+        .unwrap();
+
+        let tables = HashSet::new();
+        let schema_cols = HashMap::new();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(&spec, &root, &tables, &schema_cols, &config);
+
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("outside the project root")),
+            "expected an out-of-root rejection for `..` escape, got: {:?}",
+            result.errors
+        );
+        assert!(
+            !result.warnings.iter().any(|w| w.contains("leakMe")),
+            "escaped export leaked into warnings: {:?}",
+            result.warnings
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes a **High info-disclosure bug** found while dogfooding: a spec's `files:` entries had no path containment, so an entry resolving **outside the project root** (absolute path, `..`, or an in-repo symlink pointing out) was validated — the out-of-root file counted as covered and its exported identifiers leaked into `check`/`score`/`diff` output, PR comments, and the MCP tools.

## Fix (closes the whole class)
- `source_within_root(root, file)` (shared `pub(crate)` guard) canonicalizes both the root and the resolved path (resolving `..` **and** symlinks) and requires the file to sit inside the canonical root.
- Applied at **every** site that reads a `files:` entry's content and extracts identifiers:
  - `validate_spec` (`check`) — reports out-of-root entries as an error and skips extraction
  - `score` (and the MCP `score` tool)
  - `check --fix` (both export-collection loops — it *persists* identifiers into the spec)
  - `diff`
  - `new`
- `compute_coverage` needs no guard: it enumerates real files under `source_dirs` and uses `files:` only as a membership set, so an out-of-root path contributes **zero LOC** (verified: a 20k-line out-of-root file → <100 LOC).

## Why class-wide
The first version guarded only `validate_spec`; review then reproduced the identical leak through `specsync score`. Rather than patch one site, the guard is now a single shared helper applied at all extraction sites.

## Verified
- Real CLI: an in-repo symlink to `/etc/passwd` is rejected, the spec fails (not a silent pass), no `passwd` identifiers leak.
- Unit tests: absolute + `..` escapes rejected with no export leak; `score` on an out-of-root file no longer leaks identifiers into suggestions.
- Repo's own **60 specs still pass at 100%** (no over-blocking); full suite (658 unit + 149 integration), clippy, fmt clean.

## Known lower-severity follow-up (not in scope)
`depends_on` `.exists()` probes (validator/report/stale/scoring) are an existence-oracle only — they reveal a boolean, not identifiers. Happy to extend containment there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)