### PR TITLE
Fix: strip inline comments on scalar TOML values, not just arrays (High #6)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -761,14 +761,12 @@ fn load_toml_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
             // user's file with the corrupted result.
             let raw_value = line[eq_pos + 1..].trim();
             let is_array = raw_value.starts_with('[');
-            // For array values, strip inline `#` comments (quote-aware) so a
-            // commented item line doesn't become a bogus entry. Scalar values are
-            // left byte-for-byte unchanged.
-            let mut acc = if is_array {
-                strip_inline_comment(raw_value)
-            } else {
-                raw_value.to_string()
-            };
+            // Strip an inline `#` comment (quote/escape-aware) from the value. This
+            // applies to SCALARS too: `specs_dir = "specs" # note` must parse as
+            // `specs`, not the literal `"specs" # note` — otherwise the specs dir
+            // mis-resolves and every spec becomes invisible, silently turning
+            // `check` into an exit-0 pass. A `#` inside a quoted string is preserved.
+            let mut acc = strip_inline_comment(raw_value);
             // Close detection is quote/escape/bracket-depth aware (see
             // `find_toml_array_close`), so a `]` INSIDE a quoted item — e.g. a glob
             // char-class `"**/[abc]/**"` — does not falsely end the array.
@@ -1478,6 +1476,35 @@ mod tests {
         let config = load_config(tmp.path());
         assert_eq!(config.specs_dir, "my-specs");
         assert_eq!(config.source_dirs, vec!["lib", "app"]);
+    }
+
+    #[test]
+    fn test_load_config_toml_scalar_inline_comment_stripped() {
+        // Finding #6: an inline comment on a scalar value must be stripped, or the
+        // value carries the quotes + comment and (for specs_dir) hides every spec.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".specsync.toml"),
+            "specs_dir = \"mydocs\" # where specs live\n\
+             ai_timeout = 120 # seconds\n",
+        )
+        .unwrap();
+        let config = load_config(tmp.path());
+        assert_eq!(config.specs_dir, "mydocs");
+        assert_eq!(config.ai_timeout, Some(120));
+    }
+
+    #[test]
+    fn test_load_config_toml_hash_inside_quotes_preserved() {
+        // A `#` inside a quoted scalar is part of the value, not a comment.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join(".specsync.toml"),
+            "schema_pattern = \"CREATE #TABLE\" # trailing comment\n",
+        )
+        .unwrap();
+        let config = load_config(tmp.path());
+        assert_eq!(config.schema_pattern.as_deref(), Some("CREATE #TABLE"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6043,6 +6043,35 @@ fn score_no_specs_still_evaluates_requested_gate() {
 }
 
 #[test]
+fn check_scalar_inline_comment_does_not_hide_specs() {
+    // Regression (#6): an inline comment on `specs_dir` used to be kept in the
+    // value (`"specs" # note`), mis-resolving the specs dir so every spec became
+    // invisible and `check` silently passed. The spec must be discovered.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("mydocs")).unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    fs::write(
+        root.join(".specsync.toml"),
+        "specs_dir = \"mydocs\" # where specs live\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("mydocs/a.spec.md"),
+        "---\nmodule: a\nstatus: stable\nfiles:\n  - src/a.ts\n---\n# A\n## Purpose\nx\n",
+    )
+    .unwrap();
+
+    // The spec is now discovered (output names it) rather than "No spec files found".
+    specsync()
+        .current_dir(root)
+        .arg("check")
+        .assert()
+        .stdout(predicate::str::contains("a.spec.md"));
+}
+
+#[test]
 fn coverage_no_specs_evaluates_gate() {
     // Regression (M1): `coverage` used to take the no-spec early-exit (exit 0) and
     // its JSON path always exited 0, so the gate was never evaluated. A project


### PR DESCRIPTION
## The bug (audit finding #6 · High · silent CI false-pass)
The hand-rolled TOML reader stripped inline `#` comments only for **array** values; a **scalar** kept them verbatim. So:

```toml
specs_dir = "specs" # note
```

parsed as the literal value `"specs" # note`, mis-resolving the specs directory → **every spec became invisible** → `check` silently exited **0** (a pass) on a project it should have validated. Every scalar key was affected (e.g. `schema_pattern`, `ai_timeout`).

## The fix
Apply the quote/escape-aware `strip_inline_comment` to scalar values too (it was already used for array values and array continuation lines). A `#` **inside** a quoted string is preserved; a trailing comment is dropped — matching TOML semantics.

```
before:  specs_dir = "specs" # note   →  value = `"specs" # note`  (specs hidden, check passes)
after:   specs_dir = "specs" # note   →  value = `specs`           (specs found & validated)
         schema_pattern = "a#b" # c   →  value = `a#b`             (# inside quotes kept)
```

## Tests
Unit: scalar inline comment stripped (`specs_dir`, `ai_timeout`); `#` inside quotes preserved (`schema_pattern`). Integration: `check_scalar_inline_comment_does_not_hide_specs` (end-to-end — the spec is discovered, not silently skipped). Full suite 707 unit + 168 integration, fmt / clippy (bin) / self-check 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)