### PR TITLE
Fix: strip a leading UTF-8 BOM when reading config files

### DIFF
--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -32,6 +32,7 @@ Loads project configuration from `specsync.json` or `.specsync.toml`, with fallb
 | `is_legacy_layout` | `root: &Path` | `bool` | Detect whether a project uses a legacy 3.x layout (root-level config files without `.specsync/version` stamp) |
 | `config_to_toml` | `config: &SpecSyncConfig` | `String` | Serialize a `SpecSyncConfig` to TOML format string for v4.0.0 config files |
 | `config_to_toml_lossy_fields` | `config: &SpecSyncConfig` | `Vec<&'static str>` | List config fields `config_to_toml` cannot represent (e.g. `customRules`), so `migrate` can refuse rather than silently drop them |
+| `read_config_file` | `path: &Path` | `Option<String>` | Read a config file, dropping a leading UTF-8 BOM (lossless) so it does not attach to the first TOML key or break JSON parsing; shared by the loaders and `migrate` so config reads handle a BOM consistently. `None` if unreadable |
 
 ### Config File Structure
 
@@ -104,6 +105,7 @@ The configuration file supports the following top-level sections:
 | mcp | `load_config`, `detect_source_dirs` |
 | watch | `load_config` |
 | main | `load_config` |
+| migrate | `load_config_from_path`, `read_config_file` (config preflight + specs_dir discovery) |
 
 ## Change Log
 
@@ -112,3 +114,4 @@ The configuration file supports the following top-level sections:
 | 2026-03-25 | Initial spec |
 | 2026-03-28 | Document discover_manifest_modules |
 | 2026-04-06 | Document github config section, rules section, and full config file structure |
+| 2026-07-03 | Document `read_config_file` (leading-BOM-tolerant config read, shared with `migrate`) |

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -891,12 +891,14 @@ fn preflight_config_parseable(root: &Path) -> Result<(), (String, String)> {
         .unwrap_or(&source)
         .display()
         .to_string();
-    let content = fs::read_to_string(&source)
+    let raw = fs::read_to_string(&source)
         .map_err(|e| (name.clone(), format!("cannot read file: {e}")))?;
-    // Same parse `load_json_config` uses; on failure it would fall back to
-    // defaults, so catch it here first (unknown keys are ignored by serde, not
-    // an error — they are only warned about during a normal load).
-    serde_json::from_str::<crate::types::SpecSyncConfig>(&content)
+    // Same parse `load_json_config` uses (including its leading-BOM tolerance), so a
+    // BOM-prefixed JSON config that loads fine is not spuriously refused here; on
+    // failure it would fall back to defaults, so catch it first (unknown keys are
+    // ignored by serde, not an error — they are only warned about during a load).
+    let content = raw.trim_start_matches('\u{feff}');
+    serde_json::from_str::<crate::types::SpecSyncConfig>(content)
         .map_err(|e| (name, e.to_string()))?;
     Ok(())
 }
@@ -1307,15 +1309,16 @@ fn parse_specs_dir_from_toml(content: &str) -> Option<String> {
 
 /// Discover spec files without requiring a valid config (since config may be mid-migration).
 fn discover_specs(root: &Path) -> Vec<PathBuf> {
-    // Try loading config to find specs_dir (JSON then TOML), fall back to "specs"
-    let specs_dir_name = fs::read_to_string(root.join("specsync.json"))
-        .or_else(|_| fs::read_to_string(root.join(".specsync/config.json")))
-        .ok()
+    // Try loading config to find specs_dir (JSON then TOML), fall back to "specs".
+    // `read_config_file` strips a leading BOM so a BOM-prefixed config does not
+    // silently lose its `specsDir`/`specs_dir` (which would drop specs in a custom
+    // dir from the migration entirely).
+    let specs_dir_name = crate::config::read_config_file(&root.join("specsync.json"))
+        .or_else(|| crate::config::read_config_file(&root.join(".specsync/config.json")))
         .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
         .and_then(|v| v.get("specsDir").and_then(|s| s.as_str()).map(String::from))
         .or_else(|| {
-            fs::read_to_string(root.join(".specsync.toml"))
-                .ok()
+            crate::config::read_config_file(&root.join(".specsync.toml"))
                 .and_then(|content| parse_specs_dir_from_toml(&content))
         })
         .unwrap_or_else(|| "specs".to_string());
@@ -1387,6 +1390,63 @@ mod tests {
         // Unknown keys are ignored by serde (only warned during a real load), so
         // an otherwise-valid config must not be rejected.
         assert!(preflight_config_parseable(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn preflight_accepts_bom_prefixed_json_config() {
+        // A leading UTF-8 BOM must not make migrate refuse a config that
+        // `load_json_config` reads fine (it strips the same BOM).
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("specsync.json"),
+            "\u{feff}{ \"sourceDirs\": [\"lib\"] }",
+        )
+        .unwrap();
+        assert!(
+            preflight_config_parseable(tmp.path()).is_ok(),
+            "BOM-prefixed JSON config must not be refused"
+        );
+    }
+
+    #[test]
+    fn discover_specs_honors_bom_prefixed_specs_dir() {
+        // A BOM-prefixed config must not silently lose its `specsDir`, which would
+        // drop specs in a custom dir from the migration entirely.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::write(
+            root.join("specsync.json"),
+            "\u{feff}{ \"specsDir\": \"mydocs\" }",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("mydocs")).unwrap();
+        fs::write(
+            root.join("mydocs/a.spec.md"),
+            "---\nmodule: a\n---\n\n# A\n",
+        )
+        .unwrap();
+        let found = discover_specs(root);
+        assert_eq!(
+            found.len(),
+            1,
+            "spec in a BOM-config'd custom dir: {found:?}"
+        );
+
+        // Same via a legacy BOM-prefixed .specsync.toml.
+        let tmp2 = TempDir::new().unwrap();
+        let root2 = tmp2.path();
+        fs::write(
+            root2.join(".specsync.toml"),
+            "\u{feff}specs_dir = \"mydocs\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root2.join("mydocs")).unwrap();
+        fs::write(
+            root2.join("mydocs/b.spec.md"),
+            "---\nmodule: b\n---\n\n# B\n",
+        )
+        .unwrap();
+        assert_eq!(discover_specs(root2).len(), 1, "legacy TOML BOM path");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,6 +145,21 @@ fn dir_contains_source_files(dir: &Path, ignored: &HashSet<&str>, max_depth: usi
 /// When no config file exists, auto-detects source directories.
 ///
 /// Config file search order (v4 first, then legacy):
+/// Read a config file into a String, dropping a leading UTF-8 BOM (U+FEFF). Some
+/// editors prepend a BOM; left in place it attaches to the first TOML key (which then
+/// becomes an unknown key and is silently ignored) or breaks JSON parsing entirely.
+/// Stripping a leading BOM is lossless. Returns None when the file can't be read.
+/// Avoids allocating when there is no BOM (the common case).
+fn read_config_file(path: &Path) -> Option<String> {
+    let content = fs::read_to_string(path).ok()?;
+    let trimmed = content.trim_start_matches('\u{feff}');
+    Some(if trimmed.len() == content.len() {
+        content
+    } else {
+        trimmed.to_string()
+    })
+}
+
 /// Load config from a specific file path (JSON or TOML based on extension).
 /// Used by migration to convert a known source file rather than relying on precedence.
 pub fn load_config_from_path(config_path: &Path, root: &Path) -> SpecSyncConfig {
@@ -232,9 +247,9 @@ pub fn load_config(root: &Path) -> SpecSyncConfig {
 /// (`find_toml_array_close` accumulation) to avoid re-introducing `["["]`
 /// corruption.
 fn merge_local_config(local_path: &Path, config: &mut SpecSyncConfig) {
-    let content = match fs::read_to_string(local_path) {
-        Ok(c) => c,
-        Err(_) => return,
+    let content = match read_config_file(local_path) {
+        Some(c) => c,
+        None => return,
     };
 
     let mut current_section: Option<String> = None;
@@ -678,9 +693,9 @@ const KNOWN_JSON_KEYS: &[&str] = &[
 ];
 
 fn load_json_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
-    let content = match fs::read_to_string(config_path) {
-        Ok(c) => c,
-        Err(_) => return SpecSyncConfig::default(),
+    let content = match read_config_file(config_path) {
+        Some(c) => c,
+        None => return SpecSyncConfig::default(),
     };
 
     // Warn about unknown keys
@@ -725,9 +740,9 @@ fn load_json_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
 /// required_sections = ["Purpose", "Public API"]
 /// ```
 fn load_toml_config(config_path: &Path, root: &Path) -> SpecSyncConfig {
-    let content = match fs::read_to_string(config_path) {
-        Ok(c) => c,
-        Err(_) => return SpecSyncConfig::default(),
+    let content = match read_config_file(config_path) {
+        Some(c) => c,
+        None => return SpecSyncConfig::default(),
     };
 
     let mut config = SpecSyncConfig::default();
@@ -1990,6 +2005,46 @@ verify_issues = false
         assert!(
             !config.companions.design,
             "design companion should default to false"
+        );
+    }
+
+    #[test]
+    fn test_config_toml_with_leading_bom_first_key_honored() {
+        // A leading UTF-8 BOM must not attach to the first TOML key (which would then
+        // be an unknown key and be silently ignored). `source_dirs` is first here.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(
+            root.join(".specsync/config.toml"),
+            "\u{feff}source_dirs = [\"libx\"]\n\n[companions]\ndesign = true\n",
+        )
+        .unwrap();
+        let config = load_config(root);
+        assert!(
+            config.source_dirs.contains(&"libx".to_string()),
+            "first key after a BOM must apply: {:?}",
+            config.source_dirs
+        );
+        assert!(config.companions.design);
+    }
+
+    #[test]
+    fn test_config_json_with_leading_bom_parses() {
+        // A leading UTF-8 BOM before `{` must not break JSON parsing entirely.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(
+            root.join(".specsync/config.json"),
+            "\u{feff}{\"sourceDirs\": [\"libx\"]}\n",
+        )
+        .unwrap();
+        let config = load_config(root);
+        assert!(
+            config.source_dirs.contains(&"libx".to_string()),
+            "JSON config with a leading BOM must parse: {:?}",
+            config.source_dirs
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,7 @@ fn dir_contains_source_files(dir: &Path, ignored: &HashSet<&str>, max_depth: usi
 /// becomes an unknown key and is silently ignored) or breaks JSON parsing entirely.
 /// Stripping a leading BOM is lossless. Returns None when the file can't be read.
 /// Avoids allocating when there is no BOM (the common case).
-fn read_config_file(path: &Path) -> Option<String> {
+pub(crate) fn read_config_file(path: &Path) -> Option<String> {
     let content = fs::read_to_string(path).ok()?;
     let trimmed = content.trim_start_matches('\u{feff}');
     Some(if trimmed.len() == content.len() {


### PR DESCRIPTION
Follow-up to #313 (spec-file BOM) — the **same class of bug** affects config files.

## Problem

A `.specsync/config.toml` (or the JSON variants) saved with a leading **UTF-8 BOM** (`U+FEFF`) mis-parses:
- **TOML**: the BOM attaches to the first key, so it becomes an *"unknown key"* that is **silently ignored** — `Warning: unknown key "﻿specs_dir" (ignored)` — dropping that setting.
- **JSON**: a BOM before `{` breaks `serde_json` parsing entirely, falling back to defaults.

Either way, a setting the user wrote is silently not applied.

## Fix

Added a `read_config_file` helper (`pub(crate)`) that reads a config file and strips leading BOM(s) — lossless, a non-leading `U+FEFF` is untouched, no allocation when there's no BOM. Routed **every** config-file read through it:

**Loaders (`src/config.rs`):**
- `load_toml_config`
- `load_json_config`
- `merge_local_config` (`.specsync/config.local.toml`)

**Migrate (`src/commands/migrate.rs`) — added after adversarial review found these bypass `load_config`:**
- `preflight_config_parseable` — otherwise `migrate` *hard-refused* a BOM'd JSON config that the now-tolerant loader accepts (`not valid — expected value at line 1 column 1`).
- `discover_specs` — otherwise a BOM silently dropped a custom `specsDir`/`specs_dir` → specs in that dir were **never migrated** (silent partial migration).

## Reproduced

- BOM-prefixed `config.toml`: `Warning: unknown key "﻿specs_dir" (ignored)` → key honored.
- `specsync migrate --dry-run` on a BOM'd JSON config: exit 1 (`not valid`) → exit 0.

## Tests

- BOM'd **TOML** config's *first* key applies; BOM'd **JSON** config parses.
- `migrate` preflight accepts a BOM'd JSON config; `discover_specs` finds specs in a custom dir behind a BOM (JSON **and** legacy TOML).
- **732 unit + 168 integration**, `cargo fmt --check` clean, `cargo clippy --bin specsync -- -D warnings` clean, self-check 60/60 at 100%.

## Known follow-ups (different file classes, out of this PR's config scope)

- `registry.rs::parse_registry` — `str::trim()` does not drop `U+FEFF`, so a BOM'd registry file reads as absent.
- `manifest.rs` — language-manifest reads (`Cargo.toml`, `package.json`, …) have no BOM handling.

## Review

Two-lens adversarial review: **no blocking findings, 88%** on the loader-only version; the migrate paths it flagged as fast-follow are now included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)