### PR TITLE
Fix: write portable Windows release checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,33 @@ jobs:
         run: |
           Copy-Item "target/$env:TARGET/release/specsync.exe" $env:ARTIFACT
           Compress-Archive -Path $env:ARTIFACT -DestinationPath "$env:ARTIFACT.zip"
-          (Get-FileHash "$env:ARTIFACT.zip" -Algorithm SHA256).Hash.ToLower() + "  $env:ARTIFACT.zip" | Out-File -Encoding ascii "$env:ARTIFACT.zip.sha256"
+          $hash = (Get-FileHash "$env:ARTIFACT.zip" -Algorithm SHA256).Hash.ToLower()
+          $line = "$hash  $env:ARTIFACT.zip`n"
+          [IO.File]::WriteAllBytes(
+            "$env:ARTIFACT.zip.sha256",
+            [Text.Encoding]::ASCII.GetBytes($line)
+          )
+
+      - name: Verify packaged checksum
+        shell: python
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+        run: |
+          import hashlib
+          import os
+          from pathlib import Path
+
+          suffix = ".zip" if os.environ["RUNNER_OS"] == "Windows" else ".tar.gz"
+          archive = Path(f"{os.environ['ARTIFACT']}{suffix}")
+          checksum = Path(f"{archive}.sha256")
+          digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+          expected = f"{digest}  {archive.name}\n".encode("ascii")
+          actual = checksum.read_bytes()
+
+          if actual != expected:
+              raise SystemExit(
+                  f"invalid checksum file {checksum}: expected LF-only SHA-256 record"
+              )
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/approvals.json
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/approvals.json
@@ -20,6 +20,13 @@
       "timestamp": 1783803894,
       "digest": "e00bbffb657a83728c2e84c6cdfe44c7d3c8c9075f52cf7b457f84b1b5befd7e",
       "note": "Refresh the approved definition after recording that draft PR #343 is open."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1783804639,
+      "digest": "3417a43024a96059ad182b42640fcd699925290bcfebc8642036aa6243eb8f05",
+      "note": "Explicit closing approval provided for PR #343 on 2026-07-11 after reviewing verification evidence and green CI."
     }
   ]
 }

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/approvals.json
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/approvals.json
@@ -13,6 +13,13 @@
       "timestamp": 1783803845,
       "digest": "6b86aeedbb4dbf71c7f80e8daf0d0f53230740b5c7519c095ca6942a3b0c6b1a",
       "note": "Refresh definition digest after recording the completed implementation tasks and local evidence requested for issue #342."
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1783803894,
+      "digest": "e00bbffb657a83728c2e84c6cdfe44c7d3c8c9075f52cf7b457f84b1b5befd7e",
+      "note": "Refresh the approved definition after recording that draft PR #343 is open."
     }
   ]
 }

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/approvals.json
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/approvals.json
@@ -1,0 +1,18 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1783803538,
+      "digest": "c8d004ddf8c5e7b379cd916345c4fbd2b89b4dde06728e4badbfae0b2e8d668f",
+      "note": "User explicitly requested fixing issue #342 after reviewing the released checksum defect."
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1783803845,
+      "digest": "6b86aeedbb4dbf71c7f80e8daf0d0f53230740b5c7519c095ca6942a3b0c6b1a",
+      "note": "Refresh definition digest after recording the completed implementation tasks and local evidence requested for issue #342."
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/change.md
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0011-fix-windows-release-checksum-newline-portability
+state: implementing
+type: bug_fix
+base_commit: d6d8512f9a1d75f308df1e9a8f52b47ca9e839ee
+---
+
+# Fix Windows release checksum newline portability
+
+## Intent
+
+Fix Windows release checksum newline portability
+
+## Affected Canonical Specs
+
+- None
+
+## Acceptance Criteria
+
+- Windows release checksum files use LF and pass standard Unix shasum verification; the workflow verifies generated checksums before uploading artifacts; existing five-platform packaging remains unchanged.
+
+## No-spec Rationale
+
+The release workflow implementation changes, but no canonical Rust module API or documented SpecSync behavior changes.

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/change.md
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0011-fix-windows-release-checksum-newline-portability
-state: implementing
+state: accepted
 type: bug_fix
 base_commit: d6d8512f9a1d75f308df1e9a8f52b47ca9e839ee
 ---

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/context.md
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/context.md
@@ -1,0 +1,14 @@
+---
+change: CHG-0011-fix-windows-release-checksum-newline-portability
+artifact: context
+---
+
+# Context
+
+The v5.0.0 Windows release checksum was correct but ended with CRLF because PowerShell `Out-File`
+used the platform newline. Unix `shasum -c` treated the carriage return as part of the archive
+filename and failed. The published v5.0.0 asset was repaired manually; this change prevents the
+workflow from reproducing the defect.
+
+Keep the existing five-target build and archive layout. Generate the Windows checksum with an
+explicit ASCII LF byte sequence, then verify every platform's archive/checksum pair before upload.

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/state.json
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/state.json
@@ -8,7 +8,7 @@
   "state": "implementing",
   "base_commit": "d6d8512f9a1d75f308df1e9a8f52b47ca9e839ee",
   "created_at": 1783803446,
-  "updated_at": 1783803845,
+  "updated_at": 1783803894,
   "affected_specs": [],
   "affected_paths": [
     ".github/workflows/release.yml"

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/state.json
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/state.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0011-fix-windows-release-checksum-newline-portability",
+  "slug": "fix-windows-release-checksum-newline-portability",
+  "title": "Fix Windows release checksum newline portability",
+  "description": "Fix Windows release checksum newline portability",
+  "kind": "bug_fix",
+  "state": "implementing",
+  "base_commit": "d6d8512f9a1d75f308df1e9a8f52b47ca9e839ee",
+  "created_at": 1783803446,
+  "updated_at": 1783803845,
+  "affected_specs": [],
+  "affected_paths": [
+    ".github/workflows/release.yml"
+  ],
+  "no_spec_change": true,
+  "no_spec_change_rationale": "The release workflow implementation changes, but no canonical Rust module API or documented SpecSync behavior changes.",
+  "acceptance_criteria": [
+    "Windows release checksum files use LF and pass standard Unix shasum verification; the workflow verifies generated checksums before uploading artifacts; existing five-platform packaging remains unchanged."
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/state.json
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/state.json
@@ -5,10 +5,10 @@
   "title": "Fix Windows release checksum newline portability",
   "description": "Fix Windows release checksum newline portability",
   "kind": "bug_fix",
-  "state": "implementing",
+  "state": "accepted",
   "base_commit": "d6d8512f9a1d75f308df1e9a8f52b47ca9e839ee",
   "created_at": 1783803446,
-  "updated_at": 1783803894,
+  "updated_at": 1783804639,
   "affected_specs": [],
   "affected_paths": [
     ".github/workflows/release.yml"

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/tasks.md
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/tasks.md
@@ -9,4 +9,4 @@ artifact: tasks
 - [x] Verify every generated archive/checksum pair before artifact upload.
 - [x] Add a regression check for LF acceptance and CRLF rejection.
 - [x] Run strict lifecycle, workflow, and repository validation.
-- [ ] Open a focused PR linked to issue #342.
+- [x] Open a focused PR linked to issue #342.

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/tasks.md
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/tasks.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0011-fix-windows-release-checksum-newline-portability
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Write the Windows checksum with an explicit LF newline.
+- [x] Verify every generated archive/checksum pair before artifact upload.
+- [x] Add a regression check for LF acceptance and CRLF rejection.
+- [x] Run strict lifecycle, workflow, and repository validation.
+- [ ] Open a focused PR linked to issue #342.

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/testing.md
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/testing.md
@@ -1,0 +1,20 @@
+---
+change: CHG-0011-fix-windows-release-checksum-newline-portability
+artifact: testing
+---
+
+# Testing
+
+- Parse the workflow as YAML.
+- Exercise the portable checksum verifier locally against valid LF and invalid CRLF fixtures.
+- Run the repository CI matrix, including the Windows runner and workflow validation.
+- Confirm strict SpecSync lifecycle and canonical spec checks remain green.
+
+## Local Evidence
+
+- `actionlint .github/workflows/release.yml` passes.
+- PyYAML parses the workflow successfully.
+- The exact embedded verifier accepts a valid LF checksum record.
+- The exact embedded verifier rejects the reproduced CRLF record with exit 1.
+- `fledge run fmt` passes.
+- `fledge run test` passes all 1,527 unit and 187 integration tests.

--- a/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/verification.json
+++ b/.specsync/changes/CHG-0011-fix-windows-release-checksum-newline-portability/verification.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": 1783803926,
+  "commit": "c54defac97f89c5118540e70c08925f1dbcfe9a6",
+  "contract_digest": "e00bbffb657a83728c2e84c6cdfe44c7d3c8c9075f52cf7b457f84b1b5befd7e",
+  "workspace_digest": "6b52a4e29a973e49c7aa8be421408f27de5067ec8c79b6d140702b4dc9b516f8",
+  "acceptance_input_digest": "8402dc1ea2c725198ba8d5bbce54fdc2dd9c9c0358151cfb258d4457ee9b1009",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": []
+}


### PR DESCRIPTION
## Summary
- write the Windows SHA-256 record as explicit ASCII bytes ending in LF
- verify every platform archive/checksum pair byte-for-byte before upload
- preserve the existing five-target release matrix

## Root cause
PowerShell Out-File used CRLF. Unix shasum treated the carriage return as part of the archive filename.

## Test Plan
- [x] actionlint release workflow
- [x] parse workflow with PyYAML
- [x] exact embedded verifier accepts LF fixture
- [x] exact embedded verifier rejects CRLF fixture
- [x] 1,527 unit tests
- [x] 187 integration tests
- [x] strict 62-spec and 100% coverage gate

Closes #342