### PR TITLE
Update: add static x86_64-musl build to the release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: specsync-linux-x86_64
           - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact: specsync-linux-x86_64-musl
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             artifact: specsync-linux-aarch64
           - os: macos-latest
@@ -68,6 +71,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - name: Install musl toolchain (Linux musl)
+        if: contains(matrix.target, 'musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
+          echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 47,
-  "id": "CHG-0047-permit-audited-deterministic-ownership-corrections-for-reopened-already-applied",
+  "sequence": 48,
+  "id": "CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/approvals.json
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/approvals.json
@@ -1,0 +1,19 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784317936,
+      "digest": "a9bcafab46f4849317b26a0174c73ee426721a9a78800ccb9c998708d89226e6",
+      "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1784318518,
+      "digest": "9d061a7b5c8d05008bb18dd623561d6fa9bc8d4991a0c9105b7208c7aeccecc0",
+      "note": null
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/change.md
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin
+state: accepted
+type: operations
+base_commit: 4652ca1535eb65f7ba3ab0fc54b458b408fc174d
+---
+
+# Add static x86_64-unknown-linux-musl build to the release matrix so prebuilt binaries run on distros with glibc older than 2.39
+
+## Intent
+
+Add static x86_64-unknown-linux-musl build to the release matrix so prebuilt binaries run on distros with glibc older than 2.39
+
+## Affected Canonical Specs
+
+- None
+
+## Acceptance Criteria
+
+- Release workflow matrix includes an x86_64-unknown-linux-musl target producing a specsync-linux-x86_64-musl artifact with checksum through the existing artifact-name-driven packaging, upload, and release steps; the docs Available Binaries table lists the musl artifact.
+
+## No-spec Rationale
+
+CI release matrix and docs table only; no canonical spec module behavior changes

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/context.md
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/context.md
@@ -1,0 +1,24 @@
+---
+change: CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin
+artifact: context
+---
+
+# Context
+
+The prebuilt Linux x86_64 binary from the releases page is built on `ubuntu-latest` against
+glibc 2.39. On any distro with an older glibc (for example Debian 12, glibc 2.36), it fails at
+startup with `version 'GLIBC_2.39' not found (required by specsync)`. The "single binary, no
+toolchain needed" install path silently only works on bleeding-edge distros; everyone else
+falls back to `cargo install specsync` (roughly an 11 minute compile with the tree-sitter
+grammars). Reported in GitHub issue #392.
+
+A static `x86_64-unknown-linux-musl` artifact runs on any Linux regardless of glibc version,
+which matches the tool's "deterministic, single-binary, works everywhere" distribution story.
+The release workflow's packaging, checksum-verification, upload, and release-glob steps are all
+artifact-name-driven, so only the matrix entry and one musl toolchain step are required.
+`musl-gcc` is needed because the tree-sitter grammar crates compile C via the `cc` crate; the
+musl target otherwise links fine with Rust's bundled std. The `dtolnay/rust-toolchain` step
+already installs the musl std via its `targets:` input.
+
+aarch64-musl was considered but left out to keep this minimal: it needs a cross musl toolchain
+rather than `musl-tools`.

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/plan.md
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/plan.md
@@ -1,0 +1,16 @@
+---
+change: CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin
+artifact: plan
+---
+
+# Plan
+
+1. Add an `x86_64-unknown-linux-musl` matrix entry to `.github/workflows/release.yml` producing
+   the `specsync-linux-x86_64-musl` artifact.
+2. Add an `Install musl toolchain (Linux musl)` step gated on `contains(matrix.target, 'musl')`
+   that installs `musl-tools` and exports `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER` and
+   `CC_x86_64_unknown_linux_musl` as `musl-gcc`.
+3. Add the musl binary to the Available Binaries table in
+   `site/src/content/docs/integrations/github-action.md`.
+4. Validate the workflow YAML and confirm the packaging, checksum, upload, and release-glob
+   steps need no changes (they are artifact-name-driven).

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/state.json
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/state.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin",
+  "slug": "add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin",
+  "title": "Add static x86_64-unknown-linux-musl build to the release matrix so prebuilt binaries run on distros with glibc older than 2.39",
+  "description": "Add static x86_64-unknown-linux-musl build to the release matrix so prebuilt binaries run on distros with glibc older than 2.39",
+  "kind": "operations",
+  "state": "accepted",
+  "canonical_applied": true,
+  "base_commit": "4652ca1535eb65f7ba3ab0fc54b458b408fc174d",
+  "created_at": 1784317519,
+  "updated_at": 1784318518,
+  "affected_specs": [],
+  "affected_paths": [
+    ".github/workflows/release.yml",
+    "site/src/content/docs/integrations/github-action.md",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": true,
+  "no_spec_change_rationale": "CI release matrix and docs table only; no canonical spec module behavior changes",
+  "acceptance_criteria": [
+    "Release workflow matrix includes an x86_64-unknown-linux-musl target producing a specsync-linux-x86_64-musl artifact with checksum through the existing artifact-name-driven packaging, upload, and release steps; the docs Available Binaries table lists the musl artifact."
+  ],
+  "selected_artifacts": [
+    "context",
+    "plan",
+    "testing"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/testing.md
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/testing.md
@@ -1,0 +1,18 @@
+---
+change: CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin
+artifact: testing
+---
+
+# Testing
+
+The release workflow only runs on tag pushes, so the musl build is exercised end-to-end at the
+next tag. Pre-merge verification is static and structural:
+
+- Parse `.github/workflows/release.yml` as YAML to prove the matrix entry and toolchain step
+  are syntactically valid.
+- Confirm the musl matrix entry uses the same artifact-name-driven packaging, checksum,
+  upload-artifact, and release-glob steps as every other target, so no step changes are needed.
+- Confirm `ci.yml` and `trust.yml` build their own local mock `specsync-linux-x86_64` artifacts
+  and are unaffected by the additional release artifact.
+- Run the full `fledge trust verify` lane (fmt, clippy, build, spec-check, and tests) on the
+  branch.

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/verification-attempts.json
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/verification-attempts.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784318483,
+      "commit": "4652ca1535eb65f7ba3ab0fc54b458b408fc174d",
+      "contract_digest": "a9bcafab46f4849317b26a0174c73ee426721a9a78800ccb9c998708d89226e6",
+      "workspace_digest": "2931f040d30303fb7e03040a6f8f5a856504cd71bdca9707a7d1520e04d34442",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/verification.json
+++ b/.specsync/changes/CHG-0048-add-static-x86-64-unknown-linux-musl-build-to-the-release-matrix-so-prebuilt-bin/verification.json
@@ -1,0 +1,51 @@
+{
+  "timestamp": 1784318483,
+  "commit": "4652ca1535eb65f7ba3ab0fc54b458b408fc174d",
+  "contract_digest": "a9bcafab46f4849317b26a0174c73ee426721a9a78800ccb9c998708d89226e6",
+  "workspace_digest": "2931f040d30303fb7e03040a6f8f5a856504cd71bdca9707a7d1520e04d34442",
+  "acceptance_input_digest": "faf068747c02683a3697997e9c041437771aecb03e199ee226de01e8c590ef81",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".github/workflows/release.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "ecdfb5e5456525af4acce6a91e29414ff97e7018faa2bf758a06c9f837475895",
+        "entry_digest": "6443420aa4b60c75ccf8ce161efbaf4592f32da3908d70c34edce6e6160fef60",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/change-sequence.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "840e98586f4663fac751804786773e430f1b49a5426ffea508ae6f052576fc62",
+        "entry_digest": "dac6b4232549f527b6fa33f57a6e34351f1271da3721805ba9afa81a86843848",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/integrations/github-action.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "2fc5838f54b69d856069d63a631f1e894974e50d83a6465ba2f8b100eca6c7cf",
+        "entry_digest": "2d6c971e5c35896519459f8a64dc61fe0f181cb21d0957b383fad62085ddc958",
+        "owners": [
+          "@exact:delivery"
+        ]
+      }
+    ]
+  },
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": []
+}

--- a/site/src/content/docs/integrations/github-action.md
+++ b/site/src/content/docs/integrations/github-action.md
@@ -150,6 +150,7 @@ jobs:
 | Platform | Binary |
 |:---------|:-------|
 | Linux x86_64 | `specsync-linux-x86_64` |
+| Linux x86_64 (static musl, any distro) | `specsync-linux-x86_64-musl` |
 | Linux aarch64 | `specsync-linux-aarch64` |
 | macOS x86_64 | `specsync-macos-x86_64` |
 | macOS aarch64 (Apple Silicon) | `specsync-macos-aarch64` |


### PR DESCRIPTION
## Summary

Closes #392.

The prebuilt `specsync-linux-x86_64` binary is built on `ubuntu-latest` against glibc 2.39, so it fails to start on distros with older glibc (e.g. Debian 12, glibc 2.36) with `version 'GLIBC_2.39' not found`. This adds a static `x86_64-unknown-linux-musl` target to the release matrix, producing `specsync-linux-x86_64-musl`, which runs on any Linux regardless of glibc version.

## Changes

- `.github/workflows/release.yml`
  - New matrix entry: `x86_64-unknown-linux-musl` → `specsync-linux-x86_64-musl`
  - New `Install musl toolchain (Linux musl)` step (gated on `contains(matrix.target, 'musl')`): installs `musl-tools` and sets `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER` / `CC_x86_64_unknown_linux_musl` to `musl-gcc`. `musl-gcc` is required because the tree-sitter grammar crates compile C via the `cc` crate; the musl target otherwise links fine with Rust's bundled std (installed by the existing `dtolnay/rust-toolchain` `targets:` input).
- `site/src/content/docs/integrations/github-action.md` — musl artifact added to the Available Binaries table.
- SDD change workspace `CHG-0048` (operations, no-spec-change) with full lifecycle evidence.

No changes needed to the packaging, checksum-verification, upload, or release-glob steps — they are all artifact-name-driven. `ci.yml` and `trust.yml` build their own local mock artifacts and are unaffected. aarch64-musl is intentionally left out (needs a cross musl toolchain rather than `musl-tools`).

## Verification

- `fledge trust verify --range main...HEAD` — **trust gate passed**: verify lane (fmt, clippy, tests, release build, `specsync check --strict --require-coverage 100 --force`) green, SDD lifecycle valid (50 active changes), contract lane green, augur risk gate proceed (risk 35).
- Workflow YAML parses; matrix entry uses the same artifact-name-driven steps as all other targets.

## Caveat

As noted in the issue: `release.yml` only runs on tag pushes, so the musl build will only be truly exercised at the next tag. A temporary `workflow_dispatch` trigger on a test branch could smoke it out pre-merge if desired.