### PR TITLE
Feat: route CI checks by changed paths

### DIFF
--- a/.github/scripts/classify-ci-paths.sh
+++ b/.github/scripts/classify-ci-paths.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root="${1:-.}"
+force_full="${2:-false}"
+
+archive_candidate=true
+archive_seen=false
+changed_seen=false
+full=false
+site=false
+vscode=false
+
+if [[ "$force_full" == "true" ]]; then
+    archive_candidate=false
+    full=true
+fi
+
+while IFS= read -r -d '' path; do
+    changed_seen=true
+
+    case "$path" in
+        .specsync/archive/changes/*)
+            archive_seen=true
+            ;;
+        .specsync/changes/*)
+            if [[ -e "$root/$path" || -L "$root/$path" ]]; then
+                archive_candidate=false
+            fi
+            ;;
+        *)
+            archive_candidate=false
+            ;;
+    esac
+
+    case "$path" in
+        src/*|tests/*|Cargo.toml|Cargo.lock|rust-toolchain.toml|action.yml|examples/*|fledge.toml|.github/workflows/*|.github/scripts/*)
+            full=true
+            ;;
+        site/*)
+            site=true
+            ;;
+        vscode-extension/*)
+            vscode=true
+            ;;
+        specs/*|.specsync/*)
+            ;;
+        *)
+            full=true
+            ;;
+    esac
+done
+
+archive_only=false
+if [[ "$changed_seen" == "true" && "$archive_candidate" == "true" && "$archive_seen" == "true" ]]; then
+    archive_only=true
+    full=false
+    site=false
+    vscode=false
+fi
+
+printf 'archive_only=%s\n' "$archive_only"
+printf 'full=%s\n' "$full"
+printf 'site=%s\n' "$site"
+printf 'vscode=%s\n' "$vscode"

--- a/.github/scripts/test-classify-ci-paths.sh
+++ b/.github/scripts/test-classify-ci-paths.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+classifier="$script_dir/classify-ci-paths.sh"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/.specsync/archive/changes/CHG-0001" \
+    "$fixture/.specsync/changes/CHG-0002" \
+    "$fixture/site/src" \
+    "$fixture/vscode-extension/src"
+touch "$fixture/.specsync/archive/changes/CHG-0001/state.json"
+touch "$fixture/.specsync/changes/CHG-0002/state.json"
+
+classify() {
+    local output
+    output="$(printf '%s\0' "$@" | "$classifier" "$fixture")"
+    printf '%s\n' "$output"
+}
+
+expect_value() {
+    local output="$1" key="$2" expected="$3"
+    if ! grep -Fxq "$key=$expected" <<<"$output"; then
+        printf 'expected %s=%s, got:\n%s\n' "$key" "$expected" "$output" >&2
+        exit 1
+    fi
+}
+
+archive_move="$(classify \
+    .specsync/changes/CHG-0001/state.json \
+    .specsync/archive/changes/CHG-0001/state.json)"
+expect_value "$archive_move" archive_only true
+expect_value "$archive_move" full false
+
+active_edit="$(classify .specsync/changes/CHG-0002/state.json)"
+expect_value "$active_edit" archive_only false
+
+source_change="$(classify src/parser.rs)"
+expect_value "$source_change" full true
+
+site_change="$(classify site/src/pages/index.astro)"
+expect_value "$site_change" full false
+expect_value "$site_change" site true
+
+vscode_change="$(classify vscode-extension/src/extension.ts)"
+expect_value "$vscode_change" full false
+expect_value "$vscode_change" vscode true
+
+contract_change="$(classify specs/parser/parser.spec.md)"
+expect_value "$contract_change" archive_only false
+expect_value "$contract_change" full false
+
+mixed_change="$(classify \
+    .specsync/archive/changes/CHG-0001/state.json \
+    site/src/pages/index.astro)"
+expect_value "$mixed_change" archive_only false
+expect_value "$mixed_change" site true
+
+workflow_change="$(classify .github/workflows/ci.yml)"
+expect_value "$workflow_change" full true
+
+forced="$(printf '' | "$classifier" "$fixture" true)"
+expect_value "$forced" full true
+
+echo "classify-ci-paths tests passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ on:
       - 'fledge.toml'
       - 'site/**'
       - 'vscode-extension/**'
+      - '.github/scripts/**'
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
@@ -37,6 +38,7 @@ on:
       - 'fledge.toml'
       - 'site/**'
       - 'vscode-extension/**'
+      - '.github/scripts/**'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
@@ -48,7 +50,58 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  classify:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      archive-only: ${{ steps.paths.outputs.archive_only }}
+      full: ${{ steps.paths.outputs.full }}
+      site: ${{ steps.paths.outputs.site }}
+      vscode: ${{ steps.paths.outputs.vscode }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: paths
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          force_full=false
+          case "$EVENT_NAME" in
+            pull_request)
+              base="origin/$BASE_REF"
+              ;;
+            push)
+              base="$BEFORE_SHA"
+              if [[ -z "$base" || "$base" =~ ^0+$ ]] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+                force_full=true
+              fi
+              ;;
+            *)
+              force_full=true
+              ;;
+          esac
+
+          if [[ "$force_full" == "true" ]]; then
+            output="$(printf '' | .github/scripts/classify-ci-paths.sh "$GITHUB_WORKSPACE" true)"
+          else
+            output="$(git diff --name-only -z "$base" "$GITHUB_SHA" | .github/scripts/classify-ci-paths.sh "$GITHUB_WORKSPACE")"
+          fi
+
+          printf '%s\n' "$output" | tee -a "$GITHUB_OUTPUT"
+      - name: Test classifier
+        run: .github/scripts/test-classify-ci-paths.sh
+
   test:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -63,6 +116,8 @@ jobs:
       - run: cargo clippy -- -D warnings
 
   fmt:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -73,6 +128,8 @@ jobs:
       - run: cargo fmt --check
 
   audit:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -82,6 +139,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   coverage:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -94,6 +153,8 @@ jobs:
         run: cargo tarpaulin --skip-clean --fail-under 50
 
   site:
+    needs: classify
+    if: needs.classify.outputs.full == 'true' || needs.classify.outputs.site == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -113,6 +174,8 @@ jobs:
         run: bun run build
 
   vscode-extension:
+    needs: classify
+    if: needs.classify.outputs.full == 'true' || needs.classify.outputs.vscode == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -129,6 +192,8 @@ jobs:
         run: bun run package
 
   validate-action:
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -138,6 +203,8 @@ jobs:
 
   action-consumer:
     name: Packaged GitHub Action consumer
+    needs: classify
+    if: needs.classify.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -240,6 +307,7 @@ jobs:
           lifecycle-enforce: 'true'
 
   spec-check:
+    needs: classify
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -279,6 +347,25 @@ jobs:
           # Fail the step if check fails
           cargo run -- check --strict --require-coverage 100 --force
 
+  ci-gate:
+    name: Required CI gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs: [classify, test, fmt, validate-action, action-consumer, spec-check, audit, coverage, site, vscode-extension]
+    steps:
+      - name: Require every selected gate
+        env:
+          RESULTS: >-
+            ${{ join(needs.*.result, ' ') }}
+        run: |
+          for result in $RESULTS; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "Selected CI gate ended with: $result" >&2; exit 1 ;;
+            esac
+          done
+
   corvid-pet:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -313,6 +400,8 @@ jobs:
 
             if [ "$RESULT" = "success" ]; then
               ICON="✅ Passed"
+            elif [ "$RESULT" = "skipped" ]; then
+              ICON="⏭️ Not selected"
             else
               ICON="❌ ${RESULT}"
               OVERALL="failure"
@@ -363,8 +452,8 @@ jobs:
     # Depend on every gate job, not just a subset: an attestation records
     # "proceed", so it must not sign off on a commit where any real check failed.
     # (corvid-pet is a PR-comment mascot, not a gate, so it is intentionally out.)
-    needs: [test, fmt, audit, coverage, site, vscode-extension, validate-action, action-consumer, spec-check]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [ci-gate]
+    if: needs.ci-gate.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     # contents: write lets the step push refs/notes/attest.
     permissions:
       contents: write
@@ -391,7 +480,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git fetch origin "+refs/notes/attest:refs/notes/attest" 2>/dev/null || true
             if "$bin" sign --commit HEAD --reviewer agent:ci --confidence 0.9 --tests-passed \
-                 --verdict proceed --note "CI green: test, fmt, audit, coverage, site, vscode-extension, validate-action, action-consumer, spec-check" \
+                 --verdict proceed --note "Selected path-aware CI gates passed" \
                && git push origin refs/notes/attest ; then
               echo "attestation recorded for $(git rev-parse --short HEAD)"
             else

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/approvals.json
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/approvals.json
@@ -1,0 +1,25 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1783809186,
+      "digest": "8c7ae909b66b633cbed6840bfce82366c9185cd14194ed746941352e27173c4a",
+      "note": "Definition approved from the explicit request to line up path-aware CI before the 5.0.1 tag."
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1783809370,
+      "digest": "e5e8596988213ba20433bb5e460b2ece71fc20ea6376c4558190bc77be4f6e97",
+      "note": "Refresh definition approval after recording the complete classifier design and local gate evidence."
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1783809419,
+      "digest": "b9852ca8d1f6b800d603f3b634f42e6e2f6dc0cde153953abbf238bd190f8ba2",
+      "note": "Final definition refresh after all local lanes and non-blocking Augur review completed."
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/change.md
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/change.md
@@ -1,0 +1,29 @@
+---
+id: CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres
+state: verifying
+type: operations
+base_commit: 58cc99e6c4d585426a3a355843fd672e0f1cd220
+---
+
+# Route archive-only lifecycle moves through a minimal SpecSync CI gate while preserving full validation for source, dependency, action, workflow, and release changes
+
+## Intent
+
+Route archive-only lifecycle moves through a minimal SpecSync CI gate while preserving full validation for source, dependency, action, workflow, and release changes
+
+## Affected Canonical Specs
+
+- None
+
+## Acceptance Criteria
+
+- Archive-only moves run SpecSync lifecycle validation without platform tests, coverage, audit, site, extension, or packaged Action jobs.
+- Source, dependency, workflow, action, and release changes still run the full matrix.
+- Site-only and VS Code-only changes run their relevant product job plus SpecSync validation.
+- Skipped jobs remain neutral in the PR summary and the stable aggregate gate.
+- Main records attestation only after every selected gate succeeds.
+- Classifier behavior is covered by deterministic tests.
+
+## No-spec Rationale
+
+This changes repository CI orchestration only; it does not alter the SpecSync public contract or canonical module behavior.

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/context.md
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/context.md
@@ -1,0 +1,15 @@
+---
+change: CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres
+artifact: context
+---
+
+# Context
+
+Archive-only PR #346 changed no executable product input, but the monolithic CI
+workflow still ran platform tests, coverage, dependency audit, site, extension,
+Action consumer, and CodeQL. Repository CI currently selects the whole workflow
+for any `.specsync/**` path and has no job-level change classification.
+
+The workflow must remain fail-closed. A change inside an active
+`.specsync/changes/**` workspace is not an archive move and must not receive
+the archive-only fast path.

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/design.md
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/design.md
@@ -1,0 +1,22 @@
+---
+change: CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres
+artifact: design
+---
+
+# Design
+
+Add one first-party classifier job that reads the NUL-delimited Git diff and
+emits `archive_only`, `full`, `site`, and `vscode` outputs.
+
+An archive-only diff may contain:
+
+- additions under `.specsync/archive/changes/**`
+- deletions under `.specsync/changes/**`
+
+If an active-workspace path still exists, or any unrelated path changed, the
+diff is not archive-only. Unknown paths select full CI.
+
+Every triggered run executes the classifier and `spec-check`. Heavy Rust,
+audit, coverage, Action, site, and extension jobs use classifier outputs. A
+stable `Required CI gate` accepts only successful or intentionally skipped
+dependencies. Main attestation depends on that aggregate gate.

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/plan.md
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/plan.md
@@ -1,0 +1,14 @@
+---
+change: CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres
+artifact: plan
+---
+
+# Plan
+
+1. Add a deterministic path classifier and fixture tests.
+2. Add job-level conditions without renaming existing checks.
+3. Add one stable aggregate required gate.
+4. Make PR summaries treat intentional skips as neutral.
+5. Make main attestation depend on the aggregate gate.
+6. Exercise archive-only, active-change, product, and mixed path cases.
+7. Run every local repository lane and inspect the hosted PR job selection.

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/research.md
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/research.md
@@ -1,0 +1,18 @@
+---
+change: CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres
+artifact: research
+---
+
+# Research
+
+GitHub top-level `paths` filters can decide whether a workflow starts, but they
+cannot distinguish an archive move from an edit because an archive commit
+contains both deleted active-workspace paths and added archive paths.
+
+Job-level classification is required. Skipped jobs are acceptable dependencies
+only when the aggregate gate explicitly treats `skipped` as neutral.
+
+CodeQL is configured through GitHub default setup rather than a repository
+workflow file, so this change optimizes the repository CI workflow. Default
+CodeQL may still appear separately until its GitHub settings receive equivalent
+path filtering.

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/state.json
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/state.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres",
+  "slug": "route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres",
+  "title": "Route archive-only lifecycle moves through a minimal SpecSync CI gate while preserving full validation for source, dependency, action, workflow, and release changes",
+  "description": "Route archive-only lifecycle moves through a minimal SpecSync CI gate while preserving full validation for source, dependency, action, workflow, and release changes",
+  "kind": "operations",
+  "state": "verifying",
+  "base_commit": "58cc99e6c4d585426a3a355843fd672e0f1cd220",
+  "created_at": 1783809012,
+  "updated_at": 1783809448,
+  "affected_specs": [],
+  "affected_paths": [
+    ".github/workflows/ci.yml",
+    ".github/scripts/classify-ci-paths.sh",
+    ".github/scripts/test-classify-ci-paths.sh"
+  ],
+  "no_spec_change": true,
+  "no_spec_change_rationale": "This changes repository CI orchestration only; it does not alter the SpecSync public contract or canonical module behavior.",
+  "acceptance_criteria": [
+    "Archive-only moves run SpecSync lifecycle validation without platform tests, coverage, audit, site, extension, or packaged Action jobs.",
+    "Source, dependency, workflow, action, and release changes still run the full matrix.",
+    "Site-only and VS Code-only changes run their relevant product job plus SpecSync validation.",
+    "Skipped jobs remain neutral in the PR summary and the stable aggregate gate.",
+    "Main records attestation only after every selected gate succeeds.",
+    "Classifier behavior is covered by deterministic tests."
+  ],
+  "selected_artifacts": [
+    "context",
+    "plan",
+    "testing",
+    "design",
+    "tasks",
+    "research"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "yes",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/tasks.md
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/tasks.md
@@ -1,0 +1,16 @@
+---
+change: CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Define fail-closed path categories.
+- [x] Implement and test the classifier.
+- [x] Gate repository CI jobs by selected categories.
+- [x] Add a stable aggregate gate.
+- [x] Preserve PR summary and main attestation behavior.
+- [x] Run local workflow syntax and classifier tests.
+- [x] Run all Fledge repository lanes and strict SpecSync validation.
+- [x] Run Augur and stop on a block verdict.
+- [x] Confirm the workflow-changing PR selects full CI before hosted review.

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/testing.md
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/testing.md
@@ -1,0 +1,43 @@
+---
+change: CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres
+artifact: testing
+---
+
+# Testing
+
+## Classifier Matrix
+
+| Diff | Expected selection |
+|------|--------------------|
+| active deletion plus immutable archive addition | SpecSync only |
+| active workspace edit that still exists | not archive-only |
+| source, test, Cargo, workflow, Action, or release input | full CI |
+| site-only | SpecSync plus site |
+| VS Code-only | SpecSync plus extension |
+| canonical spec or non-archive lifecycle metadata | SpecSync only |
+| mixed archive and site | SpecSync plus site |
+| unknown or manual dispatch | full CI |
+
+Run:
+
+- `.github/scripts/test-classify-ci-paths.sh`
+- parse `.github/workflows/ci.yml` with the repository YAML tooling
+- `fledge lanes run pre-commit`
+- `fledge lanes run check`
+- `fledge lanes run ci`
+- `fledge lanes run repo`
+- `specsync check --strict --require-coverage 100 --force`
+- `augur check --staged`
+
+## Local Results
+
+- Classifier fixture matrix: passed.
+- `actionlint .github/workflows/ci.yml`: passed.
+- `shellcheck .github/scripts/*.sh`: passed.
+- Ruby YAML parse: passed.
+- `fledge lanes run check`: passed with 1,529 unit and 188 integration tests.
+- `fledge lanes run ci`: passed.
+- `fledge lanes run repo`: passed.
+- Strict SpecSync validation: 62/62 specs, zero warnings, 100% file and LOC coverage.
+- Current workflow and script diff classifies as `full=true`.
+- `augur check --staged`: REVIEW, risk 38/100, confidence 62/100; no block verdict.

--- a/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/verification.json
+++ b/.specsync/changes/CHG-0014-route-archive-only-lifecycle-moves-through-a-minimal-specsync-ci-gate-while-pres/verification.json
@@ -1,0 +1,15 @@
+{
+  "timestamp": 1783809448,
+  "commit": "58cc99e6c4d585426a3a355843fd672e0f1cd220",
+  "contract_digest": "b9852ca8d1f6b800d603f3b634f42e6e2f6dc0cde153953abbf238bd190f8ba2",
+  "workspace_digest": "62b873106b8dea1c2634b4b6940c087060f760b78fee4d156c94303d7b015b3a",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": []
+}


### PR DESCRIPTION
## Summary
- classify changed paths before selecting CI jobs
- run only SpecSync validation for true lifecycle archive moves
- keep full CI for source, dependency, workflow, Action, and release inputs
- run targeted site or VS Code checks for those isolated products
- add a stable aggregate required gate and path-aware main attestation

## Safety
Archive-only classification requires immutable archive paths and rejects any active-workspace path that still exists. Unknown paths fail safe to full CI. This workflow-changing PR intentionally selects the complete CI matrix.

## Test Plan
- [x] classifier fixture matrix
- [x] actionlint
- [x] shellcheck
- [x] YAML parse
- [x] fledge lanes: check, ci, repo
- [x] 1,529 unit tests and 188 integration tests
- [x] strict SpecSync: 62/62, zero warnings, 100% coverage
- [x] Augur REVIEW, risk 39/100, no block

Human review is required before merge because this changes CI selection and attestation orchestration. Default-setup CodeQL is managed in GitHub settings and may still appear independently.