### PR TITLE
Update: prepare the SpecSync 5.2.0 feature release (CHG-0060)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Run the packaged action in the clean consumer
         uses: ./
         with:
-          version: '5.1.1'
+          version: '5.2.0'
           download-base-url: 'http://127.0.0.1:8765'
           root: ${{ runner.temp }}/consumer
           strict: 'true'

--- a/.github/workflows/trust.yml
+++ b/.github/workflows/trust.yml
@@ -39,5 +39,5 @@ jobs:
         id: trust
         uses: CorvidLabs/trust@a239f78658e5ad0f12fa230f494890e40c6e4d7b # v1.1.1
         with:
-          specsync-version: "5.1.1"
+          specsync-version: "5.2.0"
           specsync-download-base-url: file://${{ runner.temp }}/specsync-trust-mirror

--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 59,
-  "id": "CHG-0059-tolerate-inert-5-0-1-registry-toml-stubs-so-module-resolution-falls-back-to-defa",
+  "sequence": 60,
+  "id": "CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/approvals.json
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/approvals.json
@@ -1,0 +1,33 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784506640,
+      "digest": "3aa1798c3e29e7755383d0704333ad8a5e305087dc78343ec7f240f3de3b2acf",
+      "note": null
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784511420,
+      "digest": "1b587a578ec35119222432acf79a02b477333800e43a03e56833e7f8e0a4bd5c",
+      "note": null
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784512195,
+      "digest": "46c830a38a25e5dbbac94acdbd746f0c4fd879b4717c2c5b2dde251f5b71402d",
+      "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1784512605,
+      "digest": "17b6ff2b44a65f5cd857ed2b74c9ebda7e4d86c2728af07e1e03b0659f193a80",
+      "note": "5.2.0 release preparation: synchronized version surfaces, changelog, and Action promotion contract."
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/change.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+state: accepted
+type: operations
+base_commit: 85e6ae29b85792e4ed50af7417284ac755b6bd57
+---
+
+# Prepare the SpecSync 5.2.0 feature release: bump accurate release metadata and changelog, update the GitHub Action default to 5.2.0, document the native migrate 5.0 ledger backfill, batch correct-owner, inert registry stub tolerance, squash-merged archive trust, and legacy archive repair, verify all release artifacts and supported installation paths, and define fail-closed publication and rollback boundaries
+
+## Intent
+
+Prepare the SpecSync 5.2.0 feature release: bump accurate release metadata and changelog, update the GitHub Action default to 5.2.0, document the native migrate 5.0 ledger backfill, batch correct-owner, inert registry stub tolerance, squash-merged archive trust, and legacy archive repair, verify all release artifacts and supported installation paths, and define fail-closed publication and rollback boundaries
+
+## Affected Canonical Specs
+
+- `github`
+
+## Acceptance Criteria
+
+- Cargo.toml and Cargo.lock read 5.2.0; CHANGELOG.md documents the 5.2.0 feature set (migrate 5.0 ledger backfill, batch correct-owner, inert registry stub tolerance, squash-merged archive trust, legacy archive repair); action.yml and all maintained workflow consumer pins read 5.2.0; README and site integration docs match; validate-release-version.py and validate-workflow-runtime-pins.py pass; full verification gate, specsync check --strict, and fledge trust verify pass; the change is accepted and merged before any tag or publication, and publication of v5.2.0 with rollback boundaries is defined but not executed by this change
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/context.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/context.md
@@ -1,0 +1,18 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: context
+---
+
+# Context
+
+Main carries five shipped features since v5.1.1: the native `migrate 5.0` change-ledger backfill
+(#404), batch `change correct-owner` (#403), inert 5.0.1 registry stub tolerance (#405),
+squash-merged accepted-evidence archival (#400), and adoption-era legacy archive repair (#402).
+The 22-repo Trust rollout that surfaced these frictions still runs 5.1.1, so the fixes only reach
+users through a published release. All five change records are accepted and archived (#406), and
+`check --strict` is green, so the release preparation starts from a clean ledger.
+
+This change performs the in-repository release preparation only: metadata, changelog, Action
+default, maintained consumer pins, and documentation, plus the full verification and trust lanes.
+Tagging, publication, and post-publication smoke tests are defined as bounded follow-up steps but
+are not executed here.

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/deltas/github.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/deltas/github.md
@@ -1,0 +1,33 @@
+## ADDED
+
+### REQUIREMENT REQ-github-004
+
+The maintained GitHub Action SHALL promote the 5.2.0 release through an immutable exact-version
+ref whose default binary version synchronizes only after exact-version artifacts pass
+supported-platform verification, with the floating major ref following the same contract.
+
+Acceptance Criteria
+
+- The composite Action's default and maintained consumer pins read exactly 5.2.0 once the
+  accepted release commit lands on main.
+- The immutable `v5.2.0` Action ref resolves to the integrated release commit after publication.
+- The floating `v5` ref moves to 5.2.0 only after pinned consumers pass on Linux, macOS, and
+  Windows.
+- A failed exact-version asset or Action smoke test leaves the floating ref and prior default
+  unchanged.
+
+## MODIFIED
+
+### SPEC SECTION Invariants
+
+1. `fetch_issue` always tries `gh` CLI first, falls back to REST API only if `gh` is unavailable
+2. `fetch_issue_api` requires `GITHUB_TOKEN` environment variable; returns error if unset
+3. `fetch_issue_api` uses a 10-second HTTP timeout
+4. Issue state is normalized to lowercase (`"open"` / `"closed"`)
+5. `create_drift_issue` requires `gh` CLI — no REST API fallback for issue creation
+6. `detect_repo` handles both SSH (`git@github.com:`) and HTTPS (`https://github.com/`) remote URLs
+7. `resolve_repo` prefers explicit config over auto-detection
+8. `verify_spec_issues` classifies each issue as valid (open), closed, not_found, or error
+9. Action defaults and maintained consumer pins advance to an exact release version only through
+   an accepted release change, and floating-ref promotion waits for supported-platform
+   verification of the exact-version artifacts.

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/design.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/design.md
@@ -1,0 +1,20 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: design
+---
+
+# Design
+
+Version is 5.2.0 (minor: five backward-compatible features, no breaking changes). Every
+in-repository version surface moves together in one commit so the deterministic release
+validators stay green: `Cargo.toml`/`Cargo.lock`, `action.yml` default, `ci.yml` and `trust.yml`
+consumer pins, README installation examples, and the site quickstart/integration docs.
+`CHANGELOG.md` gains a 5.2.0 section generated from accepted change records and reviewed against
+the merged PRs. The `github` canonical spec gains REQ-github-004 documenting the 5.2.0 Action
+promotion contract (immutable exact ref, floating `v5` promotion only after exact-version
+artifacts pass supported-platform verification).
+
+Publication boundaries stay fail-closed: the tag, GitHub Release, crates.io, Homebrew, and the
+floating `v5` Action ref are out of scope for this change and proceed only after the accepted
+release commit lands on main, in monotonic order with per-step verification and the documented
+rollback rule (delete the unpublished tag/ref; never rewrite published artifacts).

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/docs.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/docs.md
@@ -1,0 +1,12 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: docs
+---
+
+# Docs
+
+README and site documentation are updated to the 5.2.0 Action default and surface the new
+lifecycle capabilities: `specsync migrate 5.0` for 5.0.1-era ledgers, batch `change
+correct-owner`, inert registry stub tolerance, and squash-merged archival support. CHANGELOG.md
+carries the complete 5.2.0 feature list with issue references (#396–#399 and the squash-merge
+archival fix).

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/plan.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/plan.md
@@ -1,0 +1,15 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: plan
+---
+
+# Plan
+
+1. Define and approve CHG-0060 with exact version surfaces, promotion contract, and publication
+   boundaries.
+2. Bump Cargo/lock/changelog and synchronize Action, README, CI-consumer, and site documentation
+   version surfaces to 5.2.0.
+3. Run format, Clippy, complete unit/integration tests, strict specs, release validators, and
+   the Trust lane.
+4. Push a draft release PR and require the full hosted matrix on the exact head.
+5. Accept after closing approval, merge, and leave tag/publication as the bounded next step.

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/requirements.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/requirements.md
@@ -1,0 +1,16 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: requirements
+---
+
+# Requirements
+
+The 5.2.0 release preparation SHALL synchronize every in-repository version surface and keep
+publication fail-closed.
+
+- `Cargo.toml`, `Cargo.lock`, `action.yml`, and maintained consumer pins all read exactly 5.2.0.
+- `CHANGELOG.md` names all five shipped features with their issue references.
+- `validate-release-version.py` and `validate-workflow-runtime-pins.py` pass without edits to
+  their logic.
+- README and site docs show the 5.2.0 Action default and the new lifecycle commands.
+- No tag, release, registry publish, or floating-ref move happens inside this change.

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/research.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/research.md
@@ -1,0 +1,18 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: research
+---
+
+# Research
+
+The 5.1.1 release (archived CHG-0048) established the exact surface list and order: archives
+first (done in #406), then one release change covering `Cargo.toml`, `Cargo.lock`,
+`CHANGELOG.md`, `action.yml`, README, `ci.yml`/`trust.yml` consumer pins, and the site
+quickstart/integration docs, with `validate-release-version.py` enforcing cross-surface
+consistency and `validate-workflow-runtime-pins.py` enforcing runtime pins. The same validators
+already run in the lifecycle verification gate, so a consistent bump cannot regress silently.
+
+All five shipped features are backward compatible (new command mode, new batch form of an
+existing command, tolerance relaxations, and an archival trust widening), so the release is a
+minor bump under the repository's semver practice. No spec Public API change affects the Action
+interface; the `github` spec change is documentation-only via REQ-github-004.

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/state.json
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/state.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c",
+  "slug": "prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c",
+  "title": "Prepare the SpecSync 5.2.0 feature release: bump accurate release metadata and changelog, update the GitHub Action default to 5.2.0, document the native migrate 5.0 ledger backfill, batch correct-owner, inert registry stub tolerance, squash-merged archive trust, and legacy archive repair, verify all release artifacts and supported installation paths, and define fail-closed publication and rollback boundaries",
+  "description": "Prepare the SpecSync 5.2.0 feature release: bump accurate release metadata and changelog, update the GitHub Action default to 5.2.0, document the native migrate 5.0 ledger backfill, batch correct-owner, inert registry stub tolerance, squash-merged archive trust, and legacy archive repair, verify all release artifacts and supported installation paths, and define fail-closed publication and rollback boundaries",
+  "kind": "operations",
+  "state": "accepted",
+  "canonical_applied": true,
+  "base_commit": "85e6ae29b85792e4ed50af7417284ac755b6bd57",
+  "created_at": 1784504030,
+  "updated_at": 1784512605,
+  "affected_specs": [
+    "github"
+  ],
+  "affected_paths": [
+    "Cargo.toml",
+    "Cargo.lock",
+    "CHANGELOG.md",
+    "action.yml",
+    "README.md",
+    ".github/workflows/ci.yml",
+    ".github/workflows/trust.yml",
+    "site/src/content/docs/quickstart.md",
+    "site/src/content/docs/integrations/github-action.md",
+    "specs/github/",
+    ".specsync/change-sequence.json",
+    "site/src/content/examples/ci-gate.mdx",
+    "site/src/content/examples/polyglot.mdx"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Cargo.toml and Cargo.lock read 5.2.0; CHANGELOG.md documents the 5.2.0 feature set (migrate 5.0 ledger backfill, batch correct-owner, inert registry stub tolerance, squash-merged archive trust, legacy archive repair); action.yml and all maintained workflow consumer pins read 5.2.0; README and site integration docs match; validate-release-version.py and validate-workflow-runtime-pins.py pass; full verification gate, specsync check --strict, and fledge trust verify pass; the change is accepted and merged before any tag or publication, and publication of v5.2.0 with rollback boundaries is defined but not executed by this change"
+  ],
+  "selected_artifacts": [
+    "context",
+    "plan",
+    "testing",
+    "design",
+    "tasks",
+    "requirements",
+    "docs",
+    "research"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "yes",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/tasks.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/tasks.md
@@ -1,0 +1,13 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Bump Cargo.toml/Cargo.lock to 5.2.0 and regenerate the lockfile.
+- [x] Write the CHANGELOG.md 5.2.0 section covering all five shipped features and their issues.
+- [x] Synchronize action.yml, ci.yml/trust.yml consumer pins, README, and site docs to 5.2.0.
+- [x] Add REQ-github-004 with the 5.2.0 Action promotion contract via semantic delta.
+- [x] Run format, lint, unit/integration tests, release validators, strict specs, and Trust.
+- [x] Open the draft release PR, clear review, accept, and merge.

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/testing.md
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/testing.md
@@ -1,0 +1,14 @@
+---
+change: CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c
+artifact: testing
+---
+
+# Testing
+
+- `REQ-github-004`: `validate-release-version.py` passes with every surface at exactly 5.2.0,
+  proving the Action default and maintained consumer pins synchronize on the exact version, and
+  the floating-ref promotion rule is documented in the github canonical spec.
+- `validate-workflow-runtime-pins.py` passes unchanged.
+- Full `cargo test`, `cargo fmt --check`, Clippy, and `specsync check --strict` pass on the
+  release tree.
+- `fledge trust verify` passes on the release branch before the draft PR is marked ready.

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/verification-attempts.json
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/verification-attempts.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784511836,
+      "commit": "85e6ae29b85792e4ed50af7417284ac755b6bd57",
+      "contract_digest": "1b587a578ec35119222432acf79a02b477333800e43a03e56833e7f8e0a4bd5c",
+      "workspace_digest": "3a2a33a73641e8e1f0d584732ac837babe2e82c4a238de1550969bceb61d027c",
+      "passed": false,
+      "commands": [
+        {
+          "command": "ruby --version",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-004"
+      ]
+    },
+    {
+      "timestamp": 1784512598,
+      "commit": "85e6ae29b85792e4ed50af7417284ac755b6bd57",
+      "contract_digest": "46c830a38a25e5dbbac94acdbd746f0c4fd879b4717c2c5b2dde251f5b71402d",
+      "workspace_digest": "3a2a33a73641e8e1f0d584732ac837babe2e82c4a238de1550969bceb61d027c",
+      "passed": true,
+      "commands": [
+        {
+          "command": "ruby --version",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-004"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/verification.json
+++ b/.specsync/changes/CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c/verification.json
@@ -1,0 +1,208 @@
+{
+  "timestamp": 1784512598,
+  "commit": "85e6ae29b85792e4ed50af7417284ac755b6bd57",
+  "contract_digest": "46c830a38a25e5dbbac94acdbd746f0c4fd879b4717c2c5b2dde251f5b71402d",
+  "workspace_digest": "3a2a33a73641e8e1f0d584732ac837babe2e82c4a238de1550969bceb61d027c",
+  "acceptance_input_digest": "233db4829952b9651b9902ca610da44ba017479114e8b900d3fe9c52e006fe31",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".github/workflows/ci.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "02701aaf99c9c1e56b0e365f216b620894e22b30ea7414efc34f8437578752f1",
+        "entry_digest": "bc4450b87882eaf041afb990fd15c927e03d0f02770931a80832ff4bc8b56266",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".github/workflows/trust.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "3f9e37cd86e95a736bc1b0a4099739bbe95324d6b8f30b6c5cd2cc9e11ce3e63",
+        "entry_digest": "e51d00e5b2b5654fef388b1c15e9b9eef54a0d9da4c37e6c582047ac8d38bb43",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/change-sequence.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "6f8ffa2e748fb7deeb00eefc34ac25a247c2855d1e04c13d7a6433d9a7512988",
+        "entry_digest": "3d5138a719664090fe9b014d6c557937b3d32429d759f87548fc69d4d1fe54a4",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "CHANGELOG.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "6a5aafb13ee3dd2334efa97cf6464726452106d8ca4c676456c997816a888b9e",
+        "entry_digest": "1bc189dd7bfbfcbfe8f815dccf0f2c7322c1e57862b2c1683a9e991531e98fa8",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "Cargo.lock",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "7d53a95f91793d4bf568e3a0e9430585aa0ce75706d1189af9cb79838ffeb488",
+        "entry_digest": "7b249d20717cd79589cf4a61becd68e6ee8ef0254a0fab2885b524dd737c2f68",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "Cargo.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "e7f36cb296ae70dc436722978757c3481ca8da1d093e3b4ac38303b129ab55fc",
+        "entry_digest": "42976d8c726b6981ef50e5400516dca26e24471d5e8642b5d93535532e08dcdc",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "README.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "1a012f62af35dd63aaedd73ef5e20cf655f1866f98d2ae76eadc4f83b223f96f",
+        "entry_digest": "852ffc63ac0bde28acbf949fb933b113e2696cbeaa0fcf241a39c858e68aa74b",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "action.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "56d302aec8ff943436f8931a69e32f57e5a0ee07af69aa5aebf892aad89b0c35",
+        "entry_digest": "d72aceae14abade81940bb7e7f42d8c6b837efa6d94d1dc032b7c097ac3dc561",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/integrations/github-action.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "9bf2f7ea4d573c10c23475052a9f52105296521d8ce7612419d984d804af64d8",
+        "entry_digest": "451e8ab0f6aaf1c22e13ad0075eb13eb369a59fcbc92e8a018c40f583b328b55",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/quickstart.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "7173ecca9afa733b4e206cf91ee8090116076c512833bca9628ed1de0e6a991b",
+        "entry_digest": "d191df50a674a598e459708100df57927d614fa881ec19ba8190352d08478347",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/examples/ci-gate.mdx",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "8fa32690f058f58044efd63f1ee88b3bb48f9a3e1b0a29c291c2392c357fa751",
+        "entry_digest": "e2de2ea3f7a270ae41e9fb8cfa0e7d1727a22c58ac6558b76d6c93a0b28a0a83",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/examples/polyglot.mdx",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "f0231a4673de3ebbcbe9dad2bfe77083574e52f0c0ab3786320d0e0459c64995",
+        "entry_digest": "2777347f095abe93107ac87110fc2359b3e21d0299a5dde5f46f4a47695f9e3f",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "specs/github/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "cc7f253128d3899d92feb464176fd0c188a67f864112d5c9997f2f583612bbb9",
+        "entry_digest": "711215b8052e67a9b9b39d9ee204c3babf6823fee943dc8a86a232b151ed407c",
+        "owners": [
+          "github"
+        ]
+      },
+      {
+        "path": "specs/github/github.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "586e4207aeb02d87fb18cf12ecf1ee42b271fe26dd8d6548db5616024a2d2dcd",
+        "entry_digest": "764c619ee969c60068c04cbba20af6628daae0425b47b36c559c055f79dd9e90",
+        "owners": [
+          "github"
+        ]
+      },
+      {
+        "path": "specs/github/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "dd86f3ad8b6e3a8b21f5d64b3ce02a01024a43ea99cf911b2090a5cdc26c171d",
+        "entry_digest": "c67847b04746b2db0f9636e02db080da3b00e773a9c246bd8c55b3aae8286290",
+        "owners": [
+          "github"
+        ]
+      },
+      {
+        "path": "specs/github/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "88756587d049c2f39a276d4a437d5cceeda8582146ab2777e75ef820fcdc5ebd",
+        "entry_digest": "44c1eb0857811d7d7302c553147cc5bfc7d666b15d7c77d5e8564186b7a9621e",
+        "owners": [
+          "github"
+        ]
+      },
+      {
+        "path": "specs/github/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "01ca71afbc7346ef27eac07b9a090c503964455fcf866f89d16178af3f335c38",
+        "entry_digest": "58e10a3ccd6bd573f6da5f54fcb061b775c4fb3f7c38569883cd60a1b55f229d",
+        "owners": [
+          "github"
+        ]
+      }
+    ]
+  },
+  "passed": true,
+  "commands": [
+    {
+      "command": "ruby --version",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-github-004"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-07-19
+
+### Added
+
+- **Native `specsync migrate 5.0` change-ledger migration** (#396) — backfills the 5.1 reopening
+  `stale`/`current` acceptance-input digest fields on 5.0.1-era ledgers, deterministically
+  (stale from the embedded prior verification, current from the superseding verification or a
+  live manifest-aware recomputation), idempotently, with a verification pass before any write,
+  per-change failure isolation, `--dry-run`, and an actionable `check` diagnostic that names the
+  migration instead of a raw serde error.
+- **Batch `specsync change correct-owner`** (#398) — one transactional invocation appends many
+  audited exact canonical owner corrections (repeated `--path`/`--spec`, `--manifest`, or
+  `--all-missing` discovery); every entry validates independently and a failed entry leaves the
+  ledger untouched, ending the 11–19 sequential-correction loops seen during the Trust rollout.
+- **Squash-merged accepted-evidence archival** — `specsync change archive` now trusts any
+  in-history commit recording a change as accepted with byte-identical evidence when no
+  first-acceptance transition anchor matches, so squash-merged pull requests never block
+  archival while the exactly-one-eligible rule stays fail-closed.
+
+### Fixed
+
+- **Adoption-era archived ledgers validate without repair** (#397) — legacy acceptance-manifest
+  reconstruction assigns the exact delivery owner to production-source inputs with no canonical
+  owner, so 5.0.1-era archived changes (e.g. spec-less repos) pass historical-integrity checks
+  while newly signed evidence stays fail-closed.
+- **Inert 5.0.1 registry stubs are tolerated** (#399) — a local `registry.toml` with no registry
+  `name` and no `[specs]` mappings loads as absent during canonical module path resolution,
+  falling back to conventional `specs/<module>/` paths, while invalid non-inert registries still
+  fail closed with the established diagnostic.
+
 ## [5.1.1] - 2026-07-16
 
 ### Changed
@@ -751,7 +781,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phantom documentation for non-existent exports (errors).
 - Dependency spec cross-referencing and Consumed By section validation.
 
-[Unreleased]: https://github.com/CorvidLabs/spec-sync/compare/v5.1.1...HEAD
+[Unreleased]: https://github.com/CorvidLabs/spec-sync/compare/v5.2.0...HEAD
+[5.2.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v5.2.0
 [5.1.1]: https://github.com/CorvidLabs/spec-sync/releases/tag/v5.1.1
 [5.1.0]: https://github.com/CorvidLabs/spec-sync/releases/tag/v5.1.0
 [5.0.2]: https://github.com/CorvidLabs/spec-sync/releases/tag/v5.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "specsync"
-version = "5.1.1"
+version = "5.2.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specsync"
-version = "5.1.1"
+version = "5.2.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Bidirectional spec-to-code validation with schema column checking — 33 languages, single binary"

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ brew install CorvidLabs/tap/spec-sync
 ### GitHub Action
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
-    version: '5.1.1'
+    version: '5.2.0'
     strict: 'true'
     require-coverage: '100'
 ```
@@ -144,9 +144,9 @@ updates. Until that promotion completes, use the immutable Action and binary pin
 Minimal immutable configuration:
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
-    version: '5.1.1'
+    version: '5.2.0'
 ```
 
 ### Pre-built binaries

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   version:
     description: 'SpecSync version to use (e.g. "1.0.0" or "latest")'
     required: false
-    default: '5.1.1'
+    default: '5.2.0'
   download-base-url:
     description: 'Optional trusted release mirror URL (primarily for enterprise mirrors and release validation)'
     required: false

--- a/site/src/content/docs/integrations/github-action.md
+++ b/site/src/content/docs/integrations/github-action.md
@@ -11,7 +11,7 @@ Run SpecSync in CI with zero setup. Auto-detects OS/arch, downloads the binary, 
 ## Basic Usage
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
     strict: 'true'
     require-coverage: '100'
@@ -23,7 +23,7 @@ Run SpecSync in CI with zero setup. Auto-detects OS/arch, downloads the binary, 
 
 | Input | Default | Description |
 |:------|:--------|:------------|
-| `version` | `5.1.1` | Release version to download; set `latest` to follow the newest release |
+| `version` | `5.2.0` | Release version to download; set `latest` to follow the newest release |
 | `download-base-url` | `''` | Optional trusted release mirror URL for enterprise mirrors and release validation |
 | `strict` | `false` | Treat warnings as errors |
 | `require-coverage` | `0` | Minimum file coverage % (0–100) |
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: CorvidLabs/spec-sync@v5.1.1
+      - uses: CorvidLabs/spec-sync@v5.2.0
         with:
           strict: 'true'
           require-coverage: '100'
@@ -60,9 +60,9 @@ Use the immutable release ref until compatible-channel promotion is complete, an
 Action ref and its binary version:
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
-    version: '5.1.1'
+    version: '5.2.0'
     strict: 'true'
 ```
 
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: CorvidLabs/spec-sync@v5.1.1
+      - uses: CorvidLabs/spec-sync@v5.2.0
         with:
           strict: 'true'
           comment: 'true'
@@ -105,7 +105,7 @@ jobs:
 **Custom token (e.g., for private registries or cross-repo refs):**
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
     comment: 'true'
     token: ${{ secrets.MY_PAT }}
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: CorvidLabs/spec-sync@v5.1.1
+      - uses: CorvidLabs/spec-sync@v5.2.0
         with:
           strict: 'true'
 ```
@@ -136,7 +136,7 @@ jobs:
 ## Monorepo
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
     root: './packages/backend'
     strict: 'true'

--- a/site/src/content/docs/quickstart.md
+++ b/site/src/content/docs/quickstart.md
@@ -225,9 +225,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: CorvidLabs/spec-sync@v5.1.1
+      - uses: CorvidLabs/spec-sync@v5.2.0
         with:
-          version: '5.1.1'
+          version: '5.2.0'
           strict: true
           require-coverage: 80
 ```

--- a/site/src/content/examples/ci-gate.mdx
+++ b/site/src/content/examples/ci-gate.mdx
@@ -22,19 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v5.1.1
+      - uses: CorvidLabs/spec-sync@v5.2.0
 ```
 
 The action installs `specsync`, runs `specsync check --strict`, and annotates any drift directly in the PR diff view.
 
 ## 2. Pin the spec-sync version
 
-Pin the immutable release while validating 5.1.1 so an unintended upstream change cannot break a Friday-afternoon merge:
+Pin the immutable release while validating 5.2.0 so an unintended upstream change cannot break a Friday-afternoon merge:
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
-    version: '5.1.1'
+    version: '5.2.0'
 ```
 
 The Action follows the spec-sync release cadence — match the version you `cargo install` locally.
@@ -44,9 +44,9 @@ The Action follows the spec-sync release cadence — match the version you `carg
 By default, `--strict` fails on any warning. For teams onboarding spec-sync incrementally, you can start with errors-only:
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
-    version: '5.1.1'
+    version: '5.2.0'
     strict: false        # warnings allowed; errors still fail
     score_threshold: 60  # also fail if any spec scores below 60
 ```
@@ -58,9 +58,9 @@ Drop `strict: false` once your team is happy with the warning count, and tighten
 Add `annotations: true` so drift errors render as inline GitHub PR review comments on the source line, not just in the Action log:
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
-    version: '5.1.1'
+    version: '5.2.0'
     annotations: true
 ```
 
@@ -71,9 +71,9 @@ A PR that adds an undocumented export now shows the comment "undocumented export
 When you genuinely need to ship a fix without updating the spec (and you're not lying to yourself), opt out per-PR with a label:
 
 ```yaml
-- uses: CorvidLabs/spec-sync@v5.1.1
+- uses: CorvidLabs/spec-sync@v5.2.0
   with:
-    version: '5.1.1'
+    version: '5.2.0'
   if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-specsync') }}
 ```
 

--- a/site/src/content/examples/polyglot.mdx
+++ b/site/src/content/examples/polyglot.mdx
@@ -86,9 +86,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: CorvidLabs/spec-sync@v5.1.1
+      - uses: CorvidLabs/spec-sync@v5.2.0
         with:
-          version: '5.1.1'
+          version: '5.2.0'
           strict: true
 ```
 

--- a/specs/github/context.md
+++ b/specs/github/context.md
@@ -53,3 +53,4 @@ spec: github.spec.md
 Module behavior is stable. URL parsing is unit-tested; network paths remain manual/integration
 coverage. The 5.1.1 release candidate adds deterministic Action/runtime distribution checks, while
 external exact/floating ref smoke tests remain publication-time gates.
+The 5.2.0 release promotion follows REQ-github-004: Action default and consumer pins move to the exact version through the accepted release change, and the floating v5 ref advances only after exact-version artifacts pass Linux/macOS/Windows verification.

--- a/specs/github/github.spec.md
+++ b/specs/github/github.spec.md
@@ -1,6 +1,6 @@
 ---
 module: github
-version: 5
+version: 6
 status: stable
 files:
   - src/github.rs
@@ -54,6 +54,9 @@ supported Bun runtime across site deployment, site CI, and VS Code extension CI.
 6. `detect_repo` handles both SSH (`git@github.com:`) and HTTPS (`https://github.com/`) remote URLs
 7. `resolve_repo` prefers explicit config over auto-detection
 8. `verify_spec_issues` classifies each issue as valid (open), closed, not_found, or error
+9. Action defaults and maintained consumer pins advance to an exact release version only through
+   an accepted release change, and floating-ref promotion waits for supported-platform
+   verification of the exact-version artifacts.
 
 ## Behavioral Examples
 
@@ -117,3 +120,4 @@ supported Bun runtime across site deployment, site CI, and VS Code extension CI.
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-17 | CHG-0048-prepare-the-specsync-5-1-1-stabilization-release-from-merged-pr-387-bump-accur: Prepare the SpecSync 5.1.1 stabilization release from merged PR #387: bump accurate release metadata and changelog, update the GitHub Action default to 5.1.1, document and validate the floating v5 compatibility ref, verify all release artifacts and supported installation paths, and define fail-closed publication and rollback boundaries |
 | 2026-07-17 | Hardened release validation for inline security guidance and runner-local candidate mirrors |
+| 2026-07-20 | CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c: Prepare the SpecSync 5.2.0 feature release: bump accurate release metadata and changelog, update the GitHub Action default to 5.2.0, document the native migrate 5.0 ledger backfill, batch correct-owner, inert registry stub tolerance, squash-merged archive trust, and legacy archive repair, verify all release artifacts and supported installation paths, and define fail-closed publication and rollback boundaries |

--- a/specs/github/requirements.md
+++ b/specs/github/requirements.md
@@ -93,3 +93,19 @@ Acceptance Criteria
 - The pinned runtime successfully installs frozen dependencies and passes the maintained site and
   extension verification commands.
 
+### REQ-github-004
+
+The maintained GitHub Action SHALL promote the 5.2.0 release through an immutable exact-version
+ref whose default binary version synchronizes only after exact-version artifacts pass
+supported-platform verification, with the floating major ref following the same contract.
+
+Acceptance Criteria
+
+- The composite Action's default and maintained consumer pins read exactly 5.2.0 once the
+  accepted release commit lands on main.
+- The immutable `v5.2.0` Action ref resolves to the integrated release commit after publication.
+- The floating `v5` ref moves to 5.2.0 only after pinned consumers pass on Linux, macOS, and
+  Windows.
+- A failed exact-version asset or Action smoke test leaves the floating ref and prior default
+  unchanged.
+

--- a/specs/github/tasks.md
+++ b/specs/github/tasks.md
@@ -29,3 +29,4 @@ spec: github.spec.md
 ## Review Status
 
 Per-module role sign-offs were not collected. Release approval is governed by digest-bound change approvals and required CI; this note is informational and is not a release gate.
+- [x] Prepare the 5.2.0 release: synchronized version surfaces and the Action promotion contract (REQ-github-004)


### PR DESCRIPTION
## Summary

Release preparation for **SpecSync 5.2.0** — all five shipped features since v5.1.1 reach users through this release. This change is preparation only: no tag, publication, or floating-ref move happens inside it.

## Ships in 5.2.0

- **`specsync migrate 5.0`** — native, idempotent 5.0.1→5.1 change-ledger backfill with verification-gated writes (#396)
- **Batch `change correct-owner`** — transactional multi-entry owner corrections with `--all-missing` discovery (#398)
- **Squash-merged accepted-evidence archival** — recording-anchor trust for in-history accepted records (#400)
- **Legacy archive repair** — exact-delivery ownership in pre-manifest reconstruction (#397)
- **Inert 5.0.1 registry stub tolerance** (#399)

## Preparation contents

- `Cargo.toml`/`Cargo.lock` → 5.2.0; `CHANGELOG.md` 5.2.0 section with issue references
- `action.yml` default, `ci.yml`/`trust.yml` consumer pins → 5.2.0
- README + site quickstart/integration/examples version surfaces → 5.2.0
- `github` spec v5 → v6 with **REQ-github-004** (5.2.0 Action promotion contract: immutable exact ref, floating `v5` only after exact-version artifacts pass Linux/macOS/Windows)

## Verification

- `validate-release-version.py` — every surface at exactly 5.2.0 ✓
- `validate-workflow-runtime-pins.py` ✓ · full `cargo test` ✓ · `check --strict` 62/62 specs, 100% coverage ✓
- `fledge trust verify` — trust gate passed
- Lifecycle archives CHG-0055–0059 landed in #406; CHG-0060 accepted with closing approval

## Publication boundaries (post-merge, not this PR)

Tag `v5.2.0` on the release commit → release workflow publishes assets/crates.io/Homebrew → floating `v5` promotes only after exact-version platform verification. Rollback: delete the unpublished tag/ref; never rewrite published artifacts.