### PR TITLE
Fix: refresh merged SDD evidence

### DIFF
--- a/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/approvals.json
+++ b/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/approvals.json
@@ -20,6 +20,13 @@
       "timestamp": 1783805708,
       "digest": "ba5b9e5881380868a250c602d94f64844433643b1bf9320a527b4063b80dc640",
       "note": "Definition refreshed after adding explicit requirement evidence; authorized by the user's request."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1783807825,
+      "digest": "06af1c884cecab8f78fda77471346efcdc2b235ac0a94335754db56dc47f35dd",
+      "note": "Closing approval recorded after PR #344 was reviewed, made ready, and merged by 0xLeif."
     }
   ]
 }

--- a/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/change.md
+++ b/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links
-state: verifying
+state: accepted
 type: documentation
 base_commit: fffbef561fe7cbcfad669dac1855e711896deca4
 ---

--- a/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/state.json
+++ b/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/state.json
@@ -5,10 +5,10 @@
   "title": "Correct SpecSync 5.0 documentation, CLI help, and hub deep links",
   "description": "Correct SpecSync 5.0 documentation, CLI help, and hub deep links",
   "kind": "documentation",
-  "state": "verifying",
+  "state": "accepted",
   "base_commit": "fffbef561fe7cbcfad669dac1855e711896deca4",
   "created_at": 1783805318,
-  "updated_at": 1783806895,
+  "updated_at": 1783807825,
   "affected_specs": [
     "cli_args"
   ],

--- a/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/verification.json
+++ b/.specsync/changes/CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links/verification.json
@@ -1,8 +1,9 @@
 {
-  "timestamp": 1783806895,
-  "commit": "fffbef561fe7cbcfad669dac1855e711896deca4",
+  "timestamp": 1783807606,
+  "commit": "23ead68de8719dcf97ff4d87765d7e649f14ac3a",
   "contract_digest": "ba5b9e5881380868a250c602d94f64844433643b1bf9320a527b4063b80dc640",
   "workspace_digest": "f6c9e71e9105bc98dfffc7a64e4df903d2c3996e7af1d4c6d5da97e3ff426d10",
+  "acceptance_input_digest": "4fdc3a611844adce9d30e51daf803c0b1d4e13884bb486c6e2fb202abe17ed74",
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/approvals.json
+++ b/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/approvals.json
@@ -27,6 +27,13 @@
       "timestamp": 1783807000,
       "digest": "e4ddfaa45844943cbbbd5b27e78102cc89a48a14f6d0e5c9ae42ed91012511ef",
       "note": "Final definition refresh after recording all Fledge lanes, Trust 30/30 dogfood, clean restoration, and non-blocking Augur review evidence."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1783807900,
+      "digest": "4c2b682957af53feee8dc69974d9cb9384b2e73bff4239881a97b5b3479ec5bf",
+      "note": "Closing approval recorded after PR #344 was reviewed, made ready, and merged by 0xLeif with all hosted checks passing."
     }
   ]
 }

--- a/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/change.md
+++ b/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors
-state: verifying
+state: accepted
 type: bug_fix
 base_commit: fffbef561fe7cbcfad669dac1855e711896deca4
 ---

--- a/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/state.json
+++ b/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/state.json
@@ -5,10 +5,10 @@
   "title": "Preserve punctuated Public API symbols across all export extractors",
   "description": "Preserve punctuated Public API symbols across all export extractors",
   "kind": "bug_fix",
-  "state": "verifying",
+  "state": "accepted",
   "base_commit": "fffbef561fe7cbcfad669dac1855e711896deca4",
   "created_at": 1783805799,
-  "updated_at": 1783807046,
+  "updated_at": 1783807900,
   "affected_specs": [
     "parser",
     "ignore"

--- a/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/verification.json
+++ b/.specsync/changes/CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors/verification.json
@@ -1,8 +1,9 @@
 {
-  "timestamp": 1783807046,
-  "commit": "fffbef561fe7cbcfad669dac1855e711896deca4",
+  "timestamp": 1783807878,
+  "commit": "23ead68de8719dcf97ff4d87765d7e649f14ac3a",
   "contract_digest": "e4ddfaa45844943cbbbd5b27e78102cc89a48a14f6d0e5c9ae42ed91012511ef",
-  "workspace_digest": "f6c9e71e9105bc98dfffc7a64e4df903d2c3996e7af1d4c6d5da97e3ff426d10",
+  "workspace_digest": "4bf2f698239c36805eafdde30f5818f2e0ef2b77bd39bdb08af5c36d11e77e11",
+  "acceptance_input_digest": "094936fffc70a4ac0744f134b641378a0f1b6ea449b4d24ae2d3208148c24b0f",
   "passed": true,
   "commands": [
     {

--- a/specs/cli_args/cli_args.spec.md
+++ b/specs/cli_args/cli_args.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cli_args
-version: 5
+version: 6
 status: stable
 files:
   - src/cli.rs
@@ -107,3 +107,4 @@ Defines the complete CLI argument grammar using Clap derive macros, including gl
 | 2026-07-11 | CHG-0003-finalize-specsync-5-0-release-consistency-and-parallel-validation: Finalize SpecSync 5.0 release consistency and parallel validation |
 | 2026-07-11 | CHG-0007-harden-specsync-5-0-as-an-agent-native-secret-free-sdd-core-and-close-release-r: Harden SpecSync 5.0 as an agent-native, secret-free SDD core and close release regressions |
 | 2026-07-11 | CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links: Correct initialization and full-scaffold help while preserving the CLI grammar |
+| 2026-07-11 | CHG-0012-correct-specsync-5-0-documentation-cli-help-and-hub-deep-links: Correct SpecSync 5.0 documentation, CLI help, and hub deep links |

--- a/specs/cli_args/requirements.md
+++ b/specs/cli_args/requirements.md
@@ -25,3 +25,14 @@ Acceptance Criteria
 - `generate` exposes no provider or model flags.
 - Agent installation and MCP commands remain available.
 
+### REQ-cli-args-003
+
+The shared CLI grammar SHALL describe the files produced by initialization and full spec scaffolding accurately.
+
+Acceptance Criteria
+- `init` help names `.specsync/config.toml` rather than the retired root JSON configuration.
+- Global option help names the canonical configuration and every accepted output format.
+- `add-spec` help describes the required companion set and optional design artifact.
+- `new --full` help lists the required companion files and identifies `design.md` as optional.
+- Help-only corrections do not change argument parsing or command behavior.
+

--- a/specs/ignore/ignore.spec.md
+++ b/specs/ignore/ignore.spec.md
@@ -1,6 +1,6 @@
 ---
 module: ignore
-version: 4
+version: 5
 status: stable
 files:
   - src/ignore.rs
@@ -17,19 +17,19 @@ Provides a warning suppression system for spec-sync validation. Supports three l
 
 ## Public API
 
-### Exported Enums
+**Exported Enums**
 
 | Type | Description |
 |------|-------------|
 | `WarningCategory` | 13-variant enum representing classifiable warning types: RequirementsCompanion, StubSection, UndocumentedExport, Deprecated, UnknownStatus, UnknownAgentPolicy, SchemaColumn, SchemaTypeMismatch, ConsumedBy, ChangelogEntries, SpecSize, MinInvariants, RequireDependsOn |
 
-### Exported Structs
+**Exported Structs**
 
 | Type | Description |
 |------|-------------|
 | `IgnoreRules` | Container holding global suppression set and per-spec suppression map, loaded from `.specsyncignore` |
 
-### Exported Functions
+**Exported Functions**
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
@@ -38,16 +38,6 @@ Provides a warning suppression system for spec-sync validation. Supports three l
 | `load` | Alias for `IgnoreRules::load` | `IgnoreRules` | Load from `.specsyncignore` |
 | `parse_inline` | Alias for `IgnoreRules::parse_inline` | `HashSet<WarningCategory>` | Parse inline directives |
 | `is_suppressed` | Alias for `IgnoreRules::is_suppressed` | `bool` | Check suppression |
-
-#### Associated Methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `WarningCategory::from_str` | `s: &str` | `Option<Self>` | Parse category from string (case-insensitive, kebab-case, with aliases like "requirements" → RequirementsCompanion) |
-| `WarningCategory::classify` | `warning: &str` | `Option<Self>` | Classify a warning message text into a category by pattern matching on known prefixes/keywords |
-| `IgnoreRules::load` | `root: &Path` | `Self` | Load rules from `.specsyncignore` file; returns empty rules if file doesn't exist |
-| `IgnoreRules::parse_inline` | `body: &str` | `HashSet<WarningCategory>` | Extract inline ignore directives from spec body (`<!-- specsync-ignore: cat1, cat2 -->`) |
-| `IgnoreRules::is_suppressed` | `&self, warning, spec_rel_path, inline_ignores` | `bool` | Check if a warning should be suppressed given global, inline, and per-spec rules |
 
 ## Invariants
 
@@ -117,3 +107,4 @@ Provides a warning suppression system for spec-sync validation. Supports three l
 | 2026-04-09 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-11 | CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors: Move associated methods under the informational method subsection so exact symbol parsing validates only real module exports |
+| 2026-07-11 | CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors: Preserve punctuated Public API symbols across all export extractors |

--- a/specs/parser/parser.spec.md
+++ b/specs/parser/parser.spec.md
@@ -1,6 +1,6 @@
 ---
 module: parser
-version: 4
+version: 5
 status: stable
 files:
   - src/parser.rs
@@ -117,3 +117,4 @@ Implementation SHALL add these canonical dependency specs to `depends_on`: `spec
 | 2026-06-11 | Add `get_all_api_table_symbols` so `check --fix` treats symbols documented under any Public API table (e.g. a bare `### Functions` heading) as already documented |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-11 | CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors: Preserve complete punctuated symbols in Public API table rows |
+| 2026-07-11 | CHG-0013-preserve-punctuated-public-api-symbols-across-all-export-extractors: Preserve punctuated Public API symbols across all export extractors |

--- a/specs/parser/requirements.md
+++ b/specs/parser/requirements.md
@@ -42,7 +42,9 @@ Acceptance Criteria
 - `parse_frontmatter` returns None if the file has no `---` delimited frontmatter block
 - Handles scalar fields (module, version, status) and list fields (files, db_tables, depends_on)
 - Empty list syntax `[]` is handled correctly (produces empty vec, not a vec containing "[]")
-- `get_spec_symbols` extracts first backtick-quoted word from each row in `### Exported ...` subsections
+- `get_spec_symbols` extracts the complete first nonempty backtick-delimited symbol from each recognized table row in `### Exported ...` subsections
+- Punctuation emitted by language extractors is preserved without a second parser-specific character allowlist
+- Empty or malformed backtick cells do not produce symbols
 - Only extracts from allowlisted subsection names (Exported Functions, Exported Types, etc.)
 - Symbols are deduplicated while preserving order
 - `get_missing_sections` uses case-sensitive regex matching for `## SectionName`


### PR DESCRIPTION
## Summary
- re-verify CHG-0012 and CHG-0013 against the merged main commit
- record closing acceptance after PR #344 merged
- apply the accepted semantic deltas while retaining active delivery coverage until this repair merges

## Root cause
PR #344 passed all PR checks, but squash merge changed HEAD. Main CI then correctly rejected verification evidence tied to the pre-merge commit. The shallow Actions checkout also could not resolve the recorded base commit.

## Test Plan
- [x] 1,529 unit tests and 188 integration tests during post-merge verification
- [x] specsync check --strict --require-coverage 100 --force: 62/62, zero warnings, 100% coverage
- [x] fledge lanes run pre-commit
- [x] Augur PROCEED, risk 28/100

After this merges, archive the accepted change workspaces in a final lifecycle cleanup before tagging 5.0.1.