### PR TITLE
Fix: export-extraction fail-open (diff + score treated unreadable files as export-free)

### DIFF
--- a/specs/cmd_diff/cmd_diff.spec.md
+++ b/specs/cmd_diff/cmd_diff.spec.md
@@ -36,6 +36,7 @@ Implements the `specsync diff` command — shows which specs are affected by sou
 4. Changed files not covered by any spec are listed separately
 5. Text output delegates to `output::print_diff_markdown`
 6. A non-zero `git diff` exit (bad base ref, not a git repository) fails loud with exit code 1 — it is never treated as an empty change set ("No files changed"), so a failed comparison cannot silently pass in CI
+7. A spec whose `files:` includes a source file that exists-or-should but cannot be read (missing, or not valid UTF-8) is inconclusive: the file is surfaced (`inconclusive_files`), its unreliable export deltas are suppressed, and `diff` exits 1 — an unreadable source must not be silently treated as export-free "no drift" (a non-source file, e.g. a `.md`/`.sql` listed in `files:`, is not a failure)
 
 ## Behavioral Examples
 

--- a/specs/exports/exports.spec.md
+++ b/specs/exports/exports.spec.md
@@ -45,7 +45,15 @@ Language-aware export extraction from source files. Auto-detects the programming
 | `has_extension` | `file_path: &Path, extensions: &[String]` | `bool` | Check if file matches specific extensions, or any supported language if extensions is empty |
 | `extract_exports` | `content: &str` | `Vec<String>` | Per-language backend function that parses source text and returns exported symbol names (one per backend file) |
 | `extract_exports_with_resolver` | `content: &str, resolver: Option<&ImportResolver>` | `Vec<String>` | TypeScript-specific: extract exports with optional wildcard re-export resolution via file resolver callback |
-| `get_exported_symbols_full` | `file_path: &Path, level: ExportLevel, parse_mode: ParseMode` | `Vec<String>` | Extract exports with full control over granularity and parse mode (Regex or Ast) |
+| `get_exported_symbols_full` | `file_path: &Path, level: ExportLevel, parse_mode: ParseMode` | `Vec<String>` | Extract exports with full control over granularity and parse mode (Regex or Ast); a read/parse failure or unsupported language yields an empty vector |
+| `scan_exported_symbols` | `file_path: &Path` | `ExportScan` | Like `get_exported_symbols` but returns an `ExportScan`, distinguishing a genuine empty result from an unreadable/unsupported file |
+| `scan_exported_symbols_full` | `file_path: &Path, level: ExportLevel, parse_mode: ParseMode` | `ExportScan` | Like `get_exported_symbols_full` but returns an `ExportScan` so gating callers (`diff`, `score`) can tell a failure from genuine emptiness |
+
+### Exported Types
+
+| Type | Description |
+|------|-------------|
+| `ExportScan` | Outcome of an extraction attempt: `Parsed(Vec<String>)` (recognized language, read + parsed — the vec may be empty, meaning genuinely no exports), `UnknownLanguage` (extension not a source language, e.g. a `.md`/`.sql` file — not a failure), or `Unreadable` (missing / permission-denied / non-UTF-8 — exports unknown). Lets gating callers avoid treating an unreadable file as export-free. |
 
 ### Exported Modules
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::path::Path;
 use std::process;
 
-use crate::exports::get_exported_symbols;
 use crate::output::print_diff_markdown;
 use crate::parser::parse_frontmatter;
 use crate::types;
@@ -86,6 +85,10 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
         new_exports: Vec<String>,
         removed_exports: Vec<String>,
         spec_itself_changed: bool,
+        /// `files:` entries that exist-or-should but could not be read (missing /
+        /// non-UTF-8), so this spec's export delta is unreliable — surfaced and
+        /// failed loud rather than silently reported as "no drift".
+        inconclusive_files: Vec<String>,
     }
 
     let mut entries: Vec<DiffEntry> = Vec::new();
@@ -123,6 +126,7 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
 
         // Get current exports from changed files
         let mut current_exports: Vec<String> = Vec::new();
+        let mut inconclusive_files: Vec<String> = Vec::new();
         for file in &parsed.frontmatter.files {
             // Skip `files:` entries that escape the project root (out-of-root
             // identifier leak); `check` reports them as errors.
@@ -130,7 +134,18 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
                 continue;
             }
             let full_path = root.join(file);
-            current_exports.extend(get_exported_symbols(&full_path));
+            match crate::exports::scan_exported_symbols(&full_path) {
+                crate::exports::ExportScan::Parsed(syms) => current_exports.extend(syms),
+                // A recognized-language source file that can't be read (missing /
+                // non-UTF-8) makes this spec's export delta unreliable. Record it so
+                // the "no drift" verdict cannot be silent, and fail loud below —
+                // consistent with the invariant that a failed comparison must not
+                // silently pass in CI.
+                crate::exports::ExportScan::Unreadable => inconclusive_files.push(file.clone()),
+                // A non-source file (e.g. a `.md`/`.sql` listed in `files:`)
+                // legitimately has no extractable exports — not a failure.
+                crate::exports::ExportScan::UnknownLanguage => {}
+            }
         }
         let mut seen = std::collections::HashSet::new();
         current_exports.retain(|s| seen.insert(s.clone()));
@@ -160,6 +175,7 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
             new_exports,
             removed_exports,
             spec_itself_changed,
+            inconclusive_files,
         });
     }
 
@@ -174,6 +190,7 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
                         "new_exports": e.new_exports,
                         "removed_exports": e.removed_exports,
                         "spec_modified": e.spec_itself_changed,
+                        "inconclusive_files": e.inconclusive_files,
                     })
                 })
                 .collect();
@@ -219,7 +236,13 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
                         entry.removed_exports.join(", ")
                     );
                 }
-                if entry.new_exports.is_empty() && entry.removed_exports.is_empty() {
+                if !entry.inconclusive_files.is_empty() {
+                    println!(
+                        "  {} Could not read (drift unknown): {}",
+                        "⚠".yellow(),
+                        entry.inconclusive_files.join(", ")
+                    );
+                } else if entry.new_exports.is_empty() && entry.removed_exports.is_empty() {
                     println!("  {} Spec is up to date", "✓".green());
                 }
             }
@@ -252,6 +275,27 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
                 }
             }
         }
+    }
+
+    // Fail loud if any spec's export delta was inconclusive because a source file
+    // could not be read (missing / non-UTF-8). Such a file silently contributes zero
+    // exports, so a genuinely-changed API could otherwise be reported as "no drift".
+    // The report above already surfaces the files on stdout; the diagnostic and the
+    // non-zero exit (a failed comparison must not silently pass in CI) go here.
+    let inconclusive: Vec<&String> = entries
+        .iter()
+        .flat_map(|e| e.inconclusive_files.iter())
+        .collect();
+    if !inconclusive.is_empty() {
+        eprintln!(
+            "\ndiff is inconclusive: {} source file(s) could not be read (missing or not UTF-8), \
+             so their export drift is unknown:",
+            inconclusive.len()
+        );
+        for f in &inconclusive {
+            eprintln!("  {} {f}", "⚠".yellow());
+        }
+        process::exit(1);
     }
 }
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -157,17 +157,28 @@ pub fn cmd_diff(root: &Path, base: &str, format: types::OutputFormat) {
         let export_set: std::collections::HashSet<&str> =
             current_exports.iter().map(|s| s.as_str()).collect();
 
-        let new_exports: Vec<String> = current_exports
-            .iter()
-            .filter(|s| !spec_set.contains(s.as_str()))
-            .cloned()
-            .collect();
-
-        let removed_exports: Vec<String> = spec_symbols
-            .iter()
-            .filter(|s| !export_set.contains(s.as_str()))
-            .cloned()
-            .collect();
+        // If any of this spec's files could not be read, the export set is
+        // incomplete, so the computed deltas are unreliable — a missing file's
+        // documented symbols would otherwise show up as bogus "removed exports"
+        // (a false deletion to a machine consumer). Suppress the deltas and rely on
+        // the inconclusive marker + non-zero exit instead.
+        let (new_exports, removed_exports): (Vec<String>, Vec<String>) =
+            if inconclusive_files.is_empty() {
+                (
+                    current_exports
+                        .iter()
+                        .filter(|s| !spec_set.contains(s.as_str()))
+                        .cloned()
+                        .collect(),
+                    spec_symbols
+                        .iter()
+                        .filter(|s| !export_set.contains(s.as_str()))
+                        .cloned()
+                        .collect(),
+                )
+            } else {
+                (Vec::new(), Vec::new())
+            };
 
         entries.push(DiffEntry {
             spec: spec_rel,

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -30,24 +30,48 @@ pub fn get_exported_symbols_with_level(file_path: &Path, level: ExportLevel) -> 
     get_exported_symbols_full(file_path, level, ParseMode::Regex)
 }
 
-/// Extract exported symbol names with full control over granularity and parse mode.
-/// When `parse_mode` is `Ast`, uses tree-sitter for TypeScript, Python, and Rust.
-/// Falls back to regex for all other languages or if AST parsing fails.
-pub fn get_exported_symbols_full(
+/// The outcome of attempting to extract exported symbols from a source file,
+/// distinguishing a genuine "nothing is exported" from a failure to analyze the
+/// file. Callers that gate on coverage or export drift (`diff`, `score`) must not
+/// treat an unreadable or unsupported file as export-free — doing so silently drops
+/// a file's real API from the comparison and reports a false clean result.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExportScan {
+    /// The file's language was recognized and it was read and parsed. The vector may
+    /// be empty, which means the file genuinely exports nothing.
+    Parsed(Vec<String>),
+    /// The extension is not a recognized source language, so exports cannot be
+    /// extracted (e.g. a `.md`/`.sql` file listed in `files:`). Not a failure.
+    UnknownLanguage,
+    /// The file could not be read — missing, permission-denied, or not valid UTF-8 —
+    /// so its exports are unknown. A gate must not treat this as "no exports".
+    Unreadable,
+}
+
+/// Extract exported symbol names, distinguishing failure from genuine emptiness.
+/// Uses `ExportLevel::Member` and regex parsing (matches `get_exported_symbols`).
+pub fn scan_exported_symbols(file_path: &Path) -> ExportScan {
+    scan_exported_symbols_full(file_path, ExportLevel::Member, ParseMode::Regex)
+}
+
+/// Like `get_exported_symbols_full`, but returns an `ExportScan` so a read/parse
+/// failure or unsupported language is distinguishable from a file that genuinely
+/// exports nothing — required by callers that gate on the result.
+pub fn scan_exported_symbols_full(
     file_path: &Path,
     level: ExportLevel,
     parse_mode: ParseMode,
-) -> Vec<String> {
+) -> ExportScan {
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     let lang = match Language::from_extension(ext) {
         Some(l) => l,
-        None => return Vec::new(),
+        None => return ExportScan::UnknownLanguage,
     };
 
     let content = match std::fs::read_to_string(file_path) {
         Ok(c) => c,
-        Err(_) => return Vec::new(),
+        Err(_) => return ExportScan::Unreadable,
     };
 
     let symbols = if parse_mode == ParseMode::Ast {
@@ -99,10 +123,28 @@ pub fn get_exported_symbols_full(
 
     // Deduplicate preserving order
     let mut seen = std::collections::HashSet::new();
-    symbols
-        .into_iter()
-        .filter(|s| seen.insert(s.clone()))
-        .collect()
+    ExportScan::Parsed(
+        symbols
+            .into_iter()
+            .filter(|s| seen.insert(s.clone()))
+            .collect(),
+    )
+}
+
+/// Extract exported symbol names with full control over granularity and parse mode.
+/// When `parse_mode` is `Ast`, uses tree-sitter for TypeScript, Python, and Rust.
+/// Falls back to regex for all other languages or if AST parsing fails. A read/parse
+/// failure or unsupported language yields an empty vector — use
+/// `scan_exported_symbols_full` when that distinction matters (e.g. for gating).
+pub fn get_exported_symbols_full(
+    file_path: &Path,
+    level: ExportLevel,
+    parse_mode: ParseMode,
+) -> Vec<String> {
+    match scan_exported_symbols_full(file_path, level, parse_mode) {
+        ExportScan::Parsed(symbols) => symbols,
+        ExportScan::UnknownLanguage | ExportScan::Unreadable => Vec::new(),
+    }
 }
 
 /// Dispatch to the regex-based export extractor for the given language.
@@ -379,5 +421,47 @@ mod is_test_file_tests {
             Path::new("/home/user/myproject/tests/data.json"),
             root
         ));
+    }
+}
+
+#[cfg(test)]
+mod scan_tests {
+    use super::{ExportScan, scan_exported_symbols};
+    use std::io::Write;
+
+    #[test]
+    fn parsed_distinguishes_from_unreadable_and_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // A recognized-language file that parses → Parsed(symbols).
+        let ts = dir.path().join("a.ts");
+        std::fs::write(&ts, "export function hi() {}\n").unwrap();
+        assert_eq!(
+            scan_exported_symbols(&ts),
+            ExportScan::Parsed(vec!["hi".to_string()])
+        );
+
+        // A recognized-language file that genuinely exports nothing → Parsed(empty),
+        // NOT Unreadable — the caller can tell "clean but empty" from "could not read".
+        let empty = dir.path().join("empty.rs");
+        std::fs::write(&empty, "fn private_only() {}\n").unwrap();
+        assert_eq!(scan_exported_symbols(&empty), ExportScan::Parsed(vec![]));
+
+        // A non-source extension → UnknownLanguage (a `.md`/`.sql` listed in files:).
+        let md = dir.path().join("readme.md");
+        std::fs::write(&md, "# doc\n").unwrap();
+        assert_eq!(scan_exported_symbols(&md), ExportScan::UnknownLanguage);
+
+        // A missing file → Unreadable.
+        assert_eq!(
+            scan_exported_symbols(&dir.path().join("missing.ts")),
+            ExportScan::Unreadable
+        );
+
+        // A non-UTF-8 recognized-language file → Unreadable (not silently empty).
+        let bad = dir.path().join("bad.ts");
+        let mut f = std::fs::File::create(&bad).unwrap();
+        f.write_all(b"export function x() {}\n\xff\xfe").unwrap();
+        assert_eq!(scan_exported_symbols(&bad), ExportScan::Unreadable);
     }
 }

--- a/src/scoring.rs
+++ b/src/scoring.rs
@@ -1,4 +1,3 @@
-use crate::exports::get_exported_symbols;
 use crate::git_utils;
 use crate::parser::{
     find_stub_sections, get_missing_sections, get_spec_symbols, parse_frontmatter,
@@ -281,6 +280,7 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
     // ─── API Coverage (0-20) ─────────────────────────────────────────
     if !fm.files.is_empty() {
         let mut all_exports: Vec<String> = Vec::new();
+        let mut unreadable_files = 0usize;
         for file in &fm.files {
             // Never read a `files:` entry that escapes the project root — it would
             // leak arbitrary host-file identifiers into score suggestions (and the
@@ -289,7 +289,17 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
                 continue;
             }
             let full_path = root.join(file);
-            all_exports.extend(get_exported_symbols(&full_path));
+            match crate::exports::scan_exported_symbols(&full_path) {
+                crate::exports::ExportScan::Parsed(syms) => all_exports.extend(syms),
+                // A recognized-language source file that can't be read (missing /
+                // non-UTF-8) leaves its API unknown — it must NOT be scored as if it
+                // had nothing to document (that awarded a perfect API dimension and
+                // inflated the gating total, e.g. past a lifecycle min_score guard).
+                crate::exports::ExportScan::Unreadable => unreadable_files += 1,
+                // A non-source file (e.g. a `.md`/`.sql`) legitimately has no
+                // extractable exports — not a failure, and not counted against.
+                crate::exports::ExportScan::UnknownLanguage => {}
+            }
         }
         let mut seen = HashSet::new();
         all_exports.retain(|s| seen.insert(s.clone()));
@@ -302,7 +312,9 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
             .filter(|s| export_set.contains(s.as_str()))
             .count();
 
-        if all_exports.is_empty() {
+        if all_exports.is_empty() && unreadable_files == 0 {
+            // Genuinely nothing to document: every listed file parsed cleanly (or was
+            // a non-source file) and produced no exports. Full marks.
             score.api_score = DIMENSION_MAX;
             score.explain.push(ExplainDetail {
                 dimension: "API".to_string(),
@@ -314,6 +326,25 @@ pub fn score_spec(spec_path: &Path, root: &Path, config: &SpecSyncConfig) -> Spe
                     points: DIMENSION_MAX,
                     max_points: DIMENSION_MAX,
                     detail: Some("no exports to document".to_string()),
+                }],
+            });
+        } else if all_exports.is_empty() {
+            // Empty ONLY because listed source file(s) could not be read — API
+            // coverage is unverifiable, so withhold the credit rather than award a
+            // perfect (and gating-relevant) score for code we could not analyze.
+            score.api_score = 0;
+            score.explain.push(ExplainDetail {
+                dimension: "API".to_string(),
+                score: 0,
+                max_score: DIMENSION_MAX,
+                criteria: vec![CriterionResult {
+                    name: "documented_exports".to_string(),
+                    passed: false,
+                    points: 0,
+                    max_points: DIMENSION_MAX,
+                    detail: Some(format!(
+                        "could not analyze exports for {unreadable_files} file(s) (missing or not UTF-8)"
+                    )),
                 }],
             });
         } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2856,6 +2856,84 @@ fn diff_shows_changes_since_base_ref() {
 }
 
 #[test]
+fn diff_fails_loud_on_unreadable_source_file() {
+    // Regression: a changed source file whose exports can't be read (non-UTF-8)
+    // silently contributed zero exports, so real new API was dropped and diff
+    // reported "no drift" with exit 0. It must now surface the file and fail loud.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    for args in [
+        vec!["init"],
+        vec!["config", "user.email", "t@t.com"],
+        vec!["config", "user.name", "T"],
+    ] {
+        std::process::Command::new("git")
+            .args(&args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+    }
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/api.ts"), "export function apiFn() {}\n").unwrap();
+    fs::create_dir_all(root.join("specs/m")).unwrap();
+    fs::write(
+        root.join("specs/m/m.spec.md"),
+        valid_spec("m", &["src/api.ts"]),
+    )
+    .unwrap();
+    for args in [vec!["add", "."], vec!["commit", "-m", "init"]] {
+        std::process::Command::new("git")
+            .args(&args)
+            .current_dir(root)
+            .output()
+            .unwrap();
+    }
+
+    // Rewrite api.ts with a genuinely-new export plus an invalid UTF-8 byte, then stage.
+    let mut bad = b"export function apiFn() {}\nexport function brandNew() {}\n".to_vec();
+    bad.push(0xFF);
+    fs::write(root.join("src/api.ts"), bad).unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    specsync()
+        .args(["diff", "--base", "HEAD", "--root", root.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("inconclusive"));
+}
+
+#[test]
+fn score_withholds_api_credit_for_unreadable_file() {
+    // Regression: a `files:` entry that can't be read (here missing) produced zero
+    // exports, which the API dimension scored as a PERFECT "no exports to document"
+    // (20/20) — inflating the gating total. It must withhold the credit instead.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/foo.rs"), "pub fn f() {}\n").unwrap();
+    fs::create_dir_all(root.join("specs/foo")).unwrap();
+    fs::write(
+        root.join("specs/foo/foo.spec.md"),
+        "---\nmodule: foo\nversion: 1\nstatus: active\nfiles:\n  - src/does_not_exist.rs\n---\n# foo\n## Purpose\np\n",
+    )
+    .unwrap();
+
+    specsync()
+        .args(["score", "--explain", "--root", root.to_str().unwrap()])
+        .assert()
+        .stdout(
+            predicate::str::contains("could not analyze exports")
+                .and(predicate::str::contains("no exports to document").not()),
+        );
+}
+
+#[test]
 fn diff_no_changes_returns_empty() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();


### PR DESCRIPTION
Audit **Batch 2** — one root cause + two gating callers.

## Root cause

`get_exported_symbols_full` returned an empty `Vec` for **both** an unrecognized extension **and** a read failure (missing / permission / non-UTF-8) — indistinguishable from a file that genuinely exports nothing. Callers that gate on the result silently treated an *unanalyzable* file as having no API.

## Fixed

- **[medium] `diff` fail-open.** A changed source file whose exports couldn't be read contributed zero exports → real new API dropped → "no drift", exit 0. This defeated the command and its own spec invariant ("a failed comparison must not silently pass in CI"), previously implemented only for the git-diff exit path.
- **[medium] `score` fail-open.** The API dimension scored an empty extraction as a **perfect** "no exports to document" (20/20), so a missing/non-UTF-8 `files:` entry inflated the total — which feeds the lifecycle `min_score` gate.

## Approach

Added `ExportScan { Parsed(Vec<String>), UnknownLanguage, Unreadable }` + `scan_exported_symbols[_full]`. `get_exported_symbols_full` is now a thin wrapper that still coerces to an empty vec, so **all existing callers are unchanged** (incl. `check`, which already reports unreadable files loudly). `diff` records `Unreadable` entries as inconclusive, surfaces them, and fails loud (exit 1); `score` withholds API credit (0/20 + "could not analyze") when empty *only* because a file couldn't be read. `UnknownLanguage` (a `.md`/`.sql` legitimately listed) stays benign in both.

## Reproduced

- `diff` on a non-UTF-8 changed file: silent "no drift"/exit 0 → **inconclusive/exit 1**.
- `score` on a missing `files:` entry: **API 20/20 (total ~95) → API 0/20 (total 41)**. A readable export-free file still scores 20/20.

## Tests

`scan` unit test (Parsed vs UnknownLanguage vs Unreadable incl. non-UTF-8); diff fail-loud + score withhold-credit integration tests. Documented `ExportScan` + `scan_*` in the exports spec. **750 unit + 177 integration**, fmt / clippy / self-check 100%.

Part of the post-v4.7.1 audit sweep (Batch 2 of ~10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)