### PR TITLE
Fix: migrate refuses to run on an unparseable config instead of silently losing it (Critical)

### DIFF
--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -848,9 +848,84 @@ fn apply_stamp_version(ctx: &MigrationContext, report: &mut MigrationReport) -> 
     Ok(())
 }
 
+// ─── Pre-flight: config parseability ─────────────────────────────────────────
+
+/// The config file `migrate` would convert, mirroring `apply_relocate_config`'s
+/// source selection: legacy root `specsync.json` first, then the intermediate
+/// `.specsync/config.json`. The legacy `.specsync.toml` is intentionally omitted —
+/// its hand-rolled parser is lenient and never hard-fails.
+fn config_source_to_validate(root: &Path) -> Option<PathBuf> {
+    let old_json = root.join("specsync.json");
+    if old_json.exists() {
+        return Some(old_json);
+    }
+    if root.join(".specsync.toml").exists() {
+        return None;
+    }
+    let new_json = root.join(".specsync/config.json");
+    if new_json.exists() {
+        return Some(new_json);
+    }
+    None
+}
+
+/// Verify the JSON config `migrate` would convert actually parses. Returns
+/// `Err((relative_name, parse_error))` when the file exists but is malformed, so
+/// the caller can refuse rather than silently replace a real config with defaults
+/// and delete the original. `Ok` when parseable, absent, or a lenient TOML source.
+fn preflight_config_parseable(root: &Path) -> Result<(), (String, String)> {
+    let Some(source) = config_source_to_validate(root) else {
+        return Ok(());
+    };
+    let name = source
+        .strip_prefix(root)
+        .unwrap_or(&source)
+        .display()
+        .to_string();
+    let content =
+        fs::read_to_string(&source).map_err(|e| (name.clone(), format!("cannot read file: {e}")))?;
+    // Same parse `load_json_config` uses; on failure it would fall back to
+    // defaults, so catch it here first (unknown keys are ignored by serde, not
+    // an error — they are only warned about during a normal load).
+    serde_json::from_str::<crate::types::SpecSyncConfig>(&content)
+        .map_err(|e| (name, e.to_string()))?;
+    Ok(())
+}
+
 // ─── Main command ───────────────────────────────────────────────────────────
 
 pub fn cmd_migrate(root: &Path, format: OutputFormat, dry_run: bool, no_backup: bool) {
+    // Refuse to migrate a config we cannot parse. Otherwise the parse error is
+    // swallowed, a pure-default config.toml is written, and the original file is
+    // deleted — silent, unrecoverable config loss reported as success. Runs before
+    // any mutation (directory creation, version stamping) so a failure leaves the
+    // project byte-for-byte unchanged.
+    if let Err((name, err)) = preflight_config_parseable(root) {
+        match format {
+            OutputFormat::Json => {
+                let output = serde_json::json!({
+                    "status": "error",
+                    "error": format!("Cannot parse {name}: {err}"),
+                    "hint": "Fix the config file and re-run `specsync migrate`. Your original file was not modified.",
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            }
+            _ => {
+                eprintln!(
+                    "{} Cannot migrate: {} is not valid — {}",
+                    "✗".red(),
+                    name.cyan(),
+                    err
+                );
+                eprintln!(
+                    "  Fix the config file and re-run {}. Your original file was not modified.",
+                    "specsync migrate".cyan()
+                );
+            }
+        }
+        process::exit(1);
+    }
+
     // Discover spec files
     let spec_files = discover_specs(root);
 
@@ -1185,6 +1260,42 @@ mod tests {
         }
         assert_eq!(report.dirs_created.len(), 4);
         assert_eq!(report.steps_completed.len(), 1);
+    }
+
+    #[test]
+    fn preflight_rejects_malformed_json_config() {
+        let tmp = TempDir::new().unwrap();
+        // Trailing comma — valid intent, invalid JSON.
+        fs::write(
+            tmp.path().join("specsync.json"),
+            "{ \"sourceDirs\": [\"lib\"], \"enforcement\": \"strict\", }",
+        )
+        .unwrap();
+        let err = preflight_config_parseable(tmp.path()).unwrap_err();
+        assert_eq!(err.0, "specsync.json");
+        assert!(!err.1.is_empty());
+    }
+
+    #[test]
+    fn preflight_accepts_valid_json_including_unknown_keys() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("specsync.json"),
+            "{ \"sourceDirs\": [\"lib\"], \"somethingNew\": 1 }",
+        )
+        .unwrap();
+        // Unknown keys are ignored by serde (only warned during a real load), so
+        // an otherwise-valid config must not be rejected.
+        assert!(preflight_config_parseable(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn preflight_ok_when_no_json_source() {
+        let tmp = TempDir::new().unwrap();
+        // No config at all, and a lenient TOML source, both pass the JSON gate.
+        assert!(preflight_config_parseable(tmp.path()).is_ok());
+        fs::write(tmp.path().join(".specsync.toml"), "not = valid = toml =").unwrap();
+        assert!(preflight_config_parseable(tmp.path()).is_ok());
     }
 
     #[test]

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -851,15 +851,24 @@ fn apply_stamp_version(ctx: &MigrationContext, report: &mut MigrationReport) -> 
 // ─── Pre-flight: config parseability ─────────────────────────────────────────
 
 /// The config file `migrate` would convert, mirroring `apply_relocate_config`'s
-/// source selection: legacy root `specsync.json` first, then the intermediate
-/// `.specsync/config.json`. The legacy `.specsync.toml` is intentionally omitted —
-/// its hand-rolled parser is lenient and never hard-fails.
+/// source selection exactly: legacy root `specsync.json` first, then the
+/// intermediate `.specsync/config.json`. The legacy `.specsync.toml` is omitted —
+/// its hand-rolled parser is lenient and never hard-fails. Returns `None` when
+/// nothing would be converted, so we don't refuse a run that wouldn't touch the
+/// (leftover) file anyway.
 fn config_source_to_validate(root: &Path) -> Option<PathBuf> {
     let old_json = root.join("specsync.json");
+    let old_toml = root.join(".specsync.toml");
+    // Mirror apply_relocate_config's early return: if the v4 config.toml already
+    // exists and there are no legacy ROOT configs to convert, there is nothing to
+    // relocate — a stray `.specsync/config.json` is left as-is, so don't validate it.
+    if root.join(".specsync/config.toml").exists() && !old_json.exists() && !old_toml.exists() {
+        return None;
+    }
     if old_json.exists() {
         return Some(old_json);
     }
-    if root.join(".specsync.toml").exists() {
+    if old_toml.exists() {
         return None;
     }
     let new_json = root.join(".specsync/config.json");
@@ -882,8 +891,8 @@ fn preflight_config_parseable(root: &Path) -> Result<(), (String, String)> {
         .unwrap_or(&source)
         .display()
         .to_string();
-    let content =
-        fs::read_to_string(&source).map_err(|e| (name.clone(), format!("cannot read file: {e}")))?;
+    let content = fs::read_to_string(&source)
+        .map_err(|e| (name.clone(), format!("cannot read file: {e}")))?;
     // Same parse `load_json_config` uses; on failure it would fall back to
     // defaults, so catch it here first (unknown keys are ignored by serde, not
     // an error — they are only warned about during a normal load).
@@ -895,37 +904,6 @@ fn preflight_config_parseable(root: &Path) -> Result<(), (String, String)> {
 // ─── Main command ───────────────────────────────────────────────────────────
 
 pub fn cmd_migrate(root: &Path, format: OutputFormat, dry_run: bool, no_backup: bool) {
-    // Refuse to migrate a config we cannot parse. Otherwise the parse error is
-    // swallowed, a pure-default config.toml is written, and the original file is
-    // deleted — silent, unrecoverable config loss reported as success. Runs before
-    // any mutation (directory creation, version stamping) so a failure leaves the
-    // project byte-for-byte unchanged.
-    if let Err((name, err)) = preflight_config_parseable(root) {
-        match format {
-            OutputFormat::Json => {
-                let output = serde_json::json!({
-                    "status": "error",
-                    "error": format!("Cannot parse {name}: {err}"),
-                    "hint": "Fix the config file and re-run `specsync migrate`. Your original file was not modified.",
-                });
-                println!("{}", serde_json::to_string_pretty(&output).unwrap());
-            }
-            _ => {
-                eprintln!(
-                    "{} Cannot migrate: {} is not valid — {}",
-                    "✗".red(),
-                    name.cyan(),
-                    err
-                );
-                eprintln!(
-                    "  Fix the config file and re-run {}. Your original file was not modified.",
-                    "specsync migrate".cyan()
-                );
-            }
-        }
-        process::exit(1);
-    }
-
     // Discover spec files
     let spec_files = discover_specs(root);
 
@@ -963,6 +941,39 @@ pub fn cmd_migrate(root: &Path, format: OutputFormat, dry_run: bool, no_backup: 
             }
         }
         return;
+    }
+
+    // Refuse to migrate a config we cannot parse. Otherwise the parse error is
+    // swallowed, a pure-default config.toml is written, and the original file is
+    // deleted — silent, unrecoverable config loss reported as success. Runs after
+    // the already-migrated short-circuit (so a stray malformed file in a completed
+    // project doesn't mask the "already migrated" notice) but before any mutation
+    // (directory creation, version stamping), so a failure leaves the project
+    // byte-for-byte unchanged.
+    if let Err((name, err)) = preflight_config_parseable(root) {
+        match format {
+            OutputFormat::Json => {
+                let output = serde_json::json!({
+                    "status": "error",
+                    "error": format!("Cannot parse {name}: {err}"),
+                    "hint": "Fix the config file and re-run `specsync migrate`. Your original file was not modified.",
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            }
+            _ => {
+                eprintln!(
+                    "{} Cannot migrate: {} is not valid — {}",
+                    "✗".red(),
+                    name.cyan(),
+                    err
+                );
+                eprintln!(
+                    "  Fix the config file and re-run {}. Your original file was not modified.",
+                    "specsync migrate".cyan()
+                );
+            }
+        }
+        process::exit(1);
     }
 
     if dry_run {
@@ -1286,6 +1297,22 @@ mod tests {
         .unwrap();
         // Unknown keys are ignored by serde (only warned during a real load), so
         // an otherwise-valid config must not be rejected.
+        assert!(preflight_config_parseable(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn preflight_skips_stale_config_json_when_config_toml_exists() {
+        // Already-migrated project (config.toml present, no legacy root config) with
+        // a leftover malformed .specsync/config.json. relocate_config would skip it,
+        // so the pre-flight must not refuse the run over a file it won't touch.
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".specsync")).unwrap();
+        fs::write(
+            tmp.path().join(".specsync/config.toml"),
+            "source_dirs = [\"src\"]\n",
+        )
+        .unwrap();
+        fs::write(tmp.path().join(".specsync/config.json"), "{ bad json ,,,").unwrap();
         assert!(preflight_config_parseable(tmp.path()).is_ok());
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4266,6 +4266,40 @@ fn migrate_no_project_fails() {
 }
 
 #[test]
+fn migrate_preserves_unparseable_config_and_fails() {
+    // Regression: a single parse error (here a trailing comma) must not cause
+    // migrate to write a pure-default config.toml, delete the original, and
+    // report success. It must fail loudly and leave the project untouched.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let original = "{\n  \"sourceDirs\": [\"lib\"],\n  \"enforcement\": \"strict\",\n}\n";
+    fs::write(root.join("specsync.json"), original).unwrap();
+    fs::create_dir_all(root.join("specs")).unwrap();
+
+    specsync()
+        .args(["migrate", "--no-backup", "--root"])
+        .arg(&root)
+        .assert()
+        .failure();
+
+    // Original config preserved byte-for-byte; no default config written.
+    assert_eq!(
+        fs::read_to_string(root.join("specsync.json")).unwrap(),
+        original,
+        "the original (malformed) config must be left untouched"
+    );
+    assert!(
+        !root.join(".specsync/config.toml").exists(),
+        "no default config.toml should have been written"
+    );
+    // And no version stamp that would make a re-run refuse to migrate.
+    assert!(
+        !root.join(".specsync/version").exists(),
+        "migration must not stamp a version when it aborted"
+    );
+}
+
+#[test]
 fn migrate_no_backup_flag() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path().to_path_buf();


### PR DESCRIPTION
## The bug (dogfooding finding C1 · Critical · data loss)
`specsync migrate` converts the legacy config to `.specsync/config.toml` and then **deletes the original**. But `load_json_config` swallows a JSON parse error and returns `SpecSyncConfig::default()` — so a single bad field made migrate write a pure-default config, delete `specsync.json`, and report success at exit 0.

**Repro (before):**
```
$ printf '{ "sourceDirs": ["lib"], "enforcement": "strict", }' > specsync.json   # trailing comma
$ specsync migrate --no-backup
Done: Successfully migrated to v4.0.0!
$ ls specsync.json                 # gone
$ grep source_dirs .specsync/config.toml
source_dirs = ["src"]              # defaults — "lib" and enforcement=strict lost
```
The `enforcement=strict → warn` drop silently flips a failing CI gate to green, and `--strict` did not catch it.

## The fix
A **pre-flight parse check** in `cmd_migrate`, before any mutation (dir creation, version stamping): if the JSON config migrate would convert exists but doesn't parse, print the parse error and exit 1 — the project is left byte-for-byte unchanged. Aborting before the version stamp also avoids stranding the project in a half-migrated state a re-run would refuse to fix.

- Unknown keys are still accepted (serde ignores them; only warned on a normal load) — the guard rejects only genuine parse/type errors.
- The legacy `.specsync.toml` source is exempt: its hand-rolled parser is lenient and never hard-fails. *(That leniency — silently dropping unrecognized TOML lines — is a separate, lesser concern noted for follow-up.)*

**Repro (after):** `✗ Cannot migrate: specsync.json is not valid — trailing comma at line 4 column 1` · original preserved · no config.toml · exit 1. A valid config still migrates with `source_dirs = ["lib"]` intact.

## Tests
- Unit: pre-flight rejects a trailing comma; accepts valid-with-unknown-keys; ok when no JSON source (incl. lenient TOML).
- Integration: malformed `specsync.json` → original untouched, no `config.toml`, no version stamp, exit non-zero.
- Full suite 669 + 152, fmt / clippy (bin) / self-check 100% green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)