### PR TITLE
chore: release v4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.1] - 2026-07-04
+
+### Fixed
+
+- **TOML literal (single-quoted) config values are parsed, not silently dropped** — the hand-rolled config reader recognized only double-quoted `"..."` strings, so a valid TOML literal string like `source_dirs = ['lib']` (single-line or a formatter-style multi-line array) was mis-parsed: it scanned a directory named `'lib'` quotes-and-all, found no source files, and reported vacuous `File coverage: 0/0 (100%)` on a green build — the same silent-drop failure class as the multi-line-array and scalar-comment fixes in 4.7.0. Both TOML string kinds are now handled across every scalar and array value: basic `"..."` (escapes decoded) and literal `'...'` (taken verbatim, so a Windows path or regex keeps its backslashes); a `#`, `,`, `[`, or `]` inside either kind is content, not a comment or array structure. Configs that used single quotes are now scanned against their real directories, so `check` reports actual — and possibly failing — coverage where it previously passed vacuously.
+- **`deps --strict --format json` no longer emits the human diagnostic note** — the `--strict` failure note (`N dependency warning(s) treated as errors`) introduced in 4.7.0 was written to stderr for every output format, including JSON. It is now suppressed in JSON mode so a JSON consumer gets fully machine-readable output with nothing extraneous to parse around — the offending dependencies are already in the `warnings` array and signalled by the non-zero exit code. Human-readable formats still print the note on stderr, and the `--strict` exit-1 gating is unchanged. Also refreshes the `cmd_deps` spec and its companion docs to match the current `cmd_deps(root, strict, format, mermaid, dot)` signature.
+
 ## [4.7.0] - 2026-07-04
 
 > **Upgrade note:** This release closes a family of bugs where enforcement gates silently exited `0` in exactly the states they exist to catch — `check`, `score`, and `coverage` on warm caches or spec-less projects, `deps --strict` on undeclared imports, `lifecycle enforce` configured with the documented camelCase keys, and `--require-coverage` measured against zero source files. After upgrading, CI that passed on one of those false-greens may now correctly fail; each entry below gives the specific remedy. Shallow CI checkouts that run `specsync diff --base <ref>` should set `fetch-depth: 0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "4.7.0"
+version = "4.7.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "4.7.0"
+version = "4.7.1"
 edition = "2024"
 rust-version = "1.89"
 description = "Bidirectional spec-to-code validation with schema column checking — 11 languages, single binary"


### PR DESCRIPTION
Cuts **v4.7.1** — a small patch shipping the two fixes that merged **after** the v4.7.0 tag.

## Fixed

- **TOML literal (single-quoted) config values are parsed, not silently dropped** (#321) — `source_dirs = ['lib']` (single-line or multi-line) used to scan a directory named `'lib'` quotes-and-all and report vacuous `0/0 (100%)` coverage. Both string kinds are now handled across every scalar and array value: basic `"..."` (escapes decoded) and literal `'...'` (verbatim). Configs that used single quotes now measure real coverage — `check` may report actual, possibly failing, results where it previously passed vacuously.
- **`deps --strict --format json` no longer emits the human diagnostic note** (#307) — the `N dependency warning(s) treated as errors` note (added in 4.7.0) was written to stderr for every format; it's now suppressed in JSON mode so a JSON consumer gets clean output (the warnings are already in the `warnings` array + non-zero exit). Human formats still show it; exit-1 gating unchanged. Also syncs the `cmd_deps` spec + companion docs.

## Release mechanics

- Version: `4.7.0` → `4.7.1` (patch — two backward-compatible bug fixes).
- `Cargo.toml` + `Cargo.lock` + `CHANGELOG.md` only (`--version` reads from Cargo).
- Self-check green: 60/60 specs, File coverage 76/76 (100%), `cargo fmt --check` clean.
- **Tag held for approval** — `release.yml` fires on a `v*` tag and builds the public GitHub Release; that step waits until this merges and you give the go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)