### PR TITLE
Add: render the atlas calendar component on Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -67,7 +69,7 @@ jobs:
         with:
           path: .
           output-dir: site/public/badges
-          components: "coverage langmix treemap sunburst"
+          components: "coverage langmix treemap sunburst calendar"
 
       - name: "Build site (runs prebuild: validate + redirects)"
         working-directory: site


### PR DESCRIPTION
- Enable the atlas `calendar` component in the Pages workflow by adding it to the `components:` list (`coverage langmix treemap sunburst calendar`).
- Set `fetch-depth: 0` on the `actions/checkout` step so the calendar can read the full commit history it needs to render.
- No other changes; YAML validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)