### PR TITLE
Fix: `diff` fails loud on a bad base ref instead of reporting "no changes"

### DIFF
--- a/specs/cmd_diff/cmd_diff.spec.md
+++ b/specs/cmd_diff/cmd_diff.spec.md
@@ -32,7 +32,7 @@ Implements the `specsync diff` command — shows which specs are affected by sou
 
 1. Uses `git diff --name-only {base}` to get the list of changed files
 2. Only files matching `config.source_extensions` are considered
-3. Export deltas are computed by comparing current exports against base-ref exports (via `git show`)
+3. Export deltas compare each affected spec's currently-exported symbols (parsed from the working-tree source files) against the symbols it documents: `new_exports` are current exports the spec does not document, `removed_exports` are documented symbols no longer exported (there is no base-ref content fetch)
 4. Changed files not covered by any spec are listed separately
 5. Text output delegates to `output::print_diff_markdown`
 6. A non-zero `git diff` exit (bad base ref, not a git repository) fails loud with exit code 1 — it is never treated as an empty change set ("No files changed"), so a failed comparison cannot silently pass in CI

--- a/specs/cmd_diff/cmd_diff.spec.md
+++ b/specs/cmd_diff/cmd_diff.spec.md
@@ -35,6 +35,7 @@ Implements the `specsync diff` command — shows which specs are affected by sou
 3. Export deltas are computed by comparing current exports against base-ref exports (via `git show`)
 4. Changed files not covered by any spec are listed separately
 5. Text output delegates to `output::print_diff_markdown`
+6. A non-zero `git diff` exit (bad base ref, not a git repository) fails loud with exit code 1 — it is never treated as an empty change set ("No files changed"), so a failed comparison cannot silently pass in CI
 
 ## Behavioral Examples
 

--- a/specs/cmd_diff/testing.md
+++ b/specs/cmd_diff/testing.md
@@ -9,6 +9,7 @@ spec: cmd_diff.spec.md
 | `src/commands/diff.rs` | cargo test --test integration diff_ | No inline `#[cfg(test)]` module in `diff.rs`; behavior is covered end-to-end. Add inline coverage for `detect_pr_base` and the `--end-of-options` guard before risky changes. |
 | `tests/integration.rs` | cargo test --test integration diff_shows_changes_since_base_ref | Staged new export `logout` appears in `changes[0].new_exports` (JSON output). |
 | `tests/integration.rs` | cargo test --test integration diff_no_changes_returns_empty | Clean tree against `HEAD` yields `{"changes":[]}`. |
+| `tests/integration.rs` | cargo test --test integration diff_bad_base_ref_fails_loud | A bogus `--base` ref exits non-zero, names the ref on stderr, and never prints "No files changed" (fail-loud, not fail-open). |
 | `tests/integration.rs` | cargo test --test integration diff_detects_removed_exports | Removed export `logout` (still in spec) appears in `changes[0].removed_exports`. |
 | `tests/integration.rs` | cargo test --test integration diff_human_readable_output | Default Text format prints the `auth` spec and new export `signup`. |
 | `tests/integration.rs` | cargo test --test integration diff_detects_spec_file_only_changes | Spec-only edit reports one change with `spec_modified == true` and empty `changed_files`. |
@@ -27,7 +28,7 @@ spec: cmd_diff.spec.md
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
 | `git` fails to spawn | Prints "Failed to run git diff" to stderr and exits 1 | Keep; not currently asserted by a fixture — add before changing the spawn-error path. |
-| Bad/unknown base ref | `git diff` exits non-zero with empty stdout; command treats it as "no changes" (status is not inspected) | Document accurately; add a fixture before adding hard-failure semantics. |
+| Bad/unknown base ref | `git diff` exits non-zero (empty stdout); command inspects the exit status and fails loud (exit 1, git's stderr surfaced, names the base ref) instead of reporting "no changes" — so a failed comparison cannot silently pass in CI | Asserted by `diff_bad_base_ref_fails_loud`; keep the status check before touching the git invocation. |
 | Base ref starting with `-` | Parsed as a revision via `--end-of-options`, never as a git flag | Add a fixture before touching the `git diff` argument list. |
 | Changed source file not in any spec (Text format) | Listed under "Changed files not covered by any spec" when no specs matched | Keep or add a focused assertion before changing this behavior. |
 | PR context (`pull_request` + `GITHUB_BASE_REF`) and default `HEAD` base | Compares against `origin/<base_ref>` and logs the detection to stderr | Add a fixture that sets the env vars before changing `detect_pr_base`. |

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -53,6 +53,10 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
             }
         );
         eprintln!("  Is `{base}` a valid revision, and is this a git repository?");
+        eprintln!(
+            "  In a shallow CI checkout the base ref is often absent — fetch it first \
+             (e.g. actions/checkout with `fetch-depth: 0`)."
+        );
         process::exit(1);
     }
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -37,6 +37,25 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
         }
     };
 
+    // Git runs but exits non-zero on error (bad base ref, not a git repo, …). Its
+    // stdout is then empty — which the "no files changed" path below would report as
+    // "no drift" and exit 0, silently masking a failed comparison (a bad `--base` in
+    // CI would green-light a PR that was never actually diffed). Fail loud instead.
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = stderr.trim();
+        eprintln!(
+            "git diff failed for base ref `{base}`{}",
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        );
+        eprintln!("  Is `{base}` a valid revision, and is this a git repository?");
+        process::exit(1);
+    }
+
     let changed_files: std::collections::HashSet<String> = String::from_utf8_lossy(&output.stdout)
         .lines()
         .map(|l| l.to_string())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2894,6 +2894,81 @@ fn diff_no_changes_returns_empty() {
 }
 
 #[test]
+fn diff_bad_base_ref_fails_loud() {
+    // Regression: `git diff` exits non-zero on a bad base ref with empty stdout.
+    // The command must NOT report "no files changed" and exit 0 (that would silently
+    // mask a failed comparison and green-light CI); it must fail loud (exit != 0).
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src/auth")).unwrap();
+    fs::write(
+        root.join("src/auth/service.ts"),
+        "export function login() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/auth")).unwrap();
+    fs::write(
+        root.join("specs/auth/auth.spec.md"),
+        valid_spec("auth", &["src/auth/service.ts"]),
+    )
+    .unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    let output = specsync()
+        .args([
+            "diff",
+            "--base",
+            "no-such-ref-xyz",
+            "--root",
+            root.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "diff against a bogus base ref must fail loud, not report 'no changes' and exit 0"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no-such-ref-xyz"),
+        "error should name the bad base ref; stderr was: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("No files changed"),
+        "must not print the no-drift message on a failed diff; stdout was: {stdout}"
+    );
+}
+
+#[test]
 fn diff_detects_removed_exports() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();


### PR DESCRIPTION
Medium-tier audit finding (#13) — a **fail-open** that violates the project's "fail loud" mandate.

## Problem

`cmd_diff` only handled the case where `git diff` fails to **spawn** (`Err` → exit 1). It never inspected `output.status`. Git *runs* but exits non-zero on error (bad base ref, not a git repository) with **empty stdout** — which the "no files changed" path reported as `No files changed since <base>` and **exited 0**.

So a failed comparison is silently reported as "no drift". In CI, `specsync diff --base <bad-ref>` — even with `--strict` — would **green-light a PR that was never actually diffed**.

## Reproduced

```
$ specsync diff --base totally-bogus-ref      # git exits 128, empty stdout
No files changed since totally-bogus-ref
EXIT=0                                          # ← fail-open
```

After the fix:

```
$ specsync diff --base totally-bogus-ref
git diff failed for base ref `totally-bogus-ref`: fatal: ambiguous argument ...
  Is `totally-bogus-ref` a valid revision, and is this a git repository?
EXIT=1                                          # ← fail-loud
```

A valid base (with or without changes) is unaffected.

## Fix

After `.output()`, check `output.status.success()`; on failure, surface git's stderr, name the base ref, and `exit(1)`.

## Spec contradiction resolved

The spec already carried a contradiction this fix settles:
- `cmd_diff.spec.md` **Error Cases**: "`git diff` fails (bad ref) → Exits with code 1" ✅ (correct intent)
- `testing.md` **Regression Matrix**: documented the *actual buggy* behavior — "treats it as no changes … add a fixture **before adding hard-failure semantics**" ❌

Code now matches the Error Cases. Added invariant #6, updated the Regression Matrix + Automated Coverage to cite the new test.

## Tests

- `diff_bad_base_ref_fails_loud` (integration): a bogus `--base` exits non-zero, names the ref on stderr, and never prints "No files changed".
- **732 unit + 169 integration**, `cargo fmt --check` clean, `cargo clippy --bin specsync -- -D warnings` clean, self-check 60/60 at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)