### PR TITLE
Fix: JSON-gate the deps --strict note + sync the cmd_deps spec (follow-up to #304)

### DIFF
--- a/specs/cmd_deps/cmd_deps.spec.md
+++ b/specs/cmd_deps/cmd_deps.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_deps
-version: 1
+version: 2
 status: stable
 files:
   - src/commands/deps.rs
@@ -16,7 +16,7 @@ depends_on:
 
 ## Purpose
 
-Implements the `specsync deps` command. Validates cross-module dependency declarations and optionally renders the dependency graph as Mermaid or Graphviz DOT diagrams.
+Implements the `specsync deps` command. Validates cross-module dependency declarations and optionally renders the dependency graph as Mermaid or Graphviz DOT diagrams. Under `--strict`, dependency warnings (undeclared imports) are treated as failures so CI can gate on them.
 
 ## Public API
 
@@ -24,13 +24,15 @@ Implements the `specsync deps` command. Validates cross-module dependency declar
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `cmd_deps` | `root: &Path, format: OutputFormat, mermaid: bool, dot: bool` | `()` | Validate dependency graph; optionally output as Mermaid or DOT |
+| `cmd_deps` | `root: &Path, strict: bool, format: OutputFormat, mermaid: bool, dot: bool` | `()` | Validate dependency graph; optionally output as Mermaid or DOT. Under `strict`, dependency warnings become failures |
 
 ## Invariants
 
 1. Core validation delegates to `deps::validate_deps()`
 2. Private helpers `render_mermaid()` and `render_dot()` generate diagram syntax
 3. Exits 1 if dependency errors found (cycles, missing deps)
+4. Under `--strict`, a non-empty warning set (undeclared imports) also forces exit 1, after the report is printed in the requested format
+5. The `--strict` failure note is a human diagnostic printed to stderr and is suppressed in JSON mode — JSON stays fully machine-readable (the failing warnings are in the `warnings` array and the non-zero exit code carries the verdict)
 
 ## Behavioral Examples
 
@@ -46,12 +48,25 @@ Implements the `specsync deps` command. Validates cross-module dependency declar
 - **When** `cmd_deps` runs
 - **Then** prints cycle error and exits 1
 
+### Scenario: Strict mode gates undeclared-import warnings
+
+- **Given** a module imports another that is not in its `depends_on`, and `--strict` is set
+- **When** `cmd_deps` runs (no dependency errors, only warnings)
+- **Then** prints the report, notes on stderr that warnings are treated as errors, and exits 1
+
+### Scenario: Strict failure in JSON mode
+
+- **Given** the same undeclared-import warning under `--strict --format json`
+- **When** `cmd_deps` runs
+- **Then** stdout is the JSON report (with the warning in `warnings`), the human "treated as errors" note is **not** emitted, and the process exits 1
+
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
 | Circular dependency | Error printed, exits 1 |
 | Missing dependency spec | Error printed, exits 1 |
+| Undeclared import under `--strict` | Warning printed; stderr note (non-JSON only); exits 1 |
 | Empty dep graph | Prints hint about `depends_on` |
 
 ## Dependencies
@@ -74,4 +89,5 @@ Implements the `specsync deps` command. Validates cross-module dependency declar
 
 | Date | Change |
 |------|--------|
+| 2026-07-03 | v2: `cmd_deps` gained a `strict` parameter (#304) — undeclared-import warnings now force exit 1 under `--strict`. Documented the new signature, the strict exit-code invariant, and that the strict stderr note is suppressed in JSON mode (follow-up to #304). |
 | 2026-04-09 | Initial spec |

--- a/specs/cmd_deps/context.md
+++ b/specs/cmd_deps/context.md
@@ -7,7 +7,8 @@ spec: cmd_deps.spec.md
 - Two modes: diagram mode (`--mermaid`/`--dot`) builds the graph, prints the diagram, and returns early without validation or an exit-code change; validation mode runs `deps::validate_deps` and renders per `OutputFormat`.
 - `render_mermaid` and `render_dot` are private helpers kept in this wrapper (not the `deps` module) because they are presentation-only; both sort modules and deps for deterministic output and mark missing targets specially (dashed `❌` / dashed red).
 - The text path additionally prints a topological build order via `deps::topological_sort` when there are no cycles and the graph is non-empty.
-- Exit code: the command exits 1 whenever `report.errors` is non-empty, after the report has been printed in whatever format was requested.
+- Exit code: the command exits 1 whenever `report.errors` is non-empty, after the report has been printed in whatever format was requested. Under `--strict` it also exits 1 when `report.warnings` is non-empty (undeclared imports), so drift is gated in CI (#304).
+- The `--strict` "warnings treated as errors" note is a human diagnostic. It goes to stderr for non-JSON formats and is suppressed entirely in JSON mode — a JSON consumer relies only on the machine-readable body (the `warnings` array) plus the exit code, so no ANSI/human text leaks into its pipeline even via stderr.
 
 ## Files to Read First
 

--- a/specs/cmd_deps/requirements.md
+++ b/specs/cmd_deps/requirements.md
@@ -7,15 +7,18 @@ spec: cmd_deps.spec.md
 - As a developer, I want cross-module `depends_on` declarations validated so missing dependency specs, cycles, and undeclared imports are caught
 - As an architect, I want to render the dependency graph as Mermaid or Graphviz DOT so I can visualize module relationships
 - As a CI operator, I want `deps` to exit non-zero when there are dependency errors so broken graphs fail the build
+- As a CI operator, I want `deps --strict` to also fail on undeclared-import warnings so drift is gated, not just cycles/missing specs
+- As a tooling author, I want `deps --format json` to stay fully machine-readable (no human diagnostics, even on stderr) so I can parse it reliably
 
 ## Acceptance Criteria
 
-- `cmd_deps(root, format, mermaid, dot)` loads config and, when `--mermaid` or `--dot` is set, builds the graph and prints the corresponding diagram, then returns (no validation, no exit code change)
+- `cmd_deps(root, strict, format, mermaid, dot)` loads config and, when `--mermaid` or `--dot` is set, builds the graph and prints the corresponding diagram, then returns (no validation, no exit code change)
 - In diagram mode, if there are no `depends_on` edges but the graph is non-empty, a hint about adding `depends_on:` is printed to stderr
 - Mermaid renders missing targets as dashed `❌` nodes; DOT renders them as dashed red nodes; both sort modules/deps for deterministic output
 - Without a diagram flag, validation runs via `deps::validate_deps`, producing module/edge counts, errors, warnings, cycles, missing deps, and undeclared imports
 - Output is rendered per `OutputFormat`: Json (full report object), Markdown/Github (headed sections), and Text/Table/Csv (decorated lines plus a topological build order when there are no cycles)
 - Exits 1 if `report.errors` is non-empty (after printing the report in any format)
+- Under `--strict`, exits 1 when `report.warnings` is non-empty even if there are no errors; a "warnings treated as errors" note is printed to stderr for non-JSON formats and suppressed for JSON (the exit code and the `warnings` array are the JSON contract)
 
 ## Constraints
 

--- a/specs/cmd_deps/testing.md
+++ b/specs/cmd_deps/testing.md
@@ -11,6 +11,7 @@ spec: cmd_deps.spec.md
 | `src/deps.rs` cycles + ordering | cargo test deps::tests | `test_detect_circular_deps`, `test_detect_three_node_cycle`, `test_topological_sort_valid`, `test_topological_sort_cycle` |
 | `src/deps.rs` imports | cargo test deps::tests | `test_undeclared_rust_import`, `test_undeclared_ts_import`, `test_undeclared_python_import`, `test_self_import_not_flagged`, `test_declared_import_not_flagged` |
 | `tests/integration.rs` | cargo test --test integration dependency_spec_not_found_errors | End-to-end: a spec's `depends_on` references a nonexistent spec → error |
+| `tests/integration.rs` strict gate | cargo test --test integration deps_strict_gates_on_undeclared_imports | End-to-end: undeclared import under `--strict` exits 1; the stderr note is present for non-JSON and absent for `--format json` |
 
 ## Coverage Gaps
 
@@ -20,10 +21,12 @@ spec: cmd_deps.spec.md
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Mermaid output | clean dep graph, `--mermaid` | `cmd_deps(root, _, true, false)` | prints `graph LR` with sorted nodes/edges; missing targets shown as dashed `❌` nodes |
-| DOT output | clean dep graph, `--dot` | `cmd_deps(root, _, false, true)` | prints `digraph specs { … }` with sorted nodes/edges |
-| Valid graph, text format | no errors/warnings, no cycles | `cmd_deps(root, Text, false, false)` | prints "All dependency declarations are valid." plus a "Build order: …" line |
-| Cycle detected | A depends on B, B depends on A | `cmd_deps` runs | prints cycle error and exits 1 |
+| Mermaid output | clean dep graph, `--mermaid` | `cmd_deps(root, false, Text, true, false)` | prints `graph LR` with sorted nodes/edges; missing targets shown as dashed `❌` nodes |
+| DOT output | clean dep graph, `--dot` | `cmd_deps(root, false, Text, false, true)` | prints `digraph specs { … }` with sorted nodes/edges |
+| Valid graph, text format | no errors/warnings, no cycles | `cmd_deps(root, false, Text, false, false)` | prints "All dependency declarations are valid." plus a "Build order: …" line |
+| Cycle detected | A depends on B, B depends on A | `cmd_deps(root, false, Text, false, false)` | prints cycle error and exits 1 |
+| Undeclared import under `--strict` | a module imports a spec not in its `depends_on` | `cmd_deps(root, true, Text, false, false)` | warning printed; `--strict mode: N dependency warning(s) treated as errors` note on stderr; exits 1 |
+| Undeclared import under `--strict --format json` | same undeclared-import warning | `cmd_deps(root, true, Json, false, false)` | warning is in the JSON `warnings` array; **no** stderr note (JSON stays machine-readable); exits 1 |
 
 ## Regression Matrix
 
@@ -32,11 +35,12 @@ spec: cmd_deps.spec.md
 | Circular dependency | Error printed, exits 1 | Keep or add a focused assertion before changing this behavior |
 | Missing dependency spec | Error printed (`missing_deps`), exits 1 (covered by `dependency_spec_not_found_errors`) | Keep or add a focused assertion before changing this behavior |
 | Empty dep graph in diagram mode | Prints `depends_on` hint to stderr (diagram mode only) | Keep or add a focused assertion before changing this behavior |
-| Undeclared import | Reported as a warning (not an error → no exit 1) | Keep or add a focused assertion before changing this behavior |
+| Undeclared import (no `--strict`) | Reported as a warning; does NOT force exit 1 (only `report.errors` do) | Keep or add a focused assertion before changing this behavior |
+| Undeclared import under `--strict` | Warning forces exit 1; stderr note present for non-JSON, suppressed for JSON | `deps_strict_gates_on_undeclared_imports` (asserts exit 1 + note present non-JSON / absent JSON) |
 
 ## Reviewer Checklist
 
-- Run `cargo run -- deps --help` and confirm the help text still names the documented flags (`--format`, `--mermaid`, `--dot`).
+- Run `cargo run -- deps --help` and confirm the help text still names the documented flags (`--format`, `--strict`, `--mermaid`, `--dot`).
 - Run `cargo test deps` when changing the delegate; run `cargo test commands::deps` when changing the wrapper.
 - Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
 - If an error message or diagram syntax changes, update the matching Regression Matrix row and test assertion in the same commit.

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -107,9 +107,12 @@ pub fn cmd_deps(root: &Path, strict: bool, format: types::OutputFormat, mermaid:
     // module not listed in `depends_on`) as failures. Without this, `deps --strict`
     // was a silent no-op: undeclared imports were reported but never gated CI.
     let strict_fail = strict && !report.warnings.is_empty();
-    if strict_fail {
-        // A diagnostic, not report content — route to stderr so stdout stays a
-        // clean, machine-parseable body for every format (JSON/markdown/csv).
+    // Human diagnostic, not report content. Suppress it in JSON mode so JSON
+    // output stays fully machine-readable — no ANSI, nothing on stderr to parse
+    // around; a JSON consumer already sees the failing warnings in the
+    // `warnings` array and the non-zero exit code. Every other format gets the
+    // note on stderr, keeping stdout a clean, parseable body.
+    if strict_fail && !matches!(format, types::OutputFormat::Json) {
         eprintln!(
             "{}: {} dependency warning(s) treated as errors",
             "--strict mode".red(),

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -112,7 +112,7 @@ pub fn cmd_deps(root: &Path, strict: bool, format: types::OutputFormat, mermaid:
     // around; a JSON consumer already sees the failing warnings in the
     // `warnings` array and the non-zero exit code. Every other format gets the
     // note on stderr, keeping stdout a clean, parseable body.
-    if strict_fail && !matches!(format, types::OutputFormat::Json) {
+    if strict_fail && format != types::OutputFormat::Json {
         eprintln!(
             "{}: {} dependency warning(s) treated as errors",
             "--strict mode".red(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6079,27 +6079,35 @@ fn deps_strict_gates_on_undeclared_imports() {
 
     // Default deps is advisory (reports the warning, exits 0).
     specsync().current_dir(root).arg("deps").assert().success();
-    // --strict now fails on the undeclared import.
+    // --strict fails on the undeclared import; non-JSON formats get the human
+    // "treated as errors" note on stderr.
     specsync()
         .current_dir(root)
         .args(["deps", "--strict"])
         .assert()
-        .failure();
-    // JSON output gates AND stdout stays fully parseable JSON (the strict note
-    // is a stderr diagnostic, so it must not leak into the JSON body).
-    let out = specsync()
+        .failure()
+        .stderr(predicate::str::contains("treated as errors"));
+    // JSON output gates AND stays fully machine-readable: stdout is parseable
+    // JSON carrying the warning, and the human strict note is suppressed
+    // entirely — not even on stderr — so a JSON consumer sees only structured
+    // data plus the exit code (no ANSI, nothing to parse around).
+    let output = specsync()
         .current_dir(root)
         .args(["deps", "--strict", "--format", "json"])
         .assert()
         .failure()
         .get_output()
-        .stdout
         .clone();
-    let parsed: serde_json::Value =
-        serde_json::from_slice(&out).expect("deps --strict json stdout must be valid JSON");
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("deps --strict json stdout must be valid JSON");
     assert!(
         !parsed["undeclared_imports"].as_array().unwrap().is_empty(),
         "expected the undeclared import to be reported in JSON"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("treated as errors") && !stderr.contains("--strict mode"),
+        "JSON mode must not emit the human strict note, even on stderr; got: {stderr:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #304, addressing both review findings on that PR.

### 1. `deps --strict` note now JSON-gated

`deps --strict --format json` printed the colored `--strict mode: N dependency warning(s) treated as errors` **human diagnostic to stderr even in JSON mode**. That conflicts with the JSON contract (machine-readable, no ANSI) — consumers combining stdout/stderr, or asserting JSON output is non-human, could break.

The note is now suppressed in JSON mode. JSON consumers already have everything they need: the failing warnings are in the `warnings` array and the verdict is the non-zero exit code. Every other format still prints the note on stderr, keeping stdout a clean body.

### 2. `cmd_deps` spec set synced

#304 changed the public `cmd_deps` signature (added `strict`) and the exit-code semantics, but the specs were stale. This bumps `cmd_deps` **v1 → v2** and updates:

- `cmd_deps.spec.md` — corrected signature, new strict exit-code invariant, the JSON-suppression invariant, a strict + a strict-JSON behavioral example, an Error Cases row, and a Change Log entry.
- `requirements.md` — corrected the `cmd_deps(...)` acceptance-criterion signature, added the strict exit-code criterion and the JSON-machine-readable criterion.
- `context.md` — updated the exit-code decision (was "only depends on `report.errors`") to cover `--strict` and the JSON-suppressed stderr note.

## Test Plan

- [x] Extended `deps_strict_gates_on_undeclared_imports` to assert the note is **present on stderr** for non-JSON and **absent** for JSON. Verified it **fails without the code gate** (the note leaks to stderr in JSON mode) and passes with it — a real regression guard.
- [x] `cargo test` — 838 pass (679 unit + 159 integration), 0 fail
- [x] `cargo clippy -- -D warnings` (as CI runs it) — clean
- [x] `cargo fmt --check` — clean
- [x] `specsync check --strict` — 60 specs, 0 warnings, 0 failed, 100% coverage (the updated `cmd_deps` spec validates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AvsKakjAc3EKN2ztcMfYi
