### PR TITLE
Fix broken spec reference in greeter spec

### DIFF
--- a/examples/quickstart/specs/greeter/greeter.spec.md
+++ b/examples/quickstart/specs/greeter/greeter.spec.md
@@ -3,7 +3,7 @@ module: greeter
 version: 1
 status: draft
 files:
-  - src/lib.rs
+  - examples/quickstart/src/lib.rs
 ---
 
 # greeter


### PR DESCRIPTION
Update the file reference in `examples/quickstart/specs/greeter/greeter.spec.md` from `src/lib.rs` to the root-relative path `examples/quickstart/src/lib.rs`. This fixes the broken reference error reported by `fledge atlas --review`.

---
*PR created automatically by Jules for task [18295422738071203903](https://jules.google.com/task/18295422738071203903) started by @0xLeif*