### PR TITLE
docs: document the 5.2.0 lifecycle surfaces and refresh the AGENTS.md quick reference (CHG-0061)

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 60,
-  "id": "CHG-0060-prepare-the-specsync-5-2-0-feature-release-bump-accurate-release-metadata-and-c",
+  "sequence": 61,
+  "id": "CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/approvals.json
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/approvals.json
@@ -1,0 +1,19 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1784556664,
+      "digest": "8db163543d1c0fa994c8c0df6ed1312f5306f82bae825eae00a8f910c36bf281",
+      "note": null
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1784557269,
+      "digest": "e4b230d342de08f78532284027e70f2c46baebf28538e7f982cf63bc7daaf73f",
+      "note": "Document the 5.2.0 lifecycle surfaces across cli.md, workflow.md, cross-project-refs.md, and AGENTS.md."
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/change.md
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si
+state: accepted
+type: documentation
+base_commit: 342bd053d410211c16fcd041a9eb94ed53012fe2
+---
+
+# Document the 5.2.0 lifecycle surfaces: migrate 5.0 ledger backfill, batch and single correct-owner, change supersede, squash-merged archival trust, inert registry stub tolerance, and the actionable staleness diagnostics, and refresh the AGENTS.md quick reference with the SDD lifecycle commands
+
+## Intent
+
+Document the 5.2.0 lifecycle surfaces: migrate 5.0 ledger backfill, batch and single correct-owner, change supersede, squash-merged archival trust, inert registry stub tolerance, and the actionable staleness diagnostics, and refresh the AGENTS.md quick reference with the SDD lifecycle commands
+
+## Affected Canonical Specs
+
+- None
+
+## Acceptance Criteria
+
+- cli.md documents migrate 5.0, single and batch correct-owner, and change supersede; workflow.md describes squash-merged archival trust and actionable staleness diagnostics; cross-project-refs.md documents inert registry stub tolerance; AGENTS.md quick reference lists the SDD lifecycle and migration commands
+
+## No-spec Rationale
+
+Documentation-only update of site docs and agent instructions; no canonical spec content changes

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/context.md
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/context.md
@@ -1,0 +1,14 @@
+---
+change: CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si
+artifact: context
+---
+
+# Context
+
+SpecSync 5.2.0 shipped user-facing lifecycle surfaces that the documentation predates:
+`migrate 5.0` ledger backfill (#404), single and batch `change correct-owner` (#403), `change
+supersede`, squash-merged archival trust (#400), inert 5.0.1 registry stub tolerance (#405),
+and the actionable staleness/migrate diagnostics (#404, #396). The CLI reference (`cli.md`)
+documents none of them, `cross-project-refs.md` misses the registry tolerance, `workflow.md`
+misses the archival trust model, and the `AGENTS.md` quick reference predates the SDD lifecycle
+commands entirely. Documentation-only change; no canonical spec content or code changes.

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/docs.md
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/docs.md
@@ -1,0 +1,16 @@
+---
+change: CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si
+artifact: docs
+---
+
+# Docs
+
+- `cli.md`: document `specsync migrate 5.0` (deterministic digest backfill, idempotency,
+  `--dry-run`, per-change failure isolation) and both `correct-owner` forms (single
+  `--path`/`--spec`, and batch with repeated flags, `--manifest`, and `--all-missing`), plus
+  `change supersede` in the lifecycle command list.
+- `workflow.md`: describe squash-merged archival trust (recording anchors) and the actionable
+  staleness/migrate diagnostics operators see.
+- `cross-project-refs.md`: document that inert 5.0.1 registry stubs load as absent while
+  invalid non-inert registries still fail closed.
+- `AGENTS.md`: refresh the quick reference with the SDD lifecycle and migration commands.

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/requirements.md
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/requirements.md
@@ -1,0 +1,14 @@
+---
+change: CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si
+artifact: requirements
+---
+
+# Requirements
+
+The 5.2.0 user-facing lifecycle surfaces SHALL be documented where operators look for them.
+
+- `cli.md` covers `migrate 5.0`, both `correct-owner` forms, and `change supersede` accurately.
+- `workflow.md` explains squash-merged archival trust and the staleness/migrate diagnostics.
+- `cross-project-refs.md` states the inert registry stub tolerance and its fail-closed boundary.
+- `AGENTS.md` quick reference lists the SDD lifecycle commands and `migrate 5.0`.
+- No code, canonical spec content, or command behavior changes.

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/state.json
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/state.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si",
+  "slug": "document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si",
+  "title": "Document the 5.2.0 lifecycle surfaces: migrate 5.0 ledger backfill, batch and single correct-owner, change supersede, squash-merged archival trust, inert registry stub tolerance, and the actionable staleness diagnostics, and refresh the AGENTS.md quick reference with the SDD lifecycle commands",
+  "description": "Document the 5.2.0 lifecycle surfaces: migrate 5.0 ledger backfill, batch and single correct-owner, change supersede, squash-merged archival trust, inert registry stub tolerance, and the actionable staleness diagnostics, and refresh the AGENTS.md quick reference with the SDD lifecycle commands",
+  "kind": "documentation",
+  "state": "accepted",
+  "canonical_applied": true,
+  "base_commit": "342bd053d410211c16fcd041a9eb94ed53012fe2",
+  "created_at": 1784556519,
+  "updated_at": 1784557269,
+  "affected_specs": [],
+  "affected_paths": [
+    "site/src/content/docs/",
+    "AGENTS.md",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": true,
+  "no_spec_change_rationale": "Documentation-only update of site docs and agent instructions; no canonical spec content changes",
+  "acceptance_criteria": [
+    "cli.md documents migrate 5.0, single and batch correct-owner, and change supersede; workflow.md describes squash-merged archival trust and actionable staleness diagnostics; cross-project-refs.md documents inert registry stub tolerance; AGENTS.md quick reference lists the SDD lifecycle and migration commands"
+  ],
+  "selected_artifacts": [
+    "context",
+    "docs",
+    "requirements"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/verification-attempts.json
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/verification-attempts.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784557263,
+      "commit": "342bd053d410211c16fcd041a9eb94ed53012fe2",
+      "contract_digest": "8db163543d1c0fa994c8c0df6ed1312f5306f82bae825eae00a8f910c36bf281",
+      "workspace_digest": "f53eaf9a4f7a29ba1194463bbc3b31d479adb7f341fd4ab73a75b9131db4daa6",
+      "passed": true,
+      "commands": [
+        {
+          "command": "ruby --version",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/verification.json
+++ b/.specsync/changes/CHG-0061-document-the-5-2-0-lifecycle-surfaces-migrate-5-0-ledger-backfill-batch-and-si/verification.json
@@ -1,0 +1,246 @@
+{
+  "timestamp": 1784557263,
+  "commit": "342bd053d410211c16fcd041a9eb94ed53012fe2",
+  "contract_digest": "8db163543d1c0fa994c8c0df6ed1312f5306f82bae825eae00a8f910c36bf281",
+  "workspace_digest": "f53eaf9a4f7a29ba1194463bbc3b31d479adb7f341fd4ab73a75b9131db4daa6",
+  "acceptance_input_digest": "65a5b375c4a7dc0630c282fd7f3520aa828e8bdcf5fc670fec32f2447056b481",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".specsync/change-sequence.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "4d7ffe74e3d8f6de2ac3c34c47b1082499cbdc97f4dbb7823e7d2df4ceff6b06",
+        "entry_digest": "3761bc600d8dc8aa0711f441f7c198690153a72eea211d7bd1aa20831619439d",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "AGENTS.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "fd42105f88ebd128b8506de9aaf30c5e2cebe8cbffd94ecae4ad503206b14842",
+        "entry_digest": "6a9622797c3e30cf5f2b6f66bf1ce63ea129107710c60c75438e6a38f6100f81",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/architecture.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "c3e46859598a4622029fc0870e05e2850f3b9ec4b88127117f4f43bd96512164",
+        "entry_digest": "d6d2fb115eb13e497e08b9ae5767d3cb2f1f12d6619e2608335b5d938e8978d4",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/cli.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "3e54d1f501e35df2996487df415e61f609830da316c227c13cb735db36117c73",
+        "entry_digest": "114b0971657a91e3ec19e4d5340fc4d4c03bc445c7ef661b82c6440473b0b33b",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/companion-files.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "2d17dabdb853e7483bfc5ea04bd113f5f7c459ab5e79a617b23aa4ebef058e7d",
+        "entry_digest": "2782c0458d5e4a2a1dc66a77e1f53dc7bdd9900ecbce52f4094ecdc5f6b930b4",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/comparisons/adversarial-proof.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "1639387ebb161bcf10fd4b8fea5bc73805238a7f7c7edc3a56e2634da8d5ab07",
+        "entry_digest": "99870b96178e42cefa069dd143f11668b5fffee9826e7d402646114c950c05d0",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/comparisons/bmad.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "a4b16e67faaa512c1acde7f15b33defc0d557da845f7931ff570b0beca008821",
+        "entry_digest": "972e524a4bb28e8a5fbb5c8df91f738f095b0d448ca40823da6eb4b266e5fa78",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/comparisons/openspec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "07f8a4c86a3a0b0972c596cf88ddb7069a7d62a3feeff4650ed091f10b97c475",
+        "entry_digest": "9a1d28d85e53971c72dcf8e77b3b59520fedc718817c78890fceb9a17887d954",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/comparisons/spec-kit.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "9f68bb8b6dd6120db934a728c04e758f976aa38896f3ed721bbc0aa04d59f2c8",
+        "entry_digest": "bbfc620f5d729b7a0506f25b2e2924a46d6a5965560c1f5d4df5092761d25a57",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/comparisons/using-together.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "8a0f95675ec1039693af31277fc5dc4b7357edb9bebc6be4911482bd8e532cc0",
+        "entry_digest": "20a42c76a091e1e993e4d8f982c910cdfbf54185c783fd7dcd71dc6bb92e4a3a",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/configuration.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "4999848134e4f740cd0c0e63dae2e592dbfd71138fd357bb1b988d286f55860d",
+        "entry_digest": "bb66d367407847033fb51e771e3b10282e0b1f1104086efdc2088a6394ee4e98",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/cross-project-refs.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "4b31f455d9181531cd3693b03cd72c4b453a90da54b2196b59c25a15a4ee63d1",
+        "entry_digest": "c9d79f9e7e0294d64999fefd00c40ff5cc42a4978dfbc5e667436ad11cb75d91",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/deltas.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "13cd951e2408f40ff57e51a9efd74f4a3bc8a1d0c88a15c6790423efa4e25f38",
+        "entry_digest": "8302e685abe44baf1f310762d61bd1f62bf7fe6f6fb5f35382cb1d0031a525d4",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/index.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "6c2a54d96360183999126295670b0b762efd589815dbf80ac76d7c7d6ae6c217",
+        "entry_digest": "edd0a1d763c98f9c75400cc0c6d52ae4ed445063030e7566f2ea93cb23327fe8",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/integrations/ai-agents.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "3f1330d0b373997bc8d0abb10f7836d87b5f56f5c3c88e1b331ddb393ef71a2d",
+        "entry_digest": "95372151ee30c01a1e9e428ccb23ef002d14890c04893f0d6f2b006971767bb6",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/integrations/github-action.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "9bf2f7ea4d573c10c23475052a9f52105296521d8ce7612419d984d804af64d8",
+        "entry_digest": "451e8ab0f6aaf1c22e13ad0075eb13eb369a59fcbc92e8a018c40f583b328b55",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/integrations/vscode-extension.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "ff74bb328a7472f5358fff27b3c9941576eb9f7c5797d1b30c31a83d734ff1b7",
+        "entry_digest": "22260ed7f39fe8df94a2312846c4e0d889b5b74e650e7430d956d4d57b75541c",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/quickstart.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "7173ecca9afa733b4e206cf91ee8090116076c512833bca9628ed1de0e6a991b",
+        "entry_digest": "d191df50a674a598e459708100df57927d614fa881ec19ba8190352d08478347",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/spec-format.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "82ffca71fd41cecd8b83102eaea185c852b6cf83b53972df893d0780170df364",
+        "entry_digest": "4444d02f17311165338c0798b5d1bac539e8bd8c81fe0d0c79cddc3e69d71e1b",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/why-specsync.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "fc0dd1161fc6bcea595467b03291564671cfda2c5cb56576e00c7778445c7fdf",
+        "entry_digest": "b4f55cddf9e0dda2d9e3fa63e490731275b1721adcc538817e787fe69b33498d",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "site/src/content/docs/workflow.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "a1430cb4de5ad7c3045d0f3a7294eb9cd33c1676cb8d26dfcb216022a93fef2c",
+        "entry_digest": "731b0ca3bcc2d3a09e1f3b59f9a22c9a03c49254c0f02d231f5a844d73423f10",
+        "owners": [
+          "@exact:delivery"
+        ]
+      }
+    ]
+  },
+  "passed": true,
+  "commands": [
+    {
+      "command": "ruby --version",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ Enforcement is **strict** — CI and pre-commit hooks will block on any spec vio
 | `specsync compact` | Compact changelog tables by summarizing old entries |
 | `specsync archive-tasks` | Move completed task items to archive section |
 | `specsync merge` | Auto-resolve git merge conflicts in spec files |
+| `specsync change new <desc>` | Create a draft SDD change with the deterministic interview |
+| `specsync change approve/start/verify/accept <id>` | Drive the verified lifecycle: approve the definition, start implementation, verify, accept with closing approval |
+| `specsync change reopen <id>` | Re-verify stale accepted evidence (audited, append-only) |
+| `specsync change correct-owner <id>` | Append audited exact owner corrections (single `--path/--spec`, or batch: repeated flags, `--manifest`, `--all-missing`) |
+| `specsync change archive <id>` | Move an accepted change into the dated archive (after the delivery branch merges; squash merges supported) |
+| `specsync change check` | Validate all active/archived change workspaces and terminal evidence |
+| `specsync migrate 5.0` | Backfill 5.0.1-era reopening digest fields idempotently (the remediation `check` prints for missing-field ledgers) |
 
 ## Spec Lifecycle
 

--- a/site/src/content/docs/cli.md
+++ b/site/src/content/docs/cli.md
@@ -188,6 +188,18 @@ specsync migrate --json                    # machine-readable output
 
 The migration is step-based and idempotent — re-running on a partially migrated project resumes from where it left off. A backup is created in `.specsync/backup-3x/` before any destructive changes.
 
+#### `migrate 5.0`
+
+Backfill the 5.1 reopening digest fields (`stale_acceptance_input_digest` / `current_acceptance_input_digest`) on 5.0.1-era change ledgers. Use this when `specsync check` fails on a historical `approvals.json` with a missing-field error — the error message names this command as the remediation.
+
+```bash
+specsync migrate 5.0                       # repair reopening records across active and archived changes
+specsync migrate 5.0 --dry-run             # report planned repairs without writing
+specsync migrate 5.0 --json                # machine-readable report
+```
+
+The backfill is deterministic (`stale` reproduces the embedded prior-verification digest, `current` comes from the superseding verification or a live recomputation), idempotent (re-running changes nothing), and verification-gated (each repaired ledger must re-parse before the write lands). A reopening that cannot be repaired deterministically fails its change without mutating that ledger; other changes still migrate. Bare `specsync migrate` keeps the 3.x→4.0 pipeline and never touches change ledgers.
+
 ### `rehash`
 
 Regenerate the hash cache for all specs. Useful after `git pull`, branch switches, or manual spec edits to reset the incremental validation baseline.
@@ -325,6 +337,11 @@ specsync change verify CHG-0001-add-passkeys
 specsync change accept CHG-0001-add-passkeys
 specsync change reopen CHG-0001-add-passkeys --actor "Ada" --reason "Review fixes changed governed inputs"
 specsync change correct CHG-0001-add-passkeys architecture_risk yes --actor "Ada" --reason "Review found architectural impact"
+specsync change correct-owner CHG-0001-add-passkeys --path src/auth.rs --spec auth --actor "Ada" --reason "Owner omitted from the accepted affected-spec list"
+specsync change correct-owner CHG-0001-add-passkeys --path src/a.rs --path src/b.rs --spec auth --actor "Ada" --reason "Batch repair"
+specsync change correct-owner CHG-0001-add-passkeys --manifest owners.json --actor "Ada" --reason "Batch repair"
+specsync change correct-owner CHG-0001-add-passkeys --all-missing --spec auth --actor "Ada" --reason "Assign every omitted owner"
+specsync change supersede CHG-0002-update-ui CHG-0001-add-passkeys --path specs/auth/auth.spec.md --module auth
 specsync change archive CHG-0001-add-passkeys
 specsync change check
 specsync change adopt --dry-run
@@ -333,6 +350,8 @@ specsync change adopt --dry-run
 `acceptance_criteria` preserves scalar prose exactly; use a JSON array of strings to provide multiple criteria. `affected_specs` and `affected_paths` retain comma- and newline-separated list input.
 
 Definition and closing approvals are mandatory and digest-bound. Use `change reopen` when accepted delivery inputs became stale but the approved definition is unchanged. Use `change correct` when review proves an accepted `public_contract` or `architecture_risk` answer was wrong. Correction requires an explicit actor and reason, preserves the original answer and prior evidence in an append-only ledger, can only add newly required artifacts, returns to `verifying`, and requires fresh definition approval, verification, and closing approval. Correct/show/status expose both original and effective values in text and global `--json` output. Unsupported fields, values other than `yes`/`no`, no-op corrections, incomplete audit inputs, and non-accepted workspaces fail without mutation. Neither recovery path reapplies an already-canonical semantic delta. `change adopt` enables SDD for an existing project and can import active/canonical OpenSpec or Spec Kit artifacts.
+
+Use `change correct-owner` to append audited exact canonical owner corrections for reopened acceptance evidence — for example owners omitted from a historical affected-spec list. The single form takes one `--path`/`--spec` pair; the batch form accepts repeated `--path` flags (one shared `--spec` or paired lists), a `--manifest` file (JSON `[{path, module}]` or TSV), or `--all-missing --spec <module>` to discover every production-source affected path that lacks canonical ownership. Every entry validates independently against the single-correction rules, and the batch is transactional: if any entry is invalid, no corrections from the batch are persisted. Use `change supersede` before definition approval when a later change adopts an exact predecessor path/module obligation, so the predecessor's accepted evidence remains successor-covered instead of going stale.
 
 ### `lifecycle`
 

--- a/site/src/content/docs/cross-project-refs.md
+++ b/site/src/content/docs/cross-project-refs.md
@@ -61,6 +61,11 @@ name = "parser"
 spec = "specs/parser/parser.spec.md"
 ```
 
+> **Inert stubs are tolerated.** A 5.0.1-era `registry.toml` with no registry `name` and no
+> `[specs]`/`[[modules]]` mappings loads as absent: canonical module resolution falls back to the
+> conventional `specs/<module>/<module>.spec.md` path instead of failing. An invalid registry
+> that actually declares content still fails closed with the established parse diagnostic.
+
 ---
 
 ## Verifying References

--- a/site/src/content/docs/workflow.md
+++ b/site/src/content/docs/workflow.md
@@ -67,6 +67,8 @@ Verification runs only project-configured native test commands without a shell a
 
 Archive after the delivery branch is merged (or otherwise no longer differs from its comparison base). Until then, SpecSync keeps the accepted workspace active because the delivery diff still depends on its path coverage. This prevents the common gap where accepting and immediately archiving makes an unmerged implementation look unspecced.
 
+Squash merges are fully supported: the archiver trusts any commit on the default branch that records the change as accepted with byte-identical `state.json`, `verification.json`, and `approvals.json` evidence, even when the squash discarded the original acceptance-transition commit or the verification commit never entered mainline history. Changes with no matching in-history accepted record still fail closed, so evidence can never be fabricated by editing the working tree. If `check` reports that an accepted change's verification is stale for current delivery inputs, the error names the offending input and the concrete remediation — `change reopen <id>` when the input drifted, or `specsync migrate 5.0` when a 5.0.1-era ledger is missing reopening digest fields.
+
 ## 4. Reopen After Accepted Review Fixes
 
 If final review changes a governed source, test, configuration, policy, or contract input after acceptance, strict checking correctly rejects the stale closing evidence. Do not edit lifecycle JSON or archive the active workspace. Record an audited transition instead:


### PR DESCRIPTION
## Summary

Brings the documentation up to date with everything 5.2.0 shipped:

- **`cli.md`** — new `migrate 5.0` section (deterministic digest backfill, idempotency, `--dry-run`, per-change failure isolation); both `correct-owner` forms (single `--path`/`--spec`, batch with repeated flags/`--manifest`/`--all-missing`); `change supersede` in the lifecycle command list.
- **`workflow.md`** — squash-merged archival trust (recording anchors, fail-closed for unmatched evidence) and the actionable staleness/`migrate 5.0` diagnostics.
- **`cross-project-refs.md`** — inert 5.0.1 registry stub tolerance with the fail-closed boundary for real registries.
- **`AGENTS.md`** — quick reference now lists the SDD lifecycle commands (`change new/approve/start/verify/accept/reopen/archive/check`), both `correct-owner` forms, and `migrate 5.0`.

Documentation-only change (no code, no canonical spec content) delivered through the SDD lifecycle as accepted CHG-0061. `specsync check --strict` green (62/62 specs, 100% coverage); `fledge trust verify` passed.