### PR TITLE
Fix incomplete accepted lifecycle evidence

### DIFF
--- a/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/approvals.json
+++ b/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/approvals.json
@@ -62,6 +62,13 @@
       "timestamp": 1784040933,
       "digest": "651eec1bcd12e8e0fec49bf9011f381137580bf3ac01e229a60d6ef5d4d783de",
       "note": "Fresh closing approval after PR 370 review corrections and complete native verification; prior approval history preserved."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784047856,
+      "digest": "2e7ba97eb45befa6a381c48d245e4af5ba4ccb3507fafc5f3068a28f633a0b1a",
+      "note": "Closing approval after exact-main native verification repaired the incomplete pre-squash transition without changing the accepted definition or product code."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/change.md
+++ b/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2
-state: verifying
+state: accepted
 type: feature
 base_commit: 21e44ecf33f4fe876820ef3ef8f19553341da15a
 ---

--- a/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/state.json
+++ b/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/state.json
@@ -5,11 +5,11 @@
   "title": "Stabilize SpecSync 5 lifecycle integrity and strict validation for 5.0.2",
   "description": "Stabilize SpecSync 5 lifecycle integrity and strict validation for 5.0.2",
   "kind": "feature",
-  "state": "verifying",
+  "state": "accepted",
   "canonical_applied": true,
   "base_commit": "21e44ecf33f4fe876820ef3ef8f19553341da15a",
   "created_at": 1783985502,
-  "updated_at": 1784046677,
+  "updated_at": 1784047856,
   "affected_specs": [
     "change",
     "validator"

--- a/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/verification-attempts.json
+++ b/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/verification-attempts.json
@@ -198,6 +198,28 @@
         "REQ-validator-002",
         "REQ-validator-003"
       ]
+    },
+    {
+      "timestamp": 1784047844,
+      "commit": "eeebe807adb258a93a2c896af2d70a46859fe899",
+      "contract_digest": "0eafdd5f8e512023308e22ca1ec4179a903072d7b5a0f8729f0d09fcc1d434e4",
+      "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-022",
+        "REQ-change-023",
+        "REQ-change-024",
+        "REQ-change-025",
+        "REQ-validator-002",
+        "REQ-validator-003"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/verification.json
+++ b/.specsync/changes/CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2/verification.json
@@ -1,8 +1,9 @@
 {
-  "timestamp": 1784046677,
-  "commit": "dc91f80d180460f65e7c57cdb0c4598f34124a8e",
+  "timestamp": 1784047844,
+  "commit": "eeebe807adb258a93a2c896af2d70a46859fe899",
   "contract_digest": "0eafdd5f8e512023308e22ca1ec4179a903072d7b5a0f8729f0d09fcc1d434e4",
   "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
+  "acceptance_input_digest": "ff59600ae6769b55c911eb38efa9f8d3378ec6f56bf410d7270db9e1d043d3a6",
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/approvals.json
+++ b/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/approvals.json
@@ -62,6 +62,13 @@
       "timestamp": 1784041001,
       "digest": "6b4f4bd5077197895a7bd1ec21310c6183fd54c33ce7cf31c0f13cd9ba0cf74d",
       "note": "Fresh closing approval after PR 370 review corrections and complete native verification; prior approval history preserved."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784047883,
+      "digest": "7810d4e3ad8f5fe20bcf8ae48be9891346d35370258d7ac04940236ce911320f",
+      "note": "Closing approval after exact-main native verification repaired the incomplete pre-squash transition without changing the accepted definition or product code."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/change.md
+++ b/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0025-address-all-unresolved-review-feedback-on-pr-366
-state: verifying
+state: accepted
 type: feature
 base_commit: f2a9d2cafdaff23c904a1fd73e5c8ac21f89ca89
 ---

--- a/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/state.json
+++ b/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/state.json
@@ -5,11 +5,11 @@
   "title": "Address all unresolved review feedback on PR 366",
   "description": "Address all unresolved review feedback on PR 366",
   "kind": "feature",
-  "state": "verifying",
+  "state": "accepted",
   "canonical_applied": true,
   "base_commit": "f2a9d2cafdaff23c904a1fd73e5c8ac21f89ca89",
   "created_at": 1783991918,
-  "updated_at": 1784046693,
+  "updated_at": 1784047883,
   "affected_specs": [
     "change",
     "validator",

--- a/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/verification-attempts.json
+++ b/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/verification-attempts.json
@@ -176,6 +176,28 @@
         "REQ-config-002",
         "REQ-validator-004"
       ]
+    },
+    {
+      "timestamp": 1784047874,
+      "commit": "eeebe807adb258a93a2c896af2d70a46859fe899",
+      "contract_digest": "ee5819f2f1397f1a05d72e9ee6ac5344a78609159f42c21e7d5dbf95f643c32e",
+      "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-026",
+        "REQ-change-027",
+        "REQ-change-028",
+        "REQ-cli-003",
+        "REQ-config-002",
+        "REQ-validator-004"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/verification.json
+++ b/.specsync/changes/CHG-0025-address-all-unresolved-review-feedback-on-pr-366/verification.json
@@ -1,8 +1,9 @@
 {
-  "timestamp": 1784046693,
-  "commit": "dc91f80d180460f65e7c57cdb0c4598f34124a8e",
+  "timestamp": 1784047874,
+  "commit": "eeebe807adb258a93a2c896af2d70a46859fe899",
   "contract_digest": "ee5819f2f1397f1a05d72e9ee6ac5344a78609159f42c21e7d5dbf95f643c32e",
   "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
+  "acceptance_input_digest": "1d116c4a7d33bd54fa2eff462c1ea80aa142e08378a6a42f8f4ed337b31e263d",
   "passed": true,
   "commands": [
     {


### PR DESCRIPTION
## Summary

- complete the supported closing transition for CHG-0024 and CHG-0025
- replace their pre-squash verifying evidence with full native verification from exact main commit `eeebe807`
- record authorized closing approvals as `user:0xLeif`
- change lifecycle evidence only; no product code, canonical spec, workflow, or dependency changes

## Root cause

PR #370 refreshed CHG-0024 and CHG-0025 but left both records in `verifying`. Pull-request CI accepted their verification commit because it was an ancestor of the PR head. Squash merge made that commit off-history, so exact main correctly rejected both still-verifying records as stale.

Accepted records use SpecSync's supported squash-safe path: after merge, their canonical accepted state is recorded on the remote default branch and closing evidence remains valid even when the original verification commit is not an ancestor.

## Test Plan

- [x] full native verification for CHG-0024: 1,570 unit tests and 193 integration tests
- [x] full native verification for CHG-0025: 1,570 unit tests and 193 integration tests
- [x] `fledge lanes run verify`
- [x] strict SpecSync validation: 62/62 specs, zero warnings, 105/105 files and 72,568/72,568 LOC covered
- [x] no TODO, placeholder, fake-data, whitespace, product-code, or canonical-spec changes introduced
- [x] exact-head hosted CI and Trust checks
- [ ] exact post-merge main CI and Trust checks
