### PR TITLE
docs: name the two pre-approval gates in the quickstart

### DIFF
--- a/site/src/content/docs/quickstart.md
+++ b/site/src/content/docs/quickstart.md
@@ -77,6 +77,11 @@ specsync change new "Document and verify the existing authentication module" \
 
 Answer the returned questions, complete its adaptively selected artifacts, and approve the definition before implementation. Agents installed during `init` conduct this interview conversationally.
 
+> **Two gates fire before `change approve` succeeds:**
+>
+> 1. **Artifact completeness** — every generated artifact in the change workspace (`context.md`, `requirements.md`, `tasks.md`, `testing.md`, and any others the interview selected) must have its scaffold `TODO` marker replaced with real content. Approval fails with a path-and-line diagnostic naming the unfinished artifact.
+> 2. **Semantic deltas** — each spec module the change touches needs a delta file at `.specsync/changes/<change-id>/deltas/<module>.md` describing its contract changes (added/modified requirements and spec-section content). The set of delta modules must exactly match the change's affected specs, or approval fails with `semantic delta modules must exactly match affected specs`.
+
 Continue through the same lifecycle after the definition is complete:
 
 ```bash


### PR DESCRIPTION
## What

Adds a callout to Quickstart step 2 naming the **two gates that fire before `change approve` succeeds**:

1. **Artifact completeness** — scaffold `TODO` markers in workspace artifacts fail approval with a path-and-line diagnostic.
2. **Semantic deltas** — every affected spec module needs a `deltas/<module>.md`, and the set must exactly match affected specs.

## Why

The quickstart currently sends readers from `change new` straight to `change approve`. In practice (verified by walking the flow end-to-end on 5.1.0), approval fails twice first — both gates are undocumented at this point in the guide, and both error messages only make sense if you already know what artifacts and deltas are. This is the precise spot where a first-time user stalls.

Wording stays tool-neutral on the delta format itself; #390 documents the format in full, and the two pages cross-reference cleanly (this one doesn't link it to stay mergeable independently).

## Scope

One file, one callout block. No other content changed.