### PR TITLE
Refactor C++ friend extraction for Rust 1.95 Clippy

### DIFF
--- a/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/approvals.json
+++ b/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/approvals.json
@@ -1,0 +1,18 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "user:0xLeif",
+      "timestamp": 1783976167,
+      "digest": "4485ed748e5122c78270aa4a45f2213e577f616a23b51b8413de58b291db1d3c",
+      "note": "Approved as a non-semantic Rust 1.95 lint compatibility refactor."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1783976186,
+      "digest": "57417ffe1c3011c9bf40f2ed7cd091573a6c4500216ee52d4993bbe75cf8adf7",
+      "note": "Accepted after Rust 1.95 Clippy, formatting, all 1,717 Rust tests, and the 12 focused C++ extractor tests passed without behavior changes."
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/change.md
+++ b/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy
+state: accepted
+type: refactor
+base_commit: 60bd655c2365addc3d7a37e95f5fc20c06a746ff
+---
+
+# Keep C++ friend extraction compatible with Rust 1.95 Clippy
+
+## Intent
+
+Keep C++ friend extraction compatible with Rust 1.95 Clippy
+
+## Affected Canonical Specs
+
+- None
+
+## Acceptance Criteria
+
+- Rust 1.95 Clippy passes with warnings denied; all C++ extractor tests pass unchanged
+
+## No-spec Rationale
+
+The guarded match is equivalent to the prior nested visibility condition and changes no extraction behavior or public contract.

--- a/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/context.md
+++ b/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/context.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy
+artifact: context
+---
+
+# Context
+
+Rust 1.95 added a `collapsible_match` Clippy finding for the C++ extractor's
+public-friend branch. The existing nested condition and a match guard select
+the same nodes. This is a compiler-lint compatibility adjustment, not a parser
+contract or extraction behavior change.

--- a/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/plan.md
+++ b/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/plan.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy
+artifact: plan
+---
+
+# Plan
+
+1. Move the existing public-visibility condition into the match arm guard.
+2. Run formatting and Clippy with warnings denied.
+3. Run the complete focused C++ extractor test module.

--- a/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/state.json
+++ b/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/state.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy",
+  "slug": "keep-c-friend-extraction-compatible-with-rust-1-95-clippy",
+  "title": "Keep C++ friend extraction compatible with Rust 1.95 Clippy",
+  "description": "Keep C++ friend extraction compatible with Rust 1.95 Clippy",
+  "kind": "refactor",
+  "state": "accepted",
+  "base_commit": "60bd655c2365addc3d7a37e95f5fc20c06a746ff",
+  "created_at": 1783976135,
+  "updated_at": 1783976186,
+  "affected_specs": [],
+  "affected_paths": [
+    "src/exports/ast/cpp.rs"
+  ],
+  "no_spec_change": true,
+  "no_spec_change_rationale": "The guarded match is equivalent to the prior nested visibility condition and changes no extraction behavior or public contract.",
+  "acceptance_criteria": [
+    "Rust 1.95 Clippy passes with warnings denied; all C++ extractor tests pass unchanged"
+  ],
+  "selected_artifacts": [
+    "context",
+    "plan",
+    "testing"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/testing.md
+++ b/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/testing.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy
+artifact: testing
+---
+
+# Testing
+
+- `fledge run fmt` passes.
+- `fledge run lint` passes on Rust 1.95 with `-D warnings`.
+- `cargo test exports::cpp::` passes all 12 focused extractor tests.

--- a/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/verification.json
+++ b/.specsync/changes/CHG-0016-keep-c-friend-extraction-compatible-with-rust-1-95-clippy/verification.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": 1783976177,
+  "commit": "60bd655c2365addc3d7a37e95f5fc20c06a746ff",
+  "contract_digest": "4485ed748e5122c78270aa4a45f2213e577f616a23b51b8413de58b291db1d3c",
+  "workspace_digest": "963b55d8d77e4f798268aba16128d320454d73a070faab8753b46de26c55a1d2",
+  "acceptance_input_digest": "328c8f02f7fdaf063173b030f8a193beb9d9005db81632c40aa72fc5938c2d24",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": []
+}

--- a/src/exports/ast/cpp.rs
+++ b/src/exports/ast/cpp.rs
@@ -139,16 +139,14 @@ fn walk_field_list(node: &Node, src: &[u8], mut vis: Visibility, symbols: &mut V
                 // if a future grammar version ever does.
                 handle_node(&child, src, symbols);
             }
-            "friend_declaration" => {
+            "friend_declaration" if vis == Visibility::Public => {
                 // `friend std::ostream& operator<<(...);` wraps an inner
                 // `declaration` node (the friended function's prototype) as
                 // its only named child. Route it through the normal
                 // `declaration` handling (which itself checks `static` and
                 // extracts the function name) — gated on the current
                 // section's visibility like any other member declaration.
-                if vis == Visibility::Public {
-                    walk(&child, src, symbols);
-                }
+                walk(&child, src, symbols);
             }
             "alias_declaration"
                 // `using Pixel = std::uint32_t;` inside a class body is a


### PR DESCRIPTION
## Summary
- move the existing public-visibility condition into the `friend_declaration` match guard
- preserve C++ symbol extraction behavior while satisfying Rust 1.95 `collapsible_match`
- record the non-semantic change through the verified SpecSync lifecycle

## Test Plan
- [x] `fledge run fmt`
- [x] `fledge run lint`
- [x] `cargo test exports::cpp::` (12/12)
- [x] `cargo test` (1,717/1,717)
- [x] `fledge run spec-check` (62 specs, 100% file and LOC coverage)

Closes no product issue; this isolates a new stable-toolchain lint from the companion-scaffold validator change.