### PR TITLE
Fix: `**/**` exclude pattern panics the coverage glob matcher

### DIFF
--- a/specs/validator/validator.spec.md
+++ b/specs/validator/validator.spec.md
@@ -39,7 +39,7 @@ Core validation engine for spec-sync. Validates individual spec files against so
 1. Validation is bidirectional: spec documenting non-existent exports = ERROR; code exports not in spec = WARNING
 2. Missing frontmatter fields (module, version, status, files) are errors, not warnings
 3. Cross-project refs (`owner/repo@module`) are skipped during local validation — only checked by `specsync resolve`
-4. Coverage computation excludes test files and configured exclude patterns
+4. Coverage computation excludes test files and configured exclude patterns. Exclude globs support `**/dir/**` (path contains `dir`), `**/*.ext` (suffix), and `**/name` (filename); a degenerate `**/**` matches every path (empty middle) and is handled without panicking
 5. Source file discovery respects `source_extensions` config — empty means all supported languages
 6. `find_spec_files` returns sorted results
 7. Schema table extraction supports configurable regex patterns via `schema_pattern` config

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -838,6 +838,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_compute_coverage_double_star_exclude_no_panic() {
+        // Regression: a `**/**` exclude pattern used to panic in the glob matcher
+        // (`&pattern[3..len-3]` reverses to `[3..2]` for the len-5 string). It must
+        // instead match every path (empty middle) and exclude all source files.
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("a.ts"), "export function a() {}").unwrap();
+
+        let mut config = SpecSyncConfig::default();
+        config.source_dirs = vec!["src".to_string()];
+        config.exclude_patterns = vec!["**/**".to_string()];
+
+        // Must not panic; `**/**` excludes all source files.
+        let report = compute_coverage(tmp.path(), &[], &config);
+        assert_eq!(
+            report.total_source_files, 0,
+            "`**/**` should exclude every source file"
+        );
+
+        // A normal `**/dir/**` pattern still excludes only that directory.
+        fs::create_dir_all(src.join("gen")).unwrap();
+        fs::write(src.join("gen/z.ts"), "export function z() {}").unwrap();
+        config.exclude_patterns = vec!["**/gen/**".to_string()];
+        let report = compute_coverage(tmp.path(), &[], &config);
+        assert_eq!(
+            report.total_source_files, 1,
+            "only src/gen should be excluded, leaving src/a.ts"
+        );
+    }
+
+    #[test]
     fn test_is_cross_project_ref() {
         assert!(is_cross_project_ref("corvid-labs/algochat@auth"));
         assert!(is_cross_project_ref("owner/repo@module"));
@@ -1361,7 +1393,15 @@ pub fn compute_coverage(
                 for pattern in &config.exclude_patterns {
                     // **/dir/** — matches path containing dir
                     if pattern.starts_with("**/") && pattern.ends_with("/**") {
-                        let dir_part = &pattern[3..pattern.len() - 3];
+                        // Strip the `**/` … `/**` wrapper. A naive `pattern[3..len-3]`
+                        // panics on a degenerate `**/**` (len 5), where the prefix and
+                        // suffix overlap and the range reverses. Peeling both ends yields
+                        // an empty `dir_part`, which `contains` matches against any path —
+                        // the correct meaning of `**/**` (match everything).
+                        let dir_part = pattern
+                            .strip_prefix("**/")
+                            .and_then(|rest| rest.strip_suffix("/**"))
+                            .unwrap_or("");
                         if rel_str.contains(dir_part) {
                             return None;
                         }


### PR DESCRIPTION
Medium-tier audit finding (#7) — a **panic** (crash) in the coverage exclude-pattern matcher.

## Problem

The `**/dir/**` branch of the exclude matcher extracts the middle via `&pattern[3..pattern.len()-3]`. For the degenerate `**/**` (len 5), the `**/` prefix and `/**` suffix overlap, so the range reverses to `[3..2]` and Rust panics:

```
$ specsync check    # with exclude_patterns = ["**/**"]
thread 'main' panicked at src/validator.rs:1364: byte range starts at 3 but ends at 2
```

## Fix

Extract the middle by peeling both ends — `strip_prefix("**/")` then `strip_suffix("/**")`, falling back to `""`. For `**/**` this yields an empty `dir_part`, and `rel_str.contains("")` is always true, so `**/**` matches every path (the correct "match everything" meaning) — no panic. Normal patterns (`**/gen/**` → `gen`) are byte-for-byte unchanged.

## Reproduced

`check` with `exclude_patterns = ["**/**"]` went from a panic (exit 1) to cleanly excluding all source files (`File coverage: 0/0`).

## Tests

- `test_compute_coverage_double_star_exclude_no_panic`: `**/**` no longer panics and excludes all files; `**/gen/**` still excludes only that directory.
- Documented the supported exclude-glob forms in the validator spec (invariant #4).
- **735 unit + 170 integration**, `cargo fmt --check` clean, `cargo clippy --bin specsync -- -D warnings` clean, self-check 60/60 at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)