### PR TITLE
Fix: check no longer bypasses coverage/enforcement gates on warm cache or no specs (Critical + High)

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -90,7 +90,11 @@ pub fn cmd_check(
         );
     }
 
-    let (config, all_spec_files) = load_and_discover(root, fix);
+    // Always allow the empty-specs case through: `check` handles it itself below,
+    // where a requested coverage/enforcement gate is still evaluated (the shared
+    // early-exit would `exit(0)` and silently pass the gate — and emit a non-JSON
+    // message under --format json). Default warn mode still exits 0 there.
+    let (config, all_spec_files) = load_and_discover(root, true);
     let spec_files = filter_specs(root, &all_spec_files, spec_filters);
     let spec_files = filter_by_status(&spec_files, exclude_status, only_status);
     // CLI --enforcement flag overrides config; --strict implies strict enforcement.
@@ -127,10 +131,18 @@ pub fn cmd_check(
     }
 
     if spec_files.is_empty() {
+        // No specs to validate — but a requested gate must still be evaluated
+        // against source coverage. Otherwise `check --require-coverage N`,
+        // `--enforcement enforce-new`, or `--strict` silently PASS in exactly the
+        // state they exist to catch: a project with source code but no specs (the
+        // default state right after `specsync init`). Default mode (warn, no gate)
+        // still exits 0 with the informational message.
+        let coverage = compute_coverage(root, &spec_files, &config);
+        let exit_code = compute_exit_code(0, 0, strict, enforcement, &coverage, require_coverage);
         match format {
             Json => {
                 let output = serde_json::json!({
-                    "passed": true,
+                    "passed": exit_code == 0,
                     "errors": [],
                     "warnings": [],
                     "stale": [],
@@ -148,9 +160,14 @@ pub fn cmd_check(
                     "No spec files found in {}/. Run `specsync generate` to scaffold specs.",
                     abs_specs.display()
                 );
+                // When a gate fails, show the coverage that failed it so exit 1
+                // isn't unexplained.
+                if exit_code != 0 {
+                    print_coverage_line(&coverage);
+                }
             }
         }
-        process::exit(0);
+        process::exit(exit_code);
     }
 
     // Load hash cache and classify changes for each spec.
@@ -200,7 +217,13 @@ pub fn cmd_check(
         println!("{}", "All specs unchanged — nothing to validate.".green());
         let coverage = compute_coverage(root, &spec_files, &config);
         print_coverage_line(&coverage);
-        process::exit(0);
+        // A warm cache skips spec RE-validation, but a requested coverage/
+        // enforcement gate must still be evaluated against freshly computed
+        // coverage — otherwise an unchanged run silently flips a failing
+        // --require-coverage / --enforcement gate to exit 0. Cached specs had no
+        // errors (that's why they're cached), so 0 errors/warnings is correct here.
+        let exit_code = compute_exit_code(0, 0, strict, enforcement, &coverage, require_coverage);
+        process::exit(exit_code);
     }
 
     // Report staleness from change classifications

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5912,3 +5912,64 @@ fn hooks_uninstall_preserves_user_content_after_block() {
         "the managed block must be removed:\n{after}"
     );
 }
+
+// ─── specsync check: gate evaluation is not bypassed ─────────────────────
+
+#[test]
+fn check_no_specs_still_evaluates_requested_gate() {
+    // Regression (H2): a project with source but no specs must still FAIL a
+    // requested coverage/enforcement gate instead of short-circuiting to exit 0.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+
+    // 0% coverage must fail a 100% requirement, and enforce-new must flag the
+    // unspecced file.
+    specsync()
+        .current_dir(root)
+        .args(["check", "--require-coverage", "100"])
+        .assert()
+        .failure();
+    specsync()
+        .current_dir(root)
+        .args(["check", "--enforcement", "enforce-new"])
+        .assert()
+        .failure();
+    // Default check (no gate requested) still succeeds informationally.
+    specsync().current_dir(root).arg("check").assert().success();
+}
+
+#[test]
+fn check_require_coverage_gate_fails_on_warm_cache() {
+    // Regression (C2): the coverage gate must be evaluated even when the hash
+    // cache is warm and no specs need re-validation — a warm run must not flip a
+    // failing --require-coverage into exit 0.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // 1 specced + 1 unspecced file → 50% coverage.
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    fs::write(root.join("src/b.ts"), "export function b() {}\n").unwrap();
+    fs::create_dir_all(root.join("specs/a")).unwrap();
+    fs::write(
+        root.join("specs/a/a.spec.md"),
+        valid_spec("a", &["src/a.ts"]),
+    )
+    .unwrap();
+
+    // Cold run populates the cache and fails the 90% gate.
+    specsync()
+        .current_dir(root)
+        .args(["check", "--require-coverage", "90"])
+        .assert()
+        .failure();
+    // Warm run (specs unchanged, served from cache) must ALSO fail.
+    specsync()
+        .current_dir(root)
+        .args(["check", "--require-coverage", "90"])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## The bugs (dogfooding findings C2 · Critical, H2 · High — silent CI false-pass)
Two `check` paths exited **0 without evaluating a requested gate**, passing CI in exactly the states the gate exists to catch.

**C2 — warm cache skips the coverage gate.** With a warm hash cache and no specs to re-validate, `check` printed coverage and exited 0:
```
$ specsync check --require-coverage 90   # 2 specced + 3 unspecced files
File coverage: 2/5 (40%)                 # cold: exit 1  |  warm: exit 0  ← bug
```
Non-idempotent: a pre-commit hook or CI that caches `.specsync/` gets a false green.

**H2 — no specs bypasses every gate.** The shared `load_and_discover` exits 0 on a project with source but no specs (the default state right after `init`):
```
$ specsync check --require-coverage 100  # 0% coverage
No spec files found…                     # exit 0  ← should fail
$ specsync check --enforcement enforce-new  # exit 0  ← should fail
$ specsync check --require-coverage 100 --format json  # emitted plain text, not JSON
```

## The fix
- **C2:** the unchanged-skip now evaluates the coverage/enforcement gate against **freshly computed coverage** before exiting.
- **H2:** `check` passes `allow_empty = true` to `load_and_discover` and handles the empty case itself — evaluating the gate (0% < threshold fails; `enforce-new` flags unspecced files) and emitting proper JSON. Default *warn* mode with no gate still exits 0 informationally.

Both reuse the existing `compute_exit_code`, so gate semantics are identical to a normal run — no new policy, just no early-out around it.

## Scope
The same `load_and_discover` early-exit also affects `score` and `coverage` (a `score` gate that never gates, JSON that isn't JSON) — that's findings **H5 / M1**, tracked separately.

## Tests
- No-specs project fails `--require-coverage 100` and `--enforcement enforce-new`, but a bare `check` still passes.
- A warm-cache run fails the coverage gate just like the cold run.
- Full suite 676 + 155, fmt / clippy (bin) / self-check 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)