### PR TITLE
Fix mjs and cjs strict coverage denominators

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 36,
-  "id": "CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm",
+  "sequence": 37,
+  "id": "CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 34,
-  "id": "CHG-0034-support-extensionless-source-discovery-through-an-explicit-include-extensionless",
+  "sequence": 35,
+  "id": "CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 37,
-  "id": "CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript",
+  "sequence": 38,
+  "id": "CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 35,
-  "id": "CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo",
+  "sequence": 36,
+  "id": "CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
@@ -103,6 +103,43 @@
       },
       "stale_acceptance_input_digest": "db7d5ac353fd0589b5ec6897593c460b88e8a949dd95b026adb811abe03a473f",
       "current_acceptance_input_digest": "d0c98a938507fb9671aec2634979b0bae5c1707c26ad52d0c9fcb9fbcdad1101"
+    },
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo",
+      "actor": "user:0xLeif",
+      "reason": "CHG-0037 added a strict module JavaScript regression in the overlapping integration test path, so the accepted coverage delivery requires fresh aggregate verification.",
+      "timestamp": 1784058576,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "0xLeif",
+        "timestamp": 1784054257,
+        "digest": "23c7960a9852964d0c5706fbe9c1215d23019491a6f2dda190bc53668ff20189",
+        "note": "Closing approval after the clean review correction passed 1,577 unit tests, 198 integration tests, strict specs, release build, and the Trust gate."
+      },
+      "prior_verification": {
+        "timestamp": 1784054113,
+        "commit": "60144d67a13a00a1c1b719e9048d49d1bff7779e",
+        "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+        "workspace_digest": "205d568eb4f706e710999911faa6e20e7a07ad5e152b2c58c12f83826864a023",
+        "acceptance_input_digest": "d0c98a938507fb9671aec2634979b0bae5c1707c26ad52d0c9fcb9fbcdad1101",
+        "passed": true,
+        "commands": [
+          {
+            "command": "cargo test",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-types-002",
+          "REQ-validator-006"
+        ]
+      },
+      "stale_acceptance_input_digest": "d0c98a938507fb9671aec2634979b0bae5c1707c26ad52d0c9fcb9fbcdad1101",
+      "current_acceptance_input_digest": "fadaf1ac863471aeb803768a28358fee55456f58bf748c5b9b98971f89e675e9"
     }
   ]
 }

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
@@ -20,6 +20,13 @@
       "timestamp": 1784052913,
       "digest": "a261483ed6ae30e148586b8176a36a8e5059ac0e38687d2bc61a63e29195e9ec",
       "note": "Refreshed closing approval after canonical EOF normalization and a second complete 1,774-test native verification."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1784054257,
+      "digest": "23c7960a9852964d0c5706fbe9c1215d23019491a6f2dda190bc53668ff20189",
+      "note": "Closing approval after the clean review correction passed 1,577 unit tests, 198 integration tests, strict specs, release build, and the Trust gate."
     }
   ],
   "reopenings": [
@@ -59,6 +66,43 @@
       },
       "stale_acceptance_input_digest": "3a150aca727592ee127e18c0fa6173cc34805af06d4007be7811d9026f4fdff2",
       "current_acceptance_input_digest": "db7d5ac353fd0589b5ec6897593c460b88e8a949dd95b026adb811abe03a473f"
+    },
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo",
+      "actor": "0xLeif",
+      "reason": "The review correction legitimately updates its accepted delivery inputs.",
+      "timestamp": 1784054072,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "user:0xLeif",
+        "timestamp": 1784052913,
+        "digest": "a261483ed6ae30e148586b8176a36a8e5059ac0e38687d2bc61a63e29195e9ec",
+        "note": "Refreshed closing approval after canonical EOF normalization and a second complete 1,774-test native verification."
+      },
+      "prior_verification": {
+        "timestamp": 1784052909,
+        "commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
+        "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+        "workspace_digest": "a3eb05d2ebf389fe81f33bbc79bec701dc8c8a105e05a64848430eb31b5a31f5",
+        "acceptance_input_digest": "db7d5ac353fd0589b5ec6897593c460b88e8a949dd95b026adb811abe03a473f",
+        "passed": true,
+        "commands": [
+          {
+            "command": "cargo test",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-types-002",
+          "REQ-validator-006"
+        ]
+      },
+      "stale_acceptance_input_digest": "db7d5ac353fd0589b5ec6897593c460b88e8a949dd95b026adb811abe03a473f",
+      "current_acceptance_input_digest": "d0c98a938507fb9671aec2634979b0bae5c1707c26ad52d0c9fcb9fbcdad1101"
     }
   ]
 }

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
@@ -27,6 +27,13 @@
       "timestamp": 1784054257,
       "digest": "23c7960a9852964d0c5706fbe9c1215d23019491a6f2dda190bc53668ff20189",
       "note": "Closing approval after the clean review correction passed 1,577 unit tests, 198 integration tests, strict specs, release build, and the Trust gate."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784058602,
+      "digest": "8f14e8ed17a41fe8c72d16d3957f9d0a41fa602312a429b0a8bb1429d7f45f5f",
+      "note": "Fresh closing approval after the overlapping CHG-0037 integration fixture passed 1,582 unit tests and 199 integration tests at 0cd65664597a5f331f889c6d840806bb0765f87f."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/approvals.json
@@ -1,0 +1,64 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "user:0xLeif",
+      "timestamp": 1784052705,
+      "digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+      "note": "Approved the portable CHG-0035 definition rebased on the exact 5.0.2 main commit, with explicit mapped and uncovered coverage for both mjs and cjs."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784052771,
+      "digest": "ce181694e1126263bc20f371702ff9bdc6abb8b21e482f3f0ff13eaaabdaff26",
+      "note": "Closing approval after all 1,577 unit and 197 integration tests passed on exact main a9422ae, including mapped and uncovered mjs and cjs regressions."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784052913,
+      "digest": "a261483ed6ae30e148586b8176a36a8e5059ac0e38687d2bc61a63e29195e9ec",
+      "note": "Refreshed closing approval after canonical EOF normalization and a second complete 1,774-test native verification."
+    }
+  ],
+  "reopenings": [
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo",
+      "actor": "user:0xLeif",
+      "reason": "Normalize the canonical requirement companion EOF after semantic application so git diff validation is clean.",
+      "timestamp": 1784052897,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "user:0xLeif",
+        "timestamp": 1784052771,
+        "digest": "ce181694e1126263bc20f371702ff9bdc6abb8b21e482f3f0ff13eaaabdaff26",
+        "note": "Closing approval after all 1,577 unit and 197 integration tests passed on exact main a9422ae, including mapped and uncovered mjs and cjs regressions."
+      },
+      "prior_verification": {
+        "timestamp": 1784052765,
+        "commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
+        "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+        "workspace_digest": "f2d4a38f9dc116e811341b6192f14fe372fe62e3fd7748bb1f73733e96c14ebe",
+        "acceptance_input_digest": "3a150aca727592ee127e18c0fa6173cc34805af06d4007be7811d9026f4fdff2",
+        "passed": true,
+        "commands": [
+          {
+            "command": "cargo test",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-types-002",
+          "REQ-validator-006"
+        ]
+      },
+      "stale_acceptance_input_digest": "3a150aca727592ee127e18c0fa6173cc34805af06d4007be7811d9026f4fdff2",
+      "current_acceptance_input_digest": "db7d5ac353fd0589b5ec6897593c460b88e8a949dd95b026adb811abe03a473f"
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/change.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
-state: verifying
+state: accepted
 type: bug_fix
 base_commit: a9422aedbe12a3c50787c1fcc074749232f25dfe
 ---

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/change.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/change.md
@@ -1,0 +1,28 @@
+---
+id: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+state: accepted
+type: bug_fix
+base_commit: a9422aedbe12a3c50787c1fcc074749232f25dfe
+---
+
+# Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators
+
+## Intent
+
+Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators
+
+## Affected Canonical Specs
+
+- `types`
+- `validator`
+
+## Acceptance Criteria
+
+- Language::from_extension classifies mjs and cjs as TypeScript and TypeScript::extensions includes both suffixes.
+- A default-discovery fixture mapping ts, css, mjs, and cjs files reports exact file and non-zero LOC denominators instead of omitting module JavaScript.
+- Default-discovery fixtures with uncovered mjs or cjs files each fail strict require-coverage 100 and report those files in the denominator.
+- Existing JavaScript and TypeScript discovery remains compatible, canonical deltas and changelog are accurate, and the complete native and hosted gates pass.
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/change.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
-state: accepted
+state: verifying
 type: bug_fix
 base_commit: a9422aedbe12a3c50787c1fcc074749232f25dfe
 ---

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/context.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/context.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: context
+---
+
+# Context
+
+SpecSync's schema scanner already recognizes `.mjs` and `.cjs` as JavaScript module files, but the shared `Language` classifier omits both suffixes. Default source discovery is derived from `Language::from_extension` and `Language::extensions`, so coverage silently excludes these files even when a canonical spec maps them.
+
+The fix aligns the shared language registry with the existing schema behavior and proves both sides of the gate: mapped module files increase measured totals, and uncovered module files make strict 100 percent coverage fail.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/deltas/types.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/deltas/types.md
@@ -1,0 +1,11 @@
+## ADDED
+
+### REQUIREMENT REQ-types-002
+
+The shared language registry SHALL classify `.mjs` and `.cjs` as TypeScript-family sources for both direct detection and default extension discovery.
+
+Acceptance Criteria
+
+- Direct extension lookup maps `mjs` and `cjs` to TypeScript.
+- The TypeScript default extension list includes `mjs` and `cjs` alongside existing JavaScript and TypeScript suffixes.
+- Explicit source-extension filtering remains unchanged.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/deltas/validator.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/deltas/validator.md
@@ -1,0 +1,11 @@
+## ADDED
+
+### REQUIREMENT REQ-validator-006
+
+Default source discovery SHALL include `.mjs` and `.cjs` files in strict file and LOC coverage denominators.
+
+Acceptance Criteria
+
+- Mapped module files increase measured file and LOC totals using their real contents.
+- An uncovered `.mjs` or `.cjs` file prevents strict 100 percent coverage from passing.
+- Coverage output reports non-vacuous exact totals for mixed default-language projects.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/design.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/design.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: design
+---
+
+# Design
+
+Treat `.mjs` and `.cjs` as TypeScript-family inputs, matching the existing handling of `.js`, `.jsx`, `.mts`, and `.cts`. Add both suffixes to the two authoritative `Language` surfaces: `from_extension` for detection and `extensions` for default discovery. This preserves explicit `source_extensions` filtering, parser selection, and public language naming while closing the denominator gap.
+
+Coverage behavior requires no special case: once the shared registry recognizes the files, existing validator discovery and LOC measurement include them naturally. Regression fixtures assert exact totals so a future classification mismatch cannot produce another vacuous 100 percent result.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/docs.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/docs.md
@@ -1,0 +1,8 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: docs
+---
+
+# Docs
+
+Add an Unreleased changelog entry explaining that default JavaScript/TypeScript discovery now includes `.mjs` and `.cjs`, so those files contribute to strict file and LOC coverage. No configuration documentation changes are required because this corrects the existing default supported-language set rather than adding a setting.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/plan.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/plan.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: plan
+---
+
+# Plan
+
+1. Add `mjs` and `cjs` to the shared TypeScript-family extension classification and registry.
+2. Add focused unit coverage for direct classification and registry parity.
+3. Add integration fixtures proving mapped `.mjs` and `.cjs` files affect exact file and LOC totals and uncovered files of either suffix fail strict 100 percent coverage.
+4. Apply canonical `types` and `validator` semantic deltas and document the correction in the changelog.
+5. Run focused tests, strict 100 percent SpecSync validation, the complete Fledge verification lane, and hosted matrices.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/requirements.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/requirements.md
@@ -1,0 +1,25 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: requirements
+---
+
+# Requirements
+
+## REQ-CHG-0035-001 — Module JavaScript classification
+
+SpecSync SHALL classify `mjs` and `cjs` filename extensions as TypeScript-family source files in both direct extension lookup and the default TypeScript extension registry.
+
+Acceptance criteria:
+
+- `Language::from_extension("mjs")` and `Language::from_extension("cjs")` return `Language::TypeScript`.
+- `Language::TypeScript.extensions()` contains `mjs` and `cjs` without removing existing suffixes.
+
+## REQ-CHG-0035-002 — Non-vacuous module-file coverage
+
+Default source discovery SHALL include `.mjs` and `.cjs` files in file and LOC coverage denominators.
+
+Acceptance criteria:
+
+- A mapped fixture containing `.ts`, `.css`, `.mjs`, and `.cjs` sources reports the exact file and LOC totals from all sources.
+- Otherwise covered fixtures with an unmapped `.mjs` or `.cjs` file each fail strict `--require-coverage 100` and report the uncovered file in the denominator.
+- Explicit `source_extensions` behavior remains unchanged.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/research.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/research.md
@@ -1,0 +1,8 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: research
+---
+
+# Research
+
+`src/schema.rs` already lists `mjs` and `cjs` among JavaScript schema extensions. In contrast, `Language::from_extension` and `Language::TypeScript.extensions()` stop at `ts`, `tsx`, `js`, `jsx`, `mts`, and `cts`. The validator's default `has_extension` path relies on the shared `Language` registry, explaining why mapped module files can be present in spec frontmatter but absent from measured totals. Aligning the registry is smaller and safer than adding validator-only exceptions because generation and all other default-discovery consumers inherit the same correction.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
@@ -5,11 +5,11 @@
   "title": "Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators",
   "description": "Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators",
   "kind": "bug_fix",
-  "state": "accepted",
+  "state": "verifying",
   "canonical_applied": true,
   "base_commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
   "created_at": 1784052554,
-  "updated_at": 1784054257,
+  "updated_at": 1784058576,
   "affected_specs": [
     "types",
     "validator"

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo",
+  "slug": "count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo",
+  "title": "Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators",
+  "description": "Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators",
+  "kind": "bug_fix",
+  "state": "accepted",
+  "canonical_applied": true,
+  "base_commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
+  "created_at": 1784052554,
+  "updated_at": 1784052913,
+  "affected_specs": [
+    "types",
+    "validator"
+  ],
+  "affected_paths": [
+    "src/types.rs",
+    "tests/integration/check.rs",
+    "specs/types",
+    "specs/validator",
+    "CHANGELOG.md",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Language::from_extension classifies mjs and cjs as TypeScript and TypeScript::extensions includes both suffixes.",
+    "A default-discovery fixture mapping ts, css, mjs, and cjs files reports exact file and non-zero LOC denominators instead of omitting module JavaScript.",
+    "Default-discovery fixtures with uncovered mjs or cjs files each fail strict require-coverage 100 and report those files in the denominator.",
+    "Existing JavaScript and TypeScript discovery remains compatible, canonical deltas and changelog are accurate, and the complete native and hosted gates pass."
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "design",
+    "docs",
+    "research",
+    "requirements",
+    "plan"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "yes",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
   "created_at": 1784052554,
-  "updated_at": 1784052913,
+  "updated_at": 1784054257,
   "affected_specs": [
     "types",
     "validator"

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/state.json
@@ -5,11 +5,11 @@
   "title": "Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators",
   "description": "Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators",
   "kind": "bug_fix",
-  "state": "verifying",
+  "state": "accepted",
   "canonical_applied": true,
   "base_commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
   "created_at": 1784052554,
-  "updated_at": 1784058576,
+  "updated_at": 1784058602,
   "affected_specs": [
     "types",
     "validator"

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/tasks.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/tasks.md
@@ -1,0 +1,13 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Identify the mismatch between schema recognition and shared language discovery.
+- [x] Add `.mjs` and `.cjs` to TypeScript-family classification and default extensions.
+- [x] Add unit regressions for direct lookup and extension-list parity.
+- [x] Add exact mapped and uncovered coverage regressions for both suffixes.
+- [x] Update canonical deltas and changelog.
+- [x] Define native and hosted validation; record results only after each gate completes.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/testing.md
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/testing.md
@@ -1,0 +1,24 @@
+---
+change: CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo
+artifact: testing
+---
+
+# Testing
+
+Focused unit tests assert both direct language classification and the default TypeScript extension registry. Integration tests create real canonical specs and source files under default discovery:
+
+- a mapped `.ts`, `.css`, `.mjs`, and `.cjs` fixture must report 4/4 files and exact non-zero LOC including both module files;
+- a fully mapped `.ts` fixture plus an unmapped `.mjs` or `.cjs` source must fail strict 100 percent coverage and report 1/2 files.
+
+The final local gate is `fledge lanes run verify`, followed by `specsync check --strict --require-coverage 100 --force` and `git diff --check`. Hosted platform, packaged consumer, security, required CI, and Trust checks remain mandatory before merge.
+
+Focused regression commands:
+
+- `cargo test module_javascript_extensions_are_typescript_family_sources`
+- `cargo test --test integration default_discovery_counts_mjs_and_cjs_in_exact_coverage_totals`
+- `cargo test --test integration uncovered_mjs_and_cjs_files_fail_strict_full_coverage`
+
+Canonical requirement evidence:
+
+- `REQ-types-002`: `types::language_extension_tests::module_javascript_extensions_are_typescript_family_sources` proves direct classification and default registry parity.
+- `REQ-validator-006`: `check::default_discovery_counts_mjs_and_cjs_in_exact_coverage_totals` and `check::uncovered_mjs_and_cjs_files_fail_strict_full_coverage` prove exact mapped totals and strict uncovered-file failure for both suffixes.

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification-attempts.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification-attempts.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784052765,
+      "commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
+      "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+      "workspace_digest": "f2d4a38f9dc116e811341b6192f14fe372fe62e3fd7748bb1f73733e96c14ebe",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-types-002",
+        "REQ-validator-006"
+      ]
+    },
+    {
+      "timestamp": 1784052909,
+      "commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
+      "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+      "workspace_digest": "a3eb05d2ebf389fe81f33bbc79bec701dc8c8a105e05a64848430eb31b5a31f5",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-types-002",
+        "REQ-validator-006"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification-attempts.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification-attempts.json
@@ -54,6 +54,24 @@
         "REQ-types-002",
         "REQ-validator-006"
       ]
+    },
+    {
+      "timestamp": 1784058595,
+      "commit": "0cd65664597a5f331f889c6d840806bb0765f87f",
+      "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+      "workspace_digest": "0ba6b2f2b24aa49d1afe0f240c0b4378229ccce087a80e1a799d952d547ceec4",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-types-002",
+        "REQ-validator-006"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification-attempts.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification-attempts.json
@@ -36,6 +36,24 @@
         "REQ-types-002",
         "REQ-validator-006"
       ]
+    },
+    {
+      "timestamp": 1784054113,
+      "commit": "60144d67a13a00a1c1b719e9048d49d1bff7779e",
+      "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+      "workspace_digest": "205d568eb4f706e710999911faa6e20e7a07ad5e152b2c58c12f83826864a023",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-types-002",
+        "REQ-validator-006"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1784054113,
-  "commit": "60144d67a13a00a1c1b719e9048d49d1bff7779e",
+  "timestamp": 1784058595,
+  "commit": "0cd65664597a5f331f889c6d840806bb0765f87f",
   "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
-  "workspace_digest": "205d568eb4f706e710999911faa6e20e7a07ad5e152b2c58c12f83826864a023",
-  "acceptance_input_digest": "d0c98a938507fb9671aec2634979b0bae5c1707c26ad52d0c9fcb9fbcdad1101",
+  "workspace_digest": "0ba6b2f2b24aa49d1afe0f240c0b4378229ccce087a80e1a799d952d547ceec4",
+  "acceptance_input_digest": "fadaf1ac863471aeb803768a28358fee55456f58bf748c5b9b98971f89e675e9",
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1784052909,
-  "commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
+  "timestamp": 1784054113,
+  "commit": "60144d67a13a00a1c1b719e9048d49d1bff7779e",
   "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
-  "workspace_digest": "a3eb05d2ebf389fe81f33bbc79bec701dc8c8a105e05a64848430eb31b5a31f5",
-  "acceptance_input_digest": "db7d5ac353fd0589b5ec6897593c460b88e8a949dd95b026adb811abe03a473f",
+  "workspace_digest": "205d568eb4f706e710999911faa6e20e7a07ad5e152b2c58c12f83826864a023",
+  "acceptance_input_digest": "d0c98a938507fb9671aec2634979b0bae5c1707c26ad52d0c9fcb9fbcdad1101",
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification.json
+++ b/.specsync/changes/CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo/verification.json
@@ -1,0 +1,19 @@
+{
+  "timestamp": 1784052909,
+  "commit": "a9422aedbe12a3c50787c1fcc074749232f25dfe",
+  "contract_digest": "6c5b334ec7bdf678f86c486c2fd19277317b4346b47196e8be7a600a5913f8db",
+  "workspace_digest": "a3eb05d2ebf389fe81f33bbc79bec701dc8c8a105e05a64848430eb31b5a31f5",
+  "acceptance_input_digest": "db7d5ac353fd0589b5ec6897593c460b88e8a949dd95b026adb811abe03a473f",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-types-002",
+    "REQ-validator-006"
+  ]
+}

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
@@ -1,0 +1,19 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784055627,
+      "digest": "393d060ea9c10780133385bac7e0b62b7fe4d9f164258ef547512c61d98f4c6b",
+      "note": null
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784056326,
+      "digest": "fe2d5be34a56407075071e911bb94bad5c250dadc7b698a2f4bb1b8f8666f6db",
+      "note": null
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
@@ -27,6 +27,13 @@
       "timestamp": 1784057431,
       "digest": "da85439ed0fc8b34d611f0c977c3d567c7102e57bc9e7693c2039a2f38eefd7e",
       "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784058624,
+      "digest": "30866cfc9f20a1687c99e5b0da58914f3d452db58e764922a62d34994962b721",
+      "note": "Fresh closing approval after the combined CommonJS and extensionless resolver delivery passed 1,582 unit tests and 199 integration tests at e4a8f73110b22e1ee6a72c3a1a11cb19c1bb3f17."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
@@ -13,6 +13,20 @@
       "timestamp": 1784056326,
       "digest": "fe2d5be34a56407075071e911bb94bad5c250dadc7b698a2f4bb1b8f8666f6db",
       "note": null
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784057361,
+      "digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
+      "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1784057431,
+      "digest": "da85439ed0fc8b34d611f0c977c3d567c7102e57bc9e7693c2039a2f38eefd7e",
+      "note": null
     }
   ],
   "reopenings": []

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
@@ -72,6 +72,42 @@
       },
       "stale_acceptance_input_digest": "7f4bfa0cf1a1e8191f9f74cf28785bd8e305cf6a128a5986b2066c208abd6697",
       "current_acceptance_input_digest": "e8cfd1e2a80e3123999fcf651abbcdea199f60e6b39ae4f41b3361f64c36c2f4"
+    },
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm",
+      "actor": "user:0xLeif",
+      "reason": "CHG-0038 hardened the overlapping CommonJS export scanner and updated the canonical exports contract, so CHG-0036 requires fresh native verification and closing approval against the integrated implementation.",
+      "timestamp": 1784059893,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "user:0xLeif",
+        "timestamp": 1784058624,
+        "digest": "30866cfc9f20a1687c99e5b0da58914f3d452db58e764922a62d34994962b721",
+        "note": "Fresh closing approval after the combined CommonJS and extensionless resolver delivery passed 1,582 unit tests and 199 integration tests at e4a8f73110b22e1ee6a72c3a1a11cb19c1bb3f17."
+      },
+      "prior_verification": {
+        "timestamp": 1784058616,
+        "commit": "e4a8f73110b22e1ee6a72c3a1a11cb19c1bb3f17",
+        "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
+        "workspace_digest": "0ba6b2f2b24aa49d1afe0f240c0b4378229ccce087a80e1a799d952d547ceec4",
+        "acceptance_input_digest": "e8cfd1e2a80e3123999fcf651abbcdea199f60e6b39ae4f41b3361f64c36c2f4",
+        "passed": true,
+        "commands": [
+          {
+            "command": "cargo test",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-exports-002"
+        ]
+      },
+      "stale_acceptance_input_digest": "e8cfd1e2a80e3123999fcf651abbcdea199f60e6b39ae4f41b3361f64c36c2f4",
+      "current_acceptance_input_digest": "7f6838a29d87c55832cea6e86642cd764a2d0af267b553af1b25d19e2ec996a5"
     }
   ]
 }

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
@@ -34,6 +34,13 @@
       "timestamp": 1784058624,
       "digest": "30866cfc9f20a1687c99e5b0da58914f3d452db58e764922a62d34994962b721",
       "note": "Fresh closing approval after the combined CommonJS and extensionless resolver delivery passed 1,582 unit tests and 199 integration tests at e4a8f73110b22e1ee6a72c3a1a11cb19c1bb3f17."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784059982,
+      "digest": "d453db8a1ddd45cb387036e12f5be57b92c51078aaa3d9f69dc027455e574ae8",
+      "note": "Fresh native verification passed at 3383e15f68d90fe7be360d0e115ea948abbf29aa after CHG-0038 CommonJS hardening: 1,587 unit and 199 integration tests."
     }
   ],
   "reopenings": [

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/approvals.json
@@ -29,5 +29,42 @@
       "note": null
     }
   ],
-  "reopenings": []
+  "reopenings": [
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm",
+      "actor": "user:0xLeif",
+      "reason": "CHG-0037 added the extensionless resolver requirement in the overlapping canonical exports scope, so the accepted CommonJS delivery requires fresh combined verification.",
+      "timestamp": 1784058576,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "0xLeif",
+        "timestamp": 1784057431,
+        "digest": "da85439ed0fc8b34d611f0c977c3d567c7102e57bc9e7693c2039a2f38eefd7e",
+        "note": null
+      },
+      "prior_verification": {
+        "timestamp": 1784057388,
+        "commit": "ef87ce3a47cacbb0fa8f7077f9cf2f23ff9d5a3c",
+        "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
+        "workspace_digest": "33cf9eb70d97f0a6b8ae301f75f83b77a4fb7cb434e6a9cbcd211fdf1cf950fa",
+        "acceptance_input_digest": "7f4bfa0cf1a1e8191f9f74cf28785bd8e305cf6a128a5986b2066c208abd6697",
+        "passed": true,
+        "commands": [
+          {
+            "command": "cargo test",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-exports-002"
+        ]
+      },
+      "stale_acceptance_input_digest": "7f4bfa0cf1a1e8191f9f74cf28785bd8e305cf6a128a5986b2066c208abd6697",
+      "current_acceptance_input_digest": "e8cfd1e2a80e3123999fcf651abbcdea199f60e6b39ae4f41b3361f64c36c2f4"
+    }
+  ]
 }

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
-state: implementing
+state: accepted
 type: feature
 base_commit: 096425ec9fc32e58f18aa2d42a7c65a30fac41cf
 ---

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
-state: verifying
+state: accepted
 type: feature
 base_commit: 096425ec9fc32e58f18aa2d42a7c65a30fac41cf
 ---

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
+state: implementing
+type: feature
+base_commit: 096425ec9fc32e58f18aa2d42a7c65a30fac41cf
+---
+
+# Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior
+
+## Intent
+
+Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior
+
+## Affected Canonical Specs
+
+- `exports`
+
+## Acceptance Criteria
+
+- Regex and AST modes extract direct CommonJS property assignments,Regex and AST modes extract statically named top-level object export keys while ignoring unresolved syntax,Existing TypeScript and ESM extraction remains unchanged and deduplicated,Focused regressions plus complete tests strict specs hosted CI and Trust pass
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
-state: accepted
+state: verifying
 type: feature
 base_commit: 096425ec9fc32e58f18aa2d42a7c65a30fac41cf
 ---

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/context.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/context.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
+artifact: context
+---
+
+# Context
+
+CHG-0035 adds `.cjs` to default TypeScript-family discovery and strict coverage denominators. The current TypeScript export scanners recognize ESM declarations and TypeScript's `export = Name`, but ordinary CommonJS assignments can therefore be discovered without their public symbols being extracted.
+
+This change closes that contract gap without broadening file discovery or altering ESM behavior. A shared lexical CommonJS helper will supplement both the regex and AST paths so mixed ESM/CommonJS input and AST-success cases have the same deterministic output.
+
+The scanner intentionally recognizes only statically named exports. Dynamic computed keys and unresolved spreads are outside the contract because their exported names cannot be determined without executing user code.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/deltas/exports.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/deltas/exports.md
@@ -1,0 +1,23 @@
+## ADDED
+
+### REQUIREMENT REQ-exports-002
+
+The TypeScript/JavaScript export scanner SHALL report statically named CommonJS exports in both regex and AST modes without changing existing ESM results.
+
+Acceptance Criteria
+
+- `exports.foo = ...` and `module.exports.foo = ...` report `foo`.
+- Top-level shorthand and named keys in `module.exports = { ... }` are reported.
+- Comments, strings, computed keys, and statically unresolved spreads do not report false exports.
+- Mixed ESM/CommonJS input is stable and deduplicated in both parsing modes.
+
+### SPEC SECTION CommonJS Extraction
+
+The TypeScript/JavaScript backend supplements its ESM and TypeScript `export =` handling with static CommonJS name discovery in both regex and AST modes.
+
+- Direct `exports.foo = value` and `module.exports.foo = value` assignments report `foo`.
+- Top-level shorthand, named properties, and identifier-named methods in `module.exports = { ... }` report their static keys.
+- Comments, string and template literals, computed keys, and unresolved spreads never create exports.
+- Mixed ESM/CommonJS names are stable and deduplicated without executing source code.
+
+For `exports.foo = 1; module.exports = { bar, baz: value, [dynamic]: value, ...extra };`, both parsing modes report `foo`, `bar`, and `baz`, while ignoring `dynamic` and `extra` because their exported names are not statically determined.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/docs.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/docs.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
+artifact: docs
+---
+
+# Docs
+
+- Add a dedicated canonical `exports` spec section for direct CommonJS assignments and object exports.
+- Add a behavioral example showing supported static names and intentionally ignored dynamic forms.
+- Record the implementation and test coverage in the exports companion files.
+- No CLI syntax or user guide changes are required; this corrects extraction behavior for already discovered `.cjs` files.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/plan.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/plan.md
@@ -1,0 +1,13 @@
+---
+change: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
+artifact: plan
+---
+
+# Plan
+
+1. Add a comment- and string-aware lexical CommonJS extractor to the TypeScript/JavaScript regex backend.
+2. Merge CommonJS names into regex results with stable deduplication.
+3. Reuse the same helper from the AST backend so successful ESM parsing does not suppress CommonJS symbols.
+4. Add focused regressions for direct properties, object shorthand/named keys, mixed modules, deduplication, and ignored dynamic syntax.
+5. Apply the `exports` semantic delta and update its companions.
+6. Run focused and complete tests, strict spec validation, hosted CI, Trust, and Attest verification.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/requirements.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/requirements.md
@@ -1,0 +1,17 @@
+---
+change: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
+artifact: requirements
+---
+
+# Requirements
+
+## REQ-exports-002
+
+The TypeScript/JavaScript export scanner SHALL report statically named CommonJS exports in both regex and AST modes without changing existing ESM results.
+
+Acceptance Criteria
+
+- `exports.foo = ...` and `module.exports.foo = ...` report `foo`.
+- Top-level shorthand and named keys in `module.exports = { ... }` are reported.
+- Comments, strings, computed keys, and statically unresolved spreads do not report false exports.
+- Mixed ESM/CommonJS input is stable and deduplicated in both parsing modes.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
@@ -5,11 +5,11 @@
   "title": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "description": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "kind": "feature",
-  "state": "accepted",
+  "state": "verifying",
   "canonical_applied": true,
   "base_commit": "096425ec9fc32e58f18aa2d42a7c65a30fac41cf",
   "created_at": 1784054902,
-  "updated_at": 1784057431,
+  "updated_at": 1784058576,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
@@ -5,11 +5,11 @@
   "title": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "description": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "kind": "feature",
-  "state": "accepted",
+  "state": "verifying",
   "canonical_applied": true,
   "base_commit": "096425ec9fc32e58f18aa2d42a7c65a30fac41cf",
   "created_at": 1784054902,
-  "updated_at": 1784058624,
+  "updated_at": 1784059893,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
@@ -5,11 +5,11 @@
   "title": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "description": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "kind": "feature",
-  "state": "verifying",
+  "state": "accepted",
   "canonical_applied": true,
   "base_commit": "096425ec9fc32e58f18aa2d42a7c65a30fac41cf",
   "created_at": 1784054902,
-  "updated_at": 1784059893,
+  "updated_at": 1784059982,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
@@ -5,10 +5,11 @@
   "title": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "description": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "kind": "feature",
-  "state": "implementing",
+  "state": "accepted",
+  "canonical_applied": true,
   "base_commit": "096425ec9fc32e58f18aa2d42a7c65a30fac41cf",
   "created_at": 1784054902,
-  "updated_at": 1784056326,
+  "updated_at": 1784057431,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
@@ -5,11 +5,11 @@
   "title": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "description": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
   "kind": "feature",
-  "state": "verifying",
+  "state": "accepted",
   "canonical_applied": true,
   "base_commit": "096425ec9fc32e58f18aa2d42a7c65a30fac41cf",
   "created_at": 1784054902,
-  "updated_at": 1784058576,
+  "updated_at": 1784058624,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/state.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm",
+  "slug": "support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm",
+  "title": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
+  "description": "Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior",
+  "kind": "feature",
+  "state": "implementing",
+  "base_commit": "096425ec9fc32e58f18aa2d42a7c65a30fac41cf",
+  "created_at": 1784054902,
+  "updated_at": 1784056326,
+  "affected_specs": [
+    "exports"
+  ],
+  "affected_paths": [
+    "src/exports/typescript.rs",
+    "src/exports/ast/typescript.rs",
+    "specs/exports",
+    "CHANGELOG.md",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Regex and AST modes extract direct CommonJS property assignments,Regex and AST modes extract statically named top-level object export keys while ignoring unresolved syntax,Existing TypeScript and ESM extraction remains unchanged and deduplicated,Focused regressions plus complete tests strict specs hosted CI and Trust pass"
+  ],
+  "selected_artifacts": [
+    "context",
+    "requirements",
+    "plan",
+    "tasks",
+    "testing",
+    "docs"
+  ],
+  "dependencies": [
+    "CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo"
+  ],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/tasks.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/tasks.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Implement static CommonJS property and object export extraction.
+- [x] Integrate the shared extraction result into regex and AST modes.
+- [x] Add positive, negative, mixed-mode, and deduplication regressions.
+- [x] Update the exports canonical spec and companions through the semantic delta.
+- [ ] Run focused tests, the complete native suite, strict specs, Trust, hosted CI, and Attest.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/tasks.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/tasks.md
@@ -9,4 +9,4 @@ artifact: tasks
 - [x] Integrate the shared extraction result into regex and AST modes.
 - [x] Add positive, negative, mixed-mode, and deduplication regressions.
 - [x] Update the exports canonical spec and companions through the semantic delta.
-- [ ] Run focused tests, the complete native suite, strict specs, Trust, hosted CI, and Attest.
+- [x] Run focused tests, the complete native suite, strict specs, Trust, hosted CI, and Attest.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/testing.md
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/testing.md
@@ -1,0 +1,25 @@
+---
+change: CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm
+artifact: testing
+---
+
+# Testing
+
+| Requirement | Evidence |
+|---|---|
+| Direct assignments | Unit cases for `exports.foo` and `module.exports.foo` in regex and AST modes |
+| Object exports | Unit cases for shorthand, named properties, methods, and nested values |
+| False-positive resistance | Unit cases covering comments, strings, computed keys, and unresolved spreads |
+| Compatibility | Existing TypeScript/ESM suites plus mixed ESM/CommonJS deduplication cases |
+| Repository integrity | Complete native tests, `specsync check --strict`, hosted CI, `fledge trust verify`, and Attest verification |
+
+Focused commands:
+
+- `cargo test exports::typescript::`
+- `cargo test exports::ast::typescript::`
+
+The lifecycle verification command and its exact evidence will be recorded before closing approval.
+
+Canonical requirement evidence:
+
+- `REQ-exports-002`: `test_commonjs_direct_and_object_exports`, `test_commonjs_ignores_non_static_and_non_code_names`, `test_commonjs_mixed_with_esm_is_deduplicated`, and `test_commonjs_exports_match_static_contract` prove static extraction, false-positive resistance, deduplication, and regex/AST parity.

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification-attempts.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification-attempts.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784057388,
+      "commit": "ef87ce3a47cacbb0fa8f7077f9cf2f23ff9d5a3c",
+      "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
+      "workspace_digest": "33cf9eb70d97f0a6b8ae301f75f83b77a4fb7cb434e6a9cbcd211fdf1cf950fa",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-exports-002"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification-attempts.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification-attempts.json
@@ -17,6 +17,23 @@
       "requirement_ids": [
         "REQ-exports-002"
       ]
+    },
+    {
+      "timestamp": 1784058616,
+      "commit": "e4a8f73110b22e1ee6a72c3a1a11cb19c1bb3f17",
+      "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
+      "workspace_digest": "0ba6b2f2b24aa49d1afe0f240c0b4378229ccce087a80e1a799d952d547ceec4",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-exports-002"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification-attempts.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification-attempts.json
@@ -34,6 +34,23 @@
       "requirement_ids": [
         "REQ-exports-002"
       ]
+    },
+    {
+      "timestamp": 1784059949,
+      "commit": "3383e15f68d90fe7be360d0e115ea948abbf29aa",
+      "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
+      "workspace_digest": "c72d1f17ae5d0de8b21fb3eb8fbc2a8d85677c584452baadcdafba3e33c15516",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-exports-002"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1784058616,
-  "commit": "e4a8f73110b22e1ee6a72c3a1a11cb19c1bb3f17",
+  "timestamp": 1784059949,
+  "commit": "3383e15f68d90fe7be360d0e115ea948abbf29aa",
   "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
-  "workspace_digest": "0ba6b2f2b24aa49d1afe0f240c0b4378229ccce087a80e1a799d952d547ceec4",
-  "acceptance_input_digest": "e8cfd1e2a80e3123999fcf651abbcdea199f60e6b39ae4f41b3361f64c36c2f4",
+  "workspace_digest": "c72d1f17ae5d0de8b21fb3eb8fbc2a8d85677c584452baadcdafba3e33c15516",
+  "acceptance_input_digest": "7f6838a29d87c55832cea6e86642cd764a2d0af267b553af1b25d19e2ec996a5",
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": 1784057388,
+  "commit": "ef87ce3a47cacbb0fa8f7077f9cf2f23ff9d5a3c",
+  "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
+  "workspace_digest": "33cf9eb70d97f0a6b8ae301f75f83b77a4fb7cb434e6a9cbcd211fdf1cf950fa",
+  "acceptance_input_digest": "7f4bfa0cf1a1e8191f9f74cf28785bd8e305cf6a128a5986b2066c208abd6697",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-exports-002"
+  ]
+}

--- a/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification.json
+++ b/.specsync/changes/CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1784057388,
-  "commit": "ef87ce3a47cacbb0fa8f7077f9cf2f23ff9d5a3c",
+  "timestamp": 1784058616,
+  "commit": "e4a8f73110b22e1ee6a72c3a1a11cb19c1bb3f17",
   "contract_digest": "e537cd77dbb5e09aa1d3fc2c7ab9541aa3942fdce8433b638ca9b220bceef749",
-  "workspace_digest": "33cf9eb70d97f0a6b8ae301f75f83b77a4fb7cb434e6a9cbcd211fdf1cf950fa",
-  "acceptance_input_digest": "7f4bfa0cf1a1e8191f9f74cf28785bd8e305cf6a128a5986b2066c208abd6697",
+  "workspace_digest": "0ba6b2f2b24aa49d1afe0f240c0b4378229ccce087a80e1a799d952d547ceec4",
+  "acceptance_input_digest": "e8cfd1e2a80e3123999fcf651abbcdea199f60e6b39ae4f41b3361f64c36c2f4",
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/approvals.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/approvals.json
@@ -1,0 +1,4 @@
+{
+  "approvals": [],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/approvals.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/approvals.json
@@ -6,6 +6,13 @@
       "timestamp": 1784058361,
       "digest": "e66949c4c54a310717068cc37d7d8d3665e0216d3b808212a8e1ae34b4b5c29e",
       "note": "Approve the scoped extensionless module JavaScript resolver contract, fixtures, and lifecycle dependency on accepted CHG-0036."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784058432,
+      "digest": "45bd2f1031f6379288550107fa98a6f27c8d00e9e22e05739e0dfaabcba5b68e",
+      "note": "Closing approval after successful native verification at 82562f3787302e8f3efd67262a4c1d6f99c3cc00: 1,582 unit tests and 199 integration tests passed, including strict regex/AST module JavaScript barrel regressions."
     }
   ],
   "reopenings": []

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/approvals.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/approvals.json
@@ -1,4 +1,12 @@
 {
-  "approvals": [],
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "user:0xLeif",
+      "timestamp": 1784058361,
+      "digest": "e66949c4c54a310717068cc37d7d8d3665e0216d3b808212a8e1ae34b4b5c29e",
+      "note": "Approve the scoped extensionless module JavaScript resolver contract, fixtures, and lifecycle dependency on accepted CHG-0036."
+    }
+  ],
   "reopenings": []
 }

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
-state: draft
+state: approved
 type: bug_fix
 base_commit: dac64a1bff31cc5af0b590c8a800468440048e1e
 ---

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
-state: approved
+state: implementing
 type: bug_fix
 base_commit: dac64a1bff31cc5af0b590c8a800468440048e1e
 ---

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
@@ -1,0 +1,26 @@
+---
+id: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
+state: draft
+type: bug_fix
+base_commit: dac64a1bff31cc5af0b590c8a800468440048e1e
+---
+
+# Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources
+
+## Intent
+
+Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources
+
+## Affected Canonical Specs
+
+- `exports`
+
+## Acceptance Criteria
+
+- An extensionless export-star barrel in an mjs source resolves a sibling mjs module and reports its public names.
+- The resolver probes module JavaScript file and index variants without regressing existing TypeScript or JavaScript resolution.
+- Strict validation passes for the regression fixture in both regex and AST parse modes.
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
-state: implementing
+state: accepted
 type: bug_fix
 base_commit: dac64a1bff31cc5af0b590c8a800468440048e1e
 ---

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/context.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/context.md
@@ -1,0 +1,17 @@
+---
+change: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
+artifact: context
+---
+
+# Context
+
+SpecSync 5 now discovers `.mjs` and `.cjs` as TypeScript-family source files, and
+CHG-0036 teaches both export backends to extract static CommonJS names. Relative
+export-star resolution still probes only TypeScript, JavaScript, MTS, and CTS file
+variants. An extensionless barrel such as `export * from "./values"` therefore
+misses `values.mjs`, making strict validation report false removed or undocumented
+exports.
+
+The fix stays inside the existing one-level relative resolver. It adds module
+JavaScript file and index variants while preserving the current probe order,
+non-relative import rejection, unreadable-file behavior, and regex/AST fallback.

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/deltas/exports.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/deltas/exports.md
@@ -1,0 +1,14 @@
+## ADDED
+
+### REQUIREMENT REQ-exports-003
+
+The TypeScript/JavaScript relative export resolver SHALL resolve extensionless
+module JavaScript file and directory-index targets without changing its existing
+one-level relative traversal boundary.
+
+Acceptance Criteria
+
+- An extensionless export-star target resolves sibling `.mjs` and `.cjs` files.
+- Directory targets resolve `index.mjs` and `index.cjs` alongside existing index variants.
+- Regex and AST parse modes return the same ordered, deduplicated public names.
+- Non-relative, unresolved, and unreadable targets retain their existing best-effort behavior.

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/docs.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/docs.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
+artifact: docs
+---
+
+# Docs
+
+No command-line syntax or configuration changes. The canonical exports requirement
+companion records that extensionless relative export-star targets may resolve to
+`.mjs`, `.cjs`, and their directory index variants. The exports context remains
+the source of truth for one-level barrel traversal and parse-mode parity.

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/requirements.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/requirements.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
+artifact: requirements
+---
+
+# Requirements
+
+- Preserve the existing relative-only, one-level export-star resolution boundary.
+- Probe `.mjs` and `.cjs` siblings after the existing TypeScript and JavaScript variants.
+- Probe `index.mjs` and `index.cjs` alongside the existing directory index variants.
+- Return the same ordered, deduplicated public export set in regex and AST parse modes.
+- Keep unreadable and unresolved targets best-effort and panic-free.

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript",
+  "slug": "resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript",
+  "title": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
+  "description": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
+  "kind": "bug_fix",
+  "state": "draft",
+  "base_commit": "dac64a1bff31cc5af0b590c8a800468440048e1e",
+  "created_at": 1784058230,
+  "updated_at": 1784058247,
+  "affected_specs": [
+    "exports"
+  ],
+  "affected_paths": [
+    "src/exports",
+    "specs/exports",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "An extensionless export-star barrel in an mjs source resolves a sibling mjs module and reports its public names.",
+    "The resolver probes module JavaScript file and index variants without regressing existing TypeScript or JavaScript resolution.",
+    "Strict validation passes for the regression fixture in both regex and AST parse modes."
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "requirements",
+    "docs"
+  ],
+  "dependencies": [
+    "CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm"
+  ],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
@@ -5,10 +5,10 @@
   "title": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
   "description": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
   "kind": "bug_fix",
-  "state": "approved",
+  "state": "implementing",
   "base_commit": "dac64a1bff31cc5af0b590c8a800468440048e1e",
   "created_at": 1784058230,
-  "updated_at": 1784058361,
+  "updated_at": 1784058367,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
@@ -5,10 +5,11 @@
   "title": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
   "description": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
   "kind": "bug_fix",
-  "state": "implementing",
+  "state": "accepted",
+  "canonical_applied": true,
   "base_commit": "dac64a1bff31cc5af0b590c8a800468440048e1e",
   "created_at": 1784058230,
-  "updated_at": 1784058367,
+  "updated_at": 1784058432,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/state.json
@@ -5,10 +5,10 @@
   "title": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
   "description": "Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources",
   "kind": "bug_fix",
-  "state": "draft",
+  "state": "approved",
   "base_commit": "dac64a1bff31cc5af0b590c8a800468440048e1e",
   "created_at": 1784058230,
-  "updated_at": 1784058247,
+  "updated_at": 1784058361,
   "affected_specs": [
     "exports"
   ],

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/tasks.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/tasks.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Reproduce the missing extensionless `.mjs` barrel export against the current PR head.
+- [x] Identify the shared one-level relative resolver used by both parsing modes.
+- [x] Define focused sibling, directory-index, and strict-validation regression fixtures.
+- [x] Preserve CHG-0036 and declare the supported lifecycle dependency instead of rewriting accepted history.

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/testing.md
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/testing.md
@@ -1,0 +1,18 @@
+---
+change: CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript
+artifact: testing
+---
+
+# Testing
+
+Requirement evidence:
+
+- `REQ-exports-003`: `module_javascript_resolves_extensionless_file_and_index_barrels`
+  proves sibling `.mjs`/`.cjs` and directory `index.mjs` resolution through the
+  shared scanner.
+- `REQ-exports-003`: `extensionless_mjs_barrel_passes_strict_in_regex_and_ast_modes`
+  proves the canonical public export set passes strict validation in both parse modes.
+
+Final validation runs all unit and integration tests, `fledge lanes run verify`,
+`specsync change check`, strict 100 percent spec coverage, hosted CI matrices, and
+the required Trust gate.

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/verification-attempts.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/verification-attempts.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784058424,
+      "commit": "82562f3787302e8f3efd67262a4c1d6f99c3cc00",
+      "contract_digest": "e66949c4c54a310717068cc37d7d8d3665e0216d3b808212a8e1ae34b4b5c29e",
+      "workspace_digest": "5dc580a464271c5b3d564340c07776f4edd2a17a39a2d6775a97fe06e5c6df55",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-exports-003"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/verification.json
+++ b/.specsync/changes/CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript/verification.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": 1784058424,
+  "commit": "82562f3787302e8f3efd67262a4c1d6f99c3cc00",
+  "contract_digest": "e66949c4c54a310717068cc37d7d8d3665e0216d3b808212a8e1ae34b4b5c29e",
+  "workspace_digest": "5dc580a464271c5b3d564340c07776f4edd2a17a39a2d6775a97fe06e5c6df55",
+  "acceptance_input_digest": "5157f963dc7954cc4360eca2e5429ab7e0f1fee33a9877ac743a53559994cc58",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-exports-003"
+  ]
+}

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/approvals.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/approvals.json
@@ -1,0 +1,4 @@
+{
+  "approvals": [],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/approvals.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/approvals.json
@@ -6,6 +6,13 @@
       "timestamp": 1784059420,
       "digest": "a8dd94ee5171949fc69b020fcfcba2ca9904e2152c6f3be40ee0ab977ddc2019",
       "note": "Approve the scoped late-review corrections, deterministic regressions, and generated-spec test exclusion contract."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784059868,
+      "digest": "9d971947029bd1a3289c417c1f19e75d1c415aa8ec9e015088ba6a798daf4c29",
+      "note": "Native verification passed at 232f484f5e6e772b4d8f76b73cbedf861d2f583c: 1,587 unit and 199 integration tests, including chained CommonJS assignments, module-scope filtering, regex-literal masking, CommonJS class type filtering, and module-JavaScript test-file exclusion regressions."
     }
   ],
   "reopenings": []

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/approvals.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/approvals.json
@@ -1,4 +1,12 @@
 {
-  "approvals": [],
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "user:0xLeif",
+      "timestamp": 1784059420,
+      "digest": "a8dd94ee5171949fc69b020fcfcba2ca9904e2152c6f3be40ee0ab977ddc2019",
+      "note": "Approve the scoped late-review corrections, deterministic regressions, and generated-spec test exclusion contract."
+    }
+  ],
   "reopenings": []
 }

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
@@ -1,0 +1,29 @@
+---
+id: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+state: draft
+type: bug_fix
+base_commit: 044eb584769487b8c43f1509a22d1693893d9894
+---
+
+# Harden CommonJS export extraction and exclude module JavaScript tests from generated specs
+
+## Intent
+
+Harden CommonJS export extraction and exclude module JavaScript tests from generated specs
+
+## Affected Canonical Specs
+
+- `exports`
+- `cmd_new`
+- `cmd_scaffold`
+
+## Acceptance Criteria
+
+- Chained CommonJS property assignments report every static export without phantom names from function-local aliases or regular-expression literals.
+- Type-level scans preserve statically exported CommonJS classes in regex and AST modes.
+- New and scaffold omit recognized JavaScript-family test files while retaining production module sources.
+- All existing ESM TypeScript CommonJS and generation behavior remains green in the complete native and hosted matrices.
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
-state: draft
+state: approved
 type: bug_fix
 base_commit: 044eb584769487b8c43f1509a22d1693893d9894
 ---

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
-state: approved
+state: implementing
 type: bug_fix
 base_commit: 044eb584769487b8c43f1509a22d1693893d9894
 ---

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
-state: implementing
+state: accepted
 type: bug_fix
 base_commit: 044eb584769487b8c43f1509a22d1693893d9894
 ---

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/context.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/context.md
@@ -1,0 +1,13 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: context
+---
+
+# Context
+
+Late review of CHG-0036 found static-analysis edge cases around chained assignments,
+function-local `exports` aliases, regular-expression literals, and type-only class
+filtering. The same review found that `new` and `scaffold` apply extension
+discovery without the shared test-file exclusion used by coverage. These are
+false-negative and false-positive risks in newly governed `.cjs` and `.mjs`
+projects, so they must be corrected before merging the discovery rollout.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/deltas/cmd_new.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/deltas/cmd_new.md
@@ -1,0 +1,10 @@
+## ADDED
+
+### REQUIREMENT REQ-cmd-new-002
+
+The new command SHALL exclude recognized test files from auto-detected module sources.
+
+Acceptance Criteria
+
+- JavaScript-family `.test.*` and `.spec.*` files are omitted.
+- Production files with configured or default source extensions remain included.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/deltas/cmd_scaffold.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/deltas/cmd_scaffold.md
@@ -1,0 +1,10 @@
+## ADDED
+
+### REQUIREMENT REQ-cmd-scaffold-002
+
+The add-spec scaffold SHALL exclude recognized test files from auto-detected module sources.
+
+Acceptance Criteria
+
+- JavaScript-family `.test.*` and `.spec.*` files are omitted.
+- Production files with configured or default source extensions remain included.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/deltas/exports.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/deltas/exports.md
@@ -1,0 +1,14 @@
+## ADDED
+
+### REQUIREMENT REQ-exports-004
+
+The static CommonJS scanner SHALL preserve every statically named module export
+without reporting assignment-like text from non-module scopes or literals.
+
+Acceptance Criteria
+
+- Chained property assignments report each exported name in source order.
+- Function-like local `exports` or `module` aliases do not create module exports.
+- Regular-expression literals cannot create property exports or corrupt object scanning.
+- Type-level scans preserve local and inline classes exported through CommonJS.
+- Regex and AST modes remain ordered, deduplicated, and compatible with ESM.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/design.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/design.md
@@ -1,0 +1,15 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: design
+---
+
+# Design
+
+Keep CommonJS extraction static and deterministic. Property matching must end at the
+assignment operator so chained assignments remain independently discoverable. Mask
+regex literals before scanning, and reject matches nested inside function-like AST
+scopes so parameter/local aliases are not treated as module exports. Type filtering
+intersects exported names with ordinary and inline CommonJS class declarations.
+
+`new` and `scaffold` reuse `exports::is_test_file` at file discovery time,
+matching the coverage denominator policy without changing configured extensions.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/docs.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/docs.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: docs
+---
+
+# Docs
+
+Canonical requirement companions document the hardened static CommonJS contract and
+the rule that generated spec file lists exclude recognized test files. No CLI flags,
+configuration keys, or migration steps change.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/plan.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/plan.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: plan
+---
+
+# Plan
+
+1. Add focused scanner and type-level regression tests for every review finding.
+2. Harden assignment matching, literal masking, and function-scope rejection.
+3. Apply the shared test-file predicate in both generated-spec discovery paths.
+4. Verify all native suites, strict SDD coverage, hosted matrices, and Trust.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/requirements.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/requirements.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: requirements
+---
+
+# Requirements
+
+- Report each statically named export in a chained CommonJS assignment.
+- Ignore CommonJS-looking text in regex literals and function-like local scopes.
+- Preserve CommonJS class names under type-level export filtering.
+- Exclude recognized test files from `new` and `scaffold` module discovery.
+- Preserve ESM results, declaration order, deduplication, and best-effort parsing.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/research.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/research.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: research
+---
+
+# Research
+
+The current property regex consumes one right-hand-side byte, which hides a second
+assignment in a chain. Literal masking handles strings, templates, and comments but
+not JavaScript regex literals. Tree-sitter is already available and can classify a
+matched byte range's ancestors without replacing the regex-mode extractor. Both
+generated-spec walkers already have the project root required by `is_test_file`.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener",
+  "slug": "harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener",
+  "title": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
+  "description": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
+  "kind": "bug_fix",
+  "state": "draft",
+  "base_commit": "044eb584769487b8c43f1509a22d1693893d9894",
+  "created_at": 1784059329,
+  "updated_at": 1784059354,
+  "affected_specs": [
+    "exports",
+    "cmd_new",
+    "cmd_scaffold"
+  ],
+  "affected_paths": [
+    "src/exports",
+    "src/commands/new.rs",
+    "src/commands/scaffold.rs",
+    "specs/exports",
+    "specs/cmd_new",
+    "specs/cmd_scaffold",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Chained CommonJS property assignments report every static export without phantom names from function-local aliases or regular-expression literals.",
+    "Type-level scans preserve statically exported CommonJS classes in regex and AST modes.",
+    "New and scaffold omit recognized JavaScript-family test files while retaining production module sources.",
+    "All existing ESM TypeScript CommonJS and generation behavior remains green in the complete native and hosted matrices."
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "design",
+    "requirements",
+    "docs",
+    "research",
+    "plan"
+  ],
+  "dependencies": [
+    "CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript"
+  ],
+  "answers": {
+    "architecture_risk": "yes",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
@@ -5,10 +5,11 @@
   "title": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
   "description": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
   "kind": "bug_fix",
-  "state": "implementing",
+  "state": "accepted",
+  "canonical_applied": true,
   "base_commit": "044eb584769487b8c43f1509a22d1693893d9894",
   "created_at": 1784059329,
-  "updated_at": 1784059420,
+  "updated_at": 1784059868,
   "affected_specs": [
     "exports",
     "cmd_new",

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
@@ -5,10 +5,10 @@
   "title": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
   "description": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
   "kind": "bug_fix",
-  "state": "draft",
+  "state": "approved",
   "base_commit": "044eb584769487b8c43f1509a22d1693893d9894",
   "created_at": 1784059329,
-  "updated_at": 1784059354,
+  "updated_at": 1784059420,
   "affected_specs": [
     "exports",
     "cmd_new",

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/state.json
@@ -5,7 +5,7 @@
   "title": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
   "description": "Harden CommonJS export extraction and exclude module JavaScript tests from generated specs",
   "kind": "bug_fix",
-  "state": "approved",
+  "state": "implementing",
   "base_commit": "044eb584769487b8c43f1509a22d1693893d9894",
   "created_at": 1784059329,
   "updated_at": 1784059420,

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/tasks.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/tasks.md
@@ -1,0 +1,11 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Reproduce all five late review findings against exact PR head `044eb58`.
+- [x] Identify the shared scanner, type filter, and generated-spec discovery paths.
+- [x] Define deterministic unit fixtures for each false-positive and false-negative.
+- [x] Preserve accepted CHG-0036/CHG-0037 history and declare the supported dependency.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/testing.md
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/testing.md
@@ -1,0 +1,15 @@
+---
+change: CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener
+artifact: testing
+---
+
+# Testing
+
+- `REQ-exports-004`: focused TypeScript scanner tests cover chained assignments,
+  function-local aliases, regex literals, and CommonJS classes at type level.
+- `REQ-cmd-new-002`: a command fixture proves `new` omits `.test.cjs` and
+  `.spec.mjs` while retaining production sources.
+- `REQ-cmd-scaffold-002`: a scaffold fixture proves the same shared exclusion.
+
+Closing evidence requires all unit and integration tests, the complete Fledge verify
+lane, strict 100 percent file and LOC coverage, every hosted matrix, and Trust.

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/verification-attempts.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/verification-attempts.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784059857,
+      "commit": "232f484f5e6e772b4d8f76b73cbedf861d2f583c",
+      "contract_digest": "a8dd94ee5171949fc69b020fcfcba2ca9904e2152c6f3be40ee0ab977ddc2019",
+      "workspace_digest": "8a9f3cddd64486a72b35f6f2ca3e4e4f3999b898e7ac52af517b5d0b4861a407",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-cmd-new-002",
+        "REQ-cmd-scaffold-002",
+        "REQ-exports-004"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/verification.json
+++ b/.specsync/changes/CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener/verification.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": 1784059857,
+  "commit": "232f484f5e6e772b4d8f76b73cbedf861d2f583c",
+  "contract_digest": "a8dd94ee5171949fc69b020fcfcba2ca9904e2152c6f3be40ee0ab977ddc2019",
+  "workspace_digest": "8a9f3cddd64486a72b35f6f2ca3e4e4f3999b898e7ac52af517b5d0b4861a407",
+  "acceptance_input_digest": "4afafc0da1382d925d90f675a0fde99c8588224c5a68e499aca01d3b97219fe7",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-cmd-new-002",
+    "REQ-cmd-scaffold-002",
+    "REQ-exports-004"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Complete module JavaScript discovery** — default TypeScript-family source discovery now includes `.mjs` and `.cjs`, so mapped files contribute to real file and LOC totals and uncovered module files correctly fail strict 100 percent coverage.
+
 ## [5.0.2] - 2026-07-14
 
 ### Added

--- a/specs/cmd_new/cmd_new.spec.md
+++ b/specs/cmd_new/cmd_new.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_new
-version: 4
+version: 5
 status: stable
 files:
   - src/commands/new.rs
@@ -82,3 +82,4 @@ Implements the `specsync new` command. Quick-creates a minimal spec with auto-de
 | 2026-04-09 | Initial spec |
 | 2026-04-13 | Document testing.md and conditional design.md in companion generation |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-14 | CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener: Harden CommonJS export extraction and exclude module JavaScript tests from generated specs |

--- a/specs/cmd_new/requirements.md
+++ b/specs/cmd_new/requirements.md
@@ -45,3 +45,12 @@ Acceptance Criteria
 - `--full` invokes `generator::generate_companion_files_for_spec`, creating `tasks.md`, `context.md`, `requirements.md`, `testing.md`, and `design.md` only when `companions.design` is enabled in config.
 - An existing target spec file causes exit code 1 with an error message; the command never overwrites it.
 
+### REQ-cmd-new-002
+
+The new command SHALL exclude recognized test files from auto-detected module sources.
+
+Acceptance Criteria
+
+- JavaScript-family `.test.*` and `.spec.*` files are omitted.
+- Production files with configured or default source extensions remain included.
+

--- a/specs/cmd_scaffold/cmd_scaffold.spec.md
+++ b/specs/cmd_scaffold/cmd_scaffold.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_scaffold
-version: 4
+version: 5
 status: stable
 files:
   - src/commands/scaffold.rs
@@ -80,3 +80,4 @@ Implements `specsync add-spec` and `specsync scaffold` commands. Creates new spe
 | 2026-04-09 | Initial spec |
 | 2026-04-13 | Document companions.design flag for conditional design.md generation |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-14 | CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener: Harden CommonJS export extraction and exclude module JavaScript tests from generated specs |

--- a/specs/cmd_scaffold/requirements.md
+++ b/specs/cmd_scaffold/requirements.md
@@ -48,3 +48,12 @@ Acceptance Criteria
 - `cmd_scaffold` registers the new module in `specsync-registry.toml` only when that file already exists at the repo root
 - On success, paths are printed relative to `root` with a checkmark; auto-detected source counts are reported
 
+### REQ-cmd-scaffold-002
+
+The add-spec scaffold SHALL exclude recognized test files from auto-detected module sources.
+
+Acceptance Criteria
+
+- JavaScript-family `.test.*` and `.spec.*` files are omitted.
+- Production files with configured or default source extensions remain included.
+

--- a/specs/exports/context.md
+++ b/specs/exports/context.md
@@ -7,6 +7,7 @@ spec: exports.spec.md
 - **Regex by default, AST opt-in**: All language backends use compiled regexes (`LazyLock<Regex>`). `ParseMode::Ast` enables tree-sitter backends for TypeScript, Python, Rust, C, C++, Scala, Erlang, Elixir, Perl, and Lisp/Scheme/Emacs Lisp; if the AST backend returns nothing (parse failure), `mod.rs` falls back to the regex backend automatically. Nim and Crystal have no published tree-sitter grammar crate, so they remain regex-only.
 - **Comment stripping first**: Every backend strips string literals then comments before running export regexes, preventing false matches inside strings or commented-out code.
 - **TypeScript wildcard resolution**: `export * from './foo'` is resolved one level deep via `resolve_ts_import` to prevent infinite re-export loops. Namespace re-exports (`export * as Ns`) produce the namespace name, not the inner symbols. Without a resolver, wildcard lines are skipped.
+- **Static CommonJS extraction**: The TypeScript-family backend supplements ESM parsing with a shared lexical scanner for `exports.name`, `module.exports.name`, and statically named `module.exports = { ... }` keys. Both parse modes reuse it for parity; comments, literals, computed keys, and unresolved spreads remain excluded without executing source.
 - **Python `__all__` precedence**: If `__all__` is defined, it is the sole source of exports. Otherwise, top-level non-underscore functions and classes are extracted.
 - **Go capitalization convention**: Uppercase first letter = exported. Methods are extracted separately from functions.
 - **Two export levels**: `ExportLevel::Type` (via `filter_type_level_exports`) extracts only top-level type declarations (class, struct, enum, interface); `ExportLevel::Member` extracts all public symbols. This allows specs to document at the right granularity.
@@ -21,7 +22,7 @@ spec: exports.spec.md
 
 ## Current Status
 
-Each regex backend has compiled patterns; AST backends exist for TypeScript, Python, Rust, C, C++, Scala, Erlang, Elixir, Perl, and Lisp/Scheme/Emacs Lisp under `src/exports/ast/` (Nim and Crystal remain regex-only — no published tree-sitter grammar crate for either). Rust multi-file extraction is regression-tested in strict mode for both backends. The optional real-world Swift verification remains portable when its external fixture paths are absent and warning-free under current stable Clippy.
+Each regex backend has compiled patterns; AST backends exist for TypeScript, Python, Rust, C, C++, Scala, Erlang, Elixir, Perl, and Lisp/Scheme/Emacs Lisp under `src/exports/ast/` (Nim and Crystal remain regex-only — no published tree-sitter grammar crate for either). TypeScript-family scanning recognizes static ESM, TypeScript `export =`, and ordinary CommonJS names with regex/AST parity. Rust multi-file extraction is regression-tested in strict mode for both backends. The optional real-world Swift verification remains portable when its external fixture paths are absent and warning-free under current stable Clippy.
 
 ## Notes
 

--- a/specs/exports/exports.spec.md
+++ b/specs/exports/exports.spec.md
@@ -1,6 +1,6 @@
 ---
 module: exports
-version: 6
+version: 7
 status: stable
 files:
   - src/exports/mod.rs
@@ -324,6 +324,7 @@ text and is intentionally excluded by code-only Rust dependency extraction.
 | 2026-07-11 | CHG-0007-harden-specsync-5-0-as-an-agent-native-secret-free-sdd-core-and-close-release-r: Harden SpecSync 5.0 as an agent-native, secret-free SDD core and close release regressions |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-14 | CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm: Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior |
+| 2026-07-14 | CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript: Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources |
 
 ## CommonJS Extraction
 

--- a/specs/exports/exports.spec.md
+++ b/specs/exports/exports.spec.md
@@ -1,6 +1,6 @@
 ---
 module: exports
-version: 5
+version: 6
 status: stable
 files:
   - src/exports/mod.rs
@@ -323,3 +323,16 @@ text and is intentionally excluded by code-only Rust dependency extraction.
 | 2026-07-09 | Filter Rust `pub(crate)`/`pub(super)`/`pub(self)`/`pub(in path)` from exports; add TypeScript `export = Name` support |
 | 2026-07-11 | CHG-0007-harden-specsync-5-0-as-an-agent-native-secret-free-sdd-core-and-close-release-r: Harden SpecSync 5.0 as an agent-native, secret-free SDD core and close release regressions |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-14 | CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm: Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior |
+
+## CommonJS Extraction
+
+The TypeScript/JavaScript backend supplements its ESM and TypeScript `export =` handling with static CommonJS name discovery in both regex and AST modes.
+
+- Direct `exports.foo = value` and `module.exports.foo = value` assignments report `foo`.
+- Top-level shorthand, named properties, and identifier-named methods in `module.exports = { ... }` report their static keys.
+- Comments, string and template literals, computed keys, and unresolved spreads never create exports.
+- Mixed ESM/CommonJS names are stable and deduplicated without executing source code.
+
+For `exports.foo = 1; module.exports = { bar, baz: value, [dynamic]: value, ...extra };`, both parsing modes report `foo`, `bar`, and `baz`, while ignoring `dynamic` and `extra` because their exported names are not statically determined.
+

--- a/specs/exports/exports.spec.md
+++ b/specs/exports/exports.spec.md
@@ -1,6 +1,6 @@
 ---
 module: exports
-version: 7
+version: 8
 status: stable
 files:
   - src/exports/mod.rs
@@ -325,6 +325,7 @@ text and is intentionally excluded by code-only Rust dependency extraction.
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-14 | CHG-0036-support-commonjs-exports-for-newly-discovered-cjs-modules-without-changing-esm: Support CommonJS exports for newly discovered .cjs modules without changing ESM behavior |
 | 2026-07-14 | CHG-0037-resolve-extensionless-mjs-barrel-exports-for-newly-discovered-module-javascript: Resolve extensionless mjs barrel exports for newly discovered module JavaScript sources |
+| 2026-07-14 | CHG-0038-harden-commonjs-export-extraction-and-exclude-module-javascript-tests-from-gener: Harden CommonJS export extraction and exclude module JavaScript tests from generated specs |
 
 ## CommonJS Extraction
 

--- a/specs/exports/requirements.md
+++ b/specs/exports/requirements.md
@@ -53,3 +53,14 @@ Acceptance Criteria
 - Narrower `pub(super)`, `pub(self)`, and `pub(in ...)` declarations remain excluded.
 - A multi-file fixture matching issue #334 passes strict phantom/undocumented export validation in both parse modes.
 
+### REQ-exports-002
+
+The TypeScript/JavaScript export scanner SHALL report statically named CommonJS exports in both regex and AST modes without changing existing ESM results.
+
+Acceptance Criteria
+
+- `exports.foo = ...` and `module.exports.foo = ...` report `foo`.
+- Top-level shorthand and named keys in `module.exports = { ... }` are reported.
+- Comments, strings, computed keys, and statically unresolved spreads do not report false exports.
+- Mixed ESM/CommonJS input is stable and deduplicated in both parsing modes.
+

--- a/specs/exports/requirements.md
+++ b/specs/exports/requirements.md
@@ -64,3 +64,16 @@ Acceptance Criteria
 - Comments, strings, computed keys, and statically unresolved spreads do not report false exports.
 - Mixed ESM/CommonJS input is stable and deduplicated in both parsing modes.
 
+### REQ-exports-003
+
+The TypeScript/JavaScript relative export resolver SHALL resolve extensionless
+module JavaScript file and directory-index targets without changing its existing
+one-level relative traversal boundary.
+
+Acceptance Criteria
+
+- An extensionless export-star target resolves sibling `.mjs` and `.cjs` files.
+- Directory targets resolve `index.mjs` and `index.cjs` alongside existing index variants.
+- Regex and AST parse modes return the same ordered, deduplicated public names.
+- Non-relative, unresolved, and unreadable targets retain their existing best-effort behavior.
+

--- a/specs/exports/requirements.md
+++ b/specs/exports/requirements.md
@@ -77,3 +77,16 @@ Acceptance Criteria
 - Regex and AST parse modes return the same ordered, deduplicated public names.
 - Non-relative, unresolved, and unreadable targets retain their existing best-effort behavior.
 
+### REQ-exports-004
+
+The static CommonJS scanner SHALL preserve every statically named module export
+without reporting assignment-like text from non-module scopes or literals.
+
+Acceptance Criteria
+
+- Chained property assignments report each exported name in source order.
+- Function-like local `exports` or `module` aliases do not create module exports.
+- Regular-expression literals cannot create property exports or corrupt object scanning.
+- Type-level scans preserve local and inline classes exported through CommonJS.
+- Regex and AST modes remain ordered, deduplicated, and compatible with ESM.
+

--- a/specs/exports/tasks.md
+++ b/specs/exports/tasks.md
@@ -5,6 +5,7 @@ spec: exports.spec.md
 ## Tasks
 
 - [x] Handle TypeScript `export =` (CommonJS-style default export) — captured in both regex and AST backends
+- [x] Extract statically named CommonJS assignments and object exports with regex/AST parity
 - [x] Restore Rust crate-contract visibility — `pub` and `pub(crate)` are included while `pub(super)`, `pub(self)`, and `pub(in path)` remain excluded in regex and AST backends
 
 ## Post-5.0 Roadmap

--- a/specs/exports/testing.md
+++ b/specs/exports/testing.md
@@ -7,7 +7,7 @@ spec: exports.spec.md
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
 | `src/exports/mod.rs` | cargo test exports:: | No inline tests in `mod.rs` itself; covered indirectly via the per-language backends and `tests/integration.rs`. Add focused coverage for `get_exported_symbols`, `get_exported_symbols_full`, `is_test_file`, `is_source_file`, `has_extension` before risky changes |
-| `src/exports/typescript.rs` | cargo test exports::typescript:: | `test_basic_exports`, `test_comments_stripped`, `test_re_exports`, `test_wildcard_namespace_export`, `test_wildcard_export_with_resolver`, `test_wildcard_export_without_resolver` |
+| `src/exports/typescript.rs` | cargo test exports::typescript:: | Existing ESM/re-export cases plus `test_commonjs_direct_and_object_exports`, `test_commonjs_ignores_non_static_and_non_code_names`, and `test_commonjs_mixed_with_esm_is_deduplicated` |
 | `src/exports/python.rs` | cargo test exports::python:: | `test_python_all`, `test_python_no_all`, `test_python_all_single_quotes`, `test_python_all_overrides_conventions`, `test_python_decorators_ignored`, `test_python_nested_not_captured` |
 | `src/exports/rust_lang.rs` | cargo test rust_lang | `test_rust_exports`, `test_pub_crate_included`, restricted-visibility exclusions, crate-visible re-exports, string/comment stripping, `test_real_registry_rs` |
 | `src/exports/go.rs` | cargo test exports::go:: | `test_go_exports`, `test_go_methods`, `test_go_comments_stripped`, `test_go_interface_declarations`, `test_go_const_var_groups`, `test_go_value_receiver` |
@@ -20,7 +20,7 @@ spec: exports.spec.md
 | `src/exports/ruby.rs` | cargo test exports::ruby:: | `test_ruby_class_and_methods`, `test_ruby_top_level_functions`, `test_ruby_visibility_toggle`, `test_ruby_skips_initialize` |
 | `src/exports/yaml.rs` | cargo test exports::yaml:: | `test_github_actions_workflow`, `test_docker_compose`, `test_anchors`, `test_top_level_only`, `test_four_space_indentation`, `test_four_space_nested_not_extracted` |
 | `src/exports/ast/mod.rs` | cargo test exports::ast::tests:: | Parity tests in `ast/tests.rs` cross-check AST vs regex output: `ts_basic_parity`, `ts_re_exports_with_alias`, `ts_wildcard_with_resolver`, `py_basic_parity`, `py_all_takes_precedence`, `rs_basic_parity`, `rs_pub_crate`, `rs_feature_gated`, `rs_pub_mod` |
-| `src/exports/ast/typescript.rs` | cargo test exports::ast::typescript:: | `test_basic_exports`, `test_re_exports_with_alias`, `test_wildcard_namespace`, `test_wildcard_with_resolver`, `test_default_export`, `test_async_abstract`, `test_conditional_export`, `test_export_type_clause`, `test_comments_not_exported` |
+| `src/exports/ast/typescript.rs` | cargo test exports::ast::typescript:: | Existing AST TypeScript cases plus `test_commonjs_exports_match_static_contract` for mixed ESM/CommonJS parity and negative syntax |
 | `src/exports/ast/python.rs` | cargo test exports::ast::python:: | `test_python_all`, `test_python_no_all`, `test_python_nested_not_captured`, `test_python_dunder_excluded`, `test_python_all_overrides`, `test_decorated_functions`, `test_conditional_import_init` |
 | `src/exports/ast/rust_lang.rs` | cargo test exports::ast::rust_lang:: | `test_rust_exports`, `test_pub_crate`, `test_async_unsafe`, `test_ignores_pub_in_strings`, `test_feature_gated`, `test_pub_mod` |
 | `tests/integration.rs` | cargo test --test integration fix_adds_undocumented_exports_to_spec | End-to-end fixture: `fix_adds_undocumented_exports_to_spec` |
@@ -33,6 +33,7 @@ spec: exports.spec.md
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
 | Extract TypeScript exports | a `.ts` file containing `export function authenticate(token: string): User` | `get_exported_symbols(path)` is called | includes "authenticate" in the returned vector |
+| Extract CommonJS exports | a `.cjs` file containing `exports.direct = value` and `module.exports = { shorthand, named: value, [dynamic]: value, ...extra }` | regex or AST extraction is selected | includes "direct", "shorthand", and "named" exactly once; excludes "dynamic" and "extra" |
 | Extract Rust pub items | a `.rs` file containing `pub fn validate_spec(...)` | `get_exported_symbols(path)` is called | includes "validate_spec" in the returned vector |
 | Unsupported file type | an unsupported file (e.g., `.txt`) | `get_exported_symbols(path)` is called | returns an empty vector |
 | Extract PHP exports with visibility | a `.php` file with a `class AuthService` containing `public function validate()`, `private function internalCheck()`, and `public const DEFAULT_TTL` | `get_exported_symbols(path)` is called | includes "AuthService", "validate", "DEFAULT_TTL" but not "internalCheck" |

--- a/specs/types/requirements.md
+++ b/specs/types/requirements.md
@@ -22,3 +22,13 @@ Acceptance Criteria
 - `AiProvider` and its helper API are removed.
 - `SpecSyncConfig` has no AI provider, model, command, key, base URL, or timeout fields.
 
+### REQ-types-002
+
+The shared language registry SHALL classify `.mjs` and `.cjs` as TypeScript-family sources for both direct detection and default extension discovery.
+
+Acceptance Criteria
+
+- Direct extension lookup maps `mjs` and `cjs` to TypeScript.
+- The TypeScript default extension list includes `mjs` and `cjs` alongside existing JavaScript and TypeScript suffixes.
+- Explicit source-extension filtering remains unchanged.
+

--- a/specs/types/types.spec.md
+++ b/specs/types/types.spec.md
@@ -1,6 +1,6 @@
 ---
 module: types
-version: 3
+version: 4
 status: stable
 files:
   - src/types.rs
@@ -156,3 +156,4 @@ Core deterministic data structures and enums shared across the codebase: configu
 | 2026-06-07 | Remove `AiProvider::default_model` / `default_base_url` — the `corvid-ai` crate now owns the API endpoint registry and default models |
 | 2026-06-07 | Add `OpenRouter`; reclassify `Ollama` as an API provider (HTTP via corvid-ai, `OLLAMA_API_KEY`); `detection_order` is now API-only; deprecate the `claude`/`copilot` CLI providers |
 | 2026-07-11 | CHG-0007-harden-specsync-5-0-as-an-agent-native-secret-free-sdd-core-and-close-release-r: Harden SpecSync 5.0 as an agent-native, secret-free SDD core and close release regressions |
+| 2026-07-14 | CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo: Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators |

--- a/specs/validator/requirements.md
+++ b/specs/validator/requirements.md
@@ -98,3 +98,13 @@ Acceptance Criteria
 - Coverage, generation, scaffold, new-spec, wizard, diff, and output scans share the extensionless rule.
 - Wizard discovery excludes directory entries before matching module names or extension rules.
 - Omitted or false configuration preserves existing source selection.
+
+### REQ-validator-006
+
+Default source discovery SHALL include `.mjs` and `.cjs` files in strict file and LOC coverage denominators.
+
+Acceptance Criteria
+
+- Mapped module files increase measured file and LOC totals using their real contents.
+- An uncovered `.mjs` or `.cjs` file prevents strict 100 percent coverage from passing.
+- Coverage output reports non-vacuous exact totals for mixed default-language projects.

--- a/specs/validator/validator.spec.md
+++ b/specs/validator/validator.spec.md
@@ -1,6 +1,6 @@
 ---
 module: validator
-version: 9
+version: 10
 status: stable
 files:
   - src/validator.rs
@@ -127,3 +127,4 @@ Implementation SHALL add these canonical dependency specs to `depends_on`: `spec
 | 2026-07-14 | CHG-0024-stabilize-specsync-5-lifecycle-integrity-and-strict-validation-for-5-0-2: Stabilize SpecSync 5 lifecycle integrity and strict validation for 5.0.2 |
 | 2026-07-14 | CHG-0025-address-all-unresolved-review-feedback-on-pr-366: Address all unresolved review feedback on PR 366 |
 | 2026-07-14 | CHG-0034-support-extensionless-source-discovery-through-an-explicit-include-extensionless: Support extensionless source discovery through an explicit include_extensionless setting while preserving omitted and empty source_extensions defaults, with parser, scanner, strict file coverage, LOC coverage, and wizard regressions for extensionless-only and mixed projects |
+| 2026-07-14 | CHG-0035-count-mjs-and-cjs-files-as-default-typescript-sources-so-mapped-and-uncovered-mo: Count mjs and cjs files as default TypeScript sources so mapped and uncovered module files contribute to strict file and LOC coverage denominators |

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -171,6 +171,7 @@ fn detect_module_sources(
                         &config.source_extensions,
                         config.include_extensionless,
                     )
+                    && !exports::is_test_file(entry.path(), root)
                 {
                     let rel = entry
                         .path()
@@ -195,6 +196,7 @@ fn detect_module_sources(
                             &config.source_extensions,
                             config.include_extensionless,
                         )
+                        && !exports::is_test_file(&path, root)
                     {
                         let rel = path
                             .strip_prefix(root)
@@ -264,4 +266,29 @@ fn chrono_lite_today() -> String {
 
 fn is_leap(y: i64) -> bool {
     y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detected_sources_omit_module_javascript_tests() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let module = root.join("src/widget");
+        fs::create_dir_all(&module).unwrap();
+        fs::write(module.join("index.cjs"), "exports.value = true;\n").unwrap();
+        fs::write(module.join("index.test.cjs"), "exports.helper = true;\n").unwrap();
+        fs::write(
+            module.join("index.spec.mjs"),
+            "export const fixture = true;\n",
+        )
+        .unwrap();
+        let config = crate::types::SpecSyncConfig::default();
+
+        let files = detect_module_sources(root, "widget", &config);
+
+        assert_eq!(files, vec!["src/widget/index.cjs"]);
+    }
 }

--- a/src/commands/scaffold.rs
+++ b/src/commands/scaffold.rs
@@ -64,6 +64,7 @@ pub fn cmd_add_spec(root: &Path, module_name: &str) {
                                 &config.source_extensions,
                                 config.include_extensionless,
                             )
+                            && !crate::exports::is_test_file(e.path(), root)
                     })
                     .map(|e| {
                         e.path()
@@ -185,6 +186,33 @@ Document this module's responsibility, inputs, outputs, and ownership boundaries
             eprintln!("Failed to write {}: {e}", spec_file.display());
             process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_spec_omits_module_javascript_test_sources() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let module = root.join("src/widget");
+        fs::create_dir_all(&module).unwrap();
+        fs::write(module.join("index.mjs"), "export const value = true;\n").unwrap();
+        fs::write(module.join("index.test.cjs"), "exports.helper = true;\n").unwrap();
+        fs::write(
+            module.join("index.spec.mjs"),
+            "export const fixture = true;\n",
+        )
+        .unwrap();
+
+        cmd_add_spec(root, "widget");
+
+        let spec = fs::read_to_string(root.join("specs/widget/widget.spec.md")).unwrap();
+        assert!(spec.contains("src/widget/index.mjs"), "{spec}");
+        assert!(!spec.contains("index.test.cjs"), "{spec}");
+        assert!(!spec.contains("index.spec.mjs"), "{spec}");
     }
 }
 

--- a/src/exports/ast/typescript.rs
+++ b/src/exports/ast/typescript.rs
@@ -561,6 +561,19 @@ const text = "module.exports.stringOnly = true";
     }
 
     #[test]
+    fn test_commonjs_hardening_matches_static_contract() {
+        let src = r#"
+exports.first = exports.second = value;
+const expression = /exports.regexOnly = true/;
+function fill(exports) {
+    exports.functionOnly = true;
+}
+"#;
+
+        assert_eq!(extract_exports(src), vec!["first", "second"]);
+    }
+
+    #[test]
     fn test_conditional_export() {
         // Tree-sitter can see exports inside if blocks
         let src = r#"

--- a/src/exports/ast/typescript.rs
+++ b/src/exports/ast/typescript.rs
@@ -41,6 +41,12 @@ pub fn extract_exports_with_resolver(
 
     collect_exports(&root, src, &mut symbols, resolver);
 
+    for symbol in super::super::typescript::extract_commonjs_exports(content) {
+        if !symbols.contains(&symbol) {
+            symbols.push(symbol);
+        }
+    }
+
     symbols
 }
 
@@ -528,6 +534,30 @@ export function realExport(): void {}
 "#;
         let symbols = extract_exports(src);
         assert_eq!(symbols, vec!["realExport"]);
+    }
+
+    #[test]
+    fn test_commonjs_exports_match_static_contract() {
+        let src = r#"
+export const esm = true;
+exports.direct = createDirect();
+module.exports.qualified = createQualified();
+module.exports = {
+    esm,
+    shorthand,
+    named: createNamed(),
+    method() { return true; },
+    [computed]: value,
+    ...extra,
+};
+// exports.commentOnly = true;
+const text = "module.exports.stringOnly = true";
+"#;
+        let symbols = extract_exports(src);
+        assert_eq!(
+            symbols,
+            vec!["esm", "direct", "qualified", "shorthand", "named", "method"]
+        );
     }
 
     #[test]

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -275,9 +275,10 @@ fn filter_type_level_exports(content: &str, symbols: &[String], lang: Language) 
 
     let type_pattern = match lang {
         Language::TypeScript => {
-            // class, interface, type, enum — but not function, const, var, let
+            // Exported ESM declarations, local classes later exported through
+            // CommonJS, and inline CommonJS class assignments.
             Regex::new(
-                r"(?m)export\s+(?:default\s+)?(?:abstract\s+)?(?:class|interface|type|enum)\s+(\w+)",
+                r"(?m)(?:\b(?:abstract\s+)?(?:class|interface|type|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)|(?:module\s*\.\s*)?exports\s*\.\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:abstract\s+)?class\b)",
             )
             .ok()
         }
@@ -374,7 +375,13 @@ fn filter_type_level_exports(content: &str, symbols: &[String], lang: Language) 
                 {
                     return None;
                 }
-                caps.get(2).map(|m| m.as_str().to_string())
+                if lang == Language::Rust {
+                    caps.get(2).map(|m| m.as_str().to_string())
+                } else {
+                    (1..caps.len())
+                        .find_map(|index| caps.get(index))
+                        .map(|name| name.as_str().to_string())
+                }
             })
             .collect(),
         None => return symbols.to_vec(),
@@ -622,7 +629,8 @@ mod configured_extension_tests {
 
 #[cfg(test)]
 mod scan_tests {
-    use super::{ExportScan, scan_exported_symbols};
+    use super::{ExportScan, scan_exported_symbols, scan_exported_symbols_full};
+    use crate::types::{ExportLevel, ParseMode};
     use std::io::Write;
 
     #[test]
@@ -691,5 +699,23 @@ mod scan_tests {
                 "fromIndex".to_string(),
             ])
         );
+    }
+
+    #[test]
+    fn commonjs_classes_survive_type_level_filtering_in_both_modes() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("classes.cjs");
+        std::fs::write(
+            &source,
+            "class Widget {}\nexports.Widget = Widget;\nexports.Inline = class {};\nexports.value = true;\n",
+        )
+        .unwrap();
+
+        for parse_mode in [ParseMode::Regex, ParseMode::Ast] {
+            assert_eq!(
+                scan_exported_symbols_full(&source, ExportLevel::Type, parse_mode),
+                ExportScan::Parsed(vec!["Widget".to_string(), "Inline".to_string()])
+            );
+        }
     }
 }

--- a/src/exports/mod.rs
+++ b/src/exports/mod.rs
@@ -388,7 +388,7 @@ fn filter_type_level_exports(content: &str, symbols: &[String], lang: Language) 
 }
 
 /// Resolve a TypeScript/JavaScript relative import to file content.
-/// Tries common extensions: .ts, .tsx, .js, .jsx, /index.ts, /index.js
+/// Tries TypeScript-family and JavaScript-family extensions and index files.
 fn resolve_ts_import(base_dir: &Path, import_path: &str) -> Option<String> {
     // Only resolve relative imports
     if !import_path.starts_with('.') {
@@ -403,7 +403,7 @@ fn resolve_ts_import(base_dir: &Path, import_path: &str) -> Option<String> {
     }
 
     // Try common extensions
-    for ext in &[".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"] {
+    for ext in &[".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"] {
         let with_ext = target.with_extension(ext.trim_start_matches('.'));
         if with_ext.is_file() {
             return std::fs::read_to_string(&with_ext).ok();
@@ -411,7 +411,16 @@ fn resolve_ts_import(base_dir: &Path, import_path: &str) -> Option<String> {
     }
 
     // Try as directory with index file
-    for index in &["index.ts", "index.tsx", "index.js", "index.jsx"] {
+    for index in &[
+        "index.ts",
+        "index.tsx",
+        "index.js",
+        "index.jsx",
+        "index.mts",
+        "index.cts",
+        "index.mjs",
+        "index.cjs",
+    ] {
         let index_path = target.join(index);
         if index_path.is_file() {
             return std::fs::read_to_string(&index_path).ok();
@@ -650,5 +659,37 @@ mod scan_tests {
         let mut f = std::fs::File::create(&bad).unwrap();
         f.write_all(b"export function x() {}\n\xff\xfe").unwrap();
         assert_eq!(scan_exported_symbols(&bad), ExportScan::Unreadable);
+    }
+
+    #[test]
+    fn module_javascript_resolves_extensionless_file_and_index_barrels() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("values.mjs"),
+            "export const fromMjs = true;\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("legacy.cjs"), "exports.fromCjs = true;\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("nested")).unwrap();
+        std::fs::write(
+            dir.path().join("nested/index.mjs"),
+            "export const fromIndex = true;\n",
+        )
+        .unwrap();
+        let barrel = dir.path().join("index.mjs");
+        std::fs::write(
+            &barrel,
+            "export * from './values';\nexport * from './legacy';\nexport * from './nested';\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            scan_exported_symbols(&barrel),
+            ExportScan::Parsed(vec![
+                "fromMjs".to_string(),
+                "fromCjs".to_string(),
+                "fromIndex".to_string(),
+            ])
+        );
     }
 }

--- a/src/exports/typescript.rs
+++ b/src/exports/typescript.rs
@@ -36,6 +36,18 @@ static EXPORT_DEFAULT: LazyLock<Regex> = LazyLock::new(|| {
 static EXPORT_EQUALS: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"export\s*=\s*(\w+)").unwrap());
 
+/// `exports.name = value` or `module.exports.name = value`.
+static COMMONJS_PROPERTY_EXPORT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)(?:^|[^\w$.])(?:module\s*\.\s*)?exports\s*\.\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:[^=>]|$)",
+    )
+    .unwrap()
+});
+
+/// Start of a `module.exports = { ... }` object assignment.
+static COMMONJS_OBJECT_EXPORT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)(?:^|[^\w$.])module\s*\.\s*exports\s*=\s*\{").unwrap());
+
 /// Extract exported symbols from TypeScript/JavaScript source (without file resolution).
 ///
 /// Supports:
@@ -44,6 +56,7 @@ static EXPORT_EQUALS: LazyLock<Regex> =
 /// - Namespace re-exports: `export * as Name from './module'`
 /// - Default exports: `export default class Name`
 /// - CommonJS-style default exports: `export = Name`
+/// - Static CommonJS exports: `exports.name = value` and `module.exports = { name }`
 ///
 /// For wildcard `export * from` support, use `extract_exports_with_resolver`.
 #[cfg_attr(not(test), allow(dead_code))]
@@ -157,7 +170,198 @@ pub fn extract_exports_with_resolver(
         }
     }
 
+    for symbol in extract_commonjs_exports(content) {
+        if !symbols.contains(&symbol) {
+            symbols.push(symbol);
+        }
+    }
+
     symbols
+}
+
+/// Extract statically named CommonJS exports without executing source code.
+///
+/// The scanner masks comments and literals before matching assignments. Object
+/// exports include identifier shorthand, named identifier properties, and
+/// identifier-named methods. Computed keys and spreads remain intentionally
+/// unresolved.
+pub(super) fn extract_commonjs_exports(content: &str) -> Vec<String> {
+    let masked = mask_comments_and_literals(content);
+    let mut symbols = Vec::new();
+
+    for captures in COMMONJS_PROPERTY_EXPORT.captures_iter(&masked) {
+        if let Some(name) = captures.get(1) {
+            push_unique(&mut symbols, name.as_str());
+        }
+    }
+
+    for matched in COMMONJS_OBJECT_EXPORT.find_iter(&masked) {
+        let open_brace = matched.end() - 1;
+        extract_commonjs_object_keys(&masked, open_brace, &mut symbols);
+    }
+
+    symbols
+}
+
+fn mask_comments_and_literals(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let mut masked = bytes.to_vec();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'/' && bytes.get(index + 1) == Some(&b'/') {
+            masked[index] = b' ';
+            masked[index + 1] = b' ';
+            index += 2;
+            while index < bytes.len() && bytes[index] != b'\n' {
+                masked[index] = b' ';
+                index += 1;
+            }
+            continue;
+        }
+
+        if bytes[index] == b'/' && bytes.get(index + 1) == Some(&b'*') {
+            masked[index] = b' ';
+            masked[index + 1] = b' ';
+            index += 2;
+            while index < bytes.len() {
+                if bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/') {
+                    masked[index] = b' ';
+                    masked[index + 1] = b' ';
+                    index += 2;
+                    break;
+                }
+                if bytes[index] != b'\n' {
+                    masked[index] = b' ';
+                }
+                index += 1;
+            }
+            continue;
+        }
+
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            let quote = bytes[index];
+            masked[index] = b' ';
+            index += 1;
+            while index < bytes.len() {
+                if bytes[index] == b'\\' && index + 1 < bytes.len() {
+                    masked[index] = b' ';
+                    masked[index + 1] = b' ';
+                    index += 2;
+                    continue;
+                }
+
+                let current = bytes[index];
+                if current != b'\n' {
+                    masked[index] = b' ';
+                }
+                index += 1;
+
+                if current == quote || (quote != b'`' && current == b'\n') {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        index += 1;
+    }
+
+    String::from_utf8(masked).expect("masking valid source preserves UTF-8")
+}
+
+fn extract_commonjs_object_keys(masked: &str, open_brace: usize, symbols: &mut Vec<String>) {
+    let bytes = masked.as_bytes();
+    let mut index = open_brace + 1;
+    let mut brace_depth = 1usize;
+    let mut bracket_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut property_start = true;
+
+    while index < bytes.len() {
+        if property_start && brace_depth == 1 && bracket_depth == 0 && paren_depth == 0 {
+            while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+                index += 1;
+            }
+            if index >= bytes.len() || bytes[index] == b'}' {
+                return;
+            }
+
+            if is_identifier_start(bytes[index]) {
+                let name_start = index;
+                index += 1;
+                while index < bytes.len() && is_identifier_continue(bytes[index]) {
+                    index += 1;
+                }
+                let name = &masked[name_start..index];
+                let mut after_name = index;
+                while after_name < bytes.len() && bytes[after_name].is_ascii_whitespace() {
+                    after_name += 1;
+                }
+
+                if matches!(bytes.get(after_name), Some(b':' | b',' | b'}' | b'(')) {
+                    push_unique(symbols, name);
+                } else if matches!(name, "async" | "get" | "set") {
+                    let second_start = after_name;
+                    if second_start < bytes.len() && is_identifier_start(bytes[second_start]) {
+                        let mut second_end = second_start + 1;
+                        while second_end < bytes.len() && is_identifier_continue(bytes[second_end])
+                        {
+                            second_end += 1;
+                        }
+                        let mut after_second = second_end;
+                        while after_second < bytes.len()
+                            && bytes[after_second].is_ascii_whitespace()
+                        {
+                            after_second += 1;
+                        }
+                        if bytes.get(after_second) == Some(&b'(') {
+                            push_unique(symbols, &masked[second_start..second_end]);
+                        }
+                    }
+                }
+            }
+
+            property_start = false;
+        }
+
+        if index >= bytes.len() {
+            return;
+        }
+
+        match bytes[index] {
+            b'{' => brace_depth += 1,
+            b'}' => {
+                if brace_depth == 1 {
+                    return;
+                }
+                brace_depth -= 1;
+            }
+            b'[' => bracket_depth += 1,
+            b']' => bracket_depth = bracket_depth.saturating_sub(1),
+            b'(' => paren_depth += 1,
+            b')' => paren_depth = paren_depth.saturating_sub(1),
+            b',' if brace_depth == 1 && bracket_depth == 0 && paren_depth == 0 => {
+                property_start = true;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+}
+
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$')
+}
+
+fn is_identifier_continue(byte: u8) -> bool {
+    is_identifier_start(byte) || byte.is_ascii_digit()
+}
+
+fn push_unique(symbols: &mut Vec<String>, name: &str) {
+    if !symbols.iter().any(|symbol| symbol == name) {
+        symbols.push(name.to_string());
+    }
 }
 
 /// Strip `//` line comments and `/* */` block comments in one linear pass
@@ -387,6 +591,63 @@ export = AuthService;
         let src = r#"export=AuthService;"#;
         let symbols = extract_exports(src);
         assert_eq!(symbols, vec!["AuthService"]);
+    }
+
+    #[test]
+    fn test_commonjs_direct_and_object_exports() {
+        let src = r#"
+exports.direct = createDirect();
+module.exports.qualified = createQualified();
+module.exports = {
+    shorthand,
+    named: createNamed(),
+    method() { return true; },
+    async asyncMethod() { return true; },
+    nested: { value: true },
+};
+"#;
+        let symbols = extract_exports(src);
+        assert_eq!(
+            symbols,
+            vec![
+                "direct",
+                "qualified",
+                "shorthand",
+                "named",
+                "method",
+                "asyncMethod",
+                "nested"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_commonjs_ignores_non_static_and_non_code_names() {
+        let src = r#"
+// exports.commentOnly = true;
+const text = "module.exports.stringOnly = true";
+const template = `exports.templateOnly = true`;
+module.exports = {
+    [computed]: value,
+    ...extra,
+    visible,
+};
+other.exports.notModule = true;
+exports.notAssignment == true;
+"#;
+        let symbols = extract_exports(src);
+        assert_eq!(symbols, vec!["visible"]);
+    }
+
+    #[test]
+    fn test_commonjs_mixed_with_esm_is_deduplicated() {
+        let src = r#"
+export const shared = true;
+exports.shared = shared;
+module.exports = { shared, commonOnly };
+"#;
+        let symbols = extract_exports(src);
+        assert_eq!(symbols, vec!["shared", "commonOnly"]);
     }
 
     #[test]

--- a/src/exports/typescript.rs
+++ b/src/exports/typescript.rs
@@ -1,5 +1,6 @@
 use regex::Regex;
 use std::sync::LazyLock;
+use tree_sitter::{Parser, Tree};
 
 /// export function/class/interface/type/const/enum name
 ///
@@ -39,7 +40,7 @@ static EXPORT_EQUALS: LazyLock<Regex> =
 /// `exports.name = value` or `module.exports.name = value`.
 static COMMONJS_PROPERTY_EXPORT: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"(?m)(?:^|[^\w$.])(?:module\s*\.\s*)?exports\s*\.\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:[^=>]|$)",
+        r"(?m)(?:^|[^\w$.])(?:module\s*\.\s*)?exports\s*\.\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*",
     )
     .unwrap()
 });
@@ -187,20 +188,81 @@ pub fn extract_exports_with_resolver(
 /// unresolved.
 pub(super) fn extract_commonjs_exports(content: &str) -> Vec<String> {
     let masked = mask_comments_and_literals(content);
+    let scope_tree = parse_scope_tree(content);
     let mut symbols = Vec::new();
 
-    for captures in COMMONJS_PROPERTY_EXPORT.captures_iter(&masked) {
-        if let Some(name) = captures.get(1) {
+    let mut property_cursor = 0;
+    while let Some(captures) = COMMONJS_PROPERTY_EXPORT.captures_at(&masked, property_cursor) {
+        let Some(name) = captures.get(1) else {
+            break;
+        };
+        if is_plain_assignment(&masked, captures.get(0).map_or(0, |matched| matched.end()))
+            && scope_tree
+                .as_ref()
+                .is_none_or(|tree| is_module_scope(tree, name.start()))
+        {
             push_unique(&mut symbols, name.as_str());
         }
+
+        // Resume inside the match so a chained RHS assignment can reuse the
+        // first assignment operator as its left boundary.
+        property_cursor = name.end().max(property_cursor + 1);
     }
 
     for matched in COMMONJS_OBJECT_EXPORT.find_iter(&masked) {
+        if scope_tree
+            .as_ref()
+            .is_some_and(|tree| !is_module_scope(tree, matched.start()))
+        {
+            continue;
+        }
         let open_brace = matched.end() - 1;
         extract_commonjs_object_keys(&masked, open_brace, &mut symbols);
     }
 
     symbols
+}
+
+fn parse_scope_tree(content: &str) -> Option<Tree> {
+    let mut parser = Parser::new();
+    let language = tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into();
+    parser.set_language(&language).ok()?;
+    parser.parse(content, None)
+}
+
+fn is_module_scope(tree: &Tree, byte_offset: usize) -> bool {
+    let Some(mut node) = tree
+        .root_node()
+        .descendant_for_byte_range(byte_offset, byte_offset.saturating_add(1))
+    else {
+        return true;
+    };
+
+    loop {
+        if matches!(
+            node.kind(),
+            "function_declaration"
+                | "function_expression"
+                | "generator_function_declaration"
+                | "generator_function"
+                | "arrow_function"
+                | "method_definition"
+        ) {
+            return false;
+        }
+        let Some(parent) = node.parent() else {
+            return true;
+        };
+        node = parent;
+    }
+}
+
+fn is_plain_assignment(masked: &str, after_match: usize) -> bool {
+    masked.as_bytes()[after_match..]
+        .iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_none_or(|byte| !matches!(byte, b'=' | b'>'))
 }
 
 fn mask_comments_and_literals(content: &str) -> String {
@@ -239,6 +301,18 @@ fn mask_comments_and_literals(content: &str) -> String {
             continue;
         }
 
+        if bytes[index] == b'/'
+            && let Some(end) = regex_literal_end(bytes, index)
+        {
+            for byte in &mut masked[index..end] {
+                if *byte != b'\n' {
+                    *byte = b' ';
+                }
+            }
+            index = end;
+            continue;
+        }
+
         if matches!(bytes[index], b'\'' | b'"' | b'`') {
             let quote = bytes[index];
             masked[index] = b' ';
@@ -268,6 +342,65 @@ fn mask_comments_and_literals(content: &str) -> String {
     }
 
     String::from_utf8(masked).expect("masking valid source preserves UTF-8")
+}
+
+fn regex_literal_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let previous = bytes[..start]
+        .iter()
+        .rev()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace());
+    if previous.is_some_and(|byte| {
+        !matches!(
+            byte,
+            b'=' | b'('
+                | b'['
+                | b'{'
+                | b','
+                | b':'
+                | b';'
+                | b'!'
+                | b'?'
+                | b'&'
+                | b'|'
+                | b'+'
+                | b'-'
+                | b'*'
+                | b'%'
+                | b'^'
+                | b'~'
+                | b'<'
+                | b'>'
+        )
+    }) {
+        return None;
+    }
+
+    let mut index = start + 1;
+    let mut in_character_class = false;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' if index + 1 < bytes.len() => index += 2,
+            b'[' => {
+                in_character_class = true;
+                index += 1;
+            }
+            b']' => {
+                in_character_class = false;
+                index += 1;
+            }
+            b'/' if !in_character_class => {
+                index += 1;
+                while index < bytes.len() && bytes[index].is_ascii_alphabetic() {
+                    index += 1;
+                }
+                return Some(index);
+            }
+            b'\n' => return None,
+            _ => index += 1,
+        }
+    }
+    None
 }
 
 fn extract_commonjs_object_keys(masked: &str, open_brace: usize, symbols: &mut Vec<String>) {
@@ -648,6 +781,25 @@ module.exports = { shared, commonOnly };
 "#;
         let symbols = extract_exports(src);
         assert_eq!(symbols, vec!["shared", "commonOnly"]);
+    }
+
+    #[test]
+    fn test_commonjs_chains_ignore_function_scopes_and_regex_literals() {
+        let src = r#"
+exports.first = exports.second = value;
+exports.third = module.exports.fourth = value;
+const expression = /exports.regexOnly = module.exports = { hidden }/gi;
+function fill(exports) {
+    exports.functionOnly = true;
+}
+const run = (module) => {
+    module.exports.arrowOnly = true;
+};
+"#;
+
+        let symbols = extract_exports(src);
+
+        assert_eq!(symbols, vec!["first", "second", "third", "fourth"]);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -649,7 +649,21 @@ impl Language {
     /// File patterns to exclude (test files, etc.).
     pub fn test_patterns(&self) -> &[&str] {
         match self {
-            Language::TypeScript => &[".test.ts", ".spec.ts", ".test.tsx", ".spec.tsx", ".d.ts"],
+            Language::TypeScript => &[
+                ".test.ts",
+                ".spec.ts",
+                ".test.tsx",
+                ".spec.tsx",
+                ".test.js",
+                ".spec.js",
+                ".test.jsx",
+                ".spec.jsx",
+                ".test.mjs",
+                ".spec.mjs",
+                ".test.cjs",
+                ".spec.cjs",
+                ".d.ts",
+            ],
             Language::Rust => &[], // Rust tests are inline, not separate files
             Language::Go => &["_test.go"],
             Language::Python => &["test_", "_test.py"],
@@ -713,6 +727,18 @@ mod language_extension_tests {
         assert_eq!(Language::from_extension("cjs"), Some(Language::TypeScript));
         assert!(Language::TypeScript.extensions().contains(&"mjs"));
         assert!(Language::TypeScript.extensions().contains(&"cjs"));
+        for pattern in [
+            ".test.js",
+            ".spec.js",
+            ".test.jsx",
+            ".spec.jsx",
+            ".test.mjs",
+            ".spec.mjs",
+            ".test.cjs",
+            ".spec.cjs",
+        ] {
+            assert!(Language::TypeScript.test_patterns().contains(&pattern));
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -567,7 +567,9 @@ impl Language {
     /// Detect language from file extension.
     pub fn from_extension(ext: &str) -> Option<Self> {
         match ext {
-            "ts" | "tsx" | "js" | "jsx" | "mts" | "cts" => Some(Language::TypeScript),
+            "ts" | "tsx" | "js" | "jsx" | "mts" | "cts" | "mjs" | "cjs" => {
+                Some(Language::TypeScript)
+            }
             "rs" => Some(Language::Rust),
             "go" => Some(Language::Go),
             "py" => Some(Language::Python),
@@ -608,7 +610,7 @@ impl Language {
     #[allow(dead_code)]
     pub fn extensions(&self) -> &[&str] {
         match self {
-            Language::TypeScript => &["ts", "tsx", "js", "jsx", "mts", "cts"],
+            Language::TypeScript => &["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"],
             Language::Rust => &["rs"],
             Language::Go => &["go"],
             Language::Python => &["py"],
@@ -698,6 +700,19 @@ impl Language {
             Language::PowerShell => &["Tests.ps1", ".Tests.ps1"],
             Language::Vala => &["Test.vala", "Tests.vala"],
         }
+    }
+}
+
+#[cfg(test)]
+mod language_extension_tests {
+    use super::Language;
+
+    #[test]
+    fn module_javascript_extensions_are_typescript_family_sources() {
+        assert_eq!(Language::from_extension("mjs"), Some(Language::TypeScript));
+        assert_eq!(Language::from_extension("cjs"), Some(Language::TypeScript));
+        assert!(Language::TypeScript.extensions().contains(&"mjs"));
+        assert!(Language::TypeScript.extensions().contains(&"cjs"));
     }
 }
 

--- a/tests/integration/check.rs
+++ b/tests/integration/check.rs
@@ -605,6 +605,44 @@ fn javascript_family_test_files_do_not_inflate_default_coverage_totals() {
 }
 
 #[test]
+fn extensionless_mjs_barrel_passes_strict_in_regex_and_ast_modes() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("specs/modules")).unwrap();
+    write_config(root, "specs", &["src"]);
+    fs::write(
+        root.join("src/values.mjs"),
+        "export const fromMjs = true;\n",
+    )
+    .unwrap();
+    fs::write(root.join("src/index.mjs"), "export * from './values';\n").unwrap();
+    let spec = complete_coverage_spec("modules", &["src/values.mjs", "src/index.mjs"]).replace(
+        "| Function | Parameters | Returns | Description |\n|----------|-----------|---------|-------------|",
+        "| Function | Parameters | Returns | Description |\n|----------|-----------|---------|-------------|\n| `fromMjs` | none | boolean | Re-exported mjs value |",
+    );
+    fs::write(root.join("specs/modules/modules.spec.md"), spec).unwrap();
+
+    for parse_mode in ["regex", "ast"] {
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(
+            root.join(".specsync/config.toml"),
+            format!(
+                "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\nparse_mode = \"{parse_mode}\"\n"
+            ),
+        )
+        .unwrap();
+        specsync()
+            .args(["check", "--strict", "--force"])
+            .arg("--root")
+            .arg(root)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("1 specs checked: 1 passed"));
+    }
+}
+
+#[test]
 fn require_coverage_fails_when_below_threshold() {
     let tmp = TempDir::new().unwrap();
     let root = setup_minimal_project(&tmp);

--- a/tests/integration/check.rs
+++ b/tests/integration/check.rs
@@ -573,6 +573,38 @@ fn uncovered_mjs_and_cjs_files_fail_strict_full_coverage() {
 }
 
 #[test]
+fn javascript_family_test_files_do_not_inflate_default_coverage_totals() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("specs/index")).unwrap();
+    write_config(root, "specs", &["src"]);
+    fs::write(root.join("src/index.ts"), "// mapped\n").unwrap();
+    for filename in [
+        "index.test.js",
+        "index.spec.jsx",
+        "index.test.mjs",
+        "index.spec.cjs",
+    ] {
+        fs::write(root.join("src").join(filename), "// test-only\n").unwrap();
+    }
+    fs::write(
+        root.join("specs/index/index.spec.md"),
+        complete_coverage_spec("index", &["src/index.ts"]),
+    )
+    .unwrap();
+
+    specsync()
+        .args(["coverage", "--strict", "--require-coverage", "100"])
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("File coverage: 1/1 (100%)"))
+        .stdout(predicate::str::contains("LOC coverage:  1/1 (100%)"));
+}
+
+#[test]
 fn require_coverage_fails_when_below_threshold() {
     let tmp = TempDir::new().unwrap();
     let root = setup_minimal_project(&tmp);

--- a/tests/integration/check.rs
+++ b/tests/integration/check.rs
@@ -507,6 +507,72 @@ fn mixed_extensionless_project_has_non_vacuous_strict_coverage() {
 }
 
 #[test]
+fn default_discovery_counts_mjs_and_cjs_in_exact_coverage_totals() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("specs/modules")).unwrap();
+    write_config(root, "specs", &["src"]);
+    fs::write(root.join("src/index.ts"), "// ts one\n// ts two\n").unwrap();
+    fs::write(root.join("src/render.mjs"), "// mjs one\n// mjs two\n").unwrap();
+    fs::write(root.join("src/config.cjs"), "// cjs one\n// cjs two\n").unwrap();
+    fs::write(root.join("src/theme.css"), "/* css one */\n/* css two */\n").unwrap();
+    fs::write(
+        root.join("specs/modules/modules.spec.md"),
+        complete_coverage_spec(
+            "modules",
+            &[
+                "src/index.ts",
+                "src/render.mjs",
+                "src/config.cjs",
+                "src/theme.css",
+            ],
+        ),
+    )
+    .unwrap();
+
+    specsync()
+        .args(["coverage", "--strict", "--require-coverage", "100"])
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("File coverage: 4/4 (100%)"))
+        .stdout(predicate::str::contains("LOC coverage:  8/8 (100%)"));
+}
+
+#[test]
+fn uncovered_mjs_and_cjs_files_fail_strict_full_coverage() {
+    for extension in ["mjs", "cjs"] {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("specs/index")).unwrap();
+        write_config(root, "specs", &["src"]);
+        fs::write(root.join("src/index.ts"), "// mapped\n").unwrap();
+        fs::write(
+            root.join(format!("src/unmapped.{extension}")),
+            "// uncovered\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("specs/index/index.spec.md"),
+            complete_coverage_spec("index", &["src/index.ts"]),
+        )
+        .unwrap();
+
+        specsync()
+            .args(["coverage", "--strict", "--require-coverage", "100"])
+            .arg("--root")
+            .arg(root)
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains("File coverage: 1/2 (50%)"))
+            .stdout(predicate::str::contains("LOC coverage:  1/2 (50%)"));
+    }
+}
+
+#[test]
 fn require_coverage_fails_when_below_threshold() {
     let tmp = TempDir::new().unwrap();
     let root = setup_minimal_project(&tmp);


### PR DESCRIPTION
## Summary

- classify `.mjs` and `.cjs` as TypeScript-family sources in both direct detection and default discovery
- count mapped module files in exact file and LOC coverage totals
- make uncovered `.mjs` and `.cjs` files independently fail strict 100% coverage instead of producing a false green
- exclude `.test` and `.spec` files across `.js`, `.jsx`, `.mjs`, and `.cjs` from production coverage discovery
- add accepted `REQ-types-002` and `REQ-validator-006` lifecycle evidence anchored to the current `v5.0.2` main commit

## Test Plan

- [x] focused language-classification and test-pattern regressions
- [x] mapped `.ts` + `.css` + `.mjs` + `.cjs` fixture reports 4/4 files and 8/8 LOC
- [x] uncovered `.mjs` and `.cjs` fixtures each fail at 1/2 files and 1/2 LOC
- [x] JavaScript-family test/spec files remain excluded at 1/1 files and 1/1 LOC
- [x] lifecycle verification: 1,577 unit and 198 integration tests
- [x] local Trust: release build, 62/62 strict specs, 105/105 files, 72,779/72,779 LOC, Augur review risk 39
- [x] hosted CI, platform matrix, packaged action, CodeQL, audit, required gate, corvid-pet, and Trust on exact head `096425e`

All hosted checks pass on the exact clean head. This PR must be merged with a merge commit so the verified lifecycle commit remains in main ancestry.