### PR TITLE
Fix: coverage & score no longer bypass enforcement gates on no-spec projects (M1)

### DIFF
--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -5,7 +5,9 @@ use crate::output::{print_coverage_line, print_coverage_report, print_summary};
 use crate::types;
 use crate::validator::{compute_coverage, get_schema_table_names};
 
-use super::{build_schema_columns, exit_with_status, load_and_discover, run_validation};
+use super::{
+    build_schema_columns, compute_exit_code, exit_with_status, load_and_discover, run_validation,
+};
 
 pub fn cmd_coverage(
     root: &Path,
@@ -15,7 +17,12 @@ pub fn cmd_coverage(
     format: types::OutputFormat,
 ) {
     let json = matches!(format, types::OutputFormat::Json);
-    let (config, spec_files) = load_and_discover(root, false);
+    // `coverage` is a gate/report command: it must evaluate the requested gate
+    // even on a project with source but NO specs (0% coverage). Passing
+    // allow_empty=true stops load_and_discover from taking its no-spec early-exit
+    // (which returned exit 0 and bypassed --require-coverage/--enforcement/--strict
+    // and any config enforcement — finding M1).
+    let (config, spec_files) = load_and_discover(root, true);
     let enforcement = enforcement.unwrap_or(if strict {
         types::EnforcementMode::Strict
     } else {
@@ -72,7 +79,17 @@ pub fn cmd_coverage(
             "uncovered_files": uncovered_files,
         });
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
-        process::exit(0);
+        // Gate the exit code for machine consumers too (was an unconditional
+        // exit 0, so `coverage --format json --require-coverage N` never failed —
+        // finding M1). compute_exit_code prints nothing, so stdout stays valid JSON.
+        process::exit(compute_exit_code(
+            total_errors,
+            total_warnings,
+            strict,
+            enforcement,
+            &coverage,
+            require_coverage,
+        ));
     }
 
     print_coverage_report(&coverage);

--- a/src/commands/score.rs
+++ b/src/commands/score.rs
@@ -24,18 +24,22 @@ pub fn cmd_score(
 ) {
     let json = matches!(format, types::OutputFormat::Json);
     // The global `--strict` / `--enforcement` / `--require-coverage` flags are
-    // gates. `score` must honor them (they were previously silent no-ops here):
-    // when one is set, don't take load_and_discover's no-spec early-exit —
-    // otherwise `score --require-coverage 100` on a spec-less project would
-    // bypass the gate exactly like the `check` no-spec bug did.
-    let gate_requested = strict || enforcement.is_some() || require_coverage.is_some();
-    let (config, all_spec_files) = load_and_discover(root, gate_requested);
-    // CLI --enforcement overrides config; --strict implies strict enforcement.
-    let enforcement = enforcement.unwrap_or(if strict {
-        types::EnforcementMode::Strict
-    } else {
-        config.enforcement
+    // gates, and so is a project's configured `enforcement`. `score` must honor
+    // all of them: when a gate could fire, don't take load_and_discover's no-spec
+    // early-exit — otherwise a spec-less project bypasses the gate (exit 0) exactly
+    // like the `check` no-spec bug did. Resolve the effective enforcement up-front
+    // (peeking the config only when no CLI flag decides it) so a CONFIG-only
+    // enforce-new/strict gate is covered too, not just the CLI flags.
+    let enforcement = enforcement.unwrap_or_else(|| {
+        if strict {
+            types::EnforcementMode::Strict
+        } else {
+            crate::config::load_config(root).enforcement
+        }
     });
+    let gate_requested =
+        require_coverage.is_some() || !matches!(enforcement, types::EnforcementMode::Warn);
+    let (config, all_spec_files) = load_and_discover(root, gate_requested);
     let spec_files = filter_specs(root, &all_spec_files, spec_filters);
     let spec_files = filter_by_status(&spec_files, exclude_status, only_status);
     let scores: Vec<scoring::SpecScore> = spec_files

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6042,6 +6042,68 @@ fn score_no_specs_still_evaluates_requested_gate() {
     specsync().current_dir(root).arg("score").assert().success();
 }
 
+#[test]
+fn coverage_no_specs_evaluates_gate() {
+    // Regression (M1): `coverage` used to take the no-spec early-exit (exit 0) and
+    // its JSON path always exited 0, so the gate was never evaluated. A project
+    // with source but no specs is 0% covered and must FAIL a requested gate.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["coverage", "--require-coverage", "100"])
+        .assert()
+        .failure();
+    // JSON path must gate too, and stay valid JSON.
+    specsync()
+        .current_dir(root)
+        .args(["coverage", "--require-coverage", "100", "--format", "json"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::starts_with("{"));
+    specsync()
+        .current_dir(root)
+        .args(["coverage", "--enforcement", "enforce-new"])
+        .assert()
+        .failure();
+    // No gate requested → coverage report still exits 0.
+    specsync()
+        .current_dir(root)
+        .arg("coverage")
+        .assert()
+        .success();
+}
+
+#[test]
+fn score_config_only_enforcement_gates_no_specs() {
+    // Regression (M1 sibling): a CONFIG-level enforcement gate (no CLI flag) must
+    // also stop the no-spec early-exit — `score` on a spec-less project whose
+    // config sets enforce-new must FAIL, matching `check`.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+
+    fs::write(
+        root.join(".specsync.toml"),
+        "enforcement = \"enforce-new\"\nspecs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    specsync().current_dir(root).arg("score").assert().failure();
+
+    // A warn config keeps the friendly advisory early-exit (exit 0).
+    fs::write(
+        root.join(".specsync.toml"),
+        "enforcement = \"warn\"\nspecs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    specsync().current_dir(root).arg("score").assert().success();
+}
+
 // ─── specsync deps: --strict gates on undeclared-import warnings ─────────
 
 /// Build a two-module project where `api` imports `db` without declaring it.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6070,7 +6070,23 @@ fn coverage_no_specs_evaluates_gate() {
         .args(["coverage", "--enforcement", "enforce-new"])
         .assert()
         .failure();
-    // No gate requested → coverage report still exits 0.
+    // A CONFIG-only enforce-new gate (no CLI flag) must also fire.
+    fs::write(
+        root.join(".specsync.toml"),
+        "enforcement = \"enforce-new\"\nspecs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    specsync()
+        .current_dir(root)
+        .arg("coverage")
+        .assert()
+        .failure();
+    // Back to a warn config → coverage report still exits 0 (no gate requested).
+    fs::write(
+        root.join(".specsync.toml"),
+        "enforcement = \"warn\"\nspecs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
     specsync()
         .current_dir(root)
         .arg("coverage")


### PR DESCRIPTION
## The bug (audit finding M1 · High + its Medium sibling · silent CI false-pass)
The last of the gate-bypass family. `coverage` **never gated**:
- its no-spec early-exit (`load_and_discover(root, false)`, coverage.rs:18) returned **exit 0** on a project with source but no specs, and
- its `--format json` branch did an unconditional `process::exit(0)` (coverage.rs:75).

So `coverage --require-coverage 100` — text *or* json — passed green at 0% coverage, ignoring `--require-coverage`/`--enforcement`/`--strict` and any config enforcement. `score` had the narrower residual that its no-spec early-exit was gated only on the **CLI flags**, so a **config-level** `enforce-new`/`strict` was bypassed on a spec-less project (while `check` correctly failed).

## The fix
- **coverage:** `allow_empty=true` so it computes and reports 0% coverage and evaluates the gate instead of early-exiting; the JSON path now exits with `compute_exit_code` (silent — stdout stays valid JSON) instead of always 0.
- **score:** resolve the effective enforcement up-front (peeking the config only when no CLI flag decides it) and derive `gate_requested` from it, so a config-only `enforce-new`/`strict` also stops the no-spec early-exit. A **warn** config with no flags keeps the friendly advisory early-exit (exit 0).

All three gate commands now behave identically:

| project: source, **no specs** | before | after |
|---|---|---|
| `coverage --require-coverage 100` (text) | 0 | **1** |
| `coverage --require-coverage 100 --format json` | 0 | **1** (valid JSON) |
| `coverage --enforcement enforce-new` | 0 | **1** |
| `coverage` (no gate) | 0 | 0 |
| `score` with config `enforcement="enforce-new"` | 0 | **1** |
| `score` with config `enforcement="warn"` | 0 | 0 (advisory) |
| `check` (parity reference) | 1 | 1 |

Tests: `coverage_no_specs_evaluates_gate`, `score_config_only_enforcement_gates_no_specs`. Full suite 693 + 163, fmt / clippy (bin) / self-check 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)