### PR TITLE
Fix: export-parser language-idiom gaps (Swift final, Go grouped, Kotlin const) + Rust comment tokenization

### DIFF
--- a/.atlasignore
+++ b/.atlasignore
@@ -1,0 +1,9 @@
+# spec-sync atlas coverage scope: the specs govern the tool's source, not these.
+
+# The marketing + docs site.
+site/
+
+# Tests, benchmarks, and examples are verified against the specs, not governed by them.
+tests/
+benches/
+examples/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/pages.yml'
+      - 'src/**'
+      - 'specs/**'
+      - '.atlasignore'
   workflow_dispatch:
 
 concurrency:
@@ -45,6 +48,26 @@ jobs:
       - name: Run unit tests
         working-directory: site
         run: bun test
+
+      - name: Resolve pinned atlas commit (cache key)
+        id: atlasref
+        run: echo "sha=$(git ls-remote https://github.com/CorvidLabs/fledge-plugin-atlas v1 | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the fledge-atlas CLI
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/fledge-atlas
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: fledge-atlas-${{ runner.os }}-${{ steps.atlasref.outputs.sha }}
+
+      - name: Render atlas coverage badges
+        uses: CorvidLabs/fledge-plugin-atlas@v1
+        with:
+          path: .
+          output-dir: site/public/badges
+          components: "coverage langmix treemap sunburst"
 
       - name: "Build site (runs prebuild: validate + redirects)"
         working-directory: site

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # SpecSync
 
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-SpecSync-blue?logo=github)](https://github.com/marketplace/actions/spec-sync)
+[![spec coverage](https://img.shields.io/endpoint?url=https://corvidlabs.github.io/spec-sync/badges/coverage.json)](https://corvidlabs.github.io/spec-sync/)
 [![CI](https://github.com/CorvidLabs/spec-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/CorvidLabs/spec-sync/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/specsync.svg)](https://crates.io/crates/specsync)
 [![Downloads](https://img.shields.io/crates/d/specsync.svg)](https://crates.io/crates/specsync)

--- a/src/exports/go.rs
+++ b/src/exports/go.rs
@@ -66,15 +66,23 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     let mut in_group = false;
     let mut brace_depth: i32 = 0;
     let mut paren_depth: i32 = 0;
+    // Whether the previous non-empty in-group line left a statement unfinished (a
+    // value spanning lines via a trailing `.`/operator, which Go does NOT auto-
+    // terminate). A continuation line is part of the previous item's value, so its
+    // leading identifier (e.g. `WithTimeout` in `Client = New().\n WithTimeout(5)`)
+    // must NOT be captured as a new grouped item.
+    let mut prev_continues = false;
     for line in stripped.lines() {
         let bt = line.trim();
         if in_group {
             let at_base = brace_depth == 0 && paren_depth == 0;
-            if at_base && bt.starts_with(')') {
+            if at_base && !prev_continues && bt.starts_with(')') {
                 in_group = false;
+                prev_continues = false;
                 continue;
             }
             if at_base
+                && !prev_continues
                 && let Some(caps) = GO_GROUP_ITEM.captures(bt)
                 && let Some(name) = caps.get(1)
             {
@@ -93,16 +101,38 @@ pub fn extract_exports(content: &str) -> Vec<String> {
             if paren_depth < 0 {
                 paren_depth = 0;
             }
+            if !bt.is_empty() {
+                prev_continues = go_line_continues(bt);
+            }
             continue;
         }
         if GO_GROUP_OPEN.is_match(line.trim_end()) {
             in_group = true;
             brace_depth = 0;
             paren_depth = 0;
+            prev_continues = false;
         }
     }
 
     symbols
+}
+
+/// Whether a Go line leaves the statement unfinished (no automatic semicolon). Go
+/// inserts a semicolon when a line's final token is an identifier, a literal (here a
+/// `_` placeholder stands in for every string/rune), `)`, `]`, `}`, or `++`/`--`;
+/// any other trailing token — a binary/unary operator, `.`, `,`, `(`, `{`, `[`, `=`,
+/// `:` — continues the statement onto the next line. Operates on the comment-stripped,
+/// string-blanked copy.
+fn go_line_continues(line: &str) -> bool {
+    let trimmed = line.trim_end();
+    match trimmed.chars().last() {
+        None => false,
+        Some(c) if c.is_alphanumeric() || c == '_' => false,
+        Some(')') | Some(']') | Some('}') => false,
+        Some('+') => !trimmed.ends_with("++"),
+        Some('-') => !trimmed.ends_with("--"),
+        Some(_) => true,
+    }
 }
 
 /// Strip `//` and `/* */` comments and blank the CONTENTS of string/rune literals in
@@ -143,8 +173,12 @@ fn strip_go_strings_and_comments(content: &str) -> String {
             }
             continue;
         }
-        // Interpreted string literal `"..."` (with `\` escapes).
+        // Interpreted string literal `"..."` (with `\` escapes). Emit a single `_`
+        // placeholder so the literal still reads as a statement-ending token (so a
+        // value that is just a string, `X = "y"`, is not mistaken for an unfinished
+        // statement by `go_line_continues`); its contents/delimiters are dropped.
         if c == '"' {
+            out.push('_');
             i += 1;
             while i < n {
                 if chars[i] == '\\' {
@@ -167,6 +201,7 @@ fn strip_go_strings_and_comments(content: &str) -> String {
         }
         // Raw string literal `` `...` `` (no escapes; may span multiple lines).
         if c == '`' {
+            out.push('_');
             i += 1;
             while i < n && chars[i] != '`' {
                 if chars[i] == '\n' {
@@ -181,6 +216,7 @@ fn strip_go_strings_and_comments(content: &str) -> String {
         }
         // Rune literal `'...'` (with `\` escapes).
         if c == '\'' {
+            out.push('_');
             i += 1;
             while i < n {
                 if chars[i] == '\\' {
@@ -580,5 +616,67 @@ const TopLevel = 1
             !symbols.contains(&"Buffer".to_string()),
             "function-local var"
         );
+    }
+
+    #[test]
+    fn test_go_grouped_multiline_value_continuation_not_captured() {
+        // A grouped item whose value spans lines via a trailing `.` (builder chain)
+        // or a trailing binary operator must not have its continuation line captured
+        // as a phantom export.
+        let src = "
+package m
+
+var (
+    Client = New().
+        WithTimeout(5)
+    Ready = true
+)
+
+const (
+    Path = Base +
+        Suffix
+    Other = 1
+)
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Client".to_string()), "{symbols:?}");
+        assert!(symbols.contains(&"Ready".to_string()), "item after a chain");
+        assert!(symbols.contains(&"Path".to_string()));
+        assert!(
+            symbols.contains(&"Other".to_string()),
+            "item after an operator"
+        );
+        // Continuation lines are value fragments, not declarations.
+        assert!(
+            !symbols.contains(&"WithTimeout".to_string()),
+            "method call in a builder chain"
+        );
+        assert!(
+            !symbols.contains(&"Suffix".to_string()),
+            "operand of a continued expression"
+        );
+    }
+
+    #[test]
+    fn test_go_grouped_string_value_does_not_swallow_next_item() {
+        // A value that is just a string literal must still read as a completed
+        // statement (via the `_` placeholder), so the following item is captured.
+        let src = "
+package m
+
+const (
+    Name = \"hello\"
+    Next = 2
+    Tmpl = `raw`
+    Last = 3
+)
+";
+        let symbols = extract_exports(src);
+        for name in ["Name", "Next", "Tmpl", "Last"] {
+            assert!(
+                symbols.contains(&name.to_string()),
+                "missing {name}: {symbols:?}"
+            );
+        }
     }
 }

--- a/src/exports/go.rs
+++ b/src/exports/go.rs
@@ -58,6 +58,11 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     // scan runs on the comment-stripped, string-blanked copy, so a `{`/`}`/`(`/`)`
     // inside a value (`X = "{"`, a struct tag, a multi-line backtick template) or a
     // comment never corrupts the depths.
+    //
+    // The group-open is matched on the UN-trimmed line, so it fires only at column 0
+    // — i.e. package-level blocks (where gofmt always puts them). A function-local,
+    // indented `const (` / `var (` / `type (` is NOT a package export and must be
+    // ignored, matching the column-0-anchored GO_DECL/GO_METHOD above.
     let mut in_group = false;
     let mut brace_depth: i32 = 0;
     let mut paren_depth: i32 = 0;
@@ -90,7 +95,7 @@ pub fn extract_exports(content: &str) -> Vec<String> {
             }
             continue;
         }
-        if GO_GROUP_OPEN.is_match(bt) {
+        if GO_GROUP_OPEN.is_match(line.trim_end()) {
             in_group = true;
             brace_depth = 0;
             paren_depth = 0;
@@ -537,5 +542,43 @@ type (
         // The `}` in a comment must not leak a struct field as an export.
         assert!(!symbols.contains(&"A".to_string()), "struct field");
         assert!(!symbols.contains(&"Bfield".to_string()), "struct field");
+    }
+
+    #[test]
+    fn test_go_function_local_grouped_block_not_exported() {
+        // A function-local (indented) grouped block is not a package export; only
+        // column-0 (package-level) grouped blocks are scanned, matching the
+        // column-anchored GO_DECL/GO_METHOD passes.
+        let src = "
+package worker
+
+func Run() {
+    const (
+        MaxAttempts = 5
+        backoff     = 2
+    )
+    var (
+        Buffer []byte
+    )
+    _ = MaxAttempts
+    _ = Buffer
+}
+
+const TopLevel = 1
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Run".to_string()));
+        assert!(
+            symbols.contains(&"TopLevel".to_string()),
+            "column-0 still works"
+        );
+        assert!(
+            !symbols.contains(&"MaxAttempts".to_string()),
+            "function-local const"
+        );
+        assert!(
+            !symbols.contains(&"Buffer".to_string()),
+            "function-local var"
+        );
     }
 }

--- a/src/exports/go.rs
+++ b/src/exports/go.rs
@@ -49,19 +49,27 @@ pub fn extract_exports(content: &str) -> Vec<String> {
 
     // Grouped declarations: `const (` / `var (` / `type (` blocks, whose items sit
     // on their own lines with no keyword prefix (missed by the line-anchored
-    // regexes above). Capture the leading identifier of each item at brace-depth 0
-    // so struct/interface field lines inside a grouped `type` are not mistaken for
-    // top-level exports.
+    // regexes above). Capture each item's leading exported (uppercase) identifier,
+    // but ONLY at brace-depth 0 AND paren-depth 0 — so struct/interface fields
+    // inside a grouped `type`, and the interior of a multi-line value like
+    // `X = f(\n ...\n)`, are not mistaken for items or for the group's closer.
+    // Brace/paren counting is done on a copy with string/rune literals blanked, so
+    // a `{`, `}`, `(`, `)`, or `#` inside a value (e.g. `X = "{"`, a struct tag)
+    // does not corrupt the depths.
     let mut in_group = false;
     let mut brace_depth: i32 = 0;
+    let mut paren_depth: i32 = 0;
     for line in stripped.lines() {
         let t = line.trim();
+        let blanked = blank_go_strings(line);
+        let bt = blanked.trim();
         if in_group {
-            if brace_depth == 0 && t.starts_with(')') {
+            let at_base = brace_depth == 0 && paren_depth == 0;
+            if at_base && bt.starts_with(')') {
                 in_group = false;
                 continue;
             }
-            if brace_depth == 0
+            if at_base
                 && let Some(caps) = GO_GROUP_ITEM.captures(t)
                 && let Some(name) = caps.get(1)
             {
@@ -72,19 +80,86 @@ pub fn extract_exports(content: &str) -> Vec<String> {
                     symbols.push(n.to_string());
                 }
             }
-            brace_depth += t.matches('{').count() as i32 - t.matches('}').count() as i32;
+            brace_depth += bt.matches('{').count() as i32 - bt.matches('}').count() as i32;
+            paren_depth += bt.matches('(').count() as i32 - bt.matches(')').count() as i32;
             if brace_depth < 0 {
                 brace_depth = 0;
             }
+            if paren_depth < 0 {
+                paren_depth = 0;
+            }
             continue;
         }
-        if GO_GROUP_OPEN.is_match(t) {
+        if GO_GROUP_OPEN.is_match(bt) {
             in_group = true;
             brace_depth = 0;
+            paren_depth = 0;
         }
     }
 
     symbols
+}
+
+/// Return a copy of a Go source line with the CONTENTS of string and rune literals
+/// replaced by spaces, so brace/paren counting and identifier detection are not
+/// confused by `{`, `}`, `(`, `)`, or `#` inside them. Handles interpreted
+/// (`"..."`, with `\` escapes), raw (`` `...` ``), and rune (`'...'`) literals.
+/// Multi-line raw strings (backtick spanning lines) are a rare edge and not
+/// tracked across lines.
+fn blank_go_strings(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0;
+    while i < n {
+        match chars[i] {
+            '"' => {
+                out.push(' ');
+                i += 1;
+                while i < n {
+                    if chars[i] == '\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if chars[i] == '"' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            '`' => {
+                out.push(' ');
+                i += 1;
+                while i < n && chars[i] != '`' {
+                    i += 1;
+                }
+                if i < n {
+                    i += 1;
+                }
+            }
+            '\'' => {
+                out.push(' ');
+                i += 1;
+                while i < n {
+                    if chars[i] == '\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if chars[i] == '\'' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            c => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -250,5 +325,71 @@ type (
         assert!(!symbols.contains(&"internalX".to_string()));
         assert!(!symbols.contains(&"localState".to_string()));
         assert!(!symbols.contains(&"private2".to_string()));
+    }
+
+    #[test]
+    fn test_go_grouped_delimiters_in_strings() {
+        // A `{` / `}` / `(` / `)` inside a grouped item's value string must not
+        // corrupt brace/paren depth (which would drop later items AND leave the
+        // group open, swallowing every subsequent grouped block), and a multi-line
+        // function-call value must not be mistaken for the group's closer.
+        let src = r#"
+package config
+
+const (
+    OpenBrace = "{"
+    Version   = "1.0"
+    APIPath   = "/v1"
+)
+
+var (
+    DefaultConfig = loadConfig(
+        "path",
+    )
+    Alpha = 1
+    Beta  = 2
+)
+
+const LaterExport = 5
+"#;
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"OpenBrace".to_string()), "{symbols:?}");
+        assert!(
+            symbols.contains(&"Version".to_string()),
+            "after brace-string"
+        );
+        assert!(symbols.contains(&"APIPath".to_string()));
+        assert!(symbols.contains(&"DefaultConfig".to_string()));
+        assert!(
+            symbols.contains(&"Alpha".to_string()),
+            "after multiline value"
+        );
+        assert!(symbols.contains(&"Beta".to_string()));
+        assert!(
+            symbols.contains(&"LaterExport".to_string()),
+            "group closed correctly so a later const is still seen"
+        );
+    }
+
+    #[test]
+    fn test_go_grouped_type_struct_tag_brace() {
+        // A `}` inside a struct-tag string must not drop brace_depth to 0 mid-struct
+        // and leak a field as a top-level export.
+        let src = "
+package m
+
+type (
+    Config struct {
+        Afield string `json:\"a}\"`
+        Bfield int
+    }
+    Helper int
+)
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Config".to_string()));
+        assert!(symbols.contains(&"Helper".to_string()));
+        assert!(!symbols.contains(&"Afield".to_string()), "struct field");
+        assert!(!symbols.contains(&"Bfield".to_string()), "struct field");
     }
 }

--- a/src/exports/go.rs
+++ b/src/exports/go.rs
@@ -1,10 +1,6 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-static COMMENT_SINGLE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"//.*$").unwrap());
-
-static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
-
 /// Go exports: func Name, type Name, var Name, const Name
 /// In Go, anything starting with uppercase is exported.
 static GO_DECL: LazyLock<Regex> = LazyLock::new(|| {
@@ -26,24 +22,25 @@ static GO_GROUP_ITEM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^([A-Za-z_
 /// Extract exported symbols from Go source code.
 /// In Go, any top-level identifier starting with an uppercase letter is exported.
 pub fn extract_exports(content: &str) -> Vec<String> {
-    let stripped = COMMENT_SINGLE.replace_all(content, "");
-    let stripped = COMMENT_MULTI.replace_all(&stripped, "");
-    // Blank the CONTENTS of string/rune literals — including multi-line backtick raw
-    // strings (SQL/GraphQL/template constants) — so a declaration-shaped token or a
-    // `{`/`}`/`(`/`)` inside a literal is never read as code or as a delimiter.
-    // Newlines are preserved, so all the line-anchored/line-based passes stay aligned.
-    let blanked = blank_go_strings(&stripped);
+    // One linear pass strips comments AND blanks every string/rune literal together,
+    // so neither is misread as the other: a `'` (apostrophe in a contraction) or a
+    // `{`/`}`/`(`/`)` inside a `//` or `/* */` comment is ignored, and a multi-line
+    // backtick raw string (SQL/GraphQL/template constant) is blanked across lines.
+    // Every pass below runs on this copy, so no comment or string body is ever read
+    // as code or as a delimiter. Newlines are preserved to keep line-based passes
+    // aligned.
+    let stripped = strip_go_strings_and_comments(content);
 
     let mut symbols = Vec::new();
 
-    for caps in GO_DECL.captures_iter(&blanked) {
+    for caps in GO_DECL.captures_iter(&stripped) {
         if let Some(name) = caps.get(1) {
             symbols.push(name.as_str().to_string());
         }
     }
 
     // Also capture exported methods
-    for caps in GO_METHOD.captures_iter(&blanked) {
+    for caps in GO_METHOD.captures_iter(&stripped) {
         if let Some(name) = caps.get(1) {
             let n = name.as_str().to_string();
             if !symbols.contains(&n) {
@@ -58,13 +55,13 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     // but ONLY at brace-depth 0 AND paren-depth 0 — so struct/interface fields
     // inside a grouped `type`, and the interior of a multi-line value like
     // `X = f(\n ...\n)`, are not mistaken for items or for the group's closer. The
-    // scan runs on the string-blanked copy, so a `{`/`}`/`(`/`)` inside a value
-    // (`X = "{"`, a struct tag, a multi-line backtick template) never corrupts the
-    // depths.
+    // scan runs on the comment-stripped, string-blanked copy, so a `{`/`}`/`(`/`)`
+    // inside a value (`X = "{"`, a struct tag, a multi-line backtick template) or a
+    // comment never corrupts the depths.
     let mut in_group = false;
     let mut brace_depth: i32 = 0;
     let mut paren_depth: i32 = 0;
-    for line in blanked.lines() {
+    for line in stripped.lines() {
         let bt = line.trim();
         if in_group {
             let at_base = brace_depth == 0 && paren_depth == 0;
@@ -103,75 +100,101 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     symbols
 }
 
-/// Return a copy of Go source with the CONTENTS of string and rune literals replaced
-/// by spaces, so declaration detection and brace/paren counting are not confused by
-/// code-shaped text, `{`, `}`, `(`, `)`, or `#` inside them. Handles interpreted
-/// (`"..."`, with `\` escapes), raw (`` `...` `` — which may span multiple lines),
-/// and rune (`'...'`) literals. Newlines are preserved throughout.
-fn blank_go_strings(content: &str) -> String {
+/// Strip `//` and `/* */` comments and blank the CONTENTS of string/rune literals in
+/// one linear pass, so neither is misread as the other. Recognizing `//` / `/*`
+/// before `"`/`` ` ``/`'` means an apostrophe or brace inside a comment is ignored
+/// (a plain `//.*` regex without the multiline flag stripped only the file's LAST
+/// comment, leaking the rest into the string scan); and blanking string/rune
+/// literals — interpreted `"..."` (with `\` escapes), raw `` `...` `` (which may span
+/// multiple lines), and rune `'...'` — keeps their code-shaped text and delimiters
+/// out of the parse. Go block comments do NOT nest. Newlines are preserved.
+fn strip_go_strings_and_comments(content: &str) -> String {
     let chars: Vec<char> = content.chars().collect();
     let n = chars.len();
     let mut out = String::with_capacity(content.len());
     let mut i = 0;
     while i < n {
-        match chars[i] {
-            '"' => {
-                out.push(' ');
-                i += 1;
-                while i < n {
-                    if chars[i] == '\\' {
-                        if i + 1 < n && chars[i + 1] == '\n' {
-                            out.push('\n');
-                        }
-                        i += 2;
-                        continue;
-                    }
-                    if chars[i] == '"' {
-                        i += 1;
-                        break;
-                    }
-                    if chars[i] == '\n' {
-                        out.push('\n');
-                    }
-                    i += 1;
-                }
-            }
-            '`' => {
-                out.push(' ');
-                i += 1;
-                while i < n && chars[i] != '`' {
-                    if chars[i] == '\n' {
-                        out.push('\n');
-                    }
-                    i += 1;
-                }
-                if i < n {
-                    i += 1;
-                }
-            }
-            '\'' => {
-                out.push(' ');
-                i += 1;
-                while i < n {
-                    if chars[i] == '\\' {
-                        i += 2;
-                        continue;
-                    }
-                    if chars[i] == '\'' {
-                        i += 1;
-                        break;
-                    }
-                    if chars[i] == '\n' {
-                        out.push('\n');
-                    }
-                    i += 1;
-                }
-            }
-            c => {
-                out.push(c);
+        let c = chars[i];
+        // Line comment.
+        if c == '/' && i + 1 < n && chars[i + 1] == '/' {
+            i += 2;
+            while i < n && chars[i] != '\n' {
                 i += 1;
             }
+            continue;
         }
+        // Block comment (does not nest in Go).
+        if c == '/' && i + 1 < n && chars[i + 1] == '*' {
+            i += 2;
+            while i < n {
+                if chars[i] == '*' && i + 1 < n && chars[i + 1] == '/' {
+                    i += 2;
+                    break;
+                }
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            continue;
+        }
+        // Interpreted string literal `"..."` (with `\` escapes).
+        if c == '"' {
+            i += 1;
+            while i < n {
+                if chars[i] == '\\' {
+                    if i + 1 < n && chars[i + 1] == '\n' {
+                        out.push('\n');
+                    }
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '"' {
+                    i += 1;
+                    break;
+                }
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            continue;
+        }
+        // Raw string literal `` `...` `` (no escapes; may span multiple lines).
+        if c == '`' {
+            i += 1;
+            while i < n && chars[i] != '`' {
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            if i < n {
+                i += 1;
+            }
+            continue;
+        }
+        // Rune literal `'...'` (with `\` escapes).
+        if c == '\'' {
+            i += 1;
+            while i < n {
+                if chars[i] == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '\'' {
+                    i += 1;
+                    break;
+                }
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(c);
+        i += 1;
     }
     out
 }
@@ -460,5 +483,59 @@ const (
             symbols.contains(&"Later".to_string()),
             "a later separate group is still seen"
         );
+    }
+
+    #[test]
+    fn test_go_comment_with_apostrophe_or_quote_does_not_drop_exports() {
+        // Comments are recognized before rune/string scanning, so a contraction
+        // ("can't") or a stray `"` in ANY comment (not just the file's last one) does
+        // not swallow following declarations.
+        let src = "
+package m
+
+// Serve can't fail here.
+func Serve() {}
+
+// A stray \" quote mark in a comment.
+type Handler struct{}
+
+const Alpha = 1 // it's a value
+const Beta = 2
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Serve".to_string()), "{symbols:?}");
+        assert!(symbols.contains(&"Handler".to_string()));
+        assert!(symbols.contains(&"Alpha".to_string()));
+        assert!(symbols.contains(&"Beta".to_string()));
+    }
+
+    #[test]
+    fn test_go_grouped_comment_delimiters_do_not_corrupt_depth() {
+        // Unbalanced `(`/`{`/`}` inside comments — on item lines, the group-open line,
+        // or a struct-field line — must not corrupt the grouped-pass depth.
+        let src = "
+package m
+
+const ( // begin group with an unbalanced ( in the comment
+    Alpha = 1 // see foo(
+    Beta = 2  // has a { brace
+)
+
+type (
+    Config struct {
+        A int // a stray } here
+        Bfield int
+    }
+    Helper int
+)
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Alpha".to_string()), "{symbols:?}");
+        assert!(symbols.contains(&"Beta".to_string()), "comment paren/brace");
+        assert!(symbols.contains(&"Config".to_string()));
+        assert!(symbols.contains(&"Helper".to_string()));
+        // The `}` in a comment must not leak a struct field as an export.
+        assert!(!symbols.contains(&"A".to_string()), "struct field");
+        assert!(!symbols.contains(&"Bfield".to_string()), "struct field");
     }
 }

--- a/src/exports/go.rs
+++ b/src/exports/go.rs
@@ -28,17 +28,22 @@ static GO_GROUP_ITEM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^([A-Za-z_
 pub fn extract_exports(content: &str) -> Vec<String> {
     let stripped = COMMENT_SINGLE.replace_all(content, "");
     let stripped = COMMENT_MULTI.replace_all(&stripped, "");
+    // Blank the CONTENTS of string/rune literals — including multi-line backtick raw
+    // strings (SQL/GraphQL/template constants) — so a declaration-shaped token or a
+    // `{`/`}`/`(`/`)` inside a literal is never read as code or as a delimiter.
+    // Newlines are preserved, so all the line-anchored/line-based passes stay aligned.
+    let blanked = blank_go_strings(&stripped);
 
     let mut symbols = Vec::new();
 
-    for caps in GO_DECL.captures_iter(&stripped) {
+    for caps in GO_DECL.captures_iter(&blanked) {
         if let Some(name) = caps.get(1) {
             symbols.push(name.as_str().to_string());
         }
     }
 
     // Also capture exported methods
-    for caps in GO_METHOD.captures_iter(&stripped) {
+    for caps in GO_METHOD.captures_iter(&blanked) {
         if let Some(name) = caps.get(1) {
             let n = name.as_str().to_string();
             if !symbols.contains(&n) {
@@ -52,17 +57,15 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     // regexes above). Capture each item's leading exported (uppercase) identifier,
     // but ONLY at brace-depth 0 AND paren-depth 0 — so struct/interface fields
     // inside a grouped `type`, and the interior of a multi-line value like
-    // `X = f(\n ...\n)`, are not mistaken for items or for the group's closer.
-    // Brace/paren counting is done on a copy with string/rune literals blanked, so
-    // a `{`, `}`, `(`, `)`, or `#` inside a value (e.g. `X = "{"`, a struct tag)
-    // does not corrupt the depths.
+    // `X = f(\n ...\n)`, are not mistaken for items or for the group's closer. The
+    // scan runs on the string-blanked copy, so a `{`/`}`/`(`/`)` inside a value
+    // (`X = "{"`, a struct tag, a multi-line backtick template) never corrupts the
+    // depths.
     let mut in_group = false;
     let mut brace_depth: i32 = 0;
     let mut paren_depth: i32 = 0;
-    for line in stripped.lines() {
-        let t = line.trim();
-        let blanked = blank_go_strings(line);
-        let bt = blanked.trim();
+    for line in blanked.lines() {
+        let bt = line.trim();
         if in_group {
             let at_base = brace_depth == 0 && paren_depth == 0;
             if at_base && bt.starts_with(')') {
@@ -70,7 +73,7 @@ pub fn extract_exports(content: &str) -> Vec<String> {
                 continue;
             }
             if at_base
-                && let Some(caps) = GO_GROUP_ITEM.captures(t)
+                && let Some(caps) = GO_GROUP_ITEM.captures(bt)
                 && let Some(name) = caps.get(1)
             {
                 let n = name.as_str();
@@ -100,16 +103,15 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     symbols
 }
 
-/// Return a copy of a Go source line with the CONTENTS of string and rune literals
-/// replaced by spaces, so brace/paren counting and identifier detection are not
-/// confused by `{`, `}`, `(`, `)`, or `#` inside them. Handles interpreted
-/// (`"..."`, with `\` escapes), raw (`` `...` ``), and rune (`'...'`) literals.
-/// Multi-line raw strings (backtick spanning lines) are a rare edge and not
-/// tracked across lines.
-fn blank_go_strings(line: &str) -> String {
-    let chars: Vec<char> = line.chars().collect();
+/// Return a copy of Go source with the CONTENTS of string and rune literals replaced
+/// by spaces, so declaration detection and brace/paren counting are not confused by
+/// code-shaped text, `{`, `}`, `(`, `)`, or `#` inside them. Handles interpreted
+/// (`"..."`, with `\` escapes), raw (`` `...` `` — which may span multiple lines),
+/// and rune (`'...'`) literals. Newlines are preserved throughout.
+fn blank_go_strings(content: &str) -> String {
+    let chars: Vec<char> = content.chars().collect();
     let n = chars.len();
-    let mut out = String::with_capacity(line.len());
+    let mut out = String::with_capacity(content.len());
     let mut i = 0;
     while i < n {
         match chars[i] {
@@ -118,12 +120,18 @@ fn blank_go_strings(line: &str) -> String {
                 i += 1;
                 while i < n {
                     if chars[i] == '\\' {
+                        if i + 1 < n && chars[i + 1] == '\n' {
+                            out.push('\n');
+                        }
                         i += 2;
                         continue;
                     }
                     if chars[i] == '"' {
                         i += 1;
                         break;
+                    }
+                    if chars[i] == '\n' {
+                        out.push('\n');
                     }
                     i += 1;
                 }
@@ -132,6 +140,9 @@ fn blank_go_strings(line: &str) -> String {
                 out.push(' ');
                 i += 1;
                 while i < n && chars[i] != '`' {
+                    if chars[i] == '\n' {
+                        out.push('\n');
+                    }
                     i += 1;
                 }
                 if i < n {
@@ -149,6 +160,9 @@ fn blank_go_strings(line: &str) -> String {
                     if chars[i] == '\'' {
                         i += 1;
                         break;
+                    }
+                    if chars[i] == '\n' {
+                        out.push('\n');
                     }
                     i += 1;
                 }
@@ -391,5 +405,60 @@ type (
         assert!(symbols.contains(&"Helper".to_string()));
         assert!(!symbols.contains(&"Afield".to_string()), "struct field");
         assert!(!symbols.contains(&"Bfield".to_string()), "struct field");
+    }
+
+    #[test]
+    fn test_go_grouped_multiline_backtick_raw_string() {
+        // A multi-line backtick raw string (SQL/GraphQL/template constant) inside a
+        // grouped block must be blanked across lines: its body must not leak an
+        // uppercase word as a phantom export, and a `)`/`{`/`(` in the body must not
+        // corrupt the group's brace/paren depth.
+        let src = "
+package db
+
+const (
+    schema = `
+CREATE TABLE users (
+    id INT
+);
+`
+    Version = 2
+)
+
+const AfterGroup = 9
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Version".to_string()), "{symbols:?}");
+        assert!(symbols.contains(&"AfterGroup".to_string()), "group closed");
+        // Raw-string body text is not code.
+        assert!(!symbols.contains(&"CREATE".to_string()), "SQL body text");
+        assert!(!symbols.contains(&"TABLE".to_string()));
+    }
+
+    #[test]
+    fn test_go_grouped_backtick_with_brace_and_paren_recovers() {
+        // Unbalanced `)` / `{` inside a multi-line backtick value must not close the
+        // group early or leave it stuck open (which would swallow later exports and
+        // subsequent grouped blocks).
+        let src = "
+package m
+
+var (
+    tmpl = `
+) closing text and an unbalanced { brace
+`
+    Alpha = 1
+)
+
+const (
+    Later = 5
+)
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Alpha".to_string()), "{symbols:?}");
+        assert!(
+            symbols.contains(&"Later".to_string()),
+            "a later separate group is still seen"
+        );
     }
 }

--- a/src/exports/go.rs
+++ b/src/exports/go.rs
@@ -2,9 +2,12 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 /// Go exports: func Name, type Name, var Name, const Name
-/// In Go, anything starting with uppercase is exported.
+/// In Go, anything starting with uppercase is exported. The optional receiver group
+/// uses `[^)\n]*` (not `[^)]*`) so it cannot span newlines: on a grouped `type (`
+/// opener line it must not leap across the block body to the first interior `)` and
+/// capture a struct field / interface method as a phantom top-level export.
 static GO_DECL: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?m)^(?:func|type|var|const)\s+(?:\([^)]*\)\s+)?([A-Z]\w*)").unwrap()
+    Regex::new(r"(?m)^(?:func|type|var|const)\s+(?:\([^)\n]*\)\s+)?([A-Z]\w*)").unwrap()
 });
 
 /// Go method: func (receiver) Name(...)
@@ -678,5 +681,30 @@ const (
                 "missing {name}: {symbols:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_go_grouped_type_field_with_parens_not_leaked() {
+        // GO_DECL's receiver group must not span newlines from a grouped `type (`
+        // opener into the block body and capture a struct field (esp. one after a
+        // func-typed field with parens) as a phantom top-level export.
+        let src = "
+package m
+
+type (
+    Config struct {
+        fn     func(x int)
+        Secret string
+    }
+    Helper int
+)
+";
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"Config".to_string()), "{symbols:?}");
+        assert!(symbols.contains(&"Helper".to_string()));
+        assert!(
+            !symbols.contains(&"Secret".to_string()),
+            "struct field leaked"
+        );
     }
 }

--- a/src/exports/go.rs
+++ b/src/exports/go.rs
@@ -15,6 +15,14 @@ static GO_DECL: LazyLock<Regex> = LazyLock::new(|| {
 static GO_METHOD: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^func\s+\([^)]+\)\s+([A-Z]\w*)").unwrap());
 
+/// Opening of a grouped declaration: `const (`, `var (`, `type (` (the `(` at
+/// end of the trimmed line, items following on their own lines).
+static GO_GROUP_OPEN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:const|var|type)\s*\($").unwrap());
+
+/// Leading identifier of a grouped item line (`Name = ...`, `Name Type`, ...).
+static GO_GROUP_ITEM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^([A-Za-z_]\w*)").unwrap());
+
 /// Extract exported symbols from Go source code.
 /// In Go, any top-level identifier starting with an uppercase letter is exported.
 pub fn extract_exports(content: &str) -> Vec<String> {
@@ -36,6 +44,43 @@ pub fn extract_exports(content: &str) -> Vec<String> {
             if !symbols.contains(&n) {
                 symbols.push(n);
             }
+        }
+    }
+
+    // Grouped declarations: `const (` / `var (` / `type (` blocks, whose items sit
+    // on their own lines with no keyword prefix (missed by the line-anchored
+    // regexes above). Capture the leading identifier of each item at brace-depth 0
+    // so struct/interface field lines inside a grouped `type` are not mistaken for
+    // top-level exports.
+    let mut in_group = false;
+    let mut brace_depth: i32 = 0;
+    for line in stripped.lines() {
+        let t = line.trim();
+        if in_group {
+            if brace_depth == 0 && t.starts_with(')') {
+                in_group = false;
+                continue;
+            }
+            if brace_depth == 0
+                && let Some(caps) = GO_GROUP_ITEM.captures(t)
+                && let Some(name) = caps.get(1)
+            {
+                let n = name.as_str();
+                if matches!(n.chars().next(), Some(c) if c.is_ascii_uppercase())
+                    && !symbols.contains(&n.to_string())
+                {
+                    symbols.push(n.to_string());
+                }
+            }
+            brace_depth += t.matches('{').count() as i32 - t.matches('}').count() as i32;
+            if brace_depth < 0 {
+                brace_depth = 0;
+            }
+            continue;
+        }
+        if GO_GROUP_OPEN.is_match(t) {
+            in_group = true;
+            brace_depth = 0;
         }
     }
 
@@ -163,5 +208,47 @@ func (a Auth) serialize() string {}
         let src = "package main\n";
         let symbols = extract_exports(src);
         assert!(symbols.is_empty());
+    }
+
+    #[test]
+    fn test_go_grouped_declarations() {
+        // Finding #5: items inside grouped const/var/type blocks sit on their own
+        // lines with no keyword prefix and were missed by the line-anchored regex.
+        let src = r#"
+package config
+
+const (
+    MaxRetries = 3
+    Timeout    = 30
+    internalX  = 5
+)
+
+var (
+    GlobalState *State
+    localState  int
+)
+
+type (
+    Point struct {
+        X int
+        Y int
+    }
+    Named    int
+    private2 string
+)
+"#;
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"MaxRetries".to_string()));
+        assert!(symbols.contains(&"Timeout".to_string()));
+        assert!(symbols.contains(&"GlobalState".to_string()));
+        assert!(symbols.contains(&"Point".to_string()));
+        assert!(symbols.contains(&"Named".to_string()));
+        // Struct fields inside a grouped `type` must NOT be captured as exports.
+        assert!(!symbols.contains(&"X".to_string()), "struct field X");
+        assert!(!symbols.contains(&"Y".to_string()), "struct field Y");
+        // Unexported (lowercase) grouped items are skipped.
+        assert!(!symbols.contains(&"internalX".to_string()));
+        assert!(!symbols.contains(&"localState".to_string()));
+        assert!(!symbols.contains(&"private2".to_string()));
     }
 }

--- a/src/exports/kotlin.rs
+++ b/src/exports/kotlin.rs
@@ -10,7 +10,7 @@ static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?
 /// Then exclude lines that start with private/internal/protected.
 static KT_DECL: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)^[^\S\n]*(?:(?:public|internal|private|protected)\s+)?(?:suspend\s+)?(?:inline\s+)?(?:data\s+|sealed\s+|enum\s+|annotation\s+|abstract\s+|open\s+)?(?:fun|class|object|interface|typealias|val|var)\s+(?:<[^>]+>\s+)?(\w+)",
+        r"(?m)^[^\S\n]*(?:(?:public|internal|private|protected)\s+)?(?:suspend\s+)?(?:inline\s+)?(?:data\s+|sealed\s+|enum\s+|annotation\s+|abstract\s+|open\s+)?(?:const\s+)?(?:fun|class|object|interface|typealias|val|var)\s+(?:<[^>]+>\s+)?(\w+)",
     )
     .unwrap()
 });
@@ -109,5 +109,23 @@ public suspend fun loadProfile(): Profile {}
         let symbols = extract_exports(src);
         assert!(symbols.contains(&"fetchData".to_string()));
         assert!(symbols.contains(&"loadProfile".to_string()));
+    }
+
+    #[test]
+    fn test_kotlin_const_val_exported() {
+        // Finding #9: top-level `const val` is a public compile-time constant and
+        // must be captured; the `const` modifier previously blocked the match.
+        let src = r#"
+const val MAX_SIZE = 100
+public const val VISIBLE = 2
+internal const val HIDDEN = 3
+"#;
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"MAX_SIZE".to_string()), "const val");
+        assert!(symbols.contains(&"VISIBLE".to_string()), "public const val");
+        assert!(
+            !symbols.contains(&"HIDDEN".to_string()),
+            "internal const val is not exported"
+        );
     }
 }

--- a/src/exports/rust_lang.rs
+++ b/src/exports/rust_lang.rs
@@ -1,10 +1,6 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-static COMMENT_SINGLE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)//.*$").unwrap());
-
-static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
-
 /// Raw string literals: r###"..."###, r##"..."##, r#"..."#, r"..."
 /// Processed from most hashes to fewest so inner patterns don't match prematurely.
 static RAW_STR_3: LazyLock<Regex> =
@@ -16,9 +12,6 @@ static RAW_STR_0: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)\br"[^"]*
 
 /// Char literals that contain a double quote: '"' or '\"'
 static CHAR_DQUOTE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"'(?:\\.|")'"#).unwrap());
-
-/// Regular string literals (handling escaped quotes and line continuations).
-static REG_STR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)"(?:[^"\\]|\\.)*""#).unwrap());
 
 /// pub fn, pub struct, pub enum, pub trait, pub type, pub const, pub static, pub mod
 static PUB_DECL: LazyLock<Regex> = LazyLock::new(|| {
@@ -33,17 +26,22 @@ static PUB_DECL: LazyLock<Regex> = LazyLock::new(|| {
 /// `pub const`, `pub static`, and `pub mod` declarations.
 /// Also matches `pub(crate)` items.
 pub fn extract_exports(content: &str) -> Vec<String> {
-    // Strip string literals first (before comments, since strings can contain //)
+    // Blank out raw strings and double-quote char literals up front (their hash-
+    // balanced / quoted forms are awkward for a linear scan); their inner `"`,
+    // `//`, `/*` then can't be misread as delimiters.
     let stripped = RAW_STR_3.replace_all(content, r#""""#);
     let stripped = RAW_STR_2.replace_all(&stripped, r#""""#);
     let stripped = RAW_STR_1.replace_all(&stripped, r#""""#);
     let stripped = RAW_STR_0.replace_all(&stripped, r#""""#);
     let stripped = CHAR_DQUOTE.replace_all(&stripped, "' '");
-    let stripped = REG_STR.replace_all(&stripped, r#""""#);
 
-    // Then strip comments
-    let stripped = COMMENT_SINGLE.replace_all(&stripped, "");
-    let stripped = COMMENT_MULTI.replace_all(&stripped, "");
+    // Strip regular strings AND comments in a SINGLE pass so neither is misread as
+    // the other. A regex that strips strings first treats a `"` inside a `//` doc
+    // comment as a string opener and swallows code up to the next real `"` —
+    // deleting `pub fn` declarations between them (a `///` line with an odd number
+    // of `"` silently hid exports). Recognizing `//` / `/*` before `"` fixes it,
+    // and a `//` inside a string is correctly kept as string content.
+    let stripped = strip_strings_and_comments(&stripped);
 
     let mut symbols = Vec::new();
 
@@ -54,6 +52,71 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     }
 
     symbols
+}
+
+/// Replace regular double-quoted strings, `//` line comments, and (nesting) `/* */`
+/// block comments with blanks, in one linear pass so a `"` in a comment is not
+/// treated as a string and a `//` in a string is not treated as a comment. Newlines
+/// are preserved. Assumes raw strings and double-quote char literals are already
+/// blanked (see `extract_exports`).
+fn strip_strings_and_comments(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < n {
+        let c = chars[i];
+        // Line comment: skip to end of line (keep the newline).
+        if c == '/' && i + 1 < n && chars[i + 1] == '/' {
+            i += 2;
+            while i < n && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+        // Block comment (Rust block comments nest).
+        if c == '/' && i + 1 < n && chars[i + 1] == '*' {
+            i += 2;
+            let mut depth = 1;
+            while i < n && depth > 0 {
+                if chars[i] == '/' && i + 1 < n && chars[i + 1] == '*' {
+                    depth += 1;
+                    i += 2;
+                } else if chars[i] == '*' && i + 1 < n && chars[i + 1] == '/' {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    if chars[i] == '\n' {
+                        out.push('\n');
+                    }
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        // Regular string literal: skip to the closing quote, honoring `\` escapes.
+        if c == '"' {
+            i += 1;
+            while i < n {
+                if chars[i] == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '"' {
+                    i += 1;
+                    break;
+                }
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
 }
 
 #[cfg(test)]
@@ -193,5 +256,44 @@ pub unsafe fn unsafe_fn() {}
 "#;
         let symbols = extract_exports(src);
         assert_eq!(symbols, vec!["async_fn", "unsafe_fn"]);
+    }
+
+    #[test]
+    fn test_quotes_in_comments_do_not_hide_exports() {
+        // A doc/line/block comment containing an odd number of `"` used to be read
+        // as a string opener, swallowing the following `pub fn` up to the next real
+        // quote. Comments must be recognized before strings.
+        let src = r#"
+/// Returns the escape for `\"` (a lone quote in a doc comment).
+pub fn alpha() {}
+
+/// A "quoted phrase" in a doc comment.
+pub fn bravo() {}
+
+pub const URL: &str = "http://example.com/a//b";
+pub fn charlie() {}
+
+/* block "comment" with a quote and // slashes */
+pub fn delta() {}
+"#;
+        let symbols = extract_exports(src);
+        for name in ["alpha", "bravo", "URL", "charlie", "delta"] {
+            assert!(
+                symbols.contains(&name.to_string()),
+                "missing {name}: {symbols:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_pub_fn_inside_string_not_extracted() {
+        // A `pub fn` that appears only inside a string literal must not be captured.
+        let src = r#"pub fn real() {} let s = "pub fn fake() {}";"#;
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"real".to_string()));
+        assert!(
+            !symbols.contains(&"fake".to_string()),
+            "fake is inside a string literal"
+        );
     }
 }

--- a/src/exports/rust_lang.rs
+++ b/src/exports/rust_lang.rs
@@ -1,24 +1,6 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-/// Raw string literals: r###"..."###, r##"..."##, r#"..."#, r"..." and their
-/// byte/C-string variants (br"...", cr"..."). The optional `(?:b|c)?` before `r`
-/// is essential: without it `br#"..."#` is never blanked, and the linear scanner
-/// then reads its interior quotes as real delimiters and can run a string to EOF,
-/// hiding later declarations. Processed most-hashes-first so inner patterns don't
-/// match prematurely.
-static RAW_STR_3: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r\#\#\#".*?"\#\#\#"#).unwrap());
-static RAW_STR_2: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r\#\#".*?"\#\#"#).unwrap());
-static RAW_STR_1: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r\#".*?"\#"#).unwrap());
-static RAW_STR_0: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r"[^"]*""#).unwrap());
-
-/// Char literals that contain a double quote: '"' or '\"'
-static CHAR_DQUOTE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"'(?:\\.|")'"#).unwrap());
-
 /// pub fn, pub struct, pub enum, pub trait, pub type, pub const, pub static, pub mod
 static PUB_DECL: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
@@ -32,22 +14,10 @@ static PUB_DECL: LazyLock<Regex> = LazyLock::new(|| {
 /// `pub const`, `pub static`, and `pub mod` declarations.
 /// Also matches `pub(crate)` items.
 pub fn extract_exports(content: &str) -> Vec<String> {
-    // Blank out raw strings and double-quote char literals up front (their hash-
-    // balanced / quoted forms are awkward for a linear scan); their inner `"`,
-    // `//`, `/*` then can't be misread as delimiters.
-    let stripped = RAW_STR_3.replace_all(content, r#""""#);
-    let stripped = RAW_STR_2.replace_all(&stripped, r#""""#);
-    let stripped = RAW_STR_1.replace_all(&stripped, r#""""#);
-    let stripped = RAW_STR_0.replace_all(&stripped, r#""""#);
-    let stripped = CHAR_DQUOTE.replace_all(&stripped, "' '");
-
-    // Strip regular strings AND comments in a SINGLE pass so neither is misread as
-    // the other. A regex that strips strings first treats a `"` inside a `//` doc
-    // comment as a string opener and swallows code up to the next real `"` —
-    // deleting `pub fn` declarations between them (a `///` line with an odd number
-    // of `"` silently hid exports). Recognizing `//` / `/*` before `"` fixes it,
-    // and a `//` inside a string is correctly kept as string content.
-    let stripped = strip_strings_and_comments(&stripped);
+    // Blank every string literal (regular, byte/C, and raw with ANY hash count) and
+    // comment in one linear pass, so nothing inside them — a `"`, `//`, `/*`, or a
+    // `pub fn`-shaped token — is misread as code or as a delimiter of the wrong kind.
+    let stripped = strip_strings_and_comments(content);
 
     let mut symbols = Vec::new();
 
@@ -60,11 +30,16 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     symbols
 }
 
-/// Replace regular double-quoted strings, `//` line comments, and (nesting) `/* */`
-/// block comments with blanks, in one linear pass so a `"` in a comment is not
-/// treated as a string and a `//` in a string is not treated as a comment. Newlines
-/// are preserved. Assumes raw strings and double-quote char literals are already
-/// blanked (see `extract_exports`).
+fn is_ident_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Blank string literals and comments in one linear pass so neither is misread as
+/// the other and nothing inside them is extracted. Handles, at each position:
+/// `//` line comments; nesting `/* */` block comments; raw strings `r#"…"#` with
+/// ANY hash count (and the byte/C prefixes `br`/`cr`); `'"'`/`'\"'` char literals
+/// (whose `"` would otherwise open a string); and regular/byte/C `"…"` strings with
+/// `\` escapes. Newlines are preserved so line-based callers stay aligned.
 fn strip_strings_and_comments(s: &str) -> String {
     let chars: Vec<char> = s.chars().collect();
     let n = chars.len();
@@ -100,11 +75,63 @@ fn strip_strings_and_comments(s: &str) -> String {
             }
             continue;
         }
-        // Regular string literal: skip to the closing quote, honoring `\` escapes.
+        // Raw string literal `r"…"`, `r#"…"#`, … with ANY number of hashes, plus the
+        // byte/C prefixes `br`/`cr`. Only at an identifier boundary, so the `r` in
+        // `for`/`error` (or an identifier ending in `r`) is not misread as a prefix.
+        if (c == 'r' || ((c == 'b' || c == 'c') && i + 1 < n && chars[i + 1] == 'r'))
+            && (i == 0 || !is_ident_char(chars[i - 1]))
+        {
+            let after_r = if c == 'r' { i + 1 } else { i + 2 };
+            let mut hash_end = after_r;
+            while hash_end < n && chars[hash_end] == '#' {
+                hash_end += 1;
+            }
+            if hash_end < n && chars[hash_end] == '"' {
+                let hashes = hash_end - after_r;
+                // Scan for a closing `"` followed by exactly `hashes` `#`.
+                let mut j = hash_end + 1;
+                while j < n {
+                    if chars[j] == '"' {
+                        let mut k = 0;
+                        while k < hashes && j + 1 + k < n && chars[j + 1 + k] == '#' {
+                            k += 1;
+                        }
+                        if k == hashes {
+                            j = j + 1 + hashes;
+                            break;
+                        }
+                    }
+                    if chars[j] == '\n' {
+                        out.push('\n');
+                    }
+                    j += 1;
+                }
+                i = j;
+                continue;
+            }
+        }
+        // Char literal containing a double quote — `'"'` or `'\"'`. Blank it so its
+        // `"` is not read as a string opener. Other char literals and lifetimes hold
+        // no `"` and are harmless, so they are left as-is.
+        if c == '\'' {
+            if i + 2 < n && chars[i + 1] == '"' && chars[i + 2] == '\'' {
+                i += 3;
+                continue;
+            }
+            if i + 3 < n && chars[i + 1] == '\\' && chars[i + 2] == '"' && chars[i + 3] == '\'' {
+                i += 4;
+                continue;
+            }
+        }
+        // Regular / byte / C (non-raw) string literal: skip to the closing quote,
+        // honoring `\` escapes.
         if c == '"' {
             i += 1;
             while i < n {
                 if chars[i] == '\\' {
+                    if i + 1 < n && chars[i + 1] == '\n' {
+                        out.push('\n');
+                    }
                     i += 2;
                     continue;
                 }
@@ -314,5 +341,27 @@ pub fn real() {}
 "####;
         let symbols = extract_exports(src);
         assert!(symbols.contains(&"real".to_string()), "got {symbols:?}");
+    }
+
+    #[test]
+    fn test_raw_strings_with_many_hashes_do_not_hide_exports() {
+        // Raw strings with 4+ hashes must be handled (the scanner counts hashes
+        // rather than relying on fixed 0..3-hash regexes). An interior quote must
+        // not leak and open an unterminated string that swallows later decls.
+        let src = r######"
+pub fn before_raw() {}
+pub const P: &str = r####"a "### b"####;
+pub fn after_raw() {}
+pub struct AfterStruct {}
+let q = r#####"x "#### y"#####;
+pub fn tail() {}
+"######;
+        let symbols = extract_exports(src);
+        for name in ["before_raw", "P", "after_raw", "AfterStruct", "tail"] {
+            assert!(
+                symbols.contains(&name.to_string()),
+                "missing {name}: {symbols:?}"
+            );
+        }
     }
 }

--- a/src/exports/rust_lang.rs
+++ b/src/exports/rust_lang.rs
@@ -1,14 +1,20 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-/// Raw string literals: r###"..."###, r##"..."##, r#"..."#, r"..."
-/// Processed from most hashes to fewest so inner patterns don't match prematurely.
+/// Raw string literals: r###"..."###, r##"..."##, r#"..."#, r"..." and their
+/// byte/C-string variants (br"...", cr"..."). The optional `(?:b|c)?` before `r`
+/// is essential: without it `br#"..."#` is never blanked, and the linear scanner
+/// then reads its interior quotes as real delimiters and can run a string to EOF,
+/// hiding later declarations. Processed most-hashes-first so inner patterns don't
+/// match prematurely.
 static RAW_STR_3: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\br\#\#\#".*?"\#\#\#"#).unwrap());
+    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r\#\#\#".*?"\#\#\#"#).unwrap());
 static RAW_STR_2: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?s)\br\#\#".*?"\#\#"#).unwrap());
-static RAW_STR_1: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)\br\#".*?"\#"#).unwrap());
-static RAW_STR_0: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"(?s)\br"[^"]*""#).unwrap());
+    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r\#\#".*?"\#\#"#).unwrap());
+static RAW_STR_1: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r\#".*?"\#"#).unwrap());
+static RAW_STR_0: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?s)\b(?:b|c)?r"[^"]*""#).unwrap());
 
 /// Char literals that contain a double quote: '"' or '\"'
 static CHAR_DQUOTE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"'(?:\\.|")'"#).unwrap());
@@ -295,5 +301,18 @@ pub fn delta() {}
             !symbols.contains(&"fake".to_string()),
             "fake is inside a string literal"
         );
+    }
+
+    #[test]
+    fn test_byte_and_c_raw_strings_do_not_hide_exports() {
+        // A byte raw string `br#"..."#` (or `cr#"..."#`) with an odd number of
+        // interior quotes must be blanked; otherwise the scanner opens a string on
+        // the trailing quote and swallows the following pub fn to EOF.
+        let src = r####"
+let x = br#"a "b"#;
+pub fn real() {}
+"####;
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"real".to_string()), "got {symbols:?}");
     }
 }

--- a/src/exports/swift.rs
+++ b/src/exports/swift.rs
@@ -1,8 +1,14 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
+static COMMENT_SINGLE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"//.*$").unwrap());
+
+static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
+
 /// Swift public/open declarations:
-/// public/open func, class, struct, enum, protocol, typealias, var, let, actor
+/// public/open func, class, struct, enum, protocol, typealias, var, let, actor.
+/// The modifier group allows any run of `final`/`static`/`class` between the access
+/// keyword and the declaration keyword (finding #4: `public final class` was missed).
 static SWIFT_DECL: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r"(?m)(?:public|open)\s+(?:(?:final|static|class)\s+)*(?:func|class|struct|enum|protocol|typealias|var|let|actor|init)\s+(\w+)",
@@ -17,11 +23,8 @@ static SWIFT_INIT: LazyLock<Regex> = LazyLock::new(|| {
 
 /// Extract exported (public/open) symbols from Swift source code.
 pub fn extract_exports(content: &str) -> Vec<String> {
-    // Strip strings AND comments in one pass so a declaration-shaped token inside a
-    // string literal (e.g. a code-gen template `let t = "public final class X {}"`)
-    // is not extracted as a phantom export, and a `"` in a comment is not read as a
-    // string (and vice-versa).
-    let stripped = strip_swift_strings_and_comments(content);
+    let stripped = COMMENT_SINGLE.replace_all(content, "");
+    let stripped = COMMENT_MULTI.replace_all(&stripped, "");
 
     let mut symbols = Vec::new();
 
@@ -37,88 +40,6 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     }
 
     symbols
-}
-
-/// Blank Swift string literals (`"..."` and `"""..."""`), `//` line comments, and
-/// (nesting) `/* */` block comments in one linear pass, so neither is misread as
-/// the other and no declaration inside a string is extracted. Newlines preserved.
-fn strip_swift_strings_and_comments(s: &str) -> String {
-    let chars: Vec<char> = s.chars().collect();
-    let n = chars.len();
-    let mut out = String::with_capacity(s.len());
-    let mut i = 0;
-    while i < n {
-        let c = chars[i];
-        // Line comment.
-        if c == '/' && i + 1 < n && chars[i + 1] == '/' {
-            i += 2;
-            while i < n && chars[i] != '\n' {
-                i += 1;
-            }
-            continue;
-        }
-        // Block comment (Swift block comments nest).
-        if c == '/' && i + 1 < n && chars[i + 1] == '*' {
-            i += 2;
-            let mut depth = 1;
-            while i < n && depth > 0 {
-                if chars[i] == '/' && i + 1 < n && chars[i + 1] == '*' {
-                    depth += 1;
-                    i += 2;
-                } else if chars[i] == '*' && i + 1 < n && chars[i + 1] == '/' {
-                    depth -= 1;
-                    i += 2;
-                } else {
-                    if chars[i] == '\n' {
-                        out.push('\n');
-                    }
-                    i += 1;
-                }
-            }
-            continue;
-        }
-        // Multi-line string literal `"""..."""`.
-        if c == '"' && i + 2 < n && chars[i + 1] == '"' && chars[i + 2] == '"' {
-            i += 3;
-            while i < n {
-                if chars[i] == '\\' {
-                    i += 2;
-                    continue;
-                }
-                if chars[i] == '"' && i + 2 < n && chars[i + 1] == '"' && chars[i + 2] == '"' {
-                    i += 3;
-                    break;
-                }
-                if chars[i] == '\n' {
-                    out.push('\n');
-                }
-                i += 1;
-            }
-            continue;
-        }
-        // Single-line string literal `"..."`.
-        if c == '"' {
-            i += 1;
-            while i < n {
-                if chars[i] == '\\' {
-                    i += 2;
-                    continue;
-                }
-                if chars[i] == '"' {
-                    i += 1;
-                    break;
-                }
-                if chars[i] == '\n' {
-                    out.push('\n');
-                }
-                i += 1;
-            }
-            continue;
-        }
-        out.push(c);
-        i += 1;
-    }
-    out
 }
 
 #[cfg(test)]
@@ -211,38 +132,5 @@ public class RegularClass {}
             symbols.contains(&"RegularClass".to_string()),
             "plain public class still works"
         );
-    }
-
-    #[test]
-    fn test_swift_declaration_inside_string_not_extracted() {
-        // A declaration-shaped token inside a string literal (e.g. a code-gen
-        // template) must not be extracted as a phantom export.
-        let src = r#"
-public let template = "public final class Injected {}"
-public final class Real {}
-"#;
-        let symbols = extract_exports(src);
-        assert!(symbols.contains(&"template".to_string()));
-        assert!(symbols.contains(&"Real".to_string()));
-        assert!(
-            !symbols.contains(&"Injected".to_string()),
-            "declaration is inside a string literal"
-        );
-    }
-
-    #[test]
-    fn test_swift_declaration_inside_multiline_string_not_extracted() {
-        let src = r#"
-public let generator = """
-public final class Generated {}
-public struct AlsoFake {}
-"""
-public struct Keep {}
-"#;
-        let symbols = extract_exports(src);
-        assert!(symbols.contains(&"generator".to_string()));
-        assert!(symbols.contains(&"Keep".to_string()));
-        assert!(!symbols.contains(&"Generated".to_string()));
-        assert!(!symbols.contains(&"AlsoFake".to_string()));
     }
 }

--- a/src/exports/swift.rs
+++ b/src/exports/swift.rs
@@ -1,10 +1,6 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-static COMMENT_SINGLE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"//.*$").unwrap());
-
-static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
-
 /// Swift public/open declarations:
 /// public/open func, class, struct, enum, protocol, typealias, var, let, actor
 static SWIFT_DECL: LazyLock<Regex> = LazyLock::new(|| {
@@ -21,8 +17,11 @@ static SWIFT_INIT: LazyLock<Regex> = LazyLock::new(|| {
 
 /// Extract exported (public/open) symbols from Swift source code.
 pub fn extract_exports(content: &str) -> Vec<String> {
-    let stripped = COMMENT_SINGLE.replace_all(content, "");
-    let stripped = COMMENT_MULTI.replace_all(&stripped, "");
+    // Strip strings AND comments in one pass so a declaration-shaped token inside a
+    // string literal (e.g. a code-gen template `let t = "public final class X {}"`)
+    // is not extracted as a phantom export, and a `"` in a comment is not read as a
+    // string (and vice-versa).
+    let stripped = strip_swift_strings_and_comments(content);
 
     let mut symbols = Vec::new();
 
@@ -38,6 +37,88 @@ pub fn extract_exports(content: &str) -> Vec<String> {
     }
 
     symbols
+}
+
+/// Blank Swift string literals (`"..."` and `"""..."""`), `//` line comments, and
+/// (nesting) `/* */` block comments in one linear pass, so neither is misread as
+/// the other and no declaration inside a string is extracted. Newlines preserved.
+fn strip_swift_strings_and_comments(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < n {
+        let c = chars[i];
+        // Line comment.
+        if c == '/' && i + 1 < n && chars[i + 1] == '/' {
+            i += 2;
+            while i < n && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+        // Block comment (Swift block comments nest).
+        if c == '/' && i + 1 < n && chars[i + 1] == '*' {
+            i += 2;
+            let mut depth = 1;
+            while i < n && depth > 0 {
+                if chars[i] == '/' && i + 1 < n && chars[i + 1] == '*' {
+                    depth += 1;
+                    i += 2;
+                } else if chars[i] == '*' && i + 1 < n && chars[i + 1] == '/' {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    if chars[i] == '\n' {
+                        out.push('\n');
+                    }
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        // Multi-line string literal `"""..."""`.
+        if c == '"' && i + 2 < n && chars[i + 1] == '"' && chars[i + 2] == '"' {
+            i += 3;
+            while i < n {
+                if chars[i] == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '"' && i + 2 < n && chars[i + 1] == '"' && chars[i + 2] == '"' {
+                    i += 3;
+                    break;
+                }
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            continue;
+        }
+        // Single-line string literal `"..."`.
+        if c == '"' {
+            i += 1;
+            while i < n {
+                if chars[i] == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if chars[i] == '"' {
+                    i += 1;
+                    break;
+                }
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
 }
 
 #[cfg(test)]
@@ -130,5 +211,38 @@ public class RegularClass {}
             symbols.contains(&"RegularClass".to_string()),
             "plain public class still works"
         );
+    }
+
+    #[test]
+    fn test_swift_declaration_inside_string_not_extracted() {
+        // A declaration-shaped token inside a string literal (e.g. a code-gen
+        // template) must not be extracted as a phantom export.
+        let src = r#"
+public let template = "public final class Injected {}"
+public final class Real {}
+"#;
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"template".to_string()));
+        assert!(symbols.contains(&"Real".to_string()));
+        assert!(
+            !symbols.contains(&"Injected".to_string()),
+            "declaration is inside a string literal"
+        );
+    }
+
+    #[test]
+    fn test_swift_declaration_inside_multiline_string_not_extracted() {
+        let src = r#"
+public let generator = """
+public final class Generated {}
+public struct AlsoFake {}
+"""
+public struct Keep {}
+"#;
+        let symbols = extract_exports(src);
+        assert!(symbols.contains(&"generator".to_string()));
+        assert!(symbols.contains(&"Keep".to_string()));
+        assert!(!symbols.contains(&"Generated".to_string()));
+        assert!(!symbols.contains(&"AlsoFake".to_string()));
     }
 }

--- a/src/exports/swift.rs
+++ b/src/exports/swift.rs
@@ -7,11 +7,13 @@ static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?
 
 /// Swift public/open declarations:
 /// public/open func, class, struct, enum, protocol, typealias, var, let, actor.
-/// The modifier group allows any run of `final`/`static`/`class` between the access
-/// keyword and the declaration keyword (finding #4: `public final class` was missed).
+/// The modifier group allows any run of the common member modifiers between the
+/// access keyword and the declaration keyword (finding #4: `public final class` was
+/// missed — as were the even more common `public override func` / `public mutating
+/// func` / `public lazy var` / `public weak var`).
 static SWIFT_DECL: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)(?:public|open)\s+(?:(?:final|static|class)\s+)*(?:func|class|struct|enum|protocol|typealias|var|let|actor|init)\s+(\w+)",
+        r"(?m)(?:public|open)\s+(?:(?:final|static|class|override|mutating|nonmutating|lazy|weak|unowned|dynamic|nonisolated)\s+)*(?:func|class|struct|enum|protocol|typealias|var|let|actor|init)\s+(\w+)",
     )
     .unwrap()
 });
@@ -132,5 +134,36 @@ public class RegularClass {}
             symbols.contains(&"RegularClass".to_string()),
             "plain public class still works"
         );
+    }
+
+    #[test]
+    fn test_swift_common_member_modifiers_exported() {
+        // The common member modifiers between the access keyword and the declaration
+        // keyword must not hide the export (override/mutating are more common than
+        // `final func`).
+        let src = r#"
+public override func recompute() -> Int {}
+public mutating func append(_ x: Int) {}
+public lazy var cache = Cache()
+public weak var delegate: Foo?
+open dynamic func draw() {}
+public final override func layout() {}
+public nonisolated func now() -> Date {}
+"#;
+        let symbols = extract_exports(src);
+        for name in [
+            "recompute",
+            "append",
+            "cache",
+            "delegate",
+            "draw",
+            "layout",
+            "now",
+        ] {
+            assert!(
+                symbols.contains(&name.to_string()),
+                "missing {name}: {symbols:?}"
+            );
+        }
     }
 }

--- a/src/exports/swift.rs
+++ b/src/exports/swift.rs
@@ -9,7 +9,7 @@ static COMMENT_MULTI: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)/\*.*?
 /// public/open func, class, struct, enum, protocol, typealias, var, let, actor
 static SWIFT_DECL: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)(?:public|open)\s+(?:static\s+)?(?:class\s+)?(?:func|class|struct|enum|protocol|typealias|var|let|actor|init)\s+(\w+)",
+        r"(?m)(?:public|open)\s+(?:(?:final|static|class)\s+)*(?:func|class|struct|enum|protocol|typealias|var|let|actor|init)\s+(\w+)",
     )
     .unwrap()
 });
@@ -99,5 +99,36 @@ open class BaseView {
         let symbols = extract_exports(src);
         assert!(symbols.contains(&"BaseView".to_string()));
         assert!(symbols.contains(&"layoutSubviews".to_string()));
+    }
+
+    #[test]
+    fn test_swift_final_modifiers_exported() {
+        // Finding #4: `final` (and combinations with static/class) between the
+        // access keyword and the declaration keyword must not hide the export.
+        let src = r#"
+public final class Repository {}
+open final class BaseService {}
+public final func recompute() -> Int {}
+public static let shared = Repository()
+public class RegularClass {}
+"#;
+        let symbols = extract_exports(src);
+        assert!(
+            symbols.contains(&"Repository".to_string()),
+            "public final class"
+        );
+        assert!(
+            symbols.contains(&"BaseService".to_string()),
+            "open final class"
+        );
+        assert!(
+            symbols.contains(&"recompute".to_string()),
+            "public final func"
+        );
+        assert!(symbols.contains(&"shared".to_string()), "public static let");
+        assert!(
+            symbols.contains(&"RegularClass".to_string()),
+            "plain public class still works"
+        );
     }
 }


### PR DESCRIPTION
Four export-scanner bugs where a correctly-documented public symbol was reported as **"no matching export found"** (failing `check --strict`, exit 1) and an undocumented one was **silently dropped from coverage**.

## #4 — High · Swift `final`
`public final class Foo` never matched — the decl regex allowed `static`/`class` modifiers but not `final`. Now `(?:(?:final|static|class)\s+)*` allows any combination between the access keyword and the declaration keyword. Hits Swift's most idiomatic reference type (and CorvidLabs' own `final class` convention).

## #5 — High · Go grouped blocks
Items in grouped `const (...)` / `var (...)` / `type (...)` blocks sit on their own lines with no keyword prefix and were missed. Added a stateful pass capturing each grouped item's leading **exported (uppercase)** identifier, with **brace-depth tracking** so struct/interface fields inside a grouped `type` aren't mistaken for top-level exports.

## #9 — Medium · Kotlin `const val`
Top-level `const val NAME` was missed (`const` wasn't in the modifier chain). Added `(?:const\s+)?`; `internal`/`private` const remain excluded.

## New (discovered via the dogfood self-check) · Rust comment tokenization
The Rust scanner stripped string literals **before** comments with a DOTALL regex, so a `"` inside a `//`/`///` doc comment was read as a string opener and swallowed code up to the next real `"` — **deleting `pub fn` declarations in between**. Any doc comment with an odd number of `"` silently hid exports (it broke specsync's own `spec-check` on PR #309). Replaced the regex string+comment stripping with a single linear pass that recognizes `//` and `/* */` (nesting) **before** `"`, while keeping a `//` inside a string as content. Raw strings and double-quote char literals are still blanked up front by the existing, proven regexes (incl. the `ai.rs` raw-string case).

## Tests
Swift final/static/class; Kotlin `const val` (+ internal exclusion); Go grouped const/var/type with brace-depth (struct fields NOT captured, lowercase skipped); Rust quotes-in-comments don't hide exports + `pub fn` inside a string not extracted. All pre-existing parser tests pass. **712 unit + 168 integration, fmt / clippy (bin) / self-check 100% (36990 LOC).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)