### PR TITLE
Fix: migrate no longer silently drops config data (customRules/modules/parseMode, track_history)

### DIFF
--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -31,6 +31,7 @@ Loads project configuration from `specsync.json` or `.specsync.toml`, with fallb
 | `discover_manifest_modules` | `root: &Path` | `ManifestDiscovery` | Discover modules from manifest files (Package.swift, Cargo.toml, etc.) |
 | `is_legacy_layout` | `root: &Path` | `bool` | Detect whether a project uses a legacy 3.x layout (root-level config files without `.specsync/version` stamp) |
 | `config_to_toml` | `config: &SpecSyncConfig` | `String` | Serialize a `SpecSyncConfig` to TOML format string for v4.0.0 config files |
+| `config_to_toml_lossy_fields` | `config: &SpecSyncConfig` | `Vec<&'static str>` | List config fields `config_to_toml` cannot represent (e.g. `customRules`), so `migrate` can refuse rather than silently drop them |
 
 ### Config File Structure
 

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -904,27 +904,49 @@ fn preflight_config_parseable(root: &Path) -> Result<(), (String, String)> {
 /// Refuse to convert a config whose contents `config_to_toml` cannot faithfully
 /// represent (e.g. `customRules`). Otherwise those fields would be silently
 /// dropped on JSON→TOML conversion and the original deleted — silent, unrecoverable
-/// loss of (often security-relevant) config reported as success. Returns
-/// `Err((relative_name, lossy_field_names))` when the source config uses such a
-/// field. Runs before any mutation, so a refusal leaves the project untouched.
-fn preflight_config_lossless(root: &Path) -> Result<(), (String, Vec<String>)> {
-    let Some(source) = config_source_to_validate(root) else {
+/// loss of (often security-relevant) config reported as success. Runs before any
+/// mutation, so a refusal leaves the project untouched.
+///
+/// Checks EVERY JSON config `apply_relocate_config` would convert-or-delete, not
+/// just its chosen source: that step converts one source but also deletes the other
+/// legacy configs unconverted, so a higher-precedence `.specsync/config.json`
+/// carrying `customRules` (with a plain root `specsync.json` also present) would
+/// otherwise slip past a single-source check and be destroyed. `.specsync.toml` is
+/// not checked — the lenient TOML reader cannot represent `customRules` anyway.
+/// Returns `Err(offenders)` as `(relative_name, lossy_field_names)` pairs.
+fn preflight_config_lossless(root: &Path) -> Result<(), Vec<(String, Vec<String>)>> {
+    let old_json = root.join("specsync.json");
+    let old_toml_root = root.join(".specsync.toml");
+    let new_toml = root.join(".specsync/config.toml");
+    let new_json = root.join(".specsync/config.json");
+
+    // Mirror apply_relocate_config's early return: when config.toml already exists
+    // and there is no legacy root config, nothing is converted or deleted — so a
+    // coexisting .specsync/config.json is left untouched and nothing can be lost.
+    if new_toml.exists() && !old_json.exists() && !old_toml_root.exists() {
         return Ok(());
-    };
-    let name = source
-        .strip_prefix(root)
-        .unwrap_or(&source)
-        .display()
-        .to_string();
-    // Load exactly as `apply_relocate_config` does, then ask which fields would be
-    // lost. (This is only reached for a parseable source — the parseability
-    // preflight ran first.)
-    let config = config::load_config_from_path(&source, root);
-    let lossy = config::config_to_toml_lossy_fields(&config);
-    if lossy.is_empty() {
+    }
+
+    let mut offenders: Vec<(String, Vec<String>)> = Vec::new();
+    for path in [&old_json, &new_json] {
+        if !path.exists() {
+            continue;
+        }
+        let config = config::load_config_from_path(path, root);
+        let lossy = config::config_to_toml_lossy_fields(&config);
+        if !lossy.is_empty() {
+            let name = path
+                .strip_prefix(root)
+                .unwrap_or(path)
+                .display()
+                .to_string();
+            offenders.push((name, lossy.into_iter().map(String::from).collect()));
+        }
+    }
+    if offenders.is_empty() {
         Ok(())
     } else {
-        Err((name, lossy.into_iter().map(String::from).collect()))
+        Err(offenders)
     }
 }
 
@@ -1008,28 +1030,35 @@ pub fn cmd_migrate(root: &Path, format: OutputFormat, dry_run: bool, no_backup: 
     // unrecoverable loss of security-relevant config. Runs before any mutation, so
     // the project is left byte-for-byte unchanged; the user keeps the working
     // JSON config.
-    if let Err((name, fields)) = preflight_config_lossless(root) {
-        let field_list = fields.join(", ");
+    if let Err(offenders) = preflight_config_lossless(root) {
+        // e.g. "customRules in specsync.json; enforcement in .specsync/config.json"
+        let summary = offenders
+            .iter()
+            .map(|(name, fields)| format!("{} in {name}", fields.join(", ")))
+            .collect::<Vec<_>>()
+            .join("; ");
         match format {
             OutputFormat::Json => {
+                let files: Vec<serde_json::Value> = offenders
+                    .iter()
+                    .map(|(name, fields)| serde_json::json!({ "file": name, "fields": fields }))
+                    .collect();
                 let output = serde_json::json!({
                     "status": "error",
-                    "error": format!("Migrating {name} would drop unsupported field(s): {field_list}"),
-                    "unsupported_fields": fields,
-                    "hint": "config.toml cannot yet represent these fields. Your original file was not modified — keep using it, or remove these fields before migrating.",
+                    "error": format!("Migrating would drop unsupported config field(s): {summary}"),
+                    "unsupported": files,
+                    "hint": "config.toml cannot yet represent these fields. Your original file(s) were not modified — keep using them, or remove these fields before migrating.",
                 });
                 println!("{}", serde_json::to_string_pretty(&output).unwrap());
             }
             _ => {
                 eprintln!(
-                    "{} Cannot migrate {} without losing data: {} cannot be represented in config.toml yet.",
+                    "{} Cannot migrate without losing data: {} cannot be represented in config.toml yet.",
                     "✗".red(),
-                    name.cyan(),
-                    field_list.cyan()
+                    summary.cyan()
                 );
                 eprintln!(
-                    "  Your original file was NOT modified. Keep using it, or remove {} before migrating.",
-                    field_list.cyan()
+                    "  Your original config was NOT modified. Keep using it, or remove those field(s) before migrating."
                 );
             }
         }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -901,6 +901,33 @@ fn preflight_config_parseable(root: &Path) -> Result<(), (String, String)> {
     Ok(())
 }
 
+/// Refuse to convert a config whose contents `config_to_toml` cannot faithfully
+/// represent (e.g. `customRules`). Otherwise those fields would be silently
+/// dropped on JSON→TOML conversion and the original deleted — silent, unrecoverable
+/// loss of (often security-relevant) config reported as success. Returns
+/// `Err((relative_name, lossy_field_names))` when the source config uses such a
+/// field. Runs before any mutation, so a refusal leaves the project untouched.
+fn preflight_config_lossless(root: &Path) -> Result<(), (String, Vec<String>)> {
+    let Some(source) = config_source_to_validate(root) else {
+        return Ok(());
+    };
+    let name = source
+        .strip_prefix(root)
+        .unwrap_or(&source)
+        .display()
+        .to_string();
+    // Load exactly as `apply_relocate_config` does, then ask which fields would be
+    // lost. (This is only reached for a parseable source — the parseability
+    // preflight ran first.)
+    let config = config::load_config_from_path(&source, root);
+    let lossy = config::config_to_toml_lossy_fields(&config);
+    if lossy.is_empty() {
+        Ok(())
+    } else {
+        Err((name, lossy.into_iter().map(String::from).collect()))
+    }
+}
+
 // ─── Main command ───────────────────────────────────────────────────────────
 
 pub fn cmd_migrate(root: &Path, format: OutputFormat, dry_run: bool, no_backup: bool) {
@@ -970,6 +997,39 @@ pub fn cmd_migrate(root: &Path, format: OutputFormat, dry_run: bool, no_backup: 
                 eprintln!(
                     "  Fix the config file and re-run {}. Your original file was not modified.",
                     "specsync migrate".cyan()
+                );
+            }
+        }
+        process::exit(1);
+    }
+
+    // Refuse to convert a config that uses fields config.toml cannot yet represent
+    // (e.g. customRules). Silently dropping them and deleting the source would be
+    // unrecoverable loss of security-relevant config. Runs before any mutation, so
+    // the project is left byte-for-byte unchanged; the user keeps the working
+    // JSON config.
+    if let Err((name, fields)) = preflight_config_lossless(root) {
+        let field_list = fields.join(", ");
+        match format {
+            OutputFormat::Json => {
+                let output = serde_json::json!({
+                    "status": "error",
+                    "error": format!("Migrating {name} would drop unsupported field(s): {field_list}"),
+                    "unsupported_fields": fields,
+                    "hint": "config.toml cannot yet represent these fields. Your original file was not modified — keep using it, or remove these fields before migrating.",
+                });
+                println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            }
+            _ => {
+                eprintln!(
+                    "{} Cannot migrate {} without losing data: {} cannot be represented in config.toml yet.",
+                    "✗".red(),
+                    name.cyan(),
+                    field_list.cyan()
+                );
+                eprintln!(
+                    "  Your original file was NOT modified. Keep using it, or remove {} before migrating.",
+                    field_list.cyan()
                 );
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -402,6 +402,12 @@ pub fn config_to_toml(config: &SpecSyncConfig) -> String {
         crate::types::ExportLevel::Member => {} // default, omit
     }
 
+    // Parse mode (AST is opt-in; regex is the default, so omit it)
+    match config.parse_mode {
+        crate::types::ParseMode::Ast => lines.push("parse_mode = \"ast\"".to_string()),
+        crate::types::ParseMode::Regex => {} // default, omit
+    }
+
     // Enforcement
     match config.enforcement {
         crate::types::EnforcementMode::Warn => {} // default, omit
@@ -557,8 +563,68 @@ pub fn config_to_toml(config: &SpecSyncConfig) -> String {
         lines.push("design = true".to_string());
     }
 
+    // Module definitions — one `[modules."name"]` table each. Sorted by name so the
+    // output is deterministic (HashMap order is not) for clean diffs and stable tests.
+    if !config.modules.is_empty() {
+        let mut names: Vec<&String> = config.modules.keys().collect();
+        names.sort();
+        for name in names {
+            let module = &config.modules[name];
+            // A module with no files and no deps carries no data and would not
+            // round-trip (the reader materializes a module only from a key line),
+            // so skip it to keep the writer and reader symmetric.
+            if module.files.is_empty() && module.depends_on.is_empty() {
+                continue;
+            }
+            lines.push(String::new());
+            lines.push(format!("[modules.\"{}\"]", toml_escape(name)));
+            if !module.files.is_empty() {
+                lines.push(format!(
+                    "files = [{}]",
+                    module
+                        .files
+                        .iter()
+                        .map(|s| format!("\"{}\"", toml_escape(s)))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            if !module.depends_on.is_empty() {
+                lines.push(format!(
+                    "depends_on = [{}]",
+                    module
+                        .depends_on
+                        .iter()
+                        .map(|s| format!("\"{}\"", toml_escape(s)))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+    }
+
     lines.push(String::new()); // trailing newline
     lines.join("\n")
+}
+
+/// Config fields that `config_to_toml` cannot faithfully serialize (and that the
+/// hand-rolled TOML reader cannot parse back), so converting a config that uses
+/// them would silently drop data. `migrate` calls this to refuse rather than lose
+/// a user's config on JSON→TOML conversion.
+///
+/// Keep this in lockstep with `config_to_toml`: when a field gains real TOML
+/// round-trip support above, remove it here. `ai_api_key` is intentionally NOT
+/// listed — it is deliberately never written to disk (secrets belong in an env
+/// var) and `config_to_toml` already warns about it loudly, so it is not a silent
+/// loss.
+pub fn config_to_toml_lossy_fields(config: &SpecSyncConfig) -> Vec<&'static str> {
+    let mut fields = Vec::new();
+    if !config.custom_rules.is_empty() {
+        // `[[custom_rules]]` array-of-tables (with a nested `applies_to` filter) has
+        // no writer above and no support in the hand-rolled reader.
+        fields.push("customRules");
+    }
+    fields
 }
 
 /// Known config keys in specsync.json (camelCase).
@@ -733,6 +799,10 @@ fn load_toml_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
                         parse_toml_lifecycle_nested(s, key, value, &mut config.lifecycle);
                         continue;
                     }
+                    s if s.starts_with("modules.") => {
+                        parse_toml_modules_nested(s, key, value, &mut config.modules);
+                        continue;
+                    }
                     _ => {
                         // Unknown section — skip silently
                         continue;
@@ -775,6 +845,16 @@ fn load_toml_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
                         }
                         _ => eprintln!(
                             "Warning: unknown export_level \"{s}\" (expected \"type\" or \"member\")"
+                        ),
+                    }
+                }
+                "parse_mode" | "parseMode" => {
+                    let s = parse_toml_string(value);
+                    match s.as_str() {
+                        "ast" => config.parse_mode = crate::types::ParseMode::Ast,
+                        "regex" => config.parse_mode = crate::types::ParseMode::Regex,
+                        _ => eprintln!(
+                            "Warning: unknown parse_mode \"{s}\" (expected \"regex\" or \"ast\")"
                         ),
                     }
                 }
@@ -961,6 +1041,32 @@ fn parse_toml_companions_key(
         "design" => companions.design = parse_toml_bool(value),
         _ => {
             eprintln!("Warning: unknown key \"{key}\" in [companions] section (ignored)");
+        }
+    }
+}
+
+/// Parse a key=value pair inside a `[modules."name"]` TOML section (the form
+/// `config_to_toml` writes). The module name is the quoted segment after
+/// `modules.`; a name containing `.` is preserved (the whole remainder is the key).
+fn parse_toml_modules_nested(
+    section: &str,
+    key: &str,
+    value: &str,
+    modules: &mut std::collections::HashMap<String, crate::types::ModuleDefinition>,
+) {
+    let Some(raw_name) = section.strip_prefix("modules.") else {
+        return;
+    };
+    let name = raw_name.trim().trim_matches('"').to_string();
+    if name.is_empty() {
+        return;
+    }
+    let module = modules.entry(name).or_default();
+    match key {
+        "files" => module.files = parse_toml_string_array(value),
+        "depends_on" | "dependsOn" => module.depends_on = parse_toml_string_array(value),
+        _ => {
+            eprintln!("Warning: unknown key \"{key}\" in [modules] section (ignored)");
         }
     }
 }
@@ -1798,5 +1904,115 @@ verify_issues = false
             toml_str.contains("design = true"),
             "should contain design = true"
         );
+    }
+
+    /// Write `config_to_toml(config)` to a temp `.specsync.toml`, load it back
+    /// through the real reader, and return the reloaded config — exercising the
+    /// full write→read round-trip.
+    fn roundtrip_toml(config: &SpecSyncConfig) -> SpecSyncConfig {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".specsync.toml"), config_to_toml(config)).unwrap();
+        load_config(tmp.path())
+    }
+
+    #[test]
+    fn test_lifecycle_default_track_history_is_true() {
+        // The documented default and serde default are both `true`; the Rust
+        // `Default` must agree or the TOML reader (which starts from
+        // SpecSyncConfig::default()) silently loads an omitted key as false (#10).
+        assert!(crate::types::LifecycleConfig::default().track_history);
+        assert!(SpecSyncConfig::default().lifecycle.track_history);
+    }
+
+    #[test]
+    fn test_config_to_toml_roundtrips_track_history() {
+        // true (the default) is omitted from TOML but must reload as true, not
+        // silently flip to false on migrate (#10).
+        let mut config = SpecSyncConfig::default();
+        config.lifecycle.track_history = true;
+        assert!(
+            !config_to_toml(&config).contains("track_history"),
+            "the default (true) should be omitted"
+        );
+        assert!(roundtrip_toml(&config).lifecycle.track_history);
+
+        // false is the non-default, so it is written explicitly and must reload false.
+        config.lifecycle.track_history = false;
+        assert!(config_to_toml(&config).contains("track_history = false"));
+        assert!(!roundtrip_toml(&config).lifecycle.track_history);
+    }
+
+    #[test]
+    fn test_config_to_toml_roundtrips_parse_mode() {
+        let mut config = SpecSyncConfig::default();
+        config.parse_mode = crate::types::ParseMode::Ast;
+        assert!(config_to_toml(&config).contains("parse_mode = \"ast\""));
+        assert_eq!(
+            roundtrip_toml(&config).parse_mode,
+            crate::types::ParseMode::Ast
+        );
+
+        // regex is the default → omitted → reloads as regex.
+        config.parse_mode = crate::types::ParseMode::Regex;
+        assert!(!config_to_toml(&config).contains("parse_mode"));
+        assert_eq!(
+            roundtrip_toml(&config).parse_mode,
+            crate::types::ParseMode::Regex
+        );
+    }
+
+    #[test]
+    fn test_config_to_toml_roundtrips_modules() {
+        let mut config = SpecSyncConfig::default();
+        config.modules.insert(
+            "core".to_string(),
+            crate::types::ModuleDefinition {
+                files: vec!["src/a.ts".to_string(), "src/b.ts".to_string()],
+                depends_on: vec!["util".to_string()],
+            },
+        );
+        config.modules.insert(
+            "util".to_string(),
+            crate::types::ModuleDefinition {
+                files: vec!["src/u.ts".to_string()],
+                depends_on: vec![],
+            },
+        );
+
+        let toml_str = config_to_toml(&config);
+        // Deterministic (sorted) output: core before util.
+        assert!(
+            toml_str.find("[modules.\"core\"]").unwrap()
+                < toml_str.find("[modules.\"util\"]").unwrap(),
+            "modules should be emitted in sorted order"
+        );
+
+        let reloaded = roundtrip_toml(&config);
+        assert_eq!(reloaded.modules.len(), 2);
+        let core = reloaded.modules.get("core").expect("core module");
+        assert_eq!(core.files, vec!["src/a.ts", "src/b.ts"]);
+        assert_eq!(core.depends_on, vec!["util"]);
+        let util = reloaded.modules.get("util").expect("util module");
+        assert_eq!(util.files, vec!["src/u.ts"]);
+        assert!(util.depends_on.is_empty());
+    }
+
+    #[test]
+    fn test_config_to_toml_lossy_fields_flags_custom_rules() {
+        // A config without unsupported fields is losslessly convertible.
+        assert!(config_to_toml_lossy_fields(&SpecSyncConfig::default()).is_empty());
+
+        // customRules cannot be represented in config.toml yet, so it must be
+        // flagged (migrate refuses rather than silently dropping it).
+        let config: SpecSyncConfig = serde_json::from_str(
+            r#"{
+                "customRules": [
+                    { "name": "threat-model", "type": "require_section",
+                      "section": "Threat Model", "severity": "error" }
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(config_to_toml_lossy_fields(&config), vec!["customRules"]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2018,6 +2018,18 @@ verify_issues = false
     }
 
     #[test]
+    fn test_config_to_toml_roundtrips_ai_provider_custom() {
+        // `custom` used to write `ai_provider = "custom"` but reload as None
+        // (from_str_loose had no arm) — a silent drop on migrate.
+        let mut config = SpecSyncConfig::default();
+        config.ai_provider = Some(crate::types::AiProvider::Custom);
+        assert_eq!(
+            roundtrip_toml(&config).ai_provider,
+            Some(crate::types::AiProvider::Custom)
+        );
+    }
+
+    #[test]
     fn test_config_to_toml_roundtrips_parse_mode() {
         let mut config = SpecSyncConfig::default();
         config.parse_mode = crate::types::ParseMode::Ast;

--- a/src/config.rs
+++ b/src/config.rs
@@ -315,6 +315,41 @@ fn toml_escape(s: &str) -> String {
         .replace('\t', "\\t")
 }
 
+/// Inverse of `toml_escape` for the escapes it emits (`\\`, `\"`, `\n`, `\r`,
+/// `\t`). Without this, `config_to_toml` writes a correctly-escaped basic string
+/// that the reader would load with the escapes still present — silently changing
+/// any value containing a backslash or quote on migrate (e.g. a `schema_pattern`
+/// regex like `\s`, or a Windows module path). An unrecognized `\x` sequence is
+/// left byte-for-byte so a hand-written config with a stray backslash is not
+/// mangled.
+fn toml_unescape(s: &str) -> String {
+    if !s.contains('\\') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+        match chars.next() {
+            Some('\\') => out.push('\\'),
+            Some('"') => out.push('"'),
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('t') => out.push('\t'),
+            // Unknown escape — preserve both characters literally.
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
 /// Serialize a SpecSyncConfig to TOML format string.
 pub fn config_to_toml(config: &SpecSyncConfig) -> String {
     let mut lines: Vec<String> = Vec::new();
@@ -638,6 +673,7 @@ const KNOWN_JSON_KEYS: &[&str] = &[
     "excludePatterns",
     "sourceExtensions",
     "exportLevel",
+    "parseMode",
     "modules",
     "aiProvider",
     "aiModel",
@@ -919,7 +955,9 @@ fn strip_inline_comment(s: &str) -> String {
 fn parse_toml_string(s: &str) -> String {
     let s = s.trim();
     if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-        s[1..s.len() - 1].to_string()
+        // Quoted basic string: decode the escapes `toml_escape` emits so the value
+        // round-trips (an unquoted bare value is left as-is).
+        toml_unescape(&s[1..s.len() - 1])
     } else {
         s.to_string()
     }
@@ -974,11 +1012,45 @@ fn parse_toml_string_array(s: &str) -> Vec<String> {
     let Some(end) = find_toml_array_close(&s[start..]).map(|rel| start + rel) else {
         return vec![parse_toml_string(s)];
     };
-    s[start + 1..end]
-        .split(',')
+    // Split on commas OUTSIDE quoted strings so a quoted item containing a comma
+    // (e.g. a path or glob) is not torn into bogus entries. A bare `split(',')`
+    // would mangle `["a, b", "c"]`.
+    split_toml_array_items(&s[start + 1..end])
+        .into_iter()
         .map(|item| parse_toml_string(item.trim()))
         .filter(|item| !item.is_empty())
         .collect()
+}
+
+/// Split a TOML array body on top-level commas, skipping commas inside quoted
+/// (escape-aware) strings. Each returned segment still carries its quotes/whitespace
+/// for `parse_toml_string` to strip.
+fn split_toml_array_items(body: &str) -> Vec<String> {
+    let mut items = Vec::new();
+    let mut cur = String::new();
+    let mut in_string = false;
+    let mut prev_backslash = false;
+    for ch in body.chars() {
+        if in_string {
+            cur.push(ch);
+            if ch == '"' && !prev_backslash {
+                in_string = false;
+            }
+            prev_backslash = ch == '\\' && !prev_backslash;
+            continue;
+        }
+        prev_backslash = false;
+        match ch {
+            '"' => {
+                in_string = true;
+                cur.push(ch);
+            }
+            ',' => items.push(std::mem::take(&mut cur)),
+            _ => cur.push(ch),
+        }
+    }
+    items.push(cur);
+    items
 }
 
 /// Parse a key=value pair inside a `[rules]` TOML section.
@@ -1057,7 +1129,12 @@ fn parse_toml_modules_nested(
     let Some(raw_name) = section.strip_prefix("modules.") else {
         return;
     };
-    let name = raw_name.trim().trim_matches('"').to_string();
+    // The name is a quoted basic string in the header (`[modules."name"]`); strip
+    // the quotes and decode escapes so a name with a quote/backslash round-trips.
+    let trimmed = raw_name.trim();
+    let inner = trimmed.strip_prefix('"').unwrap_or(trimmed);
+    let inner = inner.strip_suffix('"').unwrap_or(inner);
+    let name = toml_unescape(inner);
     if name.is_empty() {
         return;
     }
@@ -1357,10 +1434,11 @@ mod tests {
     #[test]
     fn test_parse_toml_string_array_escaped_quote() {
         // An escaped quote inside a basic string must not toggle string state and
-        // false-detect the closing bracket.
+        // false-detect the closing bracket (2 items parsed), and the `\"` decodes
+        // to a literal `"` in the value (see `toml_unescape`).
         assert_eq!(
             parse_toml_string_array("[\"a\\\"]b\", \"c\"]"),
-            vec!["a\\\"]b", "c"]
+            vec!["a\"]b", "c"]
         );
     }
 
@@ -1995,6 +2073,67 @@ verify_issues = false
         let util = reloaded.modules.get("util").expect("util module");
         assert_eq!(util.files, vec!["src/u.ts"]);
         assert!(util.depends_on.is_empty());
+    }
+
+    #[test]
+    fn test_toml_unescape_inverts_toml_escape() {
+        for original in [
+            "plain",
+            "back\\slash",
+            "quote\"inside",
+            "tab\tand\nnewline",
+            "windows\\path\\file.ts",
+            "regex \\s+ (\\w+)",
+        ] {
+            assert_eq!(
+                toml_unescape(&toml_escape(original)),
+                original,
+                "escape→unescape must round-trip: {original:?}"
+            );
+        }
+        // An unrecognized escape is preserved byte-for-byte (a hand-written config
+        // with a stray backslash must not be mangled).
+        assert_eq!(toml_unescape("C:\\Users"), "C:\\Users");
+    }
+
+    #[test]
+    fn test_config_to_toml_roundtrips_schema_pattern_regex() {
+        // A regex with backslash escapes (\s \w) used to reload with doubled
+        // backslashes — a broken/different regex silently persisted by migrate.
+        let mut config = SpecSyncConfig::default();
+        config.schema_pattern = Some(r"CREATE TABLE\s+(\w+)".to_string());
+        assert_eq!(
+            roundtrip_toml(&config).schema_pattern.as_deref(),
+            Some(r"CREATE TABLE\s+(\w+)")
+        );
+    }
+
+    #[test]
+    fn test_config_to_toml_roundtrips_module_special_chars() {
+        let mut config = SpecSyncConfig::default();
+        config.modules.insert(
+            "grp\"x".to_string(), // name with a quote
+            crate::types::ModuleDefinition {
+                // a Windows path (backslashes) and a path containing a comma
+                files: vec!["src\\win\\a.ts".to_string(), "src/b,c.ts".to_string()],
+                depends_on: vec![],
+            },
+        );
+        let reloaded = roundtrip_toml(&config);
+        let module = reloaded
+            .modules
+            .get("grp\"x")
+            .expect("module name with a quote must round-trip");
+        assert_eq!(module.files, vec!["src\\win\\a.ts", "src/b,c.ts"]);
+    }
+
+    #[test]
+    fn test_split_toml_array_items_is_quote_aware() {
+        // A comma inside a quoted item must NOT split it.
+        let items = split_toml_array_items(r#""a, b", "c""#);
+        assert_eq!(items.len(), 2);
+        assert_eq!(parse_toml_string(items[0].trim()), "a, b");
+        assert_eq!(parse_toml_string(items[1].trim()), "c");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -315,6 +315,16 @@ fn toml_escape(s: &str) -> String {
         .replace('\t', "\\t")
 }
 
+/// Format a `name = ["a", "b"]` TOML array line (an empty slice → `name = []`).
+fn toml_array_line(name: &str, items: &[String]) -> String {
+    let body = items
+        .iter()
+        .map(|s| format!("\"{}\"", toml_escape(s)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{name} = [{body}]")
+}
+
 /// Inverse of `toml_escape` for the escapes it emits (`\\`, `\"`, `\n`, `\r`,
 /// `\t`). Without this, `config_to_toml` writes a correctly-escaped basic string
 /// that the reader would load with the escapes still present — silently changing
@@ -385,51 +395,28 @@ pub fn config_to_toml(config: &SpecSyncConfig) -> String {
         ));
     }
 
-    if !config.exclude_dirs.is_empty() {
-        lines.push(format!(
-            "exclude_dirs = [{}]",
-            config
-                .exclude_dirs
-                .iter()
-                .map(|s| format!("\"{}\"", toml_escape(s)))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
-    if !config.exclude_patterns.is_empty() {
-        lines.push(format!(
-            "exclude_patterns = [{}]",
-            config
-                .exclude_patterns
-                .iter()
-                .map(|s| format!("\"{}\"", toml_escape(s)))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
+    // These three fields default to a NON-empty value in the reader
+    // (SpecSyncConfig::default), so an explicitly-empty value (a user opting out of
+    // section enforcement / test-file exclusion) must be written as `= []` — omitting
+    // it would silently restore the defaults on reload, flipping check/coverage
+    // results on migrate. So they are always emitted, empty or not.
+    lines.push(toml_array_line("exclude_dirs", &config.exclude_dirs));
+    lines.push(toml_array_line(
+        "exclude_patterns",
+        &config.exclude_patterns,
+    ));
+    // source_extensions defaults to empty, so omitting it when empty round-trips.
     if !config.source_extensions.is_empty() {
-        lines.push(format!(
-            "source_extensions = [{}]",
-            config
-                .source_extensions
-                .iter()
-                .map(|s| format!("\"{}\"", toml_escape(s)))
-                .collect::<Vec<_>>()
-                .join(", ")
+        lines.push(toml_array_line(
+            "source_extensions",
+            &config.source_extensions,
         ));
     }
 
-    if !config.required_sections.is_empty() {
-        lines.push(format!(
-            "required_sections = [{}]",
-            config
-                .required_sections
-                .iter()
-                .map(|s| format!("\"{}\"", toml_escape(s)))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
+    lines.push(toml_array_line(
+        "required_sections",
+        &config.required_sections,
+    ));
 
     // Export level
     match config.export_level {
@@ -942,10 +929,20 @@ fn load_toml_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
 ///   `"has # inside"`    →  `"has # inside"`
 fn strip_inline_comment(s: &str) -> String {
     let mut in_string = false;
+    let mut prev_backslash = false;
     for (i, c) in s.char_indices() {
+        if in_string {
+            if c == '"' && !prev_backslash {
+                in_string = false;
+            }
+            prev_backslash = c == '\\' && !prev_backslash;
+            continue;
+        }
+        prev_backslash = false;
         match c {
-            '"' => in_string = !in_string,
-            '#' if !in_string => return s[..i].trim().to_string(),
+            '"' => in_string = true,
+            // A `#` outside any string starts a comment.
+            '#' => return s[..i].trim().to_string(),
             _ => {}
         }
     }
@@ -2134,6 +2131,39 @@ verify_issues = false
         assert_eq!(items.len(), 2);
         assert_eq!(parse_toml_string(items[0].trim()), "a, b");
         assert_eq!(parse_toml_string(items[1].trim()), "c");
+    }
+
+    #[test]
+    fn test_config_to_toml_roundtrips_explicitly_empty_arrays() {
+        // required_sections / exclude_dirs / exclude_patterns default to NON-empty,
+        // so an explicit [] (opting out) must survive rather than silently reverting
+        // to the defaults on migrate.
+        let mut config = SpecSyncConfig::default();
+        config.required_sections = vec![];
+        config.exclude_dirs = vec![];
+        config.exclude_patterns = vec![];
+
+        let toml_str = config_to_toml(&config);
+        assert!(toml_str.contains("required_sections = []"));
+        assert!(toml_str.contains("exclude_dirs = []"));
+        assert!(toml_str.contains("exclude_patterns = []"));
+
+        let reloaded = roundtrip_toml(&config);
+        assert!(reloaded.required_sections.is_empty(), "opted-out sections");
+        assert!(reloaded.exclude_dirs.is_empty(), "opted-out exclude_dirs");
+        assert!(
+            reloaded.exclude_patterns.is_empty(),
+            "opted-out exclude_patterns"
+        );
+    }
+
+    #[test]
+    fn test_strip_inline_comment_is_escape_aware() {
+        // An escaped quote must not toggle string state and let a later `#`
+        // truncate the value.
+        assert_eq!(strip_inline_comment(r#""a\"b#c""#), r#""a\"b#c""#);
+        // A real comment after a closed string is still stripped.
+        assert_eq!(strip_inline_comment(r#""ollama" # local"#), r#""ollama""#);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -325,13 +325,13 @@ fn toml_array_line(name: &str, items: &[String]) -> String {
     format!("{name} = [{body}]")
 }
 
-/// Inverse of `toml_escape` for the escapes it emits (`\\`, `\"`, `\n`, `\r`,
-/// `\t`). Without this, `config_to_toml` writes a correctly-escaped basic string
-/// that the reader would load with the escapes still present — silently changing
-/// any value containing a backslash or quote on migrate (e.g. a `schema_pattern`
-/// regex like `\s`, or a Windows module path). An unrecognized `\x` sequence is
-/// left byte-for-byte so a hand-written config with a stray backslash is not
-/// mangled.
+/// Inverse of `toml_escape`: decodes the backslash, double-quote, newline,
+/// carriage-return, and tab escape sequences it emits. Without this,
+/// `config_to_toml` writes a correctly-escaped basic string that the reader would
+/// load with the escapes still literal — silently changing any value containing a
+/// backslash or quote on migrate (e.g. a `schema_pattern` regex, or a Windows
+/// module path). An unrecognized escape is left byte-for-byte so a hand-written
+/// config with a stray backslash is not mangled.
 fn toml_unescape(s: &str) -> String {
     if !s.contains('\\') {
         return s.to_string();

--- a/src/types.rs
+++ b/src/types.rs
@@ -133,6 +133,10 @@ impl AiProvider {
             "mistral" => Some(AiProvider::Mistral),
             "xai" | "grok" | "x-ai" => Some(AiProvider::XAi),
             "together" | "together-ai" => Some(AiProvider::Together),
+            // `Custom` must round-trip: config_to_toml writes `ai_provider = "custom"`
+            // (via Display), so the reader must map it back rather than dropping it to
+            // None on migrate. (Custom still needs SPECSYNC_AI_COMMAND to function.)
+            "custom" => Some(AiProvider::Custom),
             _ => None,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -541,7 +541,7 @@ pub struct CompanionConfig {
 }
 
 /// Lifecycle configuration for transition guards and history tracking.
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LifecycleConfig {
     /// Transition guard rules keyed by "from→to" (e.g. "review→active").
@@ -562,6 +562,23 @@ pub struct LifecycleConfig {
     /// Empty means no restriction.
     #[serde(default)]
     pub allowed_statuses: Vec<String>,
+}
+
+// `track_history` defaults to `true` when absent (the documented default and the
+// `#[serde(default = "default_true")]` behavior). The derived `Default` would make
+// it `false`, which desyncs the hand-rolled TOML reader (it starts from
+// `SpecSyncConfig::default()`) from serde: an omitted `track_history` in config.toml
+// would silently load as `false`, dropping a user's enabled history tracking on
+// migrate. This manual impl keeps every default path consistent with serde.
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            guards: std::collections::HashMap::new(),
+            track_history: true,
+            max_age: std::collections::HashMap::new(),
+            allowed_statuses: Vec::new(),
+        }
+    }
 }
 
 /// A transition guard — conditions that must be satisfied before a lifecycle
@@ -694,7 +711,7 @@ pub struct RuleFilter {
 }
 
 /// A user-defined module grouping in specsync.json.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 pub struct ModuleDefinition {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6359,6 +6359,42 @@ fn migrate_refuses_custom_rules_in_coexisting_v4_json() {
     assert!(!root.join(".specsync/config.toml").exists());
 }
 
+#[test]
+fn migrate_preserves_explicitly_empty_arrays() {
+    // Regression (#2 re-review): an explicit requiredSections/excludeDirs/
+    // excludePatterns = [] (opting out) used to silently revert to the non-empty
+    // defaults on migrate, flipping check results. They must survive as [].
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    fs::write(
+        root.join("specsync.json"),
+        r#"{ "specsDir": "specs", "sourceDirs": ["src"], "requiredSections": [], "excludeDirs": [], "excludePatterns": [] }"#,
+    )
+    .unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["migrate", "--no-backup"])
+        .assert()
+        .success();
+
+    let migrated = fs::read_to_string(root.join(".specsync/config.toml")).unwrap();
+    assert!(
+        migrated.contains("required_sections = []"),
+        "explicit empty required_sections must be written, not omitted:\n{migrated}"
+    );
+    assert!(
+        migrated.contains("exclude_patterns = []"),
+        "explicit empty exclude_patterns must be written:\n{migrated}"
+    );
+    assert!(
+        migrated.contains("exclude_dirs = []"),
+        "explicit empty exclude_dirs must be written:\n{migrated}"
+    );
+}
+
 // ─── hooks install: claude-code-hook must not clobber user settings ──────
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6243,6 +6243,87 @@ fn migrate_preserves_multiline_toml_array_config() {
     );
 }
 
+#[test]
+fn migrate_preserves_parse_mode_and_modules() {
+    // Regression (#2, data loss): config_to_toml used to silently drop parseMode
+    // and modules, so migrating a 3.x project lost them. They must survive.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    fs::write(
+        root.join("specsync.json"),
+        r#"{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "parseMode": "ast",
+  "modules": {
+    "core": { "files": ["src/a.ts"], "dependsOn": ["util"] },
+    "util": { "files": ["src/u.ts"] }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["migrate", "--no-backup"])
+        .assert()
+        .success();
+
+    let migrated = fs::read_to_string(root.join(".specsync/config.toml")).unwrap();
+    assert!(
+        migrated.contains("parse_mode = \"ast\""),
+        "parse_mode must survive migration:\n{migrated}"
+    );
+    assert!(
+        migrated.contains("[modules.\"core\"]") && migrated.contains("[modules.\"util\"]"),
+        "module definitions must survive migration:\n{migrated}"
+    );
+    assert!(
+        migrated.contains("depends_on = [\"util\"]"),
+        "module depends_on must survive migration:\n{migrated}"
+    );
+}
+
+#[test]
+fn migrate_refuses_config_with_custom_rules() {
+    // Regression (#2, data loss): customRules cannot be represented in config.toml,
+    // so migrate must REFUSE (exit 1) and leave specsync.json intact rather than
+    // silently drop a security rule and delete the source.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    let original = r#"{
+  "specsDir": "specs",
+  "sourceDirs": ["src"],
+  "customRules": [
+    { "name": "threat-model", "type": "require_section", "section": "Threat Model", "severity": "error" }
+  ]
+}
+"#;
+    fs::write(root.join("specsync.json"), original).unwrap();
+
+    specsync()
+        .current_dir(root)
+        .arg("migrate")
+        .assert()
+        .failure();
+
+    // The original config is preserved byte-for-byte and no lossy TOML was written.
+    assert_eq!(
+        fs::read_to_string(root.join("specsync.json")).unwrap(),
+        original,
+        "specsync.json must be preserved unchanged"
+    );
+    assert!(
+        !root.join(".specsync/config.toml").exists(),
+        "no lossy config.toml should be written on refusal"
+    );
+}
+
 // ─── hooks install: claude-code-hook must not clobber user settings ──────
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6324,6 +6324,41 @@ fn migrate_refuses_config_with_custom_rules() {
     );
 }
 
+#[test]
+fn migrate_refuses_custom_rules_in_coexisting_v4_json() {
+    // Regression (#2 review): migrate converts one source but DELETES the other
+    // legacy configs unconverted. A higher-precedence .specsync/config.json with
+    // customRules (alongside a clean root specsync.json) must still be caught — it
+    // is the runtime-active config and would otherwise be silently destroyed.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    let root_json =
+        "{ \"specsDir\": \"specs\", \"sourceDirs\": [\"src\"], \"enforcement\": \"warn\" }\n";
+    let v4_json = "{ \"specsDir\": \"specs\", \"sourceDirs\": [\"src\"], \"enforcement\": \"strict\", \"customRules\": [ { \"name\": \"threat-model\", \"type\": \"require_section\", \"section\": \"Threat Model\", \"severity\": \"error\" } ] }\n";
+    fs::write(root.join("specsync.json"), root_json).unwrap();
+    fs::write(root.join(".specsync/config.json"), v4_json).unwrap();
+
+    specsync()
+        .current_dir(root)
+        .arg("migrate")
+        .assert()
+        .failure();
+
+    // Both source configs preserved; no lossy config.toml written.
+    assert_eq!(
+        fs::read_to_string(root.join("specsync.json")).unwrap(),
+        root_json
+    );
+    assert_eq!(
+        fs::read_to_string(root.join(".specsync/config.json")).unwrap(),
+        v4_json
+    );
+    assert!(!root.join(".specsync/config.toml").exists());
+}
+
 // ─── hooks install: claude-code-hook must not clobber user settings ──────
 
 #[test]


### PR DESCRIPTION
Closes two data-loss findings in the JSON→TOML config conversion `migrate` performs. Both are silent, and `migrate` deletes the source `specsync.json` — so the loss is unrecoverable (irrecoverable outright under `--no-backup`, and the default backup is gitignored).

## #2 — High (96%) · `config_to_toml` drops `parseMode` / `modules` / `customRules`
`config_to_toml` never serialized three fields the JSON loader fully populates. Upgrading a 3.x project silently lost AST parse mode, module groupings, and — worst — **security-relevant `customRules`** (e.g. a `require_section` threat-model gate).

- **`parse_mode` + `modules` now round-trip losslessly.** The writer emits `parse_mode = "ast"` and sorted, deterministic `[modules."name"]` tables; the reader parses a `parse_mode`/`parseMode` scalar and `[modules."name"]` sections (`files`, `depends_on`). A fully-empty module is skipped so writer and reader stay symmetric.
- **`customRules` can't be faithfully represented** in the hand-rolled TOML (`[[array-of-tables]]` + a nested `applies_to` filter — no reader support, and this parser just shipped a data-loss regression in #305). Rather than silently drop it, `migrate` now **refuses**: a new preflight (`config_to_toml_lossy_fields` + `preflight_config_lossless`) exits 1 **before any mutation**, leaves `specsync.json` byte-for-byte intact, and names the blocking field. Mirrors the existing unparseable-config refusal (#299). `ai_api_key` is intentionally *not* flagged — it's deliberately never written (it warns; secrets belong in an env var), so it isn't a silent loss.

## #10 — Medium (93%) · `track_history` flips true→false on migrate
A serde-vs-Rust default mismatch: `track_history` has `#[serde(default = "default_true")]` (**true** when absent) but the derived `Default` gave **false**. `load_toml_config` starts from `SpecSyncConfig::default()`, so an omitted `track_history` in `config.toml` loaded as **false** — silently turning off a user's history tracking on migrate. Fixed with a manual `Default { track_history: true }` so every default path agrees with serde and the docs.

## Design stance
Honors "only auto-resolve when losslessly safe; never silently lose data": round-trip what we can represent, **fail loud and preserve** what we can't.

## Tests
Unit: round-trip for `parse_mode`, `modules` (sorted/deterministic), `track_history` (true omitted-but-preserved, false written); `config_to_toml_lossy_fields` flags `customRules`; `LifecycleConfig::default()` is `true`. Integration: `migrate_preserves_parse_mode_and_modules`, `migrate_refuses_config_with_custom_rules` (exit 1, JSON preserved byte-for-byte, no `config.toml` written). Full suite 698 + 165, fmt / clippy (bin) / self-check 100% (36505 LOC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)