### PR TITLE
Fix: strip a leading UTF-8 BOM before parsing spec frontmatter (High #3)

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -16,6 +16,13 @@ static FRONTMATTER_RE: LazyLock<Regex> =
 /// Parse YAML frontmatter from a spec file.
 /// Zero-dependency YAML: uses regex, no YAML parser needed.
 pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
+    // A leading UTF-8 BOM (U+FEFF) is a non-semantic encoding marker that some
+    // editors prepend; left in place it sits before the opening `---`, so the
+    // `^---` anchor fails and a perfectly valid spec is reported as having
+    // "malformed frontmatter" (the delimiters are right there — the user just
+    // can't see the invisible byte). Strip only a single leading BOM (a U+FEFF
+    // anywhere else is real content and is left untouched); this is lossless.
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
     let caps = FRONTMATTER_RE.captures(content)?;
     let yaml_block = caps.get(1)?.as_str();
     let body = caps.get(2)?.as_str().to_string();
@@ -502,6 +509,37 @@ mod tests {
         assert_eq!(parsed.frontmatter.version.as_deref(), Some("1"));
         assert_eq!(parsed.frontmatter.status.as_deref(), Some("active"));
         assert_eq!(parsed.frontmatter.files, vec!["src/auth.ts"]);
+    }
+
+    #[test]
+    fn test_parse_frontmatter_leading_bom() {
+        // A leading UTF-8 BOM must not break frontmatter parsing: the spec is valid,
+        // the invisible byte just precedes the opening `---`.
+        let content = "\u{feff}---\nmodule: auth\nversion: 1\nstatus: active\nfiles:\n  - src/auth.ts\ndb_tables: []\ndepends_on: []\n---\n\n# Auth\n\n## Purpose\n";
+        let parsed = parse_frontmatter(content).expect("BOM-prefixed frontmatter should parse");
+        assert_eq!(parsed.frontmatter.module.as_deref(), Some("auth"));
+        assert_eq!(parsed.frontmatter.files, vec!["src/auth.ts"]);
+        // The body is BOM-free (the strip happens before the split).
+        assert!(
+            parsed.body.starts_with("\n# Auth"),
+            "body: {:?}",
+            parsed.body
+        );
+        assert!(!parsed.body.contains('\u{feff}'));
+    }
+
+    #[test]
+    fn test_parse_frontmatter_bom_only_leading() {
+        // Only a *leading* BOM is stripped; a U+FEFF elsewhere in the content is
+        // real (zero-width no-break space) and must be preserved.
+        let content =
+            "---\nmodule: a\nfiles:\n  - src/a.ts\n---\n\n# A\n\nZero\u{feff}width in body.\n";
+        let parsed = parse_frontmatter(content).unwrap();
+        assert_eq!(parsed.frontmatter.module.as_deref(), Some("a"));
+        assert!(
+            parsed.body.contains('\u{feff}'),
+            "a non-leading BOM must be preserved"
+        );
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,9 +20,9 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
     // editors prepend; left in place it sits before the opening `---`, so the
     // `^---` anchor fails and a perfectly valid spec is reported as having
     // "malformed frontmatter" (the delimiters are right there — the user just
-    // can't see the invisible byte). Strip only a single leading BOM (a U+FEFF
-    // anywhere else is real content and is left untouched); this is lossless.
-    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    // can't see the invisible byte). Strip leading BOM(s) only (a U+FEFF anywhere
+    // else is real content and is left untouched); this is lossless.
+    let content = content.trim_start_matches('\u{feff}');
     let caps = FRONTMATTER_RE.captures(content)?;
     let yaml_block = caps.get(1)?.as_str();
     let body = caps.get(2)?.as_str().to_string();
@@ -526,6 +526,11 @@ mod tests {
             parsed.body
         );
         assert!(!parsed.body.contains('\u{feff}'));
+
+        // Repeated leading BOMs are also tolerated (trim_start_matches).
+        let doubled = format!("\u{feff}{content}");
+        let parsed2 = parse_frontmatter(&doubled).expect("repeated-BOM frontmatter should parse");
+        assert_eq!(parsed2.frontmatter.module.as_deref(), Some("auth"));
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -133,6 +133,10 @@ fn split_sections(body: &str) -> Vec<(String, String)> {
 
 /// Strip YAML frontmatter from a markdown file.
 fn strip_frontmatter(content: &str) -> &str {
+    // Ignore a leading UTF-8 BOM so a BOM-prefixed spec's frontmatter is still
+    // recognized and stripped (mirrors `parser::parse_frontmatter`); otherwise
+    // `specsync view` would render the raw YAML block.
+    let content = content.trim_start_matches('\u{feff}');
     if let Some(stripped) = content.strip_prefix("---\n")
         && let Some(end) = stripped.find("\n---\n")
     {
@@ -169,5 +173,17 @@ mod tests {
         let content = "---\nmodule: test\n---\n\n## Purpose\n";
         let result = strip_frontmatter(content);
         assert!(result.contains("## Purpose"));
+    }
+
+    #[test]
+    fn test_strip_frontmatter_leading_bom() {
+        // A leading BOM must not prevent the frontmatter from being stripped.
+        let content = "\u{feff}---\nmodule: test\n---\n\n## Purpose\n";
+        let result = strip_frontmatter(content);
+        assert!(result.contains("## Purpose"));
+        assert!(
+            !result.contains("module: test"),
+            "frontmatter should be stripped, got: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

A spec file saved with a leading **UTF-8 BOM** (`U+FEFF` — common from Windows/Notepad and some editors) fails validation with a **loud but misleading** error. The BOM sits before the opening `---`, so the `^---\n…` frontmatter anchor never matches, `parse_frontmatter` returns `None`, and the validator reports:

```
✗ Frontmatter invalid       (Missing or malformed YAML frontmatter (expected --- delimiters))
File coverage: 0/1 (0%)
```

The `---` delimiters are right there — the user just can't see the invisible byte, so the error points them at the wrong thing.

## Fix

A leading BOM is a non-semantic encoding marker, so stripping it is **lossless** — the right auto-resolution (per our "auto-resolve only when losslessly safe" stance). `parse_frontmatter` now strips a single leading `U+FEFF` before matching:

- Only the **leading** BOM is removed; a `U+FEFF` elsewhere is a real zero-width no-break space and is **preserved**.
- Fixed at the single choke point (`parse_frontmatter`), so every caller benefits (validator, scoring, deps, registry, merge), and the returned `body` is BOM-free.

## Reproduced

A valid spec with a prepended BOM went from `✗ Frontmatter invalid, 0/1 (0%)` → `✓ Frontmatter valid, 1/1 (100%)`.

## Tests

- BOM-prefixed frontmatter parses (module/files extracted; body BOM-free).
- A non-leading BOM in the body is preserved.
- **727 unit + 168 integration**, `cargo fmt --check` clean, `cargo clippy --bin specsync -- -D warnings` clean, self-check 60/60 at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)