### PR TITLE
Fix: `--require-coverage` fails loud on zero source files (no vacuous pass)

### DIFF
--- a/specs/commands/commands.spec.md
+++ b/specs/commands/commands.spec.md
@@ -79,7 +79,7 @@ Shared command infrastructure used by all CLI subcommands. Provides config loadi
 4. In text mode, draft specs show explicit "Section validation skipped (status: draft)" and "Export validation skipped (status: draft)" notices instead of misleading green checkmarks, plus a closing hint to set `status: active`
 5. Failing checks render negated labels (e.g. "✗ Frontmatter invalid"), never a ✗ next to a passing label
 4. Exit code logic by enforcement mode: Warn → always 0; EnforceNew → 1 if unspecced files; Strict → 1 on errors, also 1 on warnings when `--strict`
-5. `--require-coverage N` triggers exit 1 if file coverage percent < N regardless of enforcement mode
+5. `--require-coverage N` triggers exit 1 if file coverage percent < N regardless of enforcement mode. When `N > 0` but 0 source files were discovered (empty/misconfigured `source_dirs` or an over-broad `exclude_patterns`), the gate fails loud (exit 1) rather than passing on the vacuous 100% reported for an empty source tree
 6. `create_drift_issues` groups errors by spec path and creates one GitHub issue per spec, not per error
 
 ## Behavioral Examples

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -604,10 +604,17 @@ pub fn compute_exit_code(
             }
         }
     }
-    if let Some(req) = require_coverage
-        && coverage.coverage_percent < req
-    {
-        return 1;
+    if let Some(req) = require_coverage {
+        // A `--require-coverage` gate over zero source files is a vacuous pass:
+        // coverage is reported as 100% when there is nothing to measure (an empty or
+        // misconfigured `source_dirs`, or an over-broad `exclude_patterns`), silently
+        // satisfying the gate. Fail loud so a broken config cannot pass CI.
+        if req > 0 && coverage.total_source_files == 0 {
+            return 1;
+        }
+        if coverage.coverage_percent < req {
+            return 1;
+        }
     }
     0
 }
@@ -649,19 +656,32 @@ pub fn exit_with_status(
         }
     }
 
-    if let Some(req) = require_coverage
-        && coverage.coverage_percent < req
-    {
-        println!(
-            "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
-            "--require-coverage".red(),
-            coverage.coverage_percent,
-            coverage.unspecced_files.len()
-        );
-        for f in &coverage.unspecced_files {
-            println!("  {} {f}", "✗".red());
+    if let Some(req) = require_coverage {
+        // Fail loud on a vacuous pass: `--require-coverage` over zero source files
+        // reports 100% because there is nothing to measure (empty/misconfigured
+        // `source_dirs` or an over-broad `exclude_patterns`), which would otherwise
+        // satisfy the gate silently.
+        if req > 0 && coverage.total_source_files == 0 {
+            println!(
+                "\n{} {req}%: no source files were found to measure coverage against — \
+                 check `source_dirs` and `exclude_patterns` (an empty or over-broad \
+                 config reports coverage as a vacuous 100%)",
+                "--require-coverage".red()
+            );
+            process::exit(1);
         }
-        process::exit(1);
+        if coverage.coverage_percent < req {
+            println!(
+                "\n{} {req}%: actual coverage is {}% ({} file(s) missing specs)",
+                "--require-coverage".red(),
+                coverage.coverage_percent,
+                coverage.unspecced_files.len()
+            );
+            for f in &coverage.unspecced_files {
+                println!("  {} {f}", "✗".red());
+            }
+            process::exit(1);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,18 @@ mod tests {
         }
     }
 
+    /// A realistic coverage report at `percent`% over a non-empty source tree (100
+    /// files). Use this for `--require-coverage` tests so they exercise the
+    /// percentage gate — not the separate zero-source-files gate.
+    fn coverage_pct(percent: usize) -> types::CoverageReport {
+        types::CoverageReport {
+            total_source_files: 100,
+            specced_file_count: percent,
+            coverage_percent: percent,
+            ..empty_coverage()
+        }
+    }
+
     fn coverage_with_unspecced(files: Vec<&str>) -> types::CoverageReport {
         let total = files.len();
         types::CoverageReport {
@@ -335,10 +347,7 @@ mod tests {
 
     #[test]
     fn warn_mode_respects_require_coverage() {
-        let coverage = types::CoverageReport {
-            coverage_percent: 50,
-            ..empty_coverage()
-        };
+        let coverage = coverage_pct(50);
         assert_eq!(
             compute_exit_code(
                 0,
@@ -458,10 +467,7 @@ mod tests {
 
     #[test]
     fn strict_mode_respects_require_coverage() {
-        let coverage = types::CoverageReport {
-            coverage_percent: 70,
-            ..empty_coverage()
-        };
+        let coverage = coverage_pct(70);
         assert_eq!(
             compute_exit_code(
                 0,
@@ -477,10 +483,7 @@ mod tests {
 
     #[test]
     fn strict_mode_exits_0_when_coverage_meets_threshold() {
-        let coverage = types::CoverageReport {
-            coverage_percent: 85,
-            ..empty_coverage()
-        };
+        let coverage = coverage_pct(85);
         assert_eq!(
             compute_exit_code(
                 0,
@@ -490,6 +493,42 @@ mod tests {
                 &coverage,
                 Some(80)
             ),
+            0
+        );
+    }
+
+    #[test]
+    fn require_coverage_fails_loud_on_zero_source_files() {
+        // Regression: `--require-coverage` over 0 source files reports a vacuous 100%
+        // and must NOT silently pass — it indicates an empty/misconfigured source tree.
+        let coverage = empty_coverage(); // total_source_files: 0, coverage_percent: 100
+        assert_eq!(
+            compute_exit_code(
+                0,
+                0,
+                false,
+                types::EnforcementMode::Strict,
+                &coverage,
+                Some(100)
+            ),
+            1,
+            "require-coverage over zero source files must fail loud"
+        );
+        // A require of 0 is a no-op requirement and still passes with no sources.
+        assert_eq!(
+            compute_exit_code(
+                0,
+                0,
+                false,
+                types::EnforcementMode::Strict,
+                &coverage,
+                Some(0)
+            ),
+            0
+        );
+        // No require-coverage flag → zero sources is fine.
+        assert_eq!(
+            compute_exit_code(0, 0, false, types::EnforcementMode::Strict, &coverage, None),
             0
         );
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -695,6 +695,40 @@ fn require_coverage_fails_when_below_threshold() {
         .stdout(predicate::str::contains("--require-coverage"));
 }
 
+#[test]
+fn require_coverage_fails_loud_on_zero_source_files() {
+    // A `--require-coverage` gate over 0 source files reports a vacuous 100% and must
+    // NOT silently pass. Here `**/**` excludes every source file; enforcement=warn so
+    // ordinary spec diagnostics never exit 1, leaving the require-coverage gate as the
+    // sole failure.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\nexclude_patterns = [\"**/**\"]\nenforcement = \"warn\"\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.ts"), "export function a() {}\n").unwrap();
+    fs::create_dir_all(root.join("specs/a")).unwrap();
+    fs::write(
+        root.join("specs/a/a.spec.md"),
+        valid_spec("a", &["src/a.ts"]),
+    )
+    .unwrap();
+
+    specsync()
+        .arg("check")
+        .arg("--require-coverage")
+        .arg("100")
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("no source files were found"));
+}
+
 // ─── 7. --root flag ────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Follow-up surfaced by the #317 review — a **fail-open** in the coverage gate.

## Problem

When 0 source files are discovered, coverage is reported as a vacuous **100%** (`validator.rs`: `if all_source_files.is_empty() { 100 }`). So `--require-coverage N` was silently satisfied. A misconfigured project — a wrong `source_dirs`, or an over-broad `exclude_patterns` like `**/**` — would **pass a coverage gate in CI while measuring nothing**.

## Fix

`compute_exit_code` / `exit_with_status` now fail loud (exit 1) when `--require-coverage N` is set with `N > 0` **and** 0 source files were found, printing a message that points at `source_dirs` / `exclude_patterns`:

```
--require-coverage 100%: no source files were found to measure coverage against —
check `source_dirs` and `exclude_patterns` (an empty or over-broad config reports
coverage as a vacuous 100%)
```

A require of `0`, or no `--require-coverage` flag, still passes (nothing is demanded). Real projects at 100% (non-zero files) are unaffected — verified this repo's own `check --require-coverage 100` still passes.

## Test fixture correction

`strict_mode_exits_0_when_coverage_meets_threshold` (and the sibling require-coverage unit tests) built a **contradictory** report — 0 source files but 85% — via `empty_coverage()`. They now use a realistic `coverage_pct()` helper so they exercise the *percentage* gate, not the new zero-sources gate.

## Tests

- Unit: `require_coverage_fails_loud_on_zero_source_files` (0 files + `Some(100)` → 1; `Some(0)` → 0; `None` → 0).
- Integration: a `**/**`-excluded project fails `check --require-coverage 100` with "no source files were found".
- **736 unit + 171 integration**, `cargo fmt --check` clean, `cargo clippy --bin specsync -- -D warnings` clean, self-check 60/60 at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)