### PR TITLE
Fix: preserve free-text arguments in generated agent commands

### DIFF
--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/approvals.json
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/approvals.json
@@ -1,0 +1,63 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "user:0xLeif",
+      "timestamp": 1783979483,
+      "digest": "0665b5c26a8322a1b34dbbfa27088e84b5d3e7f18031a0c9205bd25c46b204e9",
+      "note": "Approved the corrected full-section semantic delta for issue 356; it preserves every existing invariant and appends the new argument contract."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1783979502,
+      "digest": "eb0f81647ccd4f3784a05127697443dad342a377cc0c1c5cf0a099c87dabd8eb",
+      "note": "Accepted after the complete 1533-unit and 188-integration verification command passed with the corrected full-section semantic delta."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1783979550,
+      "digest": "f974f54d85418f22513eadabdad59796e22db5268d7124e0fe481689ee9fe526",
+      "note": "Reaccepted after the non-semantic trailing-whitespace correction and a fresh full verification pass."
+    }
+  ],
+  "reopenings": [
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0016-preserve-free-text-arguments-in-generated-agent-commands",
+      "actor": "user:0xLeif",
+      "reason": "Remove generated trailing whitespace from the canonical requirements companion before publication; semantic content is unchanged.",
+      "timestamp": 1783979529,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "user:0xLeif",
+        "timestamp": 1783979502,
+        "digest": "eb0f81647ccd4f3784a05127697443dad342a377cc0c1c5cf0a099c87dabd8eb",
+        "note": "Accepted after the complete 1533-unit and 188-integration verification command passed with the corrected full-section semantic delta."
+      },
+      "prior_verification": {
+        "timestamp": 1783979498,
+        "commit": "60bd655c2365addc3d7a37e95f5fc20c06a746ff",
+        "contract_digest": "0665b5c26a8322a1b34dbbfa27088e84b5d3e7f18031a0c9205bd25c46b204e9",
+        "workspace_digest": "d6da157206f9619aeb0bda8679c596d1abb72f56ec96f521f435e7524ab025a4",
+        "acceptance_input_digest": "825606321b643714ed28582ccc3718dfb73e72c929827ab8004657b1756198f1",
+        "passed": true,
+        "commands": [
+          {
+            "command": "cargo test",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-agents-002"
+        ]
+      },
+      "stale_acceptance_input_digest": "825606321b643714ed28582ccc3718dfb73e72c929827ab8004657b1756198f1",
+      "current_acceptance_input_digest": "e7897d14b7ad57ad0041b99b8983f934351e5368da291d7084114f418c7a3823"
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/change.md
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0016-preserve-free-text-arguments-in-generated-agent-commands
+state: accepted
+type: bug_fix
+base_commit: 60bd655c2365addc3d7a37e95f5fc20c06a746ff
+---
+
+# Preserve free-text arguments in generated agent commands
+
+## Intent
+
+Preserve free-text arguments in generated agent commands
+
+## Affected Canonical Specs
+
+- `agents`
+
+## Acceptance Criteria
+
+- Generated create-spec instructions strip supported flags before classifying the complete remaining input; bare identifiers remain unchanged; natural-language descriptions never become first-word module names; Gemini create-change uses its args placeholder and never ARGUMENTS; every integration quotes multi-word interview answers as one argument; installing all four integrations stays deterministic and idempotent; focused and full Rust tests pass
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/context.md
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/context.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0016-preserve-free-text-arguments-in-generated-agent-commands
+artifact: context
+---
+
+# Context
+
+SpecSync 5.0.1 installs deterministic command and skill templates for Claude Code, Cursor, Codex, and Gemini. The
+create-spec prose currently consumes the first token before deciding whether the full input is a module identifier
+or a natural-language description. Gemini's create-change command also inherits Claude/Cursor's
+`$ARGUMENTS` spelling, and interview guidance does not quote multi-word answers. These defects recur in every
+consumer that regenerates integrations, so the installer templates are the correct repair boundary.

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/deltas/agents.md
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/deltas/agents.md
@@ -1,0 +1,31 @@
+# Preserve generated agent arguments
+
+## ADDED
+
+### REQUIREMENT REQ-agents-002
+
+Generated agent integrations SHALL preserve complete user intent across each tool's documented argument syntax.
+
+Acceptance Criteria
+
+- Create-spec guidance removes supported flags before classifying the complete remaining input.
+- A complete single module identifier is preserved unchanged.
+- Quoted or unquoted natural-language descriptions are classified before a kebab-case module name is derived.
+- Gemini create-change guidance uses `{{args}}` and contains no `$ARGUMENTS` reference.
+- Every generated skill and create-change command quotes a free-text interview answer as one positional argument.
+- Reinstalling all four integrations remains deterministic and idempotent.
+
+## MODIFIED
+
+### SPEC SECTION Invariants
+
+1. Each `AgentTool` owns an SDD skill and, where supported, both `create-spec` and `create-change` commands — Codex has the project skill only because its command mechanism is deprecated/global.
+2. Installation is idempotent per-artifact and content-aware — `install_agent` writes an artifact when it's missing *or* when its existing content differs from the current template (so upgrading spec-sync refreshes stale installations), and returns `Ok(false)` only when every artifact already matches the current template exactly.
+3. Every artifact spec-sync writes lives inside a `spec-sync/`-named skill folder or a `specsync`-namespaced command file/directory that spec-sync fully owns — no marker-string surgery on shared files is needed (unlike `hooks.rs`).
+4. `uninstall_agent` removes the skill directory wholesale (`remove_dir_all`) and the command file, then removes the command file's immediate parent directory only if that parent is named `specsync` and is now empty — it never removes a tool's shared `commands/` directory (e.g. `.claude/commands/`, `.cursor/commands/`), which may hold unrelated user commands.
+5. Cursor's command file is flat (`.cursor/commands/specsync-create-spec.md`, no namespaced subdirectory, no YAML frontmatter) since Cursor's command mechanism doesn't support either.
+6. Claude and Gemini's commands live in a namespaced subdirectory (`.claude/commands/specsync/create-spec.md`, `.gemini/commands/specsync/create-spec.toml`) so they're invoked as `/specsync:create-spec`.
+7. Gemini's command file is TOML (`description`/`prompt` keys, `{{args}}` placeholder), hand-built as a string template since no `toml` crate dependency exists in this project.
+8. Empty targets list means "all tools", matching the `hooks` module's convention.
+9. `cmd_install` exits with code 1 if any tool installation fails.
+10. Generated create-spec and create-change assets preserve complete arguments using each tool's native placeholder and quote free-text interview answers as one CLI argument.

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/docs.md
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/docs.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0016-preserve-free-text-arguments-in-generated-agent-commands
+artifact: docs
+---
+
+# Docs
+
+The generated create-spec instructions explicitly describe two input modes after `--minimal` is removed: a complete
+single module identifier or a complete natural-language description. The generated create-change instructions use
+the native argument placeholder for each tool and show quoted interview answers. No new command or flag is added.

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/requirements.md
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/requirements.md
@@ -1,0 +1,19 @@
+---
+change: CHG-0016-preserve-free-text-arguments-in-generated-agent-commands
+artifact: requirements
+---
+
+# Requirements
+
+### REQ-agents-002
+
+Generated agent integrations SHALL preserve complete user intent across each tool's documented argument syntax.
+
+Acceptance Criteria
+
+- Create-spec guidance removes supported flags before classifying the complete remaining input.
+- A complete single module identifier is preserved unchanged.
+- Quoted or unquoted natural-language descriptions are classified before a kebab-case module name is derived.
+- Gemini create-change guidance uses `{{args}}` and contains no `$ARGUMENTS` reference.
+- Every generated skill and create-change command quotes a free-text interview answer as one positional argument.
+- Reinstalling all four integrations remains deterministic and idempotent.

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/state.json
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/state.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0016-preserve-free-text-arguments-in-generated-agent-commands",
+  "slug": "preserve-free-text-arguments-in-generated-agent-commands",
+  "title": "Preserve free-text arguments in generated agent commands",
+  "description": "Preserve free-text arguments in generated agent commands",
+  "kind": "bug_fix",
+  "state": "accepted",
+  "canonical_applied": true,
+  "base_commit": "60bd655c2365addc3d7a37e95f5fc20c06a746ff",
+  "created_at": 1783979430,
+  "updated_at": 1783979550,
+  "affected_specs": [
+    "agents"
+  ],
+  "affected_paths": [
+    "src/agents.rs",
+    "specs/agents"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Generated create-spec instructions strip supported flags before classifying the complete remaining input; bare identifiers remain unchanged; natural-language descriptions never become first-word module names; Gemini create-change uses its args placeholder and never ARGUMENTS; every integration quotes multi-word interview answers as one argument; installing all four integrations stays deterministic and idempotent; focused and full Rust tests pass"
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "requirements",
+    "docs"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/tasks.md
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/tasks.md
@@ -1,0 +1,13 @@
+---
+change: CHG-0016-preserve-free-text-arguments-in-generated-agent-commands
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Rewrite shared create-spec prose to classify the complete remaining input after flag removal.
+- [x] Render Gemini create-change with `{{args}}` instead of `$ARGUMENTS`.
+- [x] Quote interview answers in every generated skill and command template.
+- [x] Add regression tests for bare identifiers, natural-language descriptions, Gemini args, and quoted answers.
+- [x] Update the stable agents contract and testing companion.
+- [x] Prepare focused and full repository verification commands and expected evidence.

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/testing.md
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/testing.md
@@ -1,0 +1,20 @@
+---
+change: CHG-0016-preserve-free-text-arguments-in-generated-agent-commands
+artifact: testing
+---
+
+# Testing
+
+- Run `cargo test agents::` for template generation and install/idempotency coverage.
+- Assert Claude, Cursor, and Gemini create-spec assets classify the complete input only after removing flags.
+- Assert Gemini create-change contains `{{args}}` and no `$ARGUMENTS`.
+- Assert all four skills and all three command assets quote `"<answer>"`.
+- Reinstall all integrations twice and confirm the second install is a no-op.
+- Run the full Fledge verification lane and strict SpecSync coverage.
+
+## Requirement Evidence
+
+- `REQ-agents-002`: `create_spec_commands_classify_the_complete_remaining_input`,
+  `gemini_create_change_uses_native_args_and_quotes_answers`,
+  `every_generated_lifecycle_surface_quotes_free_text_answers`, and
+  `reinstall_keeps_all_generated_artifacts_byte_identical`.

--- a/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/verification.json
+++ b/.specsync/changes/CHG-0016-preserve-free-text-arguments-in-generated-agent-commands/verification.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": 1783979543,
+  "commit": "60bd655c2365addc3d7a37e95f5fc20c06a746ff",
+  "contract_digest": "0665b5c26a8322a1b34dbbfa27088e84b5d3e7f18031a0c9205bd25c46b204e9",
+  "workspace_digest": "d4f972d7077d3a115e90f3296f5dc2ae717b3af4e7d6cbd7757f318c8138d494",
+  "acceptance_input_digest": "e7897d14b7ad57ad0041b99b8983f934351e5368da291d7084114f418c7a3823",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-agents-002"
+  ]
+}

--- a/specs/agents/agents.spec.md
+++ b/specs/agents/agents.spec.md
@@ -1,6 +1,6 @@
 ---
 module: agents
-version: 4
+version: 5
 status: stable
 files:
   - src/agents.rs
@@ -53,6 +53,7 @@ Installs native, tool-owned verified-SDD skills for Claude Code, Cursor, Codex, 
 7. Gemini's command file is TOML (`description`/`prompt` keys, `{{args}}` placeholder), hand-built as a string template since no `toml` crate dependency exists in this project.
 8. Empty targets list means "all tools", matching the `hooks` module's convention.
 9. `cmd_install` exits with code 1 if any tool installation fails.
+10. Generated create-spec and create-change assets preserve complete arguments using each tool's native placeholder and quote free-text interview answers as one CLI argument.
 
 ## Behavioral Examples
 
@@ -115,3 +116,4 @@ Installs native, tool-owned verified-SDD skills for Claude Code, Cursor, Codex, 
 | 2026-07-01 | claude | v2: `install_agent` overwrites artifacts whose existing content differs from the current template (content-aware upgrade), instead of only writing missing files |
 | 2026-07-01 | claude | Initial spec — native skill/command installation for Claude Code, Cursor, Codex, Gemini CLI |
 | 2026-07-11 | CHG-0003-finalize-specsync-5-0-release-consistency-and-parallel-validation: Finalize SpecSync 5.0 release consistency and parallel validation |
+| 2026-07-13 | CHG-0016-preserve-free-text-arguments-in-generated-agent-commands: Preserve free-text arguments in generated agent commands |

--- a/specs/agents/requirements.md
+++ b/specs/agents/requirements.md
@@ -43,3 +43,16 @@ The system SHALL keep installed native agent artifacts and their canonical docum
 Acceptance Criteria
 - Claude, Cursor, and Gemini receive create-spec and create-change commands.
 - Codex receives the project-scoped lifecycle skill without a deprecated command file.
+
+### REQ-agents-002
+
+Generated agent integrations SHALL preserve complete user intent across each tool's documented argument syntax.
+
+Acceptance Criteria
+
+- Create-spec guidance removes supported flags before classifying the complete remaining input.
+- A complete single module identifier is preserved unchanged.
+- Quoted or unquoted natural-language descriptions are classified before a kebab-case module name is derived.
+- Gemini create-change guidance uses `{{args}}` and contains no `$ARGUMENTS` reference.
+- Every generated skill and create-change command quotes a free-text interview answer as one positional argument.
+- Reinstalling all four integrations remains deterministic and idempotent.

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -17,7 +17,7 @@ const SKILL_BODY: &str = r#"## Companion files
 For every meaningful source, test, public documentation, schema, or configuration change:
 
 1. Run `specsync change new "<intent>" --json` and conduct the returned interview with the user.
-2. Use `specsync change answer <id> <question-id> <answer> --json` until no questions remain.
+2. Use `specsync change answer <id> <question-id> "<answer>" --json` until no questions remain.
 3. Complete the adaptively selected artifacts and semantic deltas. Requirements use stable
    `REQ-<module>-<number>` IDs, a normative SHALL statement, and acceptance criteria.
 4. Ask the user for the definition approval, then run `specsync change approve <id>`.
@@ -80,18 +80,20 @@ the description to draft the spec's Purpose and Requirements.
 
 // ─── Create-spec command body (shared prose, per-tool argument syntax) ───────
 
-const CREATE_SPEC_STEPS_MD: &str = r#"1. Parse the arguments above: the first whitespace-separated token is the
-   module name. If the arguments also contain `--minimal` (in any position),
-   remove it and remember that minimal mode was requested.
-2. Look at whatever text remains. It will be one of:
-   - **A bare module name** — a short identifier like `auth-service` or
-     `billing`. Use it as-is.
-   - **A free-text feature description** — a sentence or phrase describing
-     what to build, e.g. `"I want a feature that lets users export their
-     data as CSV"`. In this case, invent a short, kebab-case module name that
-     captures the idea (e.g. `csv-export`). If the right name is ambiguous,
-     ask the user to confirm or rename it before continuing. Keep the full
-     description at hand — you'll use it in step 5.
+const CREATE_SPEC_STEPS_MD: &str = r#"1. Read the complete arguments above. Remove each standalone `--minimal` flag
+   (in any position) and remember that minimal mode was requested. Preserve
+   the complete remaining input for classification; do not extract a module
+   name yet. If nothing remains, ask the user for a module or description.
+2. Classify the complete remaining input as one of:
+   - **A bare module name** — the entire input is one identifier with no
+     whitespace, such as `auth-service` or `billing`. Use it as-is.
+   - **A free-text feature description** — any quoted or unquoted sentence or
+     phrase describing what to build, e.g. `"I want a feature that lets users
+     export their data as CSV"`. Only after making this classification, invent
+     a short, kebab-case module name that captures the idea (e.g. `csv-export`).
+     Never use only the first word as the module name. If the right name is
+     ambiguous, ask the user to confirm or rename it before continuing. Keep
+     the complete description at hand — you'll use it in step 5.
 3. If minimal mode was requested, run:
    ```
    specsync new <module-name>
@@ -112,18 +114,20 @@ const CREATE_SPEC_STEPS_MD: &str = r#"1. Parse the arguments above: the first wh
    (acceptance criteria) and `tasks.md` (initial task breakdown), if present.
 6. Run `specsync check` to confirm the new spec passes validation."#;
 
-const CREATE_SPEC_STEPS_TOML: &str = r#"1. Parse the arguments above: the first whitespace-separated token is the
-   module name. If the arguments also contain --minimal (in any position),
-   remove it and remember that minimal mode was requested.
-2. Look at whatever text remains. It will be one of:
-   - A bare module name - a short identifier like auth-service or billing.
-     Use it as-is.
-   - A free-text feature description - a sentence or phrase describing what
-     to build, e.g. "I want a feature that lets users export their data as
-     CSV". In this case, invent a short, kebab-case module name that captures
-     the idea (e.g. csv-export). If the right name is ambiguous, ask the user
-     to confirm or rename it before continuing. Keep the full description at
-     hand - you'll use it in step 5.
+const CREATE_SPEC_STEPS_TOML: &str = r#"1. Read the complete arguments above. Remove each standalone --minimal flag
+   (in any position) and remember that minimal mode was requested. Preserve
+   the complete remaining input for classification; do not extract a module
+   name yet. If nothing remains, ask the user for a module or description.
+2. Classify the complete remaining input as one of:
+   - A bare module name - the entire input is one identifier with no
+     whitespace, such as auth-service or billing. Use it as-is.
+   - A free-text feature description - any quoted or unquoted sentence or
+     phrase describing what to build, e.g. "I want a feature that lets users
+     export their data as CSV". Only after making this classification, invent
+     a short, kebab-case module name that captures the idea (e.g. csv-export).
+     Never use only the first word as the module name. If the right name is
+     ambiguous, ask the user to confirm or rename it before continuing. Keep
+     the complete description at hand - you'll use it in step 5.
 3. If minimal mode was requested, run:
    specsync new <module-name>
    This creates a minimal spec only (no companion files).
@@ -147,7 +151,7 @@ const CREATE_CHANGE_DESCRIPTION: &str =
 
 const CREATE_CHANGE_STEPS_MD: &str = r#"1. Run `specsync change new "$ARGUMENTS" --json`.
 2. Read the returned `questions` array and interview the user one question at a time.
-3. Record each answer with `specsync change answer <id> <question-id> <answer> --json`.
+3. Record each answer with `specsync change answer <id> <question-id> "<answer>" --json`.
 4. Continue until the question list is empty, then show the selected artifacts and next action.
 5. Do not approve, implement, verify, accept, or archive until the corresponding human gate or work stage is reached."#;
 
@@ -388,15 +392,20 @@ fn create_spec_command_content(tool: AgentTool) -> String {
 }
 
 fn create_change_command_content(tool: AgentTool) -> String {
+    let steps = match tool {
+        AgentTool::Gemini => CREATE_CHANGE_STEPS_MD.replace("$ARGUMENTS", "{{args}}"),
+        _ => CREATE_CHANGE_STEPS_MD.to_string(),
+    };
+
     match tool {
         AgentTool::Claude => format!(
-            "---\ndescription: {CREATE_CHANGE_DESCRIPTION}\nargument-hint: <change-description>\n---\n\n{CREATE_CHANGE_STEPS_MD}\n"
+            "---\ndescription: {CREATE_CHANGE_DESCRIPTION}\nargument-hint: <change-description>\n---\n\n{steps}\n"
         ),
-        AgentTool::Cursor => format!(
-            "Create a verified spec-sync SDD change.\n\nArguments: $ARGUMENTS\n\n{CREATE_CHANGE_STEPS_MD}\n"
-        ),
+        AgentTool::Cursor => {
+            format!("Create a verified spec-sync SDD change.\n\nArguments: $ARGUMENTS\n\n{steps}\n")
+        }
         AgentTool::Gemini => format!(
-            "description = \"{CREATE_CHANGE_DESCRIPTION}\"\n\nprompt = \"\"\"\nArguments: {{{{args}}}}\n\n{CREATE_CHANGE_STEPS_MD}\n\"\"\"\n"
+            "description = \"{CREATE_CHANGE_DESCRIPTION}\"\n\nprompt = \"\"\"\nArguments: {{{{args}}}}\n\n{steps}\n\"\"\"\n"
         ),
         AgentTool::Codex => unreachable!("Codex has no command file"),
     }
@@ -728,6 +737,77 @@ mod tests {
         assert_eq!(content.matches("\"\"\"").count(), 2);
 
         assert!(is_installed(tmp.path(), AgentTool::Gemini));
+    }
+
+    #[test]
+    fn create_spec_commands_classify_the_complete_remaining_input() {
+        let tmp = setup();
+
+        for tool in [AgentTool::Claude, AgentTool::Cursor, AgentTool::Gemini] {
+            install_agent(tmp.path(), tool).unwrap();
+            let path = tool.command_path(tmp.path()).unwrap();
+            let content = fs::read_to_string(path).unwrap();
+
+            assert!(content.contains("Remove each standalone"));
+            assert!(content.contains("the complete remaining input for classification"));
+            assert!(content.contains("the entire input is one identifier with no"));
+            assert!(content.contains("any quoted or unquoted sentence or"));
+            assert!(content.contains("Never use only the first word as the module name"));
+            assert!(!content.contains("first whitespace-separated token"));
+        }
+    }
+
+    #[test]
+    fn gemini_create_change_uses_native_args_and_quotes_answers() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Gemini).unwrap();
+
+        let path = AgentTool::Gemini.change_command_path(tmp.path()).unwrap();
+        let content = fs::read_to_string(path).unwrap();
+
+        assert!(content.contains("specsync change new \"{{args}}\" --json"));
+        assert!(content.contains("<question-id> \"<answer>\" --json"));
+        assert!(!content.contains("$ARGUMENTS"));
+    }
+
+    #[test]
+    fn every_generated_lifecycle_surface_quotes_free_text_answers() {
+        let tmp = setup();
+
+        for tool in AgentTool::all() {
+            install_agent(tmp.path(), *tool).unwrap();
+            let skill =
+                fs::read_to_string(tool.skill_dir(tmp.path()).unwrap().join("SKILL.md")).unwrap();
+            assert!(skill.contains("<question-id> \"<answer>\" --json"));
+
+            if let Some(path) = tool.change_command_path(tmp.path()) {
+                let command = fs::read_to_string(path).unwrap();
+                assert!(command.contains("<question-id> \"<answer>\" --json"));
+            }
+        }
+    }
+
+    #[test]
+    fn reinstall_keeps_all_generated_artifacts_byte_identical() {
+        let tmp = setup();
+
+        for tool in AgentTool::all() {
+            assert!(install_agent(tmp.path(), *tool).unwrap());
+            let mut paths = vec![tool.skill_dir(tmp.path()).unwrap().join("SKILL.md")];
+            paths.extend(tool.command_path(tmp.path()));
+            paths.extend(tool.change_command_path(tmp.path()));
+            let before = paths
+                .iter()
+                .map(|path| fs::read(path).unwrap())
+                .collect::<Vec<_>>();
+
+            assert!(!install_agent(tmp.path(), *tool).unwrap());
+            let after = paths
+                .iter()
+                .map(|path| fs::read(path).unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(before, after);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify the complete create-spec input only after removing supported flags
- render Gemini create-change with its native `{{args}}` placeholder
- quote free-text interview answers across all generated integrations
- add deterministic, idempotent regression coverage and the corresponding agents contract

Closes #356.

## Test Plan
- [x] `cargo test agents::` (29 passed)
- [x] `cargo test` (1533 unit and 188 integration tests passed)
- [x] `cargo build --release`
- [x] `cargo fmt --check`
- [x] strict SpecSync validation at 100% file and LOC coverage
- [ ] hosted CI and Trust checks pass