### PR TITLE
Fix Rust 1.95 C++ AST Clippy failure

### DIFF
--- a/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/approvals.json
+++ b/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/approvals.json
@@ -1,0 +1,18 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "user:0xLeif",
+      "timestamp": 1783975663,
+      "digest": "21d4841e79fa217927e52b0a3a77a7d3c12f6fcf8c37f7efd6a259237c76ab39",
+      "note": "Approved mechanical Rust 1.95 lint compatibility correction"
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1783975839,
+      "digest": "59ed97f770fb0883cf1cf0a35e881948af1f10c7b383cf696397208b88d549f5",
+      "note": "Closing approval after Rust 1.95 Clippy, full tests, strict SDD, and Trust verification passed"
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/change.md
+++ b/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy
+state: accepted
+type: refactor
+base_commit: 60bd655c2365addc3d7a37e95f5fc20c06a746ff
+---
+
+# Preserve C++ AST behavior under Rust 1.95 Clippy
+
+## Intent
+
+Preserve C++ AST behavior under Rust 1.95 Clippy
+
+## Affected Canonical Specs
+
+- None
+
+## Acceptance Criteria
+
+- Rust 1.95 Clippy passes with warnings denied; C++ AST unit tests remain green; the diff changes only match syntax and lifecycle evidence; no exported symbols or runtime behavior change
+
+## No-spec Rationale
+
+This mechanically collapses a match guard required by Rust 1.95 Clippy without changing C++ AST traversal, exports, or any public contract.

--- a/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/context.md
+++ b/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/context.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy
+artifact: context
+---
+
+# Context
+
+Rust 1.95 adds a `collapsible_match` Clippy diagnostic for the existing `friend_declaration` arm in the C++ AST walker. With warnings denied, current `main` cannot pass its native lint lane.
+
+The suggested match guard is semantically identical to the nested `if`: public friend declarations recurse into their child declaration, while non-public friend declarations fall through without traversal. No parser contract, exported symbol, or supported language behavior changes.

--- a/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/plan.md
+++ b/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/plan.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy
+artifact: plan
+---
+
+# Plan
+
+1. Move the existing public-visibility condition onto the `friend_declaration` match arm.
+2. Leave the traversal call and all other branches unchanged.
+3. Run formatting, Clippy with warnings denied, focused C++ AST tests, the full Rust suite, strict SpecSync validation, and Trust verification.
+4. Review the final diff to confirm it contains only the mechanical syntax correction and lifecycle evidence.

--- a/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/state.json
+++ b/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/state.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy",
+  "slug": "preserve-c-ast-behavior-under-rust-1-95-clippy",
+  "title": "Preserve C++ AST behavior under Rust 1.95 Clippy",
+  "description": "Preserve C++ AST behavior under Rust 1.95 Clippy",
+  "kind": "refactor",
+  "state": "accepted",
+  "base_commit": "60bd655c2365addc3d7a37e95f5fc20c06a746ff",
+  "created_at": 1783975629,
+  "updated_at": 1783975839,
+  "affected_specs": [],
+  "affected_paths": [
+    "src/exports/ast/cpp.rs"
+  ],
+  "no_spec_change": true,
+  "no_spec_change_rationale": "This mechanically collapses a match guard required by Rust 1.95 Clippy without changing C++ AST traversal, exports, or any public contract.",
+  "acceptance_criteria": [
+    "Rust 1.95 Clippy passes with warnings denied; C++ AST unit tests remain green; the diff changes only match syntax and lifecycle evidence; no exported symbols or runtime behavior change"
+  ],
+  "selected_artifacts": [
+    "context",
+    "plan",
+    "testing"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/testing.md
+++ b/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/testing.md
@@ -1,0 +1,17 @@
+---
+change: CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy
+artifact: testing
+---
+
+# Testing
+
+## Behavioral Evidence
+
+- `fledge run lint` passes on Rust 1.95 with `-D warnings`.
+- Focused C++ AST tests preserve public friend extraction and non-public member exclusion.
+- The complete Rust test suite remains green.
+- Strict SpecSync and Trust gates pass with the approved no-spec-change rationale.
+
+## Diff Audit
+
+The implementation diff must only move `vis == Visibility::Public` from the nested `if` to the existing match guard and remove the now-redundant block. There must be no changed traversal call, symbol extraction, fixtures, canonical specs, or public documentation.

--- a/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/verification.json
+++ b/.specsync/changes/CHG-0016-preserve-c-ast-behavior-under-rust-1-95-clippy/verification.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": 1783975787,
+  "commit": "60bd655c2365addc3d7a37e95f5fc20c06a746ff",
+  "contract_digest": "21d4841e79fa217927e52b0a3a77a7d3c12f6fcf8c37f7efd6a259237c76ab39",
+  "workspace_digest": "963b55d8d77e4f798268aba16128d320454d73a070faab8753b46de26c55a1d2",
+  "acceptance_input_digest": "328c8f02f7fdaf063173b030f8a193beb9d9005db81632c40aa72fc5938c2d24",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": []
+}

--- a/src/exports/ast/cpp.rs
+++ b/src/exports/ast/cpp.rs
@@ -139,16 +139,14 @@ fn walk_field_list(node: &Node, src: &[u8], mut vis: Visibility, symbols: &mut V
                 // if a future grammar version ever does.
                 handle_node(&child, src, symbols);
             }
-            "friend_declaration" => {
+            "friend_declaration" if vis == Visibility::Public => {
                 // `friend std::ostream& operator<<(...);` wraps an inner
                 // `declaration` node (the friended function's prototype) as
                 // its only named child. Route it through the normal
                 // `declaration` handling (which itself checks `static` and
                 // extracts the function name) — gated on the current
                 // section's visibility like any other member declaration.
-                if vis == Visibility::Public {
-                    walk(&child, src, symbols);
-                }
+                walk(&child, src, symbols);
             }
             "alias_declaration"
                 // `using Pixel = std::uint32_t;` inside a class body is a


### PR DESCRIPTION
## Summary
- move the existing public-visibility condition onto the C++ friend-declaration match guard
- preserve the same traversal behavior and exported-symbol contract
- record an accepted no-spec-change lifecycle with portable approvals

## Test Plan
- [x] Rust 1.95 Clippy passes with warnings denied
- [x] 1,529 unit tests pass
- [x] 188 integration tests pass
- [x] strict SpecSync passes at 105/105 files and 100% LOC coverage
- [x] fledge trust doctor and fledge trust verify pass

This is a mechanical syntax correction only; it does not change C++ AST behavior or public interfaces.