### PR TITLE
chore(lifecycle): record audited CHG-0033 acceptance

### DIFF
--- a/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/approvals.json
+++ b/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/approvals.json
@@ -23,10 +23,10 @@
     },
     {
       "gate": "acceptance",
-      "actor": "user:0xLeif",
-      "timestamp": 1784046659,
-      "digest": "456ce14e2cddaa1d03b6620e7192e096a00299b2446d819f33fbabe402ebcd41",
-      "note": "Refreshed closing approval after the authorized CHG-0033 contract update and successful full native verification."
+      "actor": "0xLeif",
+      "timestamp": 1784048151,
+      "digest": "70defd5e27902a484ba844d7543efbab8997a91fabbf981861c7502952c515e6",
+      "note": "Explicit reacceptance after verified CHG-0033 legitimately updated the accepted src/change.rs input."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/state.json
+++ b/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "a6706a5611b56d5998de59585386b6cec40b095e",
   "created_at": 1783996092,
-  "updated_at": 1784046659,
+  "updated_at": 1784048151,
   "affected_specs": [
     "change"
   ],

--- a/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/verification-attempts.json
+++ b/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/verification-attempts.json
@@ -60,6 +60,36 @@
         }
       ],
       "requirement_ids": []
+    },
+    {
+      "timestamp": 1784047029,
+      "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
+      "contract_digest": "6bad5c5e13b21176ad7f95d5302613b35c05de0d488adad558697c71eda79b8f",
+      "workspace_digest": "19294385ffacee20e34e84d76ced84cabee0323407e46a723bababcd1defb3bd",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
+    },
+    {
+      "timestamp": 1784048145,
+      "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
+      "contract_digest": "6bad5c5e13b21176ad7f95d5302613b35c05de0d488adad558697c71eda79b8f",
+      "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
     }
   ]
 }

--- a/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/verification.json
+++ b/.specsync/changes/CHG-0026-keep-lifecycle-recursion-detection-private-while-preserving-deterministic-nested/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1784046649,
-  "commit": "dc91f80d180460f65e7c57cdb0c4598f34124a8e",
+  "timestamp": 1784048145,
+  "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
   "contract_digest": "6bad5c5e13b21176ad7f95d5302613b35c05de0d488adad558697c71eda79b8f",
   "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
   "acceptance_input_digest": "c49e6af07597630fc6a6505da16814b239a17be0ddd50ffe3676c42d2e2ed5d6",

--- a/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/approvals.json
+++ b/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/approvals.json
@@ -30,10 +30,10 @@
     },
     {
       "gate": "acceptance",
-      "actor": "user:0xLeif",
-      "timestamp": 1784046727,
-      "digest": "20ec518fd444a1cf1cfe87a4fa7666c7986f552ef2394a03be38b8a4e64cc6e2",
-      "note": "Refreshed closing approval after the authorized CHG-0033 contract update and successful full native verification."
+      "actor": "0xLeif",
+      "timestamp": 1784048173,
+      "digest": "7078278218b20ad919d67d25210e31a6804c569c57ed7c5771d851430ea77da7",
+      "note": "Explicit reacceptance after verified CHG-0033 legitimately updated the accepted src/change.rs input."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/state.json
+++ b/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "c98d29810f78abcdd6a2fec9b137667d3ab2fc5b",
   "created_at": 1784006715,
-  "updated_at": 1784046727,
+  "updated_at": 1784048173,
   "affected_specs": [
     "change"
   ],

--- a/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/verification-attempts.json
+++ b/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/verification-attempts.json
@@ -85,6 +85,40 @@
       "requirement_ids": [
         "REQ-change-029"
       ]
+    },
+    {
+      "timestamp": 1784047095,
+      "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
+      "contract_digest": "08b11339586c84f4f39e6a800d81e80c11aeaaa4d7d4de8b1bed4fbf15598b45",
+      "workspace_digest": "19294385ffacee20e34e84d76ced84cabee0323407e46a723bababcd1defb3bd",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-029"
+      ]
+    },
+    {
+      "timestamp": 1784048167,
+      "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
+      "contract_digest": "08b11339586c84f4f39e6a800d81e80c11aeaaa4d7d4de8b1bed4fbf15598b45",
+      "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-029"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/verification.json
+++ b/.specsync/changes/CHG-0027-preserve-accepted-evidence-across-valid-later-sequence-claims/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1784046718,
-  "commit": "dc91f80d180460f65e7c57cdb0c4598f34124a8e",
+  "timestamp": 1784048167,
+  "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
   "contract_digest": "08b11339586c84f4f39e6a800d81e80c11aeaaa4d7d4de8b1bed4fbf15598b45",
   "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
   "acceptance_input_digest": "d80276fc82df270db6f8711d33cade227550393bbb1d343df690fae676d6f15a",

--- a/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/approvals.json
+++ b/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/approvals.json
@@ -37,10 +37,10 @@
     },
     {
       "gate": "acceptance",
-      "actor": "user:0xLeif",
-      "timestamp": 1784046753,
-      "digest": "8d79064a56621c9e7568d11a23fccca06ec2eb5e3e00e5e68927dcca28fd914c",
-      "note": "Refreshed closing approval after the authorized CHG-0033 contract update and successful full native verification."
+      "actor": "0xLeif",
+      "timestamp": 1784048197,
+      "digest": "e24af243092aa97508ede5cc81ccc80213a65d801792382874566ed710d6e13d",
+      "note": "Explicit reacceptance after verified CHG-0033 legitimately updated the accepted src/change.rs input."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/state.json
+++ b/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "c98d29810f78abcdd6a2fec9b137667d3ab2fc5b",
   "created_at": 1784006715,
-  "updated_at": 1784046753,
+  "updated_at": 1784048197,
   "affected_specs": [
     "change",
     "cli"

--- a/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/verification-attempts.json
+++ b/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/verification-attempts.json
@@ -126,6 +126,42 @@
         "REQ-change-030",
         "REQ-cli-004"
       ]
+    },
+    {
+      "timestamp": 1784047150,
+      "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
+      "contract_digest": "88a3212c5bfbb57319df6b0355b6c5655766d08b7200690e6ec19da140f3189f",
+      "workspace_digest": "19294385ffacee20e34e84d76ced84cabee0323407e46a723bababcd1defb3bd",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-030",
+        "REQ-cli-004"
+      ]
+    },
+    {
+      "timestamp": 1784048189,
+      "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
+      "contract_digest": "88a3212c5bfbb57319df6b0355b6c5655766d08b7200690e6ec19da140f3189f",
+      "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-030",
+        "REQ-cli-004"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/verification.json
+++ b/.specsync/changes/CHG-0029-address-all-remaining-review-feedback-from-pr-366/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1784046744,
-  "commit": "dc91f80d180460f65e7c57cdb0c4598f34124a8e",
+  "timestamp": 1784048189,
+  "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
   "contract_digest": "88a3212c5bfbb57319df6b0355b6c5655766d08b7200690e6ec19da140f3189f",
   "workspace_digest": "682e22782b3cb7c16b93bd4df94f315eb6f4ff8de745cbeff80610b096e7564f",
   "acceptance_input_digest": "27455b00e79cbd1cfed7526d1234d167c0b05f0376b8d0703f81565651af1f02",

--- a/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/approvals.json
+++ b/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/approvals.json
@@ -23,10 +23,10 @@
     },
     {
       "gate": "acceptance",
-      "actor": "user:0xLeif",
-      "timestamp": 1784046595,
-      "digest": "385806750a95e25ba3c0b4f4d6e9d8f7a6ae39f026d8a170b005600b3a353587",
-      "note": "Closing approval after the full native suite, exact strict coverage audit, public documentation, and canonical requirement updates passed."
+      "actor": "0xLeif",
+      "timestamp": 1784048107,
+      "digest": "74ae82f05bde53e962f48b3bbce89d7f1baf040dbde19c8cd3ecfeaf9693c74e",
+      "note": "Explicit closing approval after fresh verification and Trust; canonical application authorized together with predecessor reacceptance."
     }
   ],
   "reopenings": []

--- a/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/state.json
+++ b/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "dc91f80d180460f65e7c57cdb0c4598f34124a8e",
   "created_at": 1784044464,
-  "updated_at": 1784046595,
+  "updated_at": 1784048107,
   "affected_specs": [
     "change"
   ],

--- a/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/verification-attempts.json
+++ b/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/verification-attempts.json
@@ -54,6 +54,24 @@
         "REQ-change-030",
         "REQ-change-031"
       ]
+    },
+    {
+      "timestamp": 1784046975,
+      "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
+      "contract_digest": "bb11468a62abd06c8b89070450ff93ac5fdd2fcb5f44f6475af9dbe88573a10f",
+      "workspace_digest": "19294385ffacee20e34e84d76ced84cabee0323407e46a723bababcd1defb3bd",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-030",
+        "REQ-change-031"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/verification.json
+++ b/.specsync/changes/CHG-0033-close-final-5-0-2-lifecycle-review-and-intent-preservation-gaps/verification.json
@@ -1,8 +1,8 @@
 {
-  "timestamp": 1784046570,
-  "commit": "dc91f80d180460f65e7c57cdb0c4598f34124a8e",
+  "timestamp": 1784046975,
+  "commit": "ada33abc371162bc91e4ed6fc06d69378b52dddd",
   "contract_digest": "bb11468a62abd06c8b89070450ff93ac5fdd2fcb5f44f6475af9dbe88573a10f",
-  "workspace_digest": "57f5df5a81546506f261dadff6ced916be684b9bbf923caa8ab3661e7f9706a0",
+  "workspace_digest": "19294385ffacee20e34e84d76ced84cabee0323407e46a723bababcd1defb3bd",
   "acceptance_input_digest": "5c8c815886c71abcf9623dcf4ce175e9b03bf79f2f224c52bdf3a43e54ad21ef",
   "passed": true,
   "commands": [


### PR DESCRIPTION
## Summary

- preserve PR 373’s newer exact-main CHG-0024 and CHG-0025 evidence
- record the explicit 0xLeif closing approval for CHG-0033
- record the explicit 0xLeif reacceptances for CHG-0026, CHG-0027, and CHG-0029
- change lifecycle evidence only; no product code, canonical specification, workflow, or dependency changes

## Test Plan

- [x] 1,570 unit tests pass
- [x] 193 integration tests pass
- [x] candidate-bound fledge trust verify passes
- [x] 62/62 specs pass with 100% file and LOC coverage
- [x] Augur proceeds at risk 20
- [x] Attest policy passes for the exact commit