### PR TITLE
Fix: `is_test_file` misclassifies sources under a test-named ancestor

### DIFF
--- a/specs/exports/exports.spec.md
+++ b/specs/exports/exports.spec.md
@@ -40,7 +40,7 @@ Language-aware export extraction from source files. Auto-detects the programming
 |----------|-----------|---------|-------------|
 | `get_exported_symbols` | `file_path: &Path` | `Vec<String>` | Extract exported symbol names from a source file, auto-detecting language from extension |
 | `get_exported_symbols_with_level` | `file_path: &Path, level: ExportLevel` | `Vec<String>` | Extract exports with configurable granularity — Type (declarations only) or Member (all symbols) |
-| `is_test_file` | `file_path: &Path` | `bool` | Check if a file is a test file based on language-specific naming conventions |
+| `is_test_file` | `file_path: &Path, root: &Path` | `bool` | Check if a file is a test file by filename convention or a test directory *within `root`*; the directory check is bounded to project-relative components so ancestors above `root` (e.g. a parent dir named `spec`/`test`) do not misclassify ordinary sources |
 | `is_source_file` | `file_path: &Path` | `bool` | Check if a file extension belongs to a supported source language |
 | `has_extension` | `file_path: &Path, extensions: &[String]` | `bool` | Check if file matches specific extensions, or any supported language if extensions is empty |
 | `extract_exports` | `content: &str` | `Vec<String>` | Per-language backend function that parses source text and returns exported symbol names (one per backend file) |
@@ -197,8 +197,14 @@ Each language backend exposes a single `extract_exports(content: &str) -> Vec<St
 ### Scenario: Test file detection
 
 - **Given** a file named `auth.test.ts`
-- **When** `is_test_file(path)` is called
+- **When** `is_test_file(path, root)` is called
 - **Then** returns `true`
+
+### Scenario: Test-named ancestor above the project root
+
+- **Given** a project at `/home/user/spec/proj` with source `/home/user/spec/proj/src/app.ts`
+- **When** `is_test_file(path, root)` is called with `root = /home/user/spec/proj`
+- **Then** returns `false` — the `spec` component is above `root` and is not a project test directory
 
 ## Error Cases
 

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -264,7 +264,7 @@ const TEST_DIR_NAMES: &[&str] = &[
 ];
 
 /// Check if a file is a test file based on language conventions and path.
-pub fn is_test_file(file_path: &Path) -> bool {
+pub fn is_test_file(file_path: &Path, root: &Path) -> bool {
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     let lang = match Language::from_extension(ext) {
@@ -281,12 +281,18 @@ pub fn is_test_file(file_path: &Path) -> bool {
         }
     }
 
-    // Check if any ancestor directory is a test directory
-    for component in file_path.components() {
-        if let std::path::Component::Normal(dir) = component {
-            let dir_lower = dir.to_string_lossy().to_lowercase();
-            if TEST_DIR_NAMES.contains(&dir_lower.as_str()) {
-                return true;
+    // Check whether any directory *inside the project* is a test directory. Bound the
+    // walk to components below `root`: when a full/absolute path is passed (as coverage
+    // does), an ancestor above the project named `test`/`spec`/etc. must not
+    // misclassify an ordinary source file. If the path is not under `root`, we cannot
+    // tell which components are project-relative, so we rely on the filename alone.
+    if let Ok(relative) = file_path.strip_prefix(root) {
+        for component in relative.components() {
+            if let std::path::Component::Normal(dir) = component {
+                let dir_lower = dir.to_string_lossy().to_lowercase();
+                if TEST_DIR_NAMES.contains(&dir_lower.as_str()) {
+                    return true;
+                }
             }
         }
     }
@@ -308,4 +314,70 @@ pub fn has_extension(file_path: &Path, extensions: &[String]) -> bool {
     }
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
     extensions.iter().any(|e| e == ext)
+}
+
+#[cfg(test)]
+mod is_test_file_tests {
+    use super::is_test_file;
+    use std::path::Path;
+
+    #[test]
+    fn ignores_test_named_ancestors_above_root() {
+        // Regression: a project living under a directory named `spec`/`test`/etc. must
+        // not have its ordinary sources mis-classified as tests. The directory check is
+        // bounded to components below `root`.
+        let root = Path::new("/home/user/spec/myproject");
+        let file = Path::new("/home/user/spec/myproject/src/app.ts");
+        assert!(
+            !is_test_file(file, root),
+            "a `spec/` ancestor above the project root must be ignored"
+        );
+
+        let root2 = Path::new("/ci/tests/checkout/repo");
+        let file2 = Path::new("/ci/tests/checkout/repo/src/lib.rs");
+        assert!(
+            !is_test_file(file2, root2),
+            "`tests/` above root must be ignored"
+        );
+    }
+
+    #[test]
+    fn detects_in_project_test_directory() {
+        let root = Path::new("/home/user/myproject");
+        assert!(is_test_file(
+            Path::new("/home/user/myproject/src/tests/helper.ts"),
+            root
+        ));
+        assert!(is_test_file(
+            Path::new("/home/user/myproject/__tests__/util.ts"),
+            root
+        ));
+    }
+
+    #[test]
+    fn detects_test_filename_patterns() {
+        let root = Path::new("/home/user/myproject");
+        assert!(is_test_file(
+            Path::new("/home/user/myproject/src/app.test.ts"),
+            root
+        ));
+        assert!(is_test_file(
+            Path::new("/home/user/myproject/src/app.spec.ts"),
+            root
+        ));
+    }
+
+    #[test]
+    fn plain_source_is_not_a_test() {
+        let root = Path::new("/home/user/myproject");
+        assert!(!is_test_file(
+            Path::new("/home/user/myproject/src/app.ts"),
+            root
+        ));
+        // A non-source extension is never a test file.
+        assert!(!is_test_file(
+            Path::new("/home/user/myproject/tests/data.json"),
+            root
+        ));
+    }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -522,7 +522,7 @@ Document this module's responsibility, inputs, outputs, and ownership boundaries
 }
 
 /// Find source files in a module directory.
-fn find_module_source_files(dir: &Path, config: &SpecSyncConfig) -> Vec<String> {
+fn find_module_source_files(dir: &Path, config: &SpecSyncConfig, root: &Path) -> Vec<String> {
     let mut results = Vec::new();
     if !dir.exists() {
         return results;
@@ -530,7 +530,10 @@ fn find_module_source_files(dir: &Path, config: &SpecSyncConfig) -> Vec<String> 
 
     for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
         let path = entry.path();
-        if path.is_file() && has_extension(path, &config.source_extensions) && !is_test_file(path) {
+        if path.is_file()
+            && has_extension(path, &config.source_extensions)
+            && !is_test_file(path, root)
+        {
             results.push(path.to_string_lossy().to_string());
         }
     }
@@ -560,7 +563,7 @@ pub fn find_files_for_module(
             if full_path.exists() {
                 module_files.push(full_path.to_string_lossy().replace('\\', "/"));
             } else if full_path.is_dir() {
-                module_files.extend(find_module_source_files(&full_path, config));
+                module_files.extend(find_module_source_files(&full_path, config, root));
             }
         }
         if !module_files.is_empty() {
@@ -571,7 +574,7 @@ pub fn find_files_for_module(
     // Second: look for subdirectory-based modules (src/module_name/)
     for src_dir in &config.source_dirs {
         let module_dir = root.join(src_dir).join(module_name);
-        let files = find_module_source_files(&module_dir, config);
+        let files = find_module_source_files(&module_dir, config, root);
         module_files.extend(files);
     }
 
@@ -584,7 +587,7 @@ pub fn find_files_for_module(
                     let path = entry.path();
                     if !path.is_file()
                         || !has_extension(&path, &config.source_extensions)
-                        || is_test_file(&path)
+                        || is_test_file(&path, root)
                     {
                         continue;
                     }
@@ -619,7 +622,7 @@ pub fn find_single_source_fallback(root: &Path, config: &SpecSyncConfig) -> Opti
             let path = entry.path();
             if !path.is_file()
                 || !has_extension(path, &config.source_extensions)
-                || is_test_file(path)
+                || is_test_file(path, root)
             {
                 continue;
             }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -115,6 +115,7 @@ fn find_source_files(
     dir: &Path,
     exclude_dirs: &HashSet<String>,
     config: &SpecSyncConfig,
+    root: &Path,
 ) -> Vec<PathBuf> {
     let mut results = Vec::new();
     if !dir.exists() {
@@ -134,7 +135,10 @@ fn find_source_files(
         .filter_map(|e| e.ok())
     {
         let path = entry.path();
-        if path.is_file() && has_extension(path, &config.source_extensions) && !is_test_file(path) {
+        if path.is_file()
+            && has_extension(path, &config.source_extensions)
+            && !is_test_file(path, root)
+        {
             results.push(path.to_path_buf());
         }
     }
@@ -1384,7 +1388,7 @@ pub fn compute_coverage(
     let mut all_source_files: Vec<String> = Vec::new();
     for src_dir in &config.source_dirs {
         let full_dir = root.join(src_dir);
-        let files: Vec<String> = find_source_files(&full_dir, &exclude_dirs, config)
+        let files: Vec<String> = find_source_files(&full_dir, &exclude_dirs, config, root)
             .into_iter()
             .filter_map(|f| {
                 let rel = f.strip_prefix(root).ok()?;
@@ -1506,7 +1510,7 @@ pub fn compute_coverage(
                 let path = entry.path();
                 if !path.is_file()
                     || !has_extension(&path, &config.source_extensions)
-                    || is_test_file(&path)
+                    || is_test_file(&path, root)
                 {
                     continue;
                 }


### PR DESCRIPTION
Medium-tier audit finding (#11) — a **silent wrong result** in coverage.

## Problem

`is_test_file` walked **all** components of the path to decide whether a file lives in a test directory. Callers pass **absolute** paths (coverage and generator walk `root.join(src_dir)`, and `root` is canonicalized), so a project living under a directory whose name is in `TEST_DIR_NAMES` — `test`, `tests`, `spec`, `specs`, `testing`, `__tests__` — had **every source file classified as a test and silently excluded**.

A project at `~/spec/myproject` (or a repo checked out under a `test/` folder, common in CI) then reported:

```
File coverage: 0/0 (100%)     # real source silently excluded
```

That's a silent wrong result — and combined with the new `--require-coverage` zero-source gate, it fails loud on the (wrongly) empty source set.

## Fix

`is_test_file` now takes `root` and bounds the directory check to components **below** `root` (via `strip_prefix`). Ancestors above the project are ignored; filename-pattern detection is unchanged; in-project test dirs (`src/tests/`, `__tests__/`) are still excluded. Threaded `root` through `find_source_files` (validator) and `find_module_source_files` (generator) and their call sites (6 call sites total).

## Reproduced

A project under a `spec/` parent went from `0/0 (100%)` → `1/1 (100%)`; an in-project `src/tests/helper.ts` is still excluded.

## Tests

- `is_test_file` unit tests: ancestor above root ignored (`/home/user/spec/proj/src/app.ts`, `/ci/tests/checkout/repo/src/lib.rs`); in-project `tests/`/`__tests__/` + `.test.ts`/`.spec.ts` filenames detected; plain source not a test.
- Updated the exports spec signature + added a scenario.
- **740 unit + 171 integration**, `cargo fmt --check` clean, `cargo clippy --bin specsync -- -D warnings` clean, self-check 60/60 at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)