### PR TITLE
Fix: deps --strict gates on undeclared-import warnings (High)

### DIFF
--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -6,7 +6,7 @@ use crate::config::load_config;
 use crate::deps;
 use crate::types;
 
-pub fn cmd_deps(root: &Path, format: types::OutputFormat, mermaid: bool, dot: bool) {
+pub fn cmd_deps(root: &Path, strict: bool, format: types::OutputFormat, mermaid: bool, dot: bool) {
     let config = load_config(root);
 
     // --mermaid or --dot: output graph visualization and exit
@@ -103,7 +103,19 @@ pub fn cmd_deps(root: &Path, format: types::OutputFormat, mermaid: bool, dot: bo
         }
     }
 
-    if !report.errors.is_empty() {
+    // `--strict` treats dependency warnings (undeclared imports — imports of a
+    // module not listed in `depends_on`) as failures. Without this, `deps --strict`
+    // was a silent no-op: undeclared imports were reported but never gated CI.
+    let strict_fail = strict && !report.warnings.is_empty();
+    if strict_fail && !matches!(format, types::OutputFormat::Json) {
+        println!(
+            "{}: {} dependency warning(s) treated as errors",
+            "--strict mode".red(),
+            report.warnings.len()
+        );
+    }
+
+    if !report.errors.is_empty() || strict_fail {
         process::exit(1);
     }
 }

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -107,8 +107,10 @@ pub fn cmd_deps(root: &Path, strict: bool, format: types::OutputFormat, mermaid:
     // module not listed in `depends_on`) as failures. Without this, `deps --strict`
     // was a silent no-op: undeclared imports were reported but never gated CI.
     let strict_fail = strict && !report.warnings.is_empty();
-    if strict_fail && !matches!(format, types::OutputFormat::Json) {
-        println!(
+    if strict_fail {
+        // A diagnostic, not report content — route to stderr so stdout stays a
+        // clean, machine-parseable body for every format (JSON/markdown/csv).
+        eprintln!(
             "{}: {} dependency warning(s) treated as errors",
             "--strict mode".red(),
             report.warnings.len()

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,9 @@ fn run() {
         Command::Issues { create } => commands::issues::cmd_issues(&root, format, create),
         Command::New { name, full } => commands::new::cmd_new(&root, &name, full),
         Command::Wizard => commands::wizard::cmd_wizard(&root),
-        Command::Deps { mermaid, dot } => commands::deps::cmd_deps(&root, format, mermaid, dot),
+        Command::Deps { mermaid, dot } => {
+            commands::deps::cmd_deps(&root, cli.strict, format, mermaid, dot)
+        }
         Command::Import {
             source,
             id,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6085,13 +6085,22 @@ fn deps_strict_gates_on_undeclared_imports() {
         .args(["deps", "--strict"])
         .assert()
         .failure();
-    // JSON output gates AND stays valid JSON.
-    specsync()
+    // JSON output gates AND stdout stays fully parseable JSON (the strict note
+    // is a stderr diagnostic, so it must not leak into the JSON body).
+    let out = specsync()
         .current_dir(root)
         .args(["deps", "--strict", "--format", "json"])
         .assert()
         .failure()
-        .stdout(predicate::str::starts_with("{"));
+        .get_output()
+        .stdout
+        .clone();
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&out).expect("deps --strict json stdout must be valid JSON");
+    assert!(
+        !parsed["undeclared_imports"].as_array().unwrap().is_empty(),
+        "expected the undeclared import to be reported in JSON"
+    );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6041,3 +6041,74 @@ fn score_no_specs_still_evaluates_requested_gate() {
         .failure();
     specsync().current_dir(root).arg("score").assert().success();
 }
+
+// ─── specsync deps: --strict gates on undeclared-import warnings ─────────
+
+/// Build a two-module project where `api` imports `db` without declaring it.
+fn setup_undeclared_import_project(root: &std::path::Path) {
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src/api")).unwrap();
+    fs::create_dir_all(root.join("src/db")).unwrap();
+    fs::create_dir_all(root.join("specs/api")).unwrap();
+    fs::create_dir_all(root.join("specs/db")).unwrap();
+    fs::write(root.join("src/db/db.ts"), "export function query() {}\n").unwrap();
+    fs::write(
+        root.join("src/api/api.ts"),
+        "import { query } from '../db/db';\nexport function handler() { return query(); }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("specs/db/db.spec.md"),
+        "---\nmodule: db\nversion: 1\nstatus: active\nfiles:\n  - src/db/db.ts\ndepends_on: []\n---\n# db\n## Purpose\np\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("specs/api/api.spec.md"),
+        "---\nmodule: api\nversion: 1\nstatus: active\nfiles:\n  - src/api/api.ts\ndepends_on: []\n---\n# api\n## Purpose\np\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn deps_strict_gates_on_undeclared_imports() {
+    // Regression (H6): `deps --strict` was a silent no-op — undeclared imports
+    // were reported as warnings but never failed the exit code.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    setup_undeclared_import_project(root);
+
+    // Default deps is advisory (reports the warning, exits 0).
+    specsync().current_dir(root).arg("deps").assert().success();
+    // --strict now fails on the undeclared import.
+    specsync()
+        .current_dir(root)
+        .args(["deps", "--strict"])
+        .assert()
+        .failure();
+    // JSON output gates AND stays valid JSON.
+    specsync()
+        .current_dir(root)
+        .args(["deps", "--strict", "--format", "json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::starts_with("{"));
+}
+
+#[test]
+fn deps_strict_passes_when_dependency_is_declared() {
+    // No false failure: once `api` declares `depends_on: [db]`, --strict is clean.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    setup_undeclared_import_project(root);
+    fs::write(
+        root.join("specs/api/api.spec.md"),
+        "---\nmodule: api\nversion: 1\nstatus: active\nfiles:\n  - src/api/api.ts\ndepends_on:\n  - db\n---\n# api\n## Purpose\np\n",
+    )
+    .unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["deps", "--strict"])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## The bug (dogfooding finding H6 · High · silent gate no-op)
`deps` exited non-zero **only on errors** (missing declared deps, cycles). Its *warnings* — undeclared imports (a module importing another it doesn't list in `depends_on`) — were reported but never affected the exit code, and `cmd_deps` didn't even receive `--strict`:

```
$ specsync deps --strict
  ⚠ specs/api/api.spec.md: source imports 'db' but it is not in depends_on
$ echo $?
0        # ← undeclared import, but --strict is a no-op; CI stays green
```

## The fix
Pass `--strict` into `cmd_deps` and treat dependency warnings as failures under it:
- `deps --strict` with any warning → exit 1, with a `N dependency warning(s) treated as errors` note on non-JSON formats.
- **JSON** stays valid (no human text appended) and gates via the exit code.
- Default `deps` unchanged (advisory, exit 0); `--mermaid`/`--dot` return before validation so visualization never gates; a project whose imports are all declared stays green under `--strict`.

## Verified
| command | before | after |
|---|---|---|
| `deps` (undeclared import) | 0 | 0 (advisory) |
| `deps --strict` (undeclared import) | 0 | **1** |
| `deps --strict --format json` | 0 | **1**, valid JSON |
| `deps --mermaid --strict` | 0 | 0 (viz) |
| `deps --strict` (dep declared) | 0 | 0 (no false fail) |

Tests: `deps_strict_gates_on_undeclared_imports`, `deps_strict_passes_when_dependency_is_declared`. Full suite 679 + 157, fmt / clippy (bin) / self-check 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)