### PR TITLE
Fix: gate JSON/visualization paths that bypassed --strict/--enforcement/--require-coverage

### DIFF
--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -24,6 +24,23 @@ pub fn cmd_deps(root: &Path, strict: bool, format: types::OutputFormat, mermaid:
                 "Hint:".yellow()
             );
         }
+        // A visualization request must still honor the gate flags: without this,
+        // `deps --strict --mermaid`/`--dot` silently exited 0 on the same undeclared
+        // imports / cycles / missing deps that the non-visual path fails on. The
+        // diagram remains the only thing on stdout; the gate note and exit go to
+        // stderr / the exit code, consistent with the normal `deps` path.
+        let report = deps::validate_deps(root, &config.specs_dir);
+        let strict_fail = strict && !report.warnings.is_empty();
+        if strict_fail {
+            eprintln!(
+                "{}: {} dependency warning(s) treated as errors",
+                "--strict mode".red(),
+                report.warnings.len()
+            );
+        }
+        if !report.errors.is_empty() || strict_fail {
+            process::exit(1);
+        }
         return;
     }
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -10,7 +10,9 @@ use crate::output::{print_coverage_line, print_coverage_report, print_summary};
 use crate::types;
 use crate::validator::{compute_coverage, get_schema_table_names};
 
-use super::{build_schema_columns, exit_with_status, load_and_discover, run_validation};
+use super::{
+    build_schema_columns, compute_exit_code, exit_with_status, load_and_discover, run_validation,
+};
 
 /// Resolve the AI provider for `generate`, or `None` for template-only mode.
 ///
@@ -126,7 +128,11 @@ fn cmd_generate_all(
     let ignore_rules = crate::ignore::IgnoreRules::default();
 
     let (mut total_errors, mut total_warnings, mut passed, mut total) = if spec_files.is_empty() {
-        println!("No existing specs found. Scanning for source modules...");
+        // Diagnostic only — never on stdout under --format json, which must stay a
+        // clean JSON document.
+        if !json {
+            println!("No existing specs found. Scanning for source modules...");
+        }
         (0, 0, 0, 0)
     } else {
         let (te, tw, p, t, _, _) = run_validation(
@@ -156,12 +162,49 @@ fn cmd_generate_all(
             &config,
             resolved_provider.as_ref(),
         );
+        // Recompute coverage + validation post-generation so the gate reflects the
+        // newly written specs, then honor the same gate flags the text path does.
+        // Without this, `--strict`/`--enforcement`/`--require-coverage` were silently
+        // ignored on the JSON path — a machine-consumer false pass on the exact
+        // states (validation errors, unspecced files, sub-threshold/vacuous coverage)
+        // a gate exists to catch.
+        let (config, spec_files) = load_and_discover(root, true);
+        let coverage = compute_coverage(root, &spec_files, &config);
+        let (total_errors, total_warnings) = if spec_files.is_empty() {
+            (0, 0)
+        } else {
+            let schema_tables = get_schema_table_names(root, &config);
+            let schema_columns = build_schema_columns(root, &config);
+            let (te, tw, _, _, _, _) = run_validation(
+                root,
+                &spec_files,
+                &schema_tables,
+                &schema_columns,
+                &config,
+                true,
+                false,
+                &ignore_rules,
+            );
+            (te, tw)
+        };
         let output = serde_json::json!({
             "generated": outcome.generated_paths,
             "ai_errors": outcome.ai_errors,
         });
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
-        process::exit(if outcome.ai_errors.is_empty() { 0 } else { 1 });
+        let gate = compute_exit_code(
+            total_errors,
+            total_warnings,
+            strict,
+            enforcement,
+            &coverage,
+            require_coverage,
+        );
+        process::exit(if outcome.ai_errors.is_empty() && gate == 0 {
+            0
+        } else {
+            1
+        });
     }
 
     print_coverage_report(&coverage);
@@ -329,6 +372,29 @@ fn cmd_generate_batch(
             &config,
             resolved_provider.as_ref(),
         );
+        // Recompute coverage + validation post-generation and honor the gate flags,
+        // matching the text path — the JSON path previously ignored
+        // --strict/--enforcement/--require-coverage (a machine-consumer false pass).
+        let (config, spec_files) = load_and_discover(root, true);
+        let coverage = compute_coverage(root, &spec_files, &config);
+        let (total_errors, total_warnings) = if spec_files.is_empty() {
+            (0, 0)
+        } else {
+            let schema_tables = get_schema_table_names(root, &config);
+            let schema_columns = build_schema_columns(root, &config);
+            let ignore_rules = crate::ignore::IgnoreRules::default();
+            let (te, tw, _, _, _, _) = run_validation(
+                root,
+                &spec_files,
+                &schema_tables,
+                &schema_columns,
+                &config,
+                true,
+                false,
+                &ignore_rules,
+            );
+            (te, tw)
+        };
         let output = serde_json::json!({
             "requested": modules,
             "generated": outcome.generated_paths,
@@ -337,7 +403,19 @@ fn cmd_generate_batch(
             "skipped_not_found": not_found,
         });
         println!("{}", serde_json::to_string_pretty(&output).unwrap());
-        process::exit(if outcome.ai_errors.is_empty() { 0 } else { 1 });
+        let gate = compute_exit_code(
+            total_errors,
+            total_warnings,
+            strict,
+            enforcement,
+            &coverage,
+            require_coverage,
+        );
+        process::exit(if outcome.ai_errors.is_empty() && gate == 0 {
+            0
+        } else {
+            1
+        });
     }
 
     println!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6377,6 +6377,135 @@ fn deps_strict_passes_when_dependency_is_declared() {
         .success();
 }
 
+#[test]
+fn deps_strict_mermaid_still_gates() {
+    // Regression: `deps --mermaid`/`--dot` early-returned before the strict gate, so
+    // `deps --strict --mermaid` silently exited 0 on the same undeclared import that
+    // `deps --strict` fails on. The diagram must still print, but the gate must apply.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    setup_undeclared_import_project(root);
+
+    // Diagram is emitted on stdout AND the strict gate fails.
+    let output = specsync()
+        .current_dir(root)
+        .args(["deps", "--strict", "--mermaid"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("graph LR"),
+        "the mermaid diagram must still be printed to stdout"
+    );
+    // Without --strict, a render is advisory (exit 0).
+    specsync()
+        .current_dir(root)
+        .args(["deps", "--mermaid"])
+        .assert()
+        .success();
+}
+
+// ─── generate: --format json honors the same gates as the text path ──────
+
+#[test]
+fn generate_json_honors_require_coverage_gate() {
+    // Regression: `generate --format json` exited solely on AI-generation success and
+    // never gated on --require-coverage/--enforcement/--strict — a machine-consumer
+    // false pass. Here an empty source dir yields vacuous 0/0 coverage that
+    // --require-coverage 50 must fail loud on, in JSON just like text.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("specs")).unwrap();
+
+    // Text path fails the gate.
+    specsync()
+        .current_dir(root)
+        .args(["generate", "--require-coverage", "50"])
+        .assert()
+        .failure();
+    // JSON path fails identically AND stdout stays valid JSON.
+    let output = specsync()
+        .current_dir(root)
+        .args(["generate", "--require-coverage", "50", "--format", "json"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .expect("generate --format json stdout must be valid JSON even when the gate fails");
+}
+
+#[test]
+fn generate_json_honors_enforcement_strict() {
+    // An existing spec with a real validation error (a missing source file) that
+    // `generate` cannot fix must fail `--enforcement strict` on the JSON path too.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/foo.rs"), "pub fn f() {}\n").unwrap();
+    fs::create_dir_all(root.join("specs/foo")).unwrap();
+    fs::write(
+        root.join("specs/foo/foo.spec.md"),
+        "---\nmodule: foo\nversion: 1\nstatus: active\nfiles:\n  - src/foo.rs\n  - src/does_not_exist.rs\n---\n# foo\n## Purpose\np\n",
+    )
+    .unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["generate", "--enforcement", "strict"])
+        .assert()
+        .failure();
+    let output = specsync()
+        .current_dir(root)
+        .args(["generate", "--enforcement", "strict", "--format", "json"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .expect("generate --format json stdout must be valid JSON even when the gate fails");
+}
+
+#[test]
+fn generate_json_no_specs_emits_valid_json() {
+    // Regression: the "No existing specs found…" diagnostic was printed to stdout even
+    // under --format json, prepending non-JSON text and breaking any parser.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/foo.js"), "export function add() {}\n").unwrap();
+
+    let output = specsync()
+        .current_dir(root)
+        .args(["generate", "--format", "json"])
+        .assert()
+        .get_output()
+        .clone();
+    serde_json::from_slice::<serde_json::Value>(&output.stdout).expect(
+        "generate --format json stdout must be a clean JSON document with no specs present",
+    );
+}
+
 // ─── config: multi-line TOML arrays are not corrupted ────────────────────
 
 #[test]


### PR DESCRIPTION
Audit **Batch 1** — three "a gate must apply on *every* path" bugs, same class as the already-fixed coverage M1 / score JSON bypass.

## Fixed

- **[high] `generate --format json` bypassed the gates.** Both JSON early-returns (`cmd_generate_all` + `cmd_generate_batch`) exited solely on AI-generation success and never fed coverage/validation/`--strict`/`--enforcement`/`--require-coverage` into the exit code (`compute_exit_code` wasn't even imported). A CI step using `generate --format json` as a gate green-lit exactly the broken states it exists to catch. Both branches now recompute post-generation coverage + validation and gate via `compute_exit_code` (prints nothing → stdout stays valid JSON), matching the text path.
- **[medium] `generate --format json` emitted a non-JSON line.** The "No existing specs found…" diagnostic printed to stdout even in JSON mode, prepending junk that broke any parser. Suppressed under `--format json`.
- **[low] `deps --strict --mermaid`/`--dot` skipped the strict gate.** The visualization branch early-returned before the gate, so an undeclared import that fails `deps --strict` silently passed. The diagram still prints; the gate (errors always, warnings under `--strict`) now applies, note on stderr.

## Reproduced (each exit 0 → exit 1, JSON preserved)

- empty source dir → `generate --require-coverage 50 --format json` now fails (vacuous coverage)
- spec with a missing-file error → `generate --enforcement strict --format json` (+ `--batch`) now fails
- undeclared import → `deps --strict --mermaid` now fails, diagram still on stdout

## Tests

4 integration tests + **749 unit / 175 integration**, `cargo fmt --check` clean, `clippy --bin` clean, self-check 60/60 at 100%.

Part of the post-v4.7.1 audit sweep (31 findings across ~10 batches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)