### PR TITLE
Add living atlas spec-coverage badge

### DIFF
--- a/.atlasignore
+++ b/.atlasignore
@@ -1,0 +1,9 @@
+# spec-sync atlas coverage scope: the specs govern the tool's source, not these.
+
+# The marketing + docs site.
+site/
+
+# Tests, benchmarks, and examples are verified against the specs, not governed by them.
+tests/
+benches/
+examples/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/pages.yml'
+      - 'src/**'
+      - 'specs/**'
+      - '.atlasignore'
   workflow_dispatch:
 
 concurrency:
@@ -45,6 +48,26 @@ jobs:
       - name: Run unit tests
         working-directory: site
         run: bun test
+
+      - name: Resolve pinned atlas commit (cache key)
+        id: atlasref
+        run: echo "sha=$(git ls-remote https://github.com/CorvidLabs/fledge-plugin-atlas v1 | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache the fledge-atlas CLI
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/fledge-atlas
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: fledge-atlas-${{ runner.os }}-${{ steps.atlasref.outputs.sha }}
+
+      - name: Render atlas coverage badges
+        uses: CorvidLabs/fledge-plugin-atlas@v1
+        with:
+          path: .
+          output-dir: site/public/badges
+          components: "coverage langmix treemap sunburst"
 
       - name: "Build site (runs prebuild: validate + redirects)"
         working-directory: site

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # SpecSync
 
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-SpecSync-blue?logo=github)](https://github.com/marketplace/actions/spec-sync)
+[![spec coverage](https://img.shields.io/endpoint?url=https://corvidlabs.github.io/spec-sync/badges/coverage.json)](https://corvidlabs.github.io/spec-sync/)
 [![CI](https://github.com/CorvidLabs/spec-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/CorvidLabs/spec-sync/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/specsync.svg)](https://crates.io/crates/specsync)
 [![Downloads](https://img.shields.io/crates/d/specsync.svg)](https://crates.io/crates/specsync)


### PR DESCRIPTION
## Living spec-coverage badge for spec-sync

Dogfoods the atlas GitHub Action (`uses: CorvidLabs/fledge-plugin-atlas@v1`), same as augur/attest:

- **pages.yml**: renders spec-sync's spec-coverage badge + SVG cards into `site/public/badges` on every deploy (Astro copies them into the published site), and caches the CLI keyed to the pinned `v1` commit.
- **.atlasignore**: scopes coverage to the tool's source, excluding the marketing site, tests, benches, and examples.
- **README**: adds the `spec coverage` endpoint badge.

Coverage reads ~97% with this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01ApSS1xj22zGwbUSkRs3mmE
