### PR TITLE
Fix: score honors the --require-coverage/--enforcement/--strict gates (High)

### DIFF
--- a/src/commands/score.rs
+++ b/src/commands/score.rs
@@ -3,11 +3,18 @@ use std::path::Path;
 
 use crate::scoring;
 use crate::types;
+use crate::validator::compute_coverage;
 
-use super::{filter_by_status, filter_specs, load_and_discover};
+use super::{
+    compute_exit_code, exit_with_status, filter_by_status, filter_specs, load_and_discover,
+};
 
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_score(
     root: &Path,
+    strict: bool,
+    enforcement: Option<types::EnforcementMode>,
+    require_coverage: Option<usize>,
     format: types::OutputFormat,
     explain: bool,
     all: bool,
@@ -16,7 +23,19 @@ pub fn cmd_score(
     only_status: &[String],
 ) {
     let json = matches!(format, types::OutputFormat::Json);
-    let (config, all_spec_files) = load_and_discover(root, false);
+    // The global `--strict` / `--enforcement` / `--require-coverage` flags are
+    // gates. `score` must honor them (they were previously silent no-ops here):
+    // when one is set, don't take load_and_discover's no-spec early-exit —
+    // otherwise `score --require-coverage 100` on a spec-less project would
+    // bypass the gate exactly like the `check` no-spec bug did.
+    let gate_requested = strict || enforcement.is_some() || require_coverage.is_some();
+    let (config, all_spec_files) = load_and_discover(root, gate_requested);
+    // CLI --enforcement overrides config; --strict implies strict enforcement.
+    let enforcement = enforcement.unwrap_or(if strict {
+        types::EnforcementMode::Strict
+    } else {
+        config.enforcement
+    });
     let spec_files = filter_specs(root, &all_spec_files, spec_filters);
     let spec_files = filter_by_status(&spec_files, exclude_status, only_status);
     let scores: Vec<scoring::SpecScore> = spec_files
@@ -83,6 +102,25 @@ pub fn cmd_score(
             print_text_output(&project, explain);
         }
     }
+
+    // Honor the global gate flags. `score` is advisory by default (Warn config →
+    // exit 0), but `--require-coverage`, `--enforcement enforce-new`, and a strict
+    // config now gate the exit code — previously they were silent no-ops here.
+    // score does no validation, so errors/warnings are 0; coverage and
+    // unspecced-file gating still apply.
+    let coverage = compute_coverage(root, &spec_files, &config);
+    if json {
+        // Machine output already printed — gate silently so stdout stays valid JSON.
+        std::process::exit(compute_exit_code(
+            0,
+            0,
+            strict,
+            enforcement,
+            &coverage,
+            require_coverage,
+        ));
+    }
+    exit_with_status(0, 0, strict, enforcement, &coverage, require_coverage);
 }
 
 fn print_text_output(project: &scoring::ProjectScore, explain: bool) {

--- a/src/commands/score.rs
+++ b/src/commands/score.rs
@@ -109,8 +109,10 @@ pub fn cmd_score(
     // score does no validation, so errors/warnings are 0; coverage and
     // unspecced-file gating still apply.
     let coverage = compute_coverage(root, &spec_files, &config);
-    if json {
-        // Machine output already printed — gate silently so stdout stays valid JSON.
+    // JSON and CSV are machine formats: their body is already printed, so gate
+    // SILENTLY via the exit code — appending exit_with_status's human message
+    // would corrupt the parseable output. Other formats get the explanation.
+    if json || matches!(format, types::OutputFormat::Csv) {
         std::process::exit(compute_exit_code(
             0,
             0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,9 @@ fn run() {
             specs,
         } => commands::score::cmd_score(
             &root,
+            cli.strict,
+            cli.enforcement,
+            cli.require_coverage,
             format,
             explain,
             all,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6012,6 +6012,14 @@ fn score_honors_require_coverage_gate() {
         .assert()
         .failure()
         .stdout(predicate::str::starts_with("{"));
+    // CSV is a machine format too: it must gate WITHOUT the human failure message
+    // leaking into the CSV body (regression guard for the review's CSV nit).
+    specsync()
+        .current_dir(root)
+        .args(["score", "--require-coverage", "100", "--format", "csv"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("--require-coverage").not());
     specsync().current_dir(root).arg("score").assert().success();
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5973,3 +5973,63 @@ fn check_require_coverage_gate_fails_on_warm_cache() {
         .assert()
         .failure();
 }
+
+// ─── specsync score: gate flags are honored, not silent no-ops ───────────
+
+#[test]
+fn score_honors_require_coverage_gate() {
+    // Regression (H5): the global --require-coverage / --enforcement flags were
+    // silently ignored by `score` (it always exited 0). They must now gate.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // 1 specced + 1 unspecced file → below 100% coverage.
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    fs::write(root.join("src/uncovered.ts"), "export function b() {}\n").unwrap();
+    fs::create_dir_all(root.join("specs/a")).unwrap();
+    fs::write(
+        root.join("specs/a/a.spec.md"),
+        valid_spec("a", &["src/a.ts"]),
+    )
+    .unwrap();
+
+    // Gate flags now fail; default score stays advisory (exit 0).
+    specsync()
+        .current_dir(root)
+        .args(["score", "--require-coverage", "100"])
+        .assert()
+        .failure();
+    specsync()
+        .current_dir(root)
+        .args(["score", "--enforcement", "enforce-new"])
+        .assert()
+        .failure();
+    // JSON output must still gate AND remain valid JSON.
+    specsync()
+        .current_dir(root)
+        .args(["score", "--require-coverage", "100", "--format", "json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::starts_with("{"));
+    specsync().current_dir(root).arg("score").assert().success();
+}
+
+#[test]
+fn score_no_specs_still_evaluates_requested_gate() {
+    // Regression (H5/H2 class): a spec-less project must still FAIL a requested
+    // gate rather than taking the no-spec early-exit, while a plain `score`
+    // keeps its friendly early-exit.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["score", "--require-coverage", "100"])
+        .assert()
+        .failure();
+    specsync().current_dir(root).arg("score").assert().success();
+}


### PR DESCRIPTION
## The bug (dogfooding finding H5 · High · silent gate no-op)
`--strict`, `--require-coverage`, and `--enforcement` are **global** flags (they apply to every subcommand) documented as gates — `--require-coverage` literally reads *"Fail if file coverage percent is below this threshold."* But `cmd_score` never received them:

```
$ specsync score --require-coverage 100   # project is 50% covered
… A/B/C grades …
$ echo $?
0        # ← gate ignored; a CI job using `score` passes green
```
Anyone who wired `score` into CI as a gate got a silently green build.

## The fix
Wire the three flags into score's exit code using the **same `compute_exit_code` / `exit_with_status`** the sibling `check` and `coverage` commands use:
- Resolve enforcement CLI > config (`--strict` ⇒ strict), compute file coverage, gate the exit.
- score does no validation, so errors/warnings are `0` — `--require-coverage` and `--enforcement enforce-new` (unspecced files) gate; a **Warn config stays advisory (exit 0)**, so plain `score` is unchanged.
- **JSON** gates via `compute_exit_code` so stdout stays valid JSON (no human message appended).
- When a gate is requested, score no longer takes `load_and_discover`'s **no-spec early-exit** (the same bypass class as the just-fixed `check` no-spec bug): a spec-less project now fails `--require-coverage 100` instead of exiting 0; a plain `score` keeps its friendly early-exit.

## Verified
| command | before | after |
|---|---|---|
| `score --require-coverage 100` (under-covered) | 0 | **1** |
| `score --require-coverage 100 --format json` | 0 | **1**, stdout still valid JSON |
| `score --enforcement enforce-new` (unspecced files) | 0 | **1** |
| `score --require-coverage 100` (source, **no specs**) | 0 | **1** |
| `score` (default) | 0 | 0 (advisory, unchanged) |
| `score --require-coverage 0` | 0 | 0 |

Tests: `score_honors_require_coverage_gate`, `score_no_specs_still_evaluates_requested_gate`. Full suite 679 + 157, fmt / clippy (bin) / self-check 100%.

## Note
The sibling `coverage` command shares the **no-spec early-exit bypass** (`load_and_discover(root, false)` at coverage.rs:18) and does not gate in `--format json` (early `exit(0)`) — that's the related **M1** finding, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)