### PR TITLE
fix: compact idempotent summary rows, trailing newline, well-formed rows, counts/pluralization (closes #417)

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 64,
-  "id": "CHG-0064-add-capability-safe-filesystem-support-for-mcp-security-hardening",
+  "sequence": 65,
+  "id": "CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
@@ -1,0 +1,4 @@
+{
+  "approvals": [],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
@@ -1,4 +1,12 @@
 {
-  "approvals": [],
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "user",
+      "timestamp": 1785130063,
+      "digest": "8255a67b2270e520d023b6c8e3d7b962670157e090bf1ecc4b554e1fd12848e7",
+      "note": "I approve CHG-0065 digest 4cb1f669e6892906b7ed9d78d872de1eb133de0725ceac4ef262ff7451d99984."
+    }
+  ],
   "reopenings": []
 }

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
@@ -20,6 +20,13 @@
       "timestamp": 1785159032,
       "digest": "7d765c925d71023d2730b1cd80b35adcd9298679f0e9ca6a3a7bb9a5acaaf8d8",
       "note": "User approved CHG-0065 digest 7d765c925d71023d2730b1cd80b35adcd9298679f0e9ca6a3a7bb9a5acaaf8d8."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "human:leif",
+      "timestamp": 1785159899,
+      "digest": "b3e74ab3b6921d10292939aa478670c7a2eba4b4c752bb00ce4157f7ad0286ad",
+      "note": "User approved closing CHG-0065 after fresh verification."
     }
   ],
   "reopenings": []

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
@@ -13,6 +13,13 @@
       "timestamp": 1785136485,
       "digest": "b2811e155f678c3d20e299abf0a3c04cd16203ff9d3fbb5956a93122aa8dd327",
       "note": "User approved CHG-0065 digest 4cb1f669e6892906b7ed9d78d872de1eb133de0725ceac4ef262ff7451d99984."
+    },
+    {
+      "gate": "definition",
+      "actor": "human:leif",
+      "timestamp": 1785159032,
+      "digest": "7d765c925d71023d2730b1cd80b35adcd9298679f0e9ca6a3a7bb9a5acaaf8d8",
+      "note": "User approved CHG-0065 digest 7d765c925d71023d2730b1cd80b35adcd9298679f0e9ca6a3a7bb9a5acaaf8d8."
     }
   ],
   "reopenings": []

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/approvals.json
@@ -6,6 +6,13 @@
       "timestamp": 1785130063,
       "digest": "8255a67b2270e520d023b6c8e3d7b962670157e090bf1ecc4b554e1fd12848e7",
       "note": "I approve CHG-0065 digest 4cb1f669e6892906b7ed9d78d872de1eb133de0725ceac4ef262ff7451d99984."
+    },
+    {
+      "gate": "definition",
+      "actor": "human:leif",
+      "timestamp": 1785136485,
+      "digest": "b2811e155f678c3d20e299abf0a3c04cd16203ff9d3fbb5956a93122aa8dd327",
+      "note": "User approved CHG-0065 digest 4cb1f669e6892906b7ed9d78d872de1eb133de0725ceac4ef262ff7451d99984."
     }
   ],
   "reopenings": []

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
-state: approved
+state: implementing
 type: bug_fix
 base_commit: f74d52fdb6792dac2df89f545331b796dd7838ca
 ---

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
-state: draft
+state: approved
 type: bug_fix
 base_commit: f74d52fdb6792dac2df89f545331b796dd7838ca
 ---

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
@@ -1,6 +1,6 @@
 ---
 id: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
-state: implementing
+state: accepted
 type: bug_fix
 base_commit: f74d52fdb6792dac2df89f545331b796dd7838ca
 ---

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/change.md
@@ -1,0 +1,28 @@
+---
+id: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+state: draft
+type: bug_fix
+base_commit: f74d52fdb6792dac2df89f545331b796dd7838ca
+---
+
+# Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output
+
+## Intent
+
+Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output
+
+## Affected Canonical Specs
+
+- `cli`
+- `archive`
+- `cmd_compact`
+- `cmd_archive_tasks`
+- `compact`
+
+## Acceptance Criteria
+
+- Repeated compact runs are byte-for-byte idempotent; only provenance-marked generated summaries are folded; ambiguous summaries, malformed tables, and count overflow fail closed; escaped/code-span pipes, exact LF/CRLF bytes, kept counts, and singular/plural output remain correct; compact and archive-tasks preflight and atomically publish planned replacements, report every incomplete/partial operation, emit parse-clean ANSI-free JSON and injection-safe Markdown/GitHub, preserve literal Unix backslashes while normalizing Windows separators, and exit nonzero without false success on failure; targeted regressions, full repository verification, strict spec coverage and scoring, trust verification, independent review, private sandbox replay, and GitHub CI all pass.
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/context.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/context.md
@@ -1,0 +1,27 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: context
+---
+
+# Context
+
+GitHub issue #417 reports correctness and output-contract defects in `specsync compact`, with
+related structured-output gaps in `archive-tasks`. The prior implementation treated its own
+generated summary row as ordinary history on later runs, could produce malformed wide-table
+summaries, lost trailing-newline state, misreported retained counts, and did not consistently honor
+JSON or Markdown output selection.
+
+The existing PR implementation addresses those behaviors across the `compact`, `cmd_compact`,
+`cmd_archive_tasks`, and root `cli` owners. After rebasing onto the MCP-security delivery, hosted
+Windows tests exposed one remaining compatibility defect: repo-relative result paths retained
+Windows `\` separators in JSON and Markdown, making structured output host-dependent.
+
+The change must preserve the established text experience and task/changelog mutation semantics.
+It must not broaden file ownership, silently rewrite unrelated rows, or treat user-authored
+`Compacted:` prose as tool-owned state.
+
+Independent acceptance and adversarial reviews found that shape-only ownership could consume exact
+user lookalikes, multiple summaries could corrupt counts, line reconstruction normalized CRLF,
+backslash parity/code spans were parsed incorrectly, unchecked counts could overflow, Unix
+backslashes were aliased, Markdown paths were injectable, and write failures could leave partial
+state while exiting successfully. These findings are release blockers and are now in scope.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/context.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/context.md
@@ -25,3 +25,9 @@ user lookalikes, multiple summaries could corrupt counts, line reconstruction no
 backslash parity/code spans were parsed incorrectly, unchecked counts could overflow, Unix
 backslashes were aliased, Markdown paths were injectable, and write failures could leave partial
 state while exiting successfully. These findings are release blockers and are now in scope.
+
+The rebuilt PR #447 branch now contains eight dependency-ordered commits based directly on current
+`main`. Candidate `d6c12fdbf4f2a1d96c15408946392074c02244d5` passed the full local lane, private
+sandbox replay, two independent reviews, signed 0.95-confidence Attest verification, hosted Trust,
+all cross-platform GitHub checks, and Corvin approval. CHG-0065 is ready for a refreshed definition
+approval, native lifecycle verification, and explicit closing approval.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/archive.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/archive.md
@@ -1,0 +1,22 @@
+## MODIFIED
+
+### REQUIREMENT REQ-archive-001
+
+The archive module SHALL move completed tasks without losing active content and SHALL report every
+selected, succeeded, failed, and rolled-back filesystem operation.
+
+Acceptance Criteria
+
+- Dry-run returns the complete plan without writing.
+- Apply mode reads and preflights every target, stages same-directory replacements, and publishes
+  atomically only after staging succeeds everywhere.
+- Any preflight/staging failure leaves every destination byte-for-byte unchanged.
+- Late publish or rollback failures are explicit incomplete/partial outcomes.
+- Original destination permissions are preserved.
+- Structured failures contain the exact path, operation phase, and bounded error.
+
+### SPEC SECTION Invariants
+
+8. Maintenance application uses plan, preflight, stage, publish, and rollback phases.
+9. No preflight/staging failure mutates a destination.
+10. The report never claims complete success after a failed operation.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/archive.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/archive.md
@@ -2,21 +2,32 @@
 
 ### REQUIREMENT REQ-archive-001
 
-The archive module SHALL move completed tasks without losing active content and SHALL report every
-selected, succeeded, failed, and rolled-back filesystem operation.
+The archive module SHALL move only completed task items into preserved archive sections through a deterministic, typed, transactionally safe invocation.
 
 Acceptance Criteria
-
-- Dry-run returns the complete plan without writing.
-- Apply mode reads and preflights every target, stages same-directory replacements, and publishes
-  atomically only after staging succeeds everywhere.
-- Any preflight/staging failure leaves every destination byte-for-byte unchanged.
-- Late publish or rollback failures are explicit incomplete/partial outcomes.
-- Original destination permissions are preserved.
-- Structured failures contain the exact path, operation phase, and bounded error.
+- Only task items matching `- [x]` or `- [X]` (case-insensitive) are eligible for archiving
+- An `## Archive` section is automatically created at the bottom of tasks.md if it does not exist
+- Existing archive content is preserved and new completed tasks are appended to it
+- `dry_run: true` returns an `ArchiveReport` whose planned operations exactly match an apply plan without staging or writing any destination
+- Files with no completed tasks are excluded from the results vector
+- The `count_completed_tasks` function returns the total count of `- [x]` items across all tasks.md files in the specs directory
+- `ArchiveResult` entries retain a relative `PathBuf` and the count of tasks archived
+- `ArchiveReport` separates planned, succeeded, rolled-back, and failed operations
+- Every `ArchiveFailure` includes the path, operation identity, and error detail
+- Any planning or staging failure prevents all destination-file writes
+- Replacements are staged in each destination directory, preserve original permissions, and publish atomically
+- A late publish failure rolls back prior publishes when safe and truthfully retains any unrolled-back operation in `succeeded`
+- Task items use the exact markdown format `- [x] ` (with space after bracket) to be recognized as completed
 
 ### SPEC SECTION Invariants
 
-8. Maintenance application uses plan, preflight, stage, publish, and rollback phases.
-9. No preflight/staging failure mutates a destination.
-10. The report never claims complete success after a failed operation.
+1. Only items matching `- [x]` or `- [X]` (case-insensitive) are archived
+2. If no `## Archive` section exists, one is created at the bottom of the file
+3. Existing archive content is preserved — new items are appended
+4. `dry_run: true` returns the exact plan without staging or modifying files
+5. Files with no completed tasks are skipped (not included in results)
+6. Uses `find_spec_files` from validator to discover specs and their companion files
+7. Every candidate is read and preflighted before staging; any planning failure prevents all destination writes
+8. Every replacement is staged in its destination directory before the first destination is published
+9. Staged files preserve original permissions and are atomically renamed over their destination
+10. A late publish failure is reported; prior successful publishes are rolled back when safe, and any remaining changed files are exposed as partial success

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cli.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cli.md
@@ -14,5 +14,21 @@ Acceptance Criteria
 
 ### SPEC SECTION Invariants
 
+1. When no subcommand is given, `check` runs by default.
+2. `--root` defaults to the current working directory and is validated as an existing directory,
+   otherwise the process exits 2. MCP plus check/coverage/generate/score/report/comment preserve
+   the requested spelling so their retained-capability engines can detect public root replacement;
+   other commands receive the canonicalized path.
+3. `--strict` causes warnings to produce a non-zero exit code.
+4. `--require-coverage N` causes exit 1 if file coverage percent is below N.
+5. `--json` switches all output to machine-readable JSON without ANSI colors.
+6. Initialization and registry creation remain idempotent and preserve existing configuration.
+7. Generation, scoring, resolution, hooks, lifecycle, and reporting commands delegate policy to
+   their focused modules.
+8. Inherited verification context rejects recursive check/change/lifecycle dispatch before handler
+   execution.
+9. MCP dispatch forwards the parsed write capability unchanged; read-only remains the default.
+10. MCP server-root initialization failures are printed to stderr and exit 2 before request input is
+    processed.
 11. `compact` and `archive-tasks` receive the resolved global output format instead of silently
     falling back to text.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cli.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cli.md
@@ -1,0 +1,18 @@
+## ADDED
+
+### REQUIREMENT REQ-cli-007
+
+The root CLI SHALL forward the resolved global output format to compact and archive-tasks handlers.
+
+Acceptance Criteria
+
+- `--json` and `--format json` dispatch the same `OutputFormat::Json` value.
+- `--format markdown` dispatches `OutputFormat::Markdown`.
+- No human banner is emitted before the structured renderer.
+
+## MODIFIED
+
+### SPEC SECTION Invariants
+
+11. `compact` and `archive-tasks` receive the resolved global output format instead of silently
+    falling back to text.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_archive_tasks.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_archive_tasks.md
@@ -2,28 +2,36 @@
 
 ### REQUIREMENT REQ-cmd-archive-tasks-001
 
-The archive-tasks command SHALL delegate task archival safely and SHALL distinguish dry-run,
-no-op, per-file, and summary output.
+The archive-tasks command SHALL delegate task archival safely and SHALL render truthful dry-run, success, partial, rollback, and failure outcomes.
 
 Acceptance Criteria
-
-- `cmd_archive_tasks(root, dry_run, format)` loads config, resolves `config.specs_dir`, and
-  delegates to `archive::archive_tasks(root, &specs_dir, dry_run)`.
-- Dry-run prints preview output and makes no writes; apply mode reports completed work.
-- Empty results remain successful and do not print a misleading aggregate summary.
-- Per-file and aggregate counts report affected tasks and files truthfully.
-- JSON is one ANSI-free document, and `--json` is byte-equivalent to `--format json`.
-- Markdown and GitHub render a heading, optional dry-run notice, result table, and truthful summary.
-- Windows separators normalize to `/`; Unix literal backslashes retain identity.
-- Markdown/GitHub paths use sanitized variable-length code spans.
-- JSON exposes complete/partial state, planned/succeeded/failed counts, and structured errors.
-- Any incomplete operation exits 1 after rendering and never claims `applied: true`.
+- `cmd_archive_tasks(root, dry_run, format)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
+- When `dry_run` is true, an informational banner ("Dry run — no files will be modified") prints and no files are written; per-file lines read "would archive"
+- When `dry_run` is false, completed tasks are moved and per-file lines read "archived"
+- When the delegate returns no results, prints "No completed tasks to archive." and returns without a summary
+- Each affected file prints its relative `tasks_path` and `archived_count`; a trailing summary reports the summed task count across the affected file count
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-file results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- JSON separates planned, succeeded, rolled-back, and failed operations and exposes truthful `complete` and `partial` booleans
+- Incomplete apply results render before exit 1 and never report `applied: true`
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit equivalent headings, optional dry-run notices, result/failure tables, and truthful singular/plural summaries
+- Structured Windows paths use `/` separators; legal Unix backslashes remain literal
+- Markdown/GitHub paths cannot inject rows or break their single code element through pipes, backtick runs, line/control characters, or bidirectional controls
+- Text output uses task/tasks and file/files according to the actual counts
+- Text paths and errors visibly encode line/control and bidirectional-control characters rather than emitting terminal-control content
 
 ### SPEC SECTION Invariants
 
+1. Delegates entirely to `archive::archive_tasks()` for planning and transactional archival
+2. Dry-run mode prints affected files but makes no writes
+3. Gracefully handles empty results (no completed tasks to archive)
 4. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent.
 5. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary.
 6. Structured dry-run output distinguishes `would_change: true` from `applied: false`.
-7. Structured paths normalize only actual host separators.
-8. Markdown/GitHub paths cannot inject table rows or break code spans.
-9. Incomplete work renders truthful operation evidence and exits 1.
+7. Structured paths retain `PathBuf` identity until rendering: Windows separators become `/`, while literal Unix backslashes remain literal
+8. JSON exposes `complete`, `partial`, and explicit planned/succeeded/rolled-back/failed operation arrays
+9. Any incomplete report is fully rendered before the command exits 1; `applied` is never true for an incomplete invocation
+10. Markdown/GitHub paths use one code element: dynamic-backtick spans normally and entity-safe HTML code for literal-pipe paths, plus visible escapes for control and bidirectional-control characters; every legal Unix backslash parity remains unchanged
+11. Text output uses correct task/tasks and file/files labels
+12. Text paths and filesystem errors visibly escape control and bidirectional-control characters

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_archive_tasks.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_archive_tasks.md
@@ -1,0 +1,29 @@
+## MODIFIED
+
+### REQUIREMENT REQ-cmd-archive-tasks-001
+
+The archive-tasks command SHALL delegate task archival safely and SHALL distinguish dry-run,
+no-op, per-file, and summary output.
+
+Acceptance Criteria
+
+- `cmd_archive_tasks(root, dry_run, format)` loads config, resolves `config.specs_dir`, and
+  delegates to `archive::archive_tasks(root, &specs_dir, dry_run)`.
+- Dry-run prints preview output and makes no writes; apply mode reports completed work.
+- Empty results remain successful and do not print a misleading aggregate summary.
+- Per-file and aggregate counts report affected tasks and files truthfully.
+- JSON is one ANSI-free document, and `--json` is byte-equivalent to `--format json`.
+- Markdown and GitHub render a heading, optional dry-run notice, result table, and truthful summary.
+- Windows separators normalize to `/`; Unix literal backslashes retain identity.
+- Markdown/GitHub paths use sanitized variable-length code spans.
+- JSON exposes complete/partial state, planned/succeeded/failed counts, and structured errors.
+- Any incomplete operation exits 1 after rendering and never claims `applied: true`.
+
+### SPEC SECTION Invariants
+
+4. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent.
+5. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary.
+6. Structured dry-run output distinguishes `would_change: true` from `applied: false`.
+7. Structured paths normalize only actual host separators.
+8. Markdown/GitHub paths cannot inject table rows or break code spans.
+9. Incomplete work renders truthful operation evidence and exits 1.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_compact.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_compact.md
@@ -2,32 +2,37 @@
 
 ### REQUIREMENT REQ-cmd-compact-001
 
-The compact command SHALL delegate deterministic changelog compaction and SHALL preserve dry-run
-and summary behavior.
+The compact command SHALL delegate deterministic changelog compaction and SHALL preserve dry-run and summary behavior.
 
 Acceptance Criteria
-
-- `cmd_compact(root, keep, dry_run, format)` loads config, resolves `config.specs_dir`, and
-  delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`.
-- `--keep N` controls how many changelog entries to retain per spec.
-- Dry-run prints preview output and makes no writes; apply mode reports completed work.
-- Empty results remain successful and do not print a misleading aggregate summary.
-- Per-spec and aggregate counts report removed and retained ordinary rows truthfully, with correct
-  singular/plural labels.
-- JSON is one ANSI-free document, and `--json` is byte-equivalent to `--format json`.
-- Markdown and GitHub render a heading, optional dry-run notice, result table, and truthful summary.
-- Windows separators normalize to `/`; Unix literal backslashes retain identity.
-- Markdown/GitHub paths use sanitized variable-length code spans.
-- JSON exposes complete/partial state, planned/succeeded/failed counts, and structured errors.
-- Any incomplete operation exits 1 after rendering and never claims `applied: true`.
+- `cmd_compact(root, keep, dry_run, format)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
+- `--keep N` controls how many changelog entries to retain per spec
+- When `dry_run` is true, a banner prints, no files are written, and per-spec lines read "would compact"
+- When `dry_run` is false, entries are removed and per-spec lines read "compacted"
+- When the delegate returns no results, prints "No changelogs need compaction (all within limit)." and returns without a summary
+- Each affected spec prints its relative `spec_path`, the `removed` count, and the kept (`compacted_entries`) count; the trailing summary sums removed entries across affected specs
+- A count of one uses `entry`; all other counts use `entries`
+- The kept count excludes the generated compaction summary row
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-spec results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit a heading, optional dry-run notice, result table, and truthful singular/plural summary
+- JSON and Markdown result paths use `/` separators on Windows while preserving literal Unix backslashes
+- Markdown/GitHub paths are sanitized and rendered as one safe code element while preserving every legal Unix backslash parity
+- JSON exposes complete/partial state, operation counts, and structured errors
+- Any incomplete apply renders before exiting 1 and never claims `applied: true`
 
 ### SPEC SECTION Invariants
 
+1. Delegates to `compact::compact_changelogs()`
+2. `--keep N` controls how many entries to retain (default 10)
+3. Dry-run shows what would change without writing
 4. Per-spec and aggregate output use correct singular/plural labels and exclude the generated
    summary from the kept count.
 5. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent.
 6. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary.
 7. Structured dry-run output distinguishes `would_change: true` from `applied: false`.
-8. Structured paths normalize only actual host separators.
-9. Markdown/GitHub paths cannot inject table rows or break code spans.
-10. Incomplete work renders truthful operation evidence and exits 1.
+8. JSON and Markdown project paths use `/` separators on Windows while preserving literal Unix backslashes
+9. Markdown/GitHub paths use one sanitized code element: variable-length Markdown spans normally and entity-safe HTML code when a literal pipe is present, so no table row can be injected and every legal Unix backslash is preserved
+10. JSON exposes `complete`, `partial`, planned/succeeded/failed operations, structured errors, and never sets `applied: true` for incomplete work
+11. Any compact failure is rendered before the command exits 1

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_compact.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/cmd_compact.md
@@ -1,0 +1,33 @@
+## MODIFIED
+
+### REQUIREMENT REQ-cmd-compact-001
+
+The compact command SHALL delegate deterministic changelog compaction and SHALL preserve dry-run
+and summary behavior.
+
+Acceptance Criteria
+
+- `cmd_compact(root, keep, dry_run, format)` loads config, resolves `config.specs_dir`, and
+  delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`.
+- `--keep N` controls how many changelog entries to retain per spec.
+- Dry-run prints preview output and makes no writes; apply mode reports completed work.
+- Empty results remain successful and do not print a misleading aggregate summary.
+- Per-spec and aggregate counts report removed and retained ordinary rows truthfully, with correct
+  singular/plural labels.
+- JSON is one ANSI-free document, and `--json` is byte-equivalent to `--format json`.
+- Markdown and GitHub render a heading, optional dry-run notice, result table, and truthful summary.
+- Windows separators normalize to `/`; Unix literal backslashes retain identity.
+- Markdown/GitHub paths use sanitized variable-length code spans.
+- JSON exposes complete/partial state, planned/succeeded/failed counts, and structured errors.
+- Any incomplete operation exits 1 after rendering and never claims `applied: true`.
+
+### SPEC SECTION Invariants
+
+4. Per-spec and aggregate output use correct singular/plural labels and exclude the generated
+   summary from the kept count.
+5. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent.
+6. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary.
+7. Structured dry-run output distinguishes `would_change: true` from `applied: false`.
+8. Structured paths normalize only actual host separators.
+9. Markdown/GitHub paths cannot inject table rows or break code spans.
+10. Incomplete work renders truthful operation evidence and exits 1.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/compact.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/compact.md
@@ -2,28 +2,39 @@
 
 ### REQUIREMENT REQ-compact-001
 
-The compact module SHALL compact only excess Change Log rows while preserving recent entries,
-table structure, byte stability, and dry-run safety.
+The compact module SHALL compact only excess Change Log rows while preserving recent entries, table structure, and dry-run safety.
 
 Acceptance Criteria
-
-- Only the `## Change Log` slice is rewritten; header and separator rows remain intact.
-- The last `keep` ordinary rows are retained and older ordinary rows become one well-formed summary.
-- A generated summary is recognized only by its exact provenance marker, range, placeholders, and
-  grammatical checked fixed-width count.
-- New excess rows fold prior generated counts while retaining the original range start.
-- Unmarked lookalikes remain ordinary history; multiple marked summaries fail closed.
-- Odd escaped pipes and code-span pipes stay inside cells; even backslash runs expose delimiters.
-- Only the first contiguous width-valid table is compacted.
-- No-op repeats are byte-for-byte idempotent; changed runs preserve exact LF/CRLF terminators.
-- Dry-run returns results without writes, and only results with removed rows are surfaced.
-- `CompactResult.compacted_entries` counts retained ordinary rows and excludes the summary.
-- Every input is inspected and same-directory replacement staged before publication; failures are
-  structured and incomplete/partial work never claims success.
+- `compact_changelogs(root, specs_dir, keep, dry_run)` walks every spec found by `find_spec_files` and compacts each spec's `## Change Log` table
+- The `## Change Log` section ends at the next `## ` heading or EOF; only that slice is rewritten
+- The first two `|`-prefixed lines in the section (header + separator) are always preserved
+- The last `keep` ordinary data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
+- The summary row reads `| <first_date> — <last_date> | Compacted: <N> entries |` for 2-column tables, and inserts a `—` placeholder for the middle column(s) on 3+ column tables
+- A generated summary row is recognized only when its first cell contains a non-empty `start — end` range, every interior cell is `—`, and its final cell contains a grammatically-correct fixed-width count plus the exact `<!-- specsync:compact:v1 -->` marker
+- When new ordinary rows require another compaction, prior generated summary counts are accumulated and the original range start is retained
+- Multiple marked summaries fail closed instead of being summed
+- Column count and cells are parsed from one contiguous table without treating odd-backslash escaped pipes or code-span pipes as delimiters
+- If `total <= keep`, no rows are removed (`removed == 0`) and the spec is not written; such results are filtered out by `compact_changelogs`
+- `dry_run: true` collects `CompactResult` values but never writes files
+- Only results where `removed > 0` are returned from `compact_changelogs`
+- Re-running with no excess ordinary rows leaves the file byte-for-byte unchanged, including exact LF/CRLF terminators
+- `CompactResult.compacted_entries` reports ordinary entries retained and excludes the generated summary row
+- Count overflow, malformed widths, and ambiguous generated state fail closed
+- Preflight or staging failure writes nothing, and every incomplete apply is represented in the typed report
 
 ### SPEC SECTION Invariants
 
+1. Only an exact `## Change Log` H2 outside fenced and indented code is processed
+2. Only the first contiguous, width-valid table outside fenced and indented code in the section is compacted; later tables are preserved
+3. The last `keep` data rows are preserved; earlier rows are summarized
+4. Summary row contains the date range of compacted entries and their count
+5. If a changelog has fewer than `keep + 1` entries, no compaction occurs
+6. `dry_run: true` returns results without modifying files
+7. Handles both 2-column and 3+ column tables with appropriate summary format
 8. Re-running compaction with the same `keep` value is byte-for-byte idempotent.
-9. Escaped/code-span pipes and exact LF/CRLF terminators are preserved.
-10. Only provenance-marked summaries are folded; duplicate markers and overflow fail closed.
-11. Preflight/staging completes before publication and failures remain explicit.
+9. Escaped table pipes, code-span pipes, every original LF/CRLF line terminator, and the original final-newline state are preserved
+10. Only rows carrying the exact `<!-- specsync:compact:v1 -->` provenance marker are folded as prior summaries
+11. Multiple marked summaries, malformed table widths, and fixed-width count overflow fail closed
+12. Apply mode preflights every replacement and stages same-directory temporary files before publication
+13. Staging failures retain every planned result/count with zero writes; late publish failures retain all results and report exact partial progress
+14. Indented pipe code terminates table data, indented separators fail before writes, and a generated summary is valid only as the first data row

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/compact.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/deltas/compact.md
@@ -1,0 +1,29 @@
+## MODIFIED
+
+### REQUIREMENT REQ-compact-001
+
+The compact module SHALL compact only excess Change Log rows while preserving recent entries,
+table structure, byte stability, and dry-run safety.
+
+Acceptance Criteria
+
+- Only the `## Change Log` slice is rewritten; header and separator rows remain intact.
+- The last `keep` ordinary rows are retained and older ordinary rows become one well-formed summary.
+- A generated summary is recognized only by its exact provenance marker, range, placeholders, and
+  grammatical checked fixed-width count.
+- New excess rows fold prior generated counts while retaining the original range start.
+- Unmarked lookalikes remain ordinary history; multiple marked summaries fail closed.
+- Odd escaped pipes and code-span pipes stay inside cells; even backslash runs expose delimiters.
+- Only the first contiguous width-valid table is compacted.
+- No-op repeats are byte-for-byte idempotent; changed runs preserve exact LF/CRLF terminators.
+- Dry-run returns results without writes, and only results with removed rows are surfaced.
+- `CompactResult.compacted_entries` counts retained ordinary rows and excludes the summary.
+- Every input is inspected and same-directory replacement staged before publication; failures are
+  structured and incomplete/partial work never claims success.
+
+### SPEC SECTION Invariants
+
+8. Re-running compaction with the same `keep` value is byte-for-byte idempotent.
+9. Escaped/code-span pipes and exact LF/CRLF terminators are preserved.
+10. Only provenance-marked summaries are folded; duplicate markers and overflow fail closed.
+11. Preflight/staging completes before publication and failures remain explicit.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/design.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/design.md
@@ -1,0 +1,39 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: design
+---
+
+# Design
+
+## Compaction ownership
+
+A row is tool-owned only when it carries `<!-- specsync:compact:v1 -->`, has a non-empty range,
+valid placeholders, and a grammatical fixed-width count. Unmarked lookalikes remain ordinary
+history; multiple marked rows are rejected. Backslash parity and code-span delimiters govern pipe
+splitting, and only one contiguous width-valid changelog table is processed.
+
+## Byte stability
+
+The changelog section is reconstructed without changing content outside that section. A no-op
+second run returns the original bytes. Inclusive source-line reconstruction preserves each original
+LF/CRLF terminator, including mixed-ending files. Checked `u64` arithmetic rejects summary overflow.
+
+## Output contract
+
+The root dispatcher forwards the resolved global `OutputFormat` to both maintenance commands.
+Command wrappers own presentation:
+
+- text preserves the existing terminal-oriented output;
+- JSON emits exactly one ANSI-free document and separates `would_change` from `applied`;
+- Markdown and GitHub emit a heading, optional dry-run notice, table, and summary.
+
+Structured renderers normalize separators only on Windows. Unix literal backslashes keep their
+identity. Markdown/GitHub sanitizes controls/bidi marks, escapes table pipes, and selects a code-span
+delimiter longer than every embedded backtick run.
+
+## Safety
+
+Dry-run delegates collect plans without writing. Apply mode inspects every input and stages
+same-directory temporary replacements before publication. Preflight failure writes nothing; late
+publication/rollback failure is explicit incomplete/partial evidence and exits 1 after rendering.
+Empty results remain successful no-ops.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/docs.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/docs.md
@@ -1,0 +1,23 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: docs
+---
+
+# Docs
+
+Update canonical specs and companions for `archive`, `compact`, `cmd_compact`,
+`cmd_archive_tasks`, and `cli`.
+The documentation must state:
+
+- provenance-bound ownership and ambiguity/overflow rejection for generated summary rows;
+- idempotent folding, pipe-escape/code-span handling, table isolation, exact LF/CRLF behavior,
+  and truthful retained counts;
+- supported text, JSON, Markdown, and GitHub maintenance output;
+- equivalence of `--json` and `--format json`;
+- dry-run `would_change`/`applied` semantics; and
+- platform-aware separators that preserve Unix literal backslashes;
+- injection-safe Markdown/GitHub path rendering; and
+- preflight/atomic publication with truthful complete/partial failures and exit status.
+
+Increment affected spec versions and add dated change-log entries. Release or PR notes must call
+out the structured-output compatibility correction without claiming a change to text-path spelling.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/plan.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/plan.md
@@ -1,0 +1,24 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: plan
+---
+
+# Plan
+
+1. Capture the issue #417 regressions for repeated compaction, summary ownership, escaped pipes,
+   table width, trailing newlines, retained counts, pluralization, dry-run behavior, and structured
+   output.
+2. Provenance-mark generated summaries; reject ambiguity/overflow/malformed tables; preserve exact
+   LF/CRLF bytes and parse pipe escapes/code spans correctly.
+3. Forward the resolved output format through the root dispatcher and implement truthful JSON and
+   Markdown/GitHub renderers for compact and archive-tasks.
+4. Normalize actual Windows separators without aliasing Unix filenames, and safely render hostile
+   Markdown/GitHub paths.
+5. Preflight and atomically stage compact/archive replacements; expose complete/partial failures and
+   nonzero incomplete outcomes.
+6. Synchronize all five canonical specs and companions.
+7. Run targeted tests, formatting, lint, the full repository lane, strict 100% spec coverage,
+   score gates, and trust verification.
+8. Replay compact/archive flows in `CorvidLabs/spec-sync-sandbox`, obtain independent implementation
+   and adversarial reviews, resolve all high/medium findings, and require green GitHub CI.
+9. Present exact verification evidence for closing approval; accept and archive only after merge.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/requirements.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/requirements.md
@@ -1,0 +1,56 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: requirements
+---
+
+# Requirements
+
+## REQ-417-001 — Idempotent compaction
+
+Repeated `compact` runs SHALL be byte-for-byte stable when no new ordinary changelog rows exceed
+the keep limit. A later run with new excess rows SHALL fold prior generated counts into one summary
+and retain the original range start.
+
+## REQ-417-002 — Exact row ownership
+
+Only summary rows carrying the exact SpecSync provenance marker SHALL be treated as generated
+state. Unmarked lookalikes SHALL remain ordinary history, and multiple marked summaries SHALL fail
+closed. Odd-backslash escapes and Markdown code spans SHALL retain embedded pipes while even
+backslash runs expose delimiters. Only the first contiguous width-valid table SHALL be compacted.
+
+## REQ-417-003 — Byte and count fidelity
+
+Compaction SHALL preserve every LF/CRLF terminator and all bytes outside the changed rows.
+Fixed-width summary counts SHALL use checked arithmetic. Reported kept counts SHALL exclude the
+generated summary row. Entry/spec labels SHALL use correct singular and plural forms.
+
+## REQ-417-004 — Structured maintenance output
+
+`compact` and `archive-tasks` SHALL honor text, JSON, Markdown, and GitHub output selection.
+`--json` SHALL equal `--format json`. JSON SHALL be one parseable ANSI-free document. Markdown and
+GitHub SHALL contain a structured result table and truthful summary.
+
+## REQ-417-005 — Dry-run truth
+
+Dry runs SHALL make no file writes. Structured output SHALL report selected work through
+`would_change` while leaving `applied` false.
+
+## REQ-417-006 — Cross-platform determinism
+
+JSON and Markdown/GitHub repo-relative result paths SHALL use `/` separators on Linux, macOS, and
+Windows without changing legal Unix literal backslashes. Markdown/GitHub paths SHALL use sanitized
+variable-length code spans that cannot inject rows through pipes, backticks, controls, or bidi
+formatting. Existing text output SHALL sanitize unsafe terminal characters.
+
+## REQ-417-008 — Transactional maintenance truth
+
+`compact` and `archive-tasks` SHALL inspect and stage every selected replacement before
+publication. Preflight/staging failure SHALL write nothing. A later publication/rollback failure
+SHALL be represented as incomplete/partial structured evidence, SHALL exit 1, and SHALL never claim
+`applied: true` or complete success.
+
+## REQ-417-007 — Delivery evidence
+
+Targeted regressions, the full repository lane, strict 100% spec coverage, score thresholds, trust
+verification, independent review, private-sandbox replay, and required GitHub CI SHALL pass before
+closing approval.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/research.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/research.md
@@ -1,0 +1,36 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: research
+---
+
+# Research
+
+## Reproductions
+
+- A second compaction previously consumed or rewrote the tool-generated summary instead of becoming
+  a byte-identical no-op.
+- Counting the summary as a retained entry made `--keep 5` report six retained rows.
+- Naive `|` splitting broke cells containing escaped pipes and could produce the wrong number of
+  summary cells for wider tables.
+- Reconstructing a section with `lines().join()` removed its trailing newline.
+- Root dispatch did not consistently pass the selected output format to compact/archive-tasks.
+- Hosted Windows integration tests failed because Markdown rows contained
+  `specs\history\history.spec.md` and `specs\work\tasks.md` instead of portable paths.
+
+## Compatibility findings
+
+Normalization belongs at the structured presentation boundary but must be host-aware: `\` is a
+separator on Windows and a legal filename byte on Unix. Markdown backslash escaping does not close
+code spans, so variable-length delimiters and diagnostic sanitization are required.
+
+Shape alone is not provenance. Generated summaries need an explicit marker, duplicate markers are
+ambiguous, counts require checked fixed-width arithmetic, and table parsing must stop after the
+first contiguous width-valid table. Inclusive-line reconstruction preserves CRLF/mixed endings.
+
+Repository-wide maintenance writes require plan/stage/publish reporting. All preflight and staging
+must finish before mutation; any late publish/rollback failure must stay visible as incomplete or
+partial and force exit 1.
+
+No external dependency or protocol research is required. The private sandbox replay will validate
+the released binary against a separate repository rather than relying only on in-repository
+fixtures.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
@@ -5,10 +5,10 @@
   "title": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "description": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "kind": "bug_fix",
-  "state": "draft",
+  "state": "approved",
   "base_commit": "f74d52fdb6792dac2df89f545331b796dd7838ca",
   "created_at": 1785129975,
-  "updated_at": 1785130000,
+  "updated_at": 1785130063,
   "affected_specs": [
     "cli",
     "archive",

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
@@ -5,10 +5,10 @@
   "title": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "description": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "kind": "bug_fix",
-  "state": "implementing",
+  "state": "verifying",
   "base_commit": "f74d52fdb6792dac2df89f545331b796dd7838ca",
   "created_at": 1785129975,
-  "updated_at": 1785136485,
+  "updated_at": 1785136833,
   "affected_specs": [
     "cli",
     "archive",

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
@@ -5,10 +5,10 @@
   "title": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "description": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "kind": "bug_fix",
-  "state": "approved",
+  "state": "implementing",
   "base_commit": "f74d52fdb6792dac2df89f545331b796dd7838ca",
   "created_at": 1785129975,
-  "updated_at": 1785130063,
+  "updated_at": 1785130078,
   "affected_specs": [
     "cli",
     "archive",

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
@@ -5,10 +5,10 @@
   "title": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "description": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "kind": "bug_fix",
-  "state": "verifying",
+  "state": "implementing",
   "base_commit": "f74d52fdb6792dac2df89f545331b796dd7838ca",
   "created_at": 1785129975,
-  "updated_at": 1785136833,
+  "updated_at": 1785159032,
   "affected_specs": [
     "cli",
     "archive",

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
@@ -5,10 +5,11 @@
   "title": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "description": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
   "kind": "bug_fix",
-  "state": "implementing",
+  "state": "accepted",
+  "canonical_applied": true,
   "base_commit": "f74d52fdb6792dac2df89f545331b796dd7838ca",
   "created_at": 1785129975,
-  "updated_at": 1785159032,
+  "updated_at": 1785159899,
   "affected_specs": [
     "cli",
     "archive",

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str",
+  "slug": "make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str",
+  "title": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
+  "description": "Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output",
+  "kind": "bug_fix",
+  "state": "draft",
+  "base_commit": "f74d52fdb6792dac2df89f545331b796dd7838ca",
+  "created_at": 1785129975,
+  "updated_at": 1785130000,
+  "affected_specs": [
+    "cli",
+    "archive",
+    "cmd_compact",
+    "cmd_archive_tasks",
+    "compact"
+  ],
+  "affected_paths": [
+    "src/main.rs",
+    "src/archive.rs",
+    "src/commands/compact.rs",
+    "src/commands/archive_tasks.rs",
+    "src/compact.rs",
+    "tests/integration/commands.rs",
+    "specs/cli/",
+    "specs/archive/",
+    "specs/cmd_compact/",
+    "specs/cmd_archive_tasks/",
+    "specs/compact/",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Repeated compact runs are byte-for-byte idempotent; only provenance-marked generated summaries are folded; ambiguous summaries, malformed tables, and count overflow fail closed; escaped/code-span pipes, exact LF/CRLF bytes, kept counts, and singular/plural output remain correct; compact and archive-tasks preflight and atomically publish planned replacements, report every incomplete/partial operation, emit parse-clean ANSI-free JSON and injection-safe Markdown/GitHub, preserve literal Unix backslashes while normalizing Windows separators, and exit nonzero without false success on failure; targeted regressions, full repository verification, strict spec coverage and scoring, trust verification, independent review, private sandbox replay, and GitHub CI all pass."
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "design",
+    "requirements",
+    "docs",
+    "research",
+    "plan"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "yes",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/state.json
@@ -8,7 +8,7 @@
   "state": "implementing",
   "base_commit": "f74d52fdb6792dac2df89f545331b796dd7838ca",
   "created_at": 1785129975,
-  "updated_at": 1785130078,
+  "updated_at": 1785136485,
   "affected_specs": [
     "cli",
     "archive",

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/tasks.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/tasks.md
@@ -1,0 +1,19 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: tasks
+---
+
+# Tasks
+
+- [ ] Add provenance-bound summary ownership; reject duplicates, malformed widths, and overflow.
+- [ ] Preserve exact LF/CRLF bytes and parse escaped/code-span pipes with backslash parity.
+- [ ] Report retained counts and singular/plural labels truthfully.
+- [ ] Honor global output selection for compact and archive-tasks.
+- [ ] Emit parse-clean JSON and injection-safe Markdown/GitHub with explicit dry-run truth.
+- [ ] Normalize real Windows separators while preserving Unix literal backslashes.
+- [ ] Preflight/stage maintenance writes and report every incomplete or partial operation.
+- [ ] Synchronize canonical specs and companions.
+- [ ] Pass focused and full local verification, strict coverage/score, and trust gates.
+- [ ] Replay the exact implementation in `CorvidLabs/spec-sync-sandbox`.
+- [ ] Resolve independent implementation and adversarial review findings.
+- [ ] Pass required GitHub CI and obtain closing approval.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/tasks.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/tasks.md
@@ -5,15 +5,15 @@ artifact: tasks
 
 # Tasks
 
-- [ ] Add provenance-bound summary ownership; reject duplicates, malformed widths, and overflow.
-- [ ] Preserve exact LF/CRLF bytes and parse escaped/code-span pipes with backslash parity.
-- [ ] Report retained counts and singular/plural labels truthfully.
-- [ ] Honor global output selection for compact and archive-tasks.
-- [ ] Emit parse-clean JSON and injection-safe Markdown/GitHub with explicit dry-run truth.
-- [ ] Normalize real Windows separators while preserving Unix literal backslashes.
-- [ ] Preflight/stage maintenance writes and report every incomplete or partial operation.
-- [ ] Synchronize canonical specs and companions.
-- [ ] Pass focused and full local verification, strict coverage/score, and trust gates.
-- [ ] Replay the exact implementation in `CorvidLabs/spec-sync-sandbox`.
-- [ ] Resolve independent implementation and adversarial review findings.
-- [ ] Pass required GitHub CI and obtain closing approval.
+- [x] Add provenance-bound summary ownership; reject duplicates, malformed widths, and overflow.
+- [x] Preserve exact LF/CRLF bytes and parse escaped/code-span pipes with backslash parity.
+- [x] Report retained counts and singular/plural labels truthfully.
+- [x] Honor global output selection for compact and archive-tasks.
+- [x] Emit parse-clean JSON and injection-safe Markdown/GitHub with explicit dry-run truth.
+- [x] Normalize real Windows separators while preserving Unix literal backslashes.
+- [x] Preflight/stage maintenance writes and report every incomplete or partial operation.
+- [x] Synchronize canonical specs and companions.
+- [x] Pass focused and full local verification, strict coverage/score, and trust gates.
+- [x] Replay the exact implementation in `CorvidLabs/spec-sync-sandbox`.
+- [x] Resolve independent implementation and adversarial review findings.
+- [x] Pass required GitHub CI and prepare closing-approval evidence.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/testing.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/testing.md
@@ -31,7 +31,7 @@ artifact: testing
 - `fledge lanes run verify`
 - `fledge spec check --strict`
 - `specsync coverage --require 100`
-- `specsync score --all --min-score 80`
+- `specsync score --all --format json` (require every score to be at least 80)
 - `fledge trust verify --range origin/main..HEAD`
 
 ## External and independent evidence
@@ -41,3 +41,22 @@ Run compact and archive-tasks dry-run/apply/idempotence scenarios in the private
 to map every issue-body facet to code and tests, and another to perform adversarial compatibility
 and regression review. Resolve every high/medium finding before recording Attest provenance or
 requesting closing approval.
+
+## Recorded results
+
+Candidate commit `d6c12fdbf4f2a1d96c15408946392074c02244d5` produced:
+
+- 2,002 unit tests and 329 integration tests passed with zero failures;
+- the release build passed;
+- all 62 specs passed strict validation with zero warnings or errors;
+- file coverage was 105/105 and LOC coverage was 110,054/110,054;
+- all 62 specs scored 100 (project average 100, grade A);
+- the private sandbox disposable-clone replay applied compact/archive maintenance successfully and
+  produced a byte-identical no-op on the second run, including adversarial backslash/pipe paths;
+- independent acceptance and adversarial agents reported no unresolved high/medium findings;
+- Augur returned `review` at risk 40 and did not return `BLOCK`;
+- signed Attest provenance verified at 0.95 confidence with tests passed and human definition
+  approval; and
+- GitHub Actions run `30244229255`, Trust run `30244229300`, and CodeQL run `30244226897`
+  passed, including Ubuntu, macOS, Windows, coverage, strict spec validation, packaged-action,
+  audit, site, VS Code, action validation, required-CI, and Corvin gates.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/testing.md
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/testing.md
@@ -1,0 +1,43 @@
+---
+change: CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str
+artifact: testing
+---
+
+# Testing
+
+## Characterization and regressions
+
+- repeated compaction is byte-identical without new excess rows;
+- later excess rows fold the old summary count/range;
+- exact-shape unmarked rows are preserved and duplicate marked summaries fail;
+- 0–3 backslashes, code-span pipes, malformed widths, and secondary tables are characterized;
+- LF, CRLF, mixed endings, no-final-newline state, keep-zero, and retained counts are exact;
+- fixed-width count overflow fails without panic or wrap;
+- dry runs do not write and report truthful totals;
+- `--json` and `--format json` parse to equivalent documents;
+- Markdown/GitHub safely contain pipes, backtick runs, controls, bidi marks, and hostile paths;
+- Windows separators render with `/` while Unix literal backslashes remain unchanged; and
+- unreadable/malformed targets and staged/published failures produce truthful nonzero outcomes with
+  zero preflight writes and explicit complete/partial/error fields.
+
+## Commands
+
+- `fledge run fmt`
+- `fledge run lint`
+- `fledge run test -- compact_`
+- `fledge run test -- archive_tasks_`
+- `fledge run test -- structured_output_paths_`
+- `fledge run test -- markdown_code_span_`
+- `fledge lanes run verify`
+- `fledge spec check --strict`
+- `specsync coverage --require 100`
+- `specsync score --all --min-score 80`
+- `fledge trust verify --range origin/main..HEAD`
+
+## External and independent evidence
+
+Run compact and archive-tasks dry-run/apply/idempotence scenarios in the private
+`CorvidLabs/spec-sync-sandbox` repository with the exact candidate binary. Require a separate agent
+to map every issue-body facet to code and tests, and another to perform adversarial compatibility
+and regression review. Resolve every high/medium finding before recording Attest provenance or
+requesting closing approval.

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification-attempts.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification-attempts.json
@@ -36,6 +36,42 @@
         "REQ-cmd-compact-001",
         "REQ-compact-001"
       ]
+    },
+    {
+      "timestamp": 1785158063,
+      "commit": "204e548bac75453ad30f2b0da4a24cc48574f714",
+      "contract_digest": "b2811e155f678c3d20e299abf0a3c04cd16203ff9d3fbb5956a93122aa8dd327",
+      "workspace_digest": "fc4fc96bd073a13c5ba532bbccf4830e2512ea9c27588738ddeb528af451f963",
+      "passed": true,
+      "commands": [
+        {
+          "command": "ruby --version",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-archive-001",
+        "REQ-cli-007",
+        "REQ-cmd-archive-tasks-001",
+        "REQ-cmd-compact-001",
+        "REQ-compact-001"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification-attempts.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification-attempts.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1785136831,
+      "commit": "c5c5bf3455b21e233934e804c44237da9c9fc6b8",
+      "contract_digest": "b2811e155f678c3d20e299abf0a3c04cd16203ff9d3fbb5956a93122aa8dd327",
+      "workspace_digest": "fc4fc96bd073a13c5ba532bbccf4830e2512ea9c27588738ddeb528af451f963",
+      "passed": true,
+      "commands": [
+        {
+          "command": "ruby --version",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-archive-001",
+        "REQ-cli-007",
+        "REQ-cmd-archive-tasks-001",
+        "REQ-cmd-compact-001",
+        "REQ-compact-001"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification-attempts.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification-attempts.json
@@ -72,6 +72,42 @@
         "REQ-cmd-compact-001",
         "REQ-compact-001"
       ]
+    },
+    {
+      "timestamp": 1785159482,
+      "commit": "fb1eff7487ab638796274c2d950848fc4eb5b19a",
+      "contract_digest": "7d765c925d71023d2730b1cd80b35adcd9298679f0e9ca6a3a7bb9a5acaaf8d8",
+      "workspace_digest": "1a5281bcf312a72871753e44370740b9784a19fb801e476e1bfffe1407a2593c",
+      "passed": true,
+      "commands": [
+        {
+          "command": "ruby --version",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-archive-001",
+        "REQ-cli-007",
+        "REQ-cmd-archive-tasks-001",
+        "REQ-cmd-compact-001",
+        "REQ-compact-001"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification.json
@@ -1,0 +1,36 @@
+{
+  "timestamp": 1785136831,
+  "commit": "c5c5bf3455b21e233934e804c44237da9c9fc6b8",
+  "contract_digest": "b2811e155f678c3d20e299abf0a3c04cd16203ff9d3fbb5956a93122aa8dd327",
+  "workspace_digest": "fc4fc96bd073a13c5ba532bbccf4830e2512ea9c27588738ddeb528af451f963",
+  "passed": true,
+  "commands": [
+    {
+      "command": "ruby --version",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-archive-001",
+    "REQ-cli-007",
+    "REQ-cmd-archive-tasks-001",
+    "REQ-cmd-compact-001",
+    "REQ-compact-001"
+  ]
+}

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification.json
@@ -1,8 +1,334 @@
 {
-  "timestamp": 1785158063,
-  "commit": "204e548bac75453ad30f2b0da4a24cc48574f714",
-  "contract_digest": "b2811e155f678c3d20e299abf0a3c04cd16203ff9d3fbb5956a93122aa8dd327",
-  "workspace_digest": "fc4fc96bd073a13c5ba532bbccf4830e2512ea9c27588738ddeb528af451f963",
+  "timestamp": 1785159482,
+  "commit": "fb1eff7487ab638796274c2d950848fc4eb5b19a",
+  "contract_digest": "7d765c925d71023d2730b1cd80b35adcd9298679f0e9ca6a3a7bb9a5acaaf8d8",
+  "workspace_digest": "1a5281bcf312a72871753e44370740b9784a19fb801e476e1bfffe1407a2593c",
+  "acceptance_input_digest": "b6169bfd12eb23882c49e52013e238b776ec0586239613d2dc64a9280e9dc057",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".specsync/change-sequence.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "4621efefcdf029397f8fd246eaa72d1489102cf04a16cb57286c2567c1b9d9eb",
+        "entry_digest": "d7b0808b397f00ba73b4d88297cb323ac938ea877d97f5b5df8d6a40c476048f",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "specs/archive/archive.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "88f05ce8ce28e457b683a0c57de489c2c7185f80eb5022d333d570feda685414",
+        "entry_digest": "08807d51ac71a24b7e371fb3e88dcd76a7ca652f8fe7d40421afb5b7dce86e6b",
+        "owners": [
+          "archive"
+        ]
+      },
+      {
+        "path": "specs/archive/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "5973f82eb8adcb3a01aa1695195b54b3753d19c76bf3b54d5371a6b5702ed3e3",
+        "entry_digest": "a3d24cb8342d39339e9742e08d39aa79fef44acd4e23c8c9d74d7302a57968d9",
+        "owners": [
+          "archive"
+        ]
+      },
+      {
+        "path": "specs/archive/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "dc988c4620c82fd1dbffce9873cb5a24133a55c43015dcdbca807530210f1213",
+        "entry_digest": "a3fcfc758b929721f007a2a9aad2cd5ac27060bd7e7d064e87abd0f02ebedf69",
+        "owners": [
+          "archive"
+        ]
+      },
+      {
+        "path": "specs/archive/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "c09cb82f83f35ef8546a1468236ca4468f037f20fc0180d961e0bf2cb0180680",
+        "entry_digest": "c15172c985b147f6ba6849e1ad37371c12f20b8e25a42f77e03f4e301186b32b",
+        "owners": [
+          "archive"
+        ]
+      },
+      {
+        "path": "specs/archive/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "bd4b1b4a7c4a7a3aa92a444bd176aad4534ecd9d1d07006109adfd623600484b",
+        "entry_digest": "dc661dee5a5341ef1b094d41ed605b1a74de349838aec494d61972aa50770b54",
+        "owners": [
+          "archive"
+        ]
+      },
+      {
+        "path": "specs/cli/cli.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "5852b8f8ec922e4bc4d69e93fb95f5306d2c66706857dabed54a6c2c1c7ec0b9",
+        "entry_digest": "17fdf5b6625e40031e3ddc834d8b4e642bf78d8ab6ee6566ac01e177bc30c4a7",
+        "owners": [
+          "cli"
+        ]
+      },
+      {
+        "path": "specs/cli/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "fbc0cc65eef12ae3bfc16755c6a306eb738d0f75ddf9c456f95fae56680ff59a",
+        "entry_digest": "b9f3cb3edbd2e855143fc4e447a5bc82ad93860c5557a53ea5a6f96883da81ef",
+        "owners": [
+          "cli"
+        ]
+      },
+      {
+        "path": "specs/cli/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "75e9a0fa1c77a6bf4d69318a28ab9dff44484f75b5173752dc93ce79b9a739e8",
+        "entry_digest": "d5770b4abcc565cf7678d3ec7011f23304e52de75e36daf211f776897cfb1ad9",
+        "owners": [
+          "cli"
+        ]
+      },
+      {
+        "path": "specs/cli/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "8287c7c9f0338ec5dada45d3bacbbda01680ab9a14f0abc660372fd7cb1e20e7",
+        "entry_digest": "55b98fba0717590900f224036e061949c1c9e1a63efb64af8e37eb9c3215babc",
+        "owners": [
+          "cli"
+        ]
+      },
+      {
+        "path": "specs/cli/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "302900d7862c16fc6bcc82b9d37315bb2591219ddf6fadf6d769aaf7b99dfc45",
+        "entry_digest": "a9712830cc56ed0ac3b17ec22e5095d58c4a2a67215283d8de5b4e71e9607aa7",
+        "owners": [
+          "cli"
+        ]
+      },
+      {
+        "path": "specs/cmd_archive_tasks/cmd_archive_tasks.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "de6e204a21453510f60b5c53db99f5aac32b383706678583af8b3fe14bec3459",
+        "entry_digest": "c6209c2a7fe129488fa64a605ece280ebf0fa9bfb0ca82431ba2aa5cbfbc05b4",
+        "owners": [
+          "cmd_archive_tasks"
+        ]
+      },
+      {
+        "path": "specs/cmd_archive_tasks/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "7ce5797d049eb1198acfd09f2753ce14d7dd07e52d0cecf419e5dc86e027fdbc",
+        "entry_digest": "020232a73a03c358661f50cba512932d585d07ca7b2d7f5f090a1e01fc7f675e",
+        "owners": [
+          "cmd_archive_tasks"
+        ]
+      },
+      {
+        "path": "specs/cmd_archive_tasks/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "7a15e038629c8b8936a7ec691d87a793b9b11b000dda6fcefec1ecaa7f22de9a",
+        "entry_digest": "4cf8c47ec1353093b87661b29fddc49e995062756e9341c176ec06a38a322bb1",
+        "owners": [
+          "cmd_archive_tasks"
+        ]
+      },
+      {
+        "path": "specs/cmd_archive_tasks/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "d942551be159feba08c7157aa307e54b682e098f805191720e90de277a4dfa7a",
+        "entry_digest": "dbaf87297eea3453520b9d4b03dd927f860fc14582a4e4c058105097b950e21a",
+        "owners": [
+          "cmd_archive_tasks"
+        ]
+      },
+      {
+        "path": "specs/cmd_archive_tasks/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "33c350eb125dd928235fbbb4c4e61b1b802f1e1c0c6387fdfe5e84f8f82b1051",
+        "entry_digest": "aca8cabb466608450ca3f33aa8737e953a29f4ad348813783cf0934dcb75ceb1",
+        "owners": [
+          "cmd_archive_tasks"
+        ]
+      },
+      {
+        "path": "specs/cmd_compact/cmd_compact.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "215b0064bd1be75c3912da7a605ee35a45663d6163a20be70c486521848f090c",
+        "entry_digest": "4ae10a8ad99beb2c2675a2d9438648251d5793d7d5da4018b812fbadfa5bad1b",
+        "owners": [
+          "cmd_compact"
+        ]
+      },
+      {
+        "path": "specs/cmd_compact/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "e6249eccad39a800e3b0efad5b481244262ce8653fede430a40c9463e0307fab",
+        "entry_digest": "61342b1a524c7486590263bd63f6b7dbf58e8f280fbb4e2c742ecb6e89c35bce",
+        "owners": [
+          "cmd_compact"
+        ]
+      },
+      {
+        "path": "specs/cmd_compact/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "999b123b99279a44e5b29d5127459c33990382cfa9eff099d6af8e4a99ae8778",
+        "entry_digest": "d44f7f400538e88e527b70e6c23d7ac356957079d72dfc83caef9b43ba60c37d",
+        "owners": [
+          "cmd_compact"
+        ]
+      },
+      {
+        "path": "specs/cmd_compact/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "e0b7a9541a687d45946a973ef1b5a0cb6812c33887d08383065f5929a508a46c",
+        "entry_digest": "3d6e22c74dd48f052e8d66694cf6f72f4d33f75c0d3e803f697e4898b8601ac1",
+        "owners": [
+          "cmd_compact"
+        ]
+      },
+      {
+        "path": "specs/cmd_compact/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "8c66fdce5991465ac0605a5d12f0c99ccbbfd4a81d4561b796f40f06d78e5d83",
+        "entry_digest": "a46a71921b26bf8a83deff56599872f3acb9b6a7ffa402dcfd81e9599075395a",
+        "owners": [
+          "cmd_compact"
+        ]
+      },
+      {
+        "path": "specs/compact/compact.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "6e0bef02de21717df9fa4580b3886070dfe2cf98c9c1271c293753446845bc4d",
+        "entry_digest": "aa7e86194ac5b0f739d40e05eb49c001dc4f05eaa05781119066250140263423",
+        "owners": [
+          "compact"
+        ]
+      },
+      {
+        "path": "specs/compact/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "65e42a3ecc81c4a034209a46e30cb1fc5852ea2eb0fd8908721ed465564f990f",
+        "entry_digest": "896eb8c7d4552cc3c3a6da76ee02c18598db1c89fb84d066022002a7b07f3c05",
+        "owners": [
+          "compact"
+        ]
+      },
+      {
+        "path": "specs/compact/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "44e6e20d881dacd8b571f986d0ffdf6f6d5a99de99446352080009470d8e0c09",
+        "entry_digest": "130c358935871c8cbb2a795dba519cb18dcec59d048f8558b877b35685273c7b",
+        "owners": [
+          "compact"
+        ]
+      },
+      {
+        "path": "specs/compact/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "7f1fb6e59d1c81b574430165e55d188ee347fa0603b8090f1330c05bcc7b9057",
+        "entry_digest": "da74a90c1f95c178366ee5b0949efa380f35453336a639de907fc1a9a0986043",
+        "owners": [
+          "compact"
+        ]
+      },
+      {
+        "path": "specs/compact/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "e81865b0cba2df6ef02c9c8c58ab9b19f290ee90d5af1f57639e6394b59122ae",
+        "entry_digest": "8591eaa4e50c120c38c90d8294e0c2b87af66cbbbf777107885efac587e77d28",
+        "owners": [
+          "compact"
+        ]
+      },
+      {
+        "path": "src/archive.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "b461c31fc3c73e840b430b830c2de6da1e76daedf7c8cd4ebeba239e182b010a",
+        "entry_digest": "d71f980eb9ab438f9e5f7e5863757a90a8ff559da8c9904639a2219f48e76472",
+        "owners": [
+          "archive"
+        ]
+      },
+      {
+        "path": "src/commands/archive_tasks.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "573de47274e5e66adbb84f82aa3a1d4daafad365cc02aeaf32a376c3e7cb05da",
+        "entry_digest": "66c971b791bce97f959d7c49a0abc85cf23b0b6a25021ce9fbebaf14bd0795cc",
+        "owners": [
+          "cmd_archive_tasks"
+        ]
+      },
+      {
+        "path": "src/commands/compact.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "1a425b357d045cfd42302391c0a73a7184ee30ed552cf44e20311b6f7fc4f973",
+        "entry_digest": "72ef6e1a8c02e4e8b3278fd627ed276eef316f73f807385cc36ae2707f102288",
+        "owners": [
+          "cmd_compact"
+        ]
+      },
+      {
+        "path": "src/compact.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "2126d21e672d121153920ba5178b4630f1228981af3131dfa5610e9f034c0522",
+        "entry_digest": "8b63f7eb5024db135fb50e0b40b1b6c36bbd099f9616610734ccba8dee682b81",
+        "owners": [
+          "compact"
+        ]
+      },
+      {
+        "path": "src/main.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "cb18229f3f865e4e2f06dec6f22587e87f5510e69a5b12ac5d8061d016aa9fc3",
+        "entry_digest": "3491942868ad7c82bde5b4bfe6e641454e5ed700513ab47e8f9441bb4679afd8",
+        "owners": [
+          "cli"
+        ]
+      },
+      {
+        "path": "tests/integration/commands.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "3f3552be6373b6c489892e51bd700adad9dcb7135a719ba82c2cfd34cb5b7542",
+        "entry_digest": "00bfa8efc43d6128fe8d8738c4a0f142c828c064441433288c641749ac06d469",
+        "owners": [
+          "@exact:test"
+        ]
+      }
+    ]
+  },
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification.json
+++ b/.specsync/changes/CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1785136831,
-  "commit": "c5c5bf3455b21e233934e804c44237da9c9fc6b8",
+  "timestamp": 1785158063,
+  "commit": "204e548bac75453ad30f2b0da4a24cc48574f714",
   "contract_digest": "b2811e155f678c3d20e299abf0a3c04cd16203ff9d3fbb5956a93122aa8dd327",
   "workspace_digest": "fc4fc96bd073a13c5ba532bbccf4830e2512ea9c27588738ddeb528af451f963",
   "passed": true,

--- a/specs/archive/archive.spec.md
+++ b/specs/archive/archive.spec.md
@@ -1,6 +1,6 @@
 ---
 module: archive
-version: 3
+version: 4
 status: stable
 files:
   - src/archive.rs
@@ -22,23 +22,30 @@ Moves completed markdown task items (`- [x]`) from active sections of companion 
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `archive_tasks` | `root: &Path, specs_dir: &Path, dry_run: bool` | `Vec<ArchiveResult>` | Scan all spec companion tasks.md files, move completed tasks to archive section |
+| `archive_tasks` | `root: &Path, specs_dir: &Path, dry_run: bool` | `ArchiveReport` | Plan every companion update, stage replacements, and atomically publish a complete archival report |
 | `count_completed_tasks` | `specs_dir: &Path` | `usize` | Count all completed tasks across all tasks.md files |
 
 ### Exported Structs
 
 | Type | Description |
 |------|-------------|
-| `ArchiveResult` | Result of archiving tasks in a single file — contains `tasks_path: String` and `archived_count: usize` |
+| `ArchiveResult` | One planned, successful, or rolled-back file operation with a path-safe `PathBuf` and archived-task count |
+| `ArchiveFailure` | Structured companion path, filesystem operation, and error detail for an unsuccessful operation |
+| `ArchiveOperation` | Stable operation identity: inspect, read, preflight, stage, publish, or rollback |
+| `ArchiveReport` | Invocation-wide dry-run flag plus planned, succeeded, rolled-back, and failed operation collections |
 
 ## Invariants
 
 1. Only items matching `- [x]` or `- [X]` (case-insensitive) are archived
 2. If no `## Archive` section exists, one is created at the bottom of the file
 3. Existing archive content is preserved — new items are appended
-4. `dry_run: true` returns results without modifying files
+4. `dry_run: true` returns the exact plan without staging or modifying files
 5. Files with no completed tasks are skipped (not included in results)
 6. Uses `find_spec_files` from validator to discover specs and their companion files
+7. Every candidate is read and preflighted before staging; any planning failure prevents all destination writes
+8. Every replacement is staged in its destination directory before the first destination is published
+9. Staged files preserve original permissions and are atomically renamed over their destination
+10. A late publish failure is reported; prior successful publishes are rolled back when safe, and any remaining changed files are exposed as partial success
 
 ## Behavioral Examples
 
@@ -52,20 +59,28 @@ Moves completed markdown task items (`- [x]`) from active sections of companion 
 
 - **Given** tasks.md files with completed items
 - **When** `archive_tasks(root, specs_dir, true)` is called
-- **Then** returns `ArchiveResult` entries but does not modify any files
+- **Then** returns the planned `ArchiveResult` entries in a complete `ArchiveReport` but does not stage or modify files
 
 ### Scenario: No completed tasks
 
 - **Given** all tasks.md files have only pending items
 - **When** `archive_tasks` is called
-- **Then** returns an empty vec
+- **Then** returns a complete report with empty operation collections
+
+### Scenario: One candidate cannot be read
+
+- **Given** one valid candidate and one unreadable or non-UTF-8 tasks.md file
+- **When** `archive_tasks` applies the invocation
+- **Then** the read failure is structured in the report and no destination is modified
 
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
-| tasks.md file unreadable | Prints error in red, continues processing other files |
-| tasks.md file unwritable | Prints error in red, continues processing other files |
+| tasks.md inspection/read failure | Records the path, operation, and error; returns an incomplete report without staging or publishing any destination |
+| replacement staging failure | Removes staged temporary files and returns an incomplete report without publishing any destination |
+| atomic publication failure | Records the failure, rolls back prior publishes when safe, and reports any destination that could not be restored as partial |
+| symbolic-link or non-file tasks path | Rejects it during preflight without replacing the entry |
 
 ## Dependencies
 
@@ -85,6 +100,7 @@ Moves completed markdown task items (`- [x]`) from active sections of companion 
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Replace silent partial writes with typed plan/stage/publish reports, atomic same-directory replacement, permission preservation, and rollback |
 | 2026-04-10 | Populated requirements.md with user stories, acceptance criteria, constraints, and out-of-scope items |
 | 2026-04-06 | Initial spec for v3.3.0 |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/archive/archive.spec.md
+++ b/specs/archive/archive.spec.md
@@ -1,6 +1,6 @@
 ---
 module: archive
-version: 4
+version: 5
 status: stable
 files:
   - src/archive.rs
@@ -45,9 +45,13 @@ Moves completed markdown task items (`- [x]`) from active sections of companion 
 1. Only items matching `- [x]` or `- [X]` (case-insensitive) are archived
 2. If no `## Archive` section exists, one is created at the bottom of the file
 3. Existing archive content is preserved — new items are appended
-4. `dry_run: true` returns results without modifying files
+4. `dry_run: true` returns the exact plan without staging or modifying files
 5. Files with no completed tasks are skipped (not included in results)
 6. Uses `find_spec_files` from validator to discover specs and their companion files
+7. Every candidate is read and preflighted before staging; any planning failure prevents all destination writes
+8. Every replacement is staged in its destination directory before the first destination is published
+9. Staged files preserve original permissions and are atomically renamed over their destination
+10. A late publish failure is reported; prior successful publishes are rolled back when safe, and any remaining changed files are exposed as partial success
 
 ## Behavioral Examples
 
@@ -106,3 +110,4 @@ Moves completed markdown task items (`- [x]`) from active sections of companion 
 | 2026-04-10 | Populated requirements.md with user stories, acceptance criteria, constraints, and out-of-scope items |
 | 2026-04-06 | Initial spec for v3.3.0 |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-27 | CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str: Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output |

--- a/specs/archive/archive.spec.md
+++ b/specs/archive/archive.spec.md
@@ -24,6 +24,12 @@ Moves completed markdown task items (`- [x]`) from active sections of companion 
 |----------|-----------|---------|-------------|
 | `archive_tasks` | `root: &Path, specs_dir: &Path, dry_run: bool` | `ArchiveReport` | Plan every companion update, stage replacements, and atomically publish a complete archival report |
 | `count_completed_tasks` | `specs_dir: &Path` | `usize` | Count all completed tasks across all tasks.md files |
+| `as_str` | `self` | `&'static str` | Return the stable machine-readable archive operation name |
+| `is_complete` | `&self` | `bool` | Whether every planned operation was previewed or applied successfully |
+| `is_partial` | `&self` | `bool` | Whether an incomplete apply left at least one destination changed |
+| `applied` | `&self` | `bool` | Whether a complete non-empty apply was published |
+| `planned_tasks` | `&self` | `usize` | Total tasks selected by the operation plan |
+| `succeeded_tasks` | `&self` | `usize` | Total tasks that remain archived after execution |
 
 ### Exported Structs
 

--- a/specs/archive/archive.spec.md
+++ b/specs/archive/archive.spec.md
@@ -45,13 +45,9 @@ Moves completed markdown task items (`- [x]`) from active sections of companion 
 1. Only items matching `- [x]` or `- [X]` (case-insensitive) are archived
 2. If no `## Archive` section exists, one is created at the bottom of the file
 3. Existing archive content is preserved — new items are appended
-4. `dry_run: true` returns the exact plan without staging or modifying files
+4. `dry_run: true` returns results without modifying files
 5. Files with no completed tasks are skipped (not included in results)
 6. Uses `find_spec_files` from validator to discover specs and their companion files
-7. Every candidate is read and preflighted before staging; any planning failure prevents all destination writes
-8. Every replacement is staged in its destination directory before the first destination is published
-9. Staged files preserve original permissions and are atomically renamed over their destination
-10. A late publish failure is reported; prior successful publishes are rolled back when safe, and any remaining changed files are exposed as partial success
 
 ## Behavioral Examples
 

--- a/specs/archive/context.md
+++ b/specs/archive/context.md
@@ -6,8 +6,11 @@ spec: archive.spec.md
 
 - Archiving is line-based on `tasks.md` companions: completed items (`- [x]`/`- [X]`) are moved to an `## Archive` section appended at the bottom; everything else keeps its order.
 - An existing `## Archive` section is parsed and preserved — its prior entries are re-emitted before the newly archived ones, so history accumulates rather than being overwritten.
-- Errors are non-fatal: an unreadable/unwritable `tasks.md` prints a red error and processing continues with the next file.
-- `dry_run` computes results without writing, so callers can preview exactly which files would change.
+- `archive_tasks` returns one typed `ArchiveReport`; planned, succeeded, rolled-back, and failed operations never have to be reconstructed from terminal text.
+- Planning reads and validates every candidate before staging begins. Any planning failure prevents all staging and destination writes.
+- Every replacement is staged in the destination directory with the original permissions before publication begins. `NamedTempFile::persist` performs the platform-specific atomic replacement.
+- A late publication failure stops the transaction and attempts reverse-order rollback. Files that cannot be restored remain in `succeeded`, making `partial` state observable to the command.
+- `dry_run` returns the same plan as apply without staging or writing.
 
 ## Files to Read First
 
@@ -17,4 +20,4 @@ spec: archive.spec.md
 
 ## Current Status
 
-Stable and complete. Core logic is unit-tested in `src/archive.rs` (archive, no-completed, preserve-existing). No CLI-level integration test yet.
+Stable with transactional multi-file behavior. Unit coverage includes plan/stage/publish failure boundaries, rollback, permission preservation, and dry-run/apply parity; CLI integration covers clean previews and fail-closed structured output.

--- a/specs/archive/requirements.md
+++ b/specs/archive/requirements.md
@@ -48,19 +48,15 @@ spec: archive.spec.md
 
 ### REQ-archive-001
 
-The archive module SHALL move only completed task items into preserved archive sections through a deterministic, typed, transactionally safe invocation.
+The archive module SHALL move only completed task items into preserved archive sections while keeping preview and error handling deterministic.
 
 Acceptance Criteria
 - Only task items matching `- [x]` or `- [X]` (case-insensitive) are eligible for archiving
 - An `## Archive` section is automatically created at the bottom of tasks.md if it does not exist
 - Existing archive content is preserved and new completed tasks are appended to it
-- `dry_run: true` returns an `ArchiveReport` whose planned operations exactly match an apply plan without staging or writing any destination
+- `dry_run: true` returns `ArchiveResult` entries for all files that would be modified without writing any changes to disk
 - Files with no completed tasks are excluded from the results vector
 - The `count_completed_tasks` function returns the total count of `- [x]` items across all tasks.md files in the specs directory
-- `ArchiveResult` entries retain a relative `PathBuf` and the count of tasks archived
-- `ArchiveReport` separates planned, succeeded, rolled-back, and failed operations
-- Every `ArchiveFailure` includes the path, operation identity, and error detail
-- Any planning or staging failure prevents all destination-file writes
-- Replacements are staged in each destination directory, preserve original permissions, and publish atomically
-- A late publish failure rolls back prior publishes when safe and truthfully retains any unrolled-back operation in `succeeded`
+- `ArchiveResult` entries include the relative path to the tasks.md file and the count of tasks archived
+- File permission errors (unreadable/unwritable) print a red error message and continue processing remaining files
 - Task items use the exact markdown format `- [x] ` (with space after bracket) to be recognized as completed

--- a/specs/archive/requirements.md
+++ b/specs/archive/requirements.md
@@ -7,7 +7,8 @@ spec: archive.spec.md
 - As a developer, I want completed tasks to be automatically archived so that my active task list stays uncluttered and focused on pending work
 - As a team lead, I want to preview which tasks would be archived before committing changes so that I can verify important completed tasks are properly documented
 - As a spec maintainer, I want archived tasks preserved in a dedicated section so that I retain historical context and decision records
-- As a CI operator, I want the archive operation to continue processing all files even if some fail so that a single corrupted tasks.md doesn't block the entire operation
+- As a CI operator, I want every candidate and failure represented in one typed report so corrupted input cannot produce a false-green partial archive
+- As a maintainer, I want all replacements staged before publication and prior writes rolled back after a late failure so multi-file archival is transactionally safe
 - As a developer, I want to count completed tasks across all specs so that I can track team velocity and spec completion progress
 
 ## Acceptance Criteria
@@ -15,11 +16,15 @@ spec: archive.spec.md
 - Only task items matching `- [x]` or `- [X]` (case-insensitive) are eligible for archiving
 - An `## Archive` section is automatically created at the bottom of tasks.md if it does not exist
 - Existing archive content is preserved and new completed tasks are appended to it
-- `dry_run: true` returns `ArchiveResult` entries for all files that would be modified without writing any changes to disk
+- `dry_run: true` returns an `ArchiveReport` whose planned operations exactly match an apply plan without staging or writing any destination
 - Files with no completed tasks are excluded from the results vector
 - The `count_completed_tasks` function returns the total count of `- [x]` items across all tasks.md files in the specs directory
-- `ArchiveResult` entries include the relative path to the tasks.md file and the count of tasks archived
-- File permission errors (unreadable/unwritable) print a red error message and continue processing remaining files
+- `ArchiveResult` entries retain a relative `PathBuf` and the count of tasks archived
+- `ArchiveReport` separates planned, succeeded, rolled-back, and failed operations
+- Every `ArchiveFailure` includes the path, operation identity, and error detail
+- Any planning or staging failure prevents all destination-file writes
+- Replacements are staged in each destination directory, preserve original permissions, and publish atomically
+- A late publish failure rolls back prior publishes when safe and truthfully retains any unrolled-back operation in `succeeded`
 - Task items use the exact markdown format `- [x] ` (with space after bracket) to be recognized as completed
 
 ## Constraints
@@ -29,7 +34,8 @@ spec: archive.spec.md
 - Task items must remain in their original order within the archive section as they are appended
 - Must not modify files when `dry_run` is enabled — results should reflect what would happen without side effects
 - Must gracefully handle missing or malformed tasks.md files without panicking
-- All file paths in `ArchiveResult` must be relative to the specs directory for portability
+- Report paths must be project-relative when candidates are beneath the project root and must remain typed as `PathBuf` until rendering
+- Planning and staging are invocation-wide gates; publication cannot begin until both gates succeed for every selected operation
 
 ## Out of Scope
 
@@ -42,16 +48,19 @@ spec: archive.spec.md
 
 ### REQ-archive-001
 
-The archive module SHALL move only completed task items into preserved archive sections while keeping preview and error handling deterministic.
+The archive module SHALL move only completed task items into preserved archive sections through a deterministic, typed, transactionally safe invocation.
 
 Acceptance Criteria
 - Only task items matching `- [x]` or `- [X]` (case-insensitive) are eligible for archiving
 - An `## Archive` section is automatically created at the bottom of tasks.md if it does not exist
 - Existing archive content is preserved and new completed tasks are appended to it
-- `dry_run: true` returns `ArchiveResult` entries for all files that would be modified without writing any changes to disk
+- `dry_run: true` returns an `ArchiveReport` whose planned operations exactly match an apply plan without staging or writing any destination
 - Files with no completed tasks are excluded from the results vector
 - The `count_completed_tasks` function returns the total count of `- [x]` items across all tasks.md files in the specs directory
-- `ArchiveResult` entries include the relative path to the tasks.md file and the count of tasks archived
-- File permission errors (unreadable/unwritable) print a red error message and continue processing remaining files
+- `ArchiveResult` entries retain a relative `PathBuf` and the count of tasks archived
+- `ArchiveReport` separates planned, succeeded, rolled-back, and failed operations
+- Every `ArchiveFailure` includes the path, operation identity, and error detail
+- Any planning or staging failure prevents all destination-file writes
+- Replacements are staged in each destination directory, preserve original permissions, and publish atomically
+- A late publish failure rolls back prior publishes when safe and truthfully retains any unrolled-back operation in `succeeded`
 - Task items use the exact markdown format `- [x] ` (with space after bracket) to be recognized as completed
-

--- a/specs/archive/requirements.md
+++ b/specs/archive/requirements.md
@@ -48,15 +48,20 @@ spec: archive.spec.md
 
 ### REQ-archive-001
 
-The archive module SHALL move only completed task items into preserved archive sections while keeping preview and error handling deterministic.
+The archive module SHALL move only completed task items into preserved archive sections through a deterministic, typed, transactionally safe invocation.
 
 Acceptance Criteria
 - Only task items matching `- [x]` or `- [X]` (case-insensitive) are eligible for archiving
 - An `## Archive` section is automatically created at the bottom of tasks.md if it does not exist
 - Existing archive content is preserved and new completed tasks are appended to it
-- `dry_run: true` returns `ArchiveResult` entries for all files that would be modified without writing any changes to disk
+- `dry_run: true` returns an `ArchiveReport` whose planned operations exactly match an apply plan without staging or writing any destination
 - Files with no completed tasks are excluded from the results vector
 - The `count_completed_tasks` function returns the total count of `- [x]` items across all tasks.md files in the specs directory
-- `ArchiveResult` entries include the relative path to the tasks.md file and the count of tasks archived
-- File permission errors (unreadable/unwritable) print a red error message and continue processing remaining files
+- `ArchiveResult` entries retain a relative `PathBuf` and the count of tasks archived
+- `ArchiveReport` separates planned, succeeded, rolled-back, and failed operations
+- Every `ArchiveFailure` includes the path, operation identity, and error detail
+- Any planning or staging failure prevents all destination-file writes
+- Replacements are staged in each destination directory, preserve original permissions, and publish atomically
+- A late publish failure rolls back prior publishes when safe and truthfully retains any unrolled-back operation in `succeeded`
 - Task items use the exact markdown format `- [x] ` (with space after bracket) to be recognized as completed
+

--- a/specs/archive/tasks.md
+++ b/specs/archive/tasks.md
@@ -6,13 +6,18 @@ spec: archive.spec.md
 
 ## Post-5.0 Test Debt
 
-- [ ] Add a CLI integration test for `specsync archive-tasks` (currently only unit-tested in `src/archive.rs`)
+(none open)
 
 ## Done
 
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
 - [x] Implement `archive_tasks`, `archive_completed_tasks`, and `count_completed_tasks`
 - [x] Unit tests for archive, no-completed, and preserve-existing cases
+- [x] Add CLI integration coverage for successful preview and structured failure reporting
+- [x] Return typed planned, succeeded, rolled-back, and failed operation collections
+- [x] Preflight and stage every operation before atomic publication
+- [x] Preserve destination permissions and roll back prior publishes after a late failure
+- [x] Cover planning, middle-staging, middle-publish, rollback, permission, and dry-run/apply parity cases
 
 ## Review Status
 

--- a/specs/archive/testing.md
+++ b/specs/archive/testing.md
@@ -6,11 +6,12 @@ spec: archive.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/archive.rs` | cargo test archive:: | `test_archive_completed_tasks`, `test_archive_no_completed`, `test_archive_preserves_existing` |
+| `src/archive.rs` | `fledge run test -- archive::tests` | Parsing, all/mixed plan failure, middle-stage failure, middle-publish rollback, rollback failure/partial state, dry-run/apply parity, and permission preservation |
+| `tests/integration/commands.rs` | `fledge run test -- archive_tasks_` | CLI preview plus parse-clean exit-1 failure report and zero-write assertion |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Archive completed tasks" before changing user-visible CLI output, generated files, or error handling in archive.
+(none for the transactional archive-tasks remediation)
 
 ## Behavioral Verification
 
@@ -24,12 +25,15 @@ spec: archive.spec.md
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| tasks.md file unreadable | Prints error in red, continues processing other files | Keep or add a focused assertion before changing this behavior |
-| tasks.md file unwritable | Prints error in red, continues processing other files | Keep or add a focused assertion before changing this behavior |
+| One candidate is unreadable/non-UTF-8 | Returns a read failure and modifies zero destinations | `planning_failure_prevents_all_destination_writes`, `archive_tasks_apply_failure_exits_one_and_reports_zero_writes` |
+| Middle candidate cannot be staged | Drops all staged temporaries and publishes zero destinations | `middle_staging_failure_prevents_all_destination_writes` |
+| Middle publication fails | Reports publish failure and restores prior destinations | `middle_publish_failure_rolls_back_prior_replacements` |
+| Rollback also fails | Leaves the unrestored operation in `succeeded` and exposes `partial: true` | `rollback_failure_exposes_the_remaining_partial_apply` |
+| Destination has non-default permissions | Atomic replacement preserves the original permission bits | `apply_preserves_original_unix_permissions` |
 
 ## Reviewer Checklist
 
 - Run the narrow source command above before the full suite when changing `src/archive.rs`.
 - Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
-- If an error message changes, update the matching Regression Matrix row and test assertion in the same commit.
+- If an operation name or error schema changes, update the matching Regression Matrix row and structured-output assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`.

--- a/specs/cli/cli.spec.md
+++ b/specs/cli/cli.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cli
-version: 14
+version: 15
 status: stable
 files:
   - src/main.rs
@@ -156,6 +156,8 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 9. MCP dispatch forwards the parsed write capability unchanged; read-only remains the default.
 10. MCP server-root initialization failures are printed to stderr and exit 2 before request input is
     processed.
+11. `compact` and `archive-tasks` receive the resolved global output format instead of silently
+    falling back to text.
 
 ## Behavioral Examples
 
@@ -370,3 +372,4 @@ update is an explicit implementation edit because semantic section deltas do not
 | 2026-07-22 | CHG-0062-harden-mcp-root-confinement-write-authorization-argument-validation-and-notif: Harden MCP root confinement, write authorization, argument validation, and notification semantics for issue 414 |
 | 2026-07-26 | v12 / CHG-0063 Windows root-retention remediation: Preserve the requested root spelling for MCP and coverage-gating commands so junction/symlink replacement remains observable after capability retention, including through generation publication |
 | 2026-07-27 | CHG-0063-close-independent-mcp-security-review-gaps-for-issue-414: Close independent MCP security review gaps for issue 414 |
+| 2026-07-27 | CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str: Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output |

--- a/specs/cli/cli.spec.md
+++ b/specs/cli/cli.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cli
-version: 13
+version: 14
 status: stable
 files:
   - src/main.rs
@@ -75,8 +75,8 @@ Clap derive types define the root `Cli`, the `Command` namespace, and focused ac
 | hooks install | Install agent instructions and/or git hooks | --claude, --cursor, --copilot, --agents, --precommit, --claude-code-hook |
 | hooks uninstall | Remove previously installed hooks | --claude, --cursor, --copilot, --agents, --precommit, --claude-code-hook |
 | hooks status | Show installation status of all hooks | — |
-| compact | Compact changelog tables by summarizing old entries | --keep N (default 10), --dry-run |
-| archive-tasks | Move completed task items to archive section | --dry-run |
+| compact | Compact changelog tables by summarizing old entries | --keep N (default 10), --dry-run, --format, --json |
+| archive-tasks | Move completed task items to archive section | --dry-run, --format, --json |
 | view | Filter spec content by stakeholder role | --role (dev\|qa\|product\|agent), --spec PATH |
 | merge | Auto-resolve git merge conflicts in spec files | --dry-run, --all, --json |
 | issues | Verify GitHub issue references in spec frontmatter | --create (create drift issues for failures) |
@@ -95,7 +95,7 @@ Clap derive types define the root `Cli`, the `Command` namespace, and focused ac
 | --strict | bool | false | Treat warnings as errors (exit 1) |
 | --require-coverage | Option usize | None | Fail if file coverage percent is below threshold |
 | --root | Option PathBuf | cwd | Project root directory |
-| --format | text\|json\|markdown | text | Output format: colored text, machine-readable JSON, or markdown |
+| --format | text\|json\|markdown\|github\|table\|csv | text | Select a command-supported output renderer |
 | --json | bool | false | Shorthand for `--format json` |
 | --enforcement | Option EnforcementMode | None | Override configured enforcement mode (warn, enforce-new, strict) |
 | --force | bool | false | Bypass hash cache and re-validate all specs |
@@ -156,6 +156,8 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 9. MCP dispatch forwards the parsed write capability unchanged; read-only remains the default.
 10. MCP server-root initialization failures are printed to stderr and exit 2 before request input is
     processed.
+11. `compact` and `archive-tasks` receive the resolved global output format instead of silently
+    falling back to text.
 
 ## Behavioral Examples
 
@@ -173,8 +175,8 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 
 ### Scenario: JSON output
 
-- **Given** `--json` flag is passed
-- **When** any command runs
+- **Given** `--json` is passed to a structured-output command such as `compact` or `archive-tasks`
+- **When** the root dispatcher invokes the handler
 - **Then** output is valid JSON with no ANSI escape codes
 
 ### Scenario: Init idempotency
@@ -355,6 +357,7 @@ update is an explicit implementation edit because semantic section deltas do not
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Fix #417: forward resolved output format to compact/archive-tasks so JSON shorthand and Markdown are honored |
 | 2026-07-10 | v5: dispatch the verified `specsync change` SDD lifecycle |
 | 2026-06-11 | v4: `--root` now errors (exit 2) for nonexistent paths; init scenario covers the v4 config layout |
 | 2026-04-10 | Add Performance Requirements section with response time targets, cache requirements, resource limits, and scalability targets |

--- a/specs/cli/cli.spec.md
+++ b/specs/cli/cli.spec.md
@@ -156,8 +156,6 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 9. MCP dispatch forwards the parsed write capability unchanged; read-only remains the default.
 10. MCP server-root initialization failures are printed to stderr and exit 2 before request input is
     processed.
-11. `compact` and `archive-tasks` receive the resolved global output format instead of silently
-    falling back to text.
 
 ## Behavioral Examples
 

--- a/specs/cli/context.md
+++ b/specs/cli/context.md
@@ -6,7 +6,8 @@ spec: cli.spec.md
 
 - **Thin dispatcher**: `main.rs` parses CLI args with `clap`, then routes to `cmd_*` handler functions that orchestrate calls to the library modules. No domain logic lives here — purely argument parsing, output formatting, and exit code management.
 - **Default subcommand**: `check` runs when no subcommand is given, making the most common operation the easiest to invoke.
-- **JSON mode**: `--json` is a global flag so all commands can produce machine-readable output for CI/scripting.
+- **JSON mode**: `--json` is normalized globally so structured-output handlers receive one consistent machine-readable format selection.
+- **Structured maintenance output**: `main.rs` forwards the resolved format to `compact` and `archive-tasks`; those wrappers own JSON/Markdown rendering and keep mutation logic in their delegates.
 - **Strict mode**: `--strict` converts warnings to errors, useful for CI pipelines that want zero-warning enforcement.
 - **Idempotent init**: Both `init` and `init-registry` check for existing files before writing, preventing accidental overwrites.
 - **No network by default**: `resolve` only performs network calls with `--remote`, keeping default behavior offline and fast.
@@ -32,7 +33,8 @@ spec: cli.spec.md
 Fully implemented. The CLI exposes deterministic validation/generation, complete lifecycle/change
 commands, and native Agents/MCP integration without embedded inference configuration. MCP mutation
 remains opt-in at dispatch, startup fails closed before request processing when the root is invalid,
-and capability-sensitive gates retain the requested root spelling for replacement detection.
+capability-sensitive gates retain the requested root spelling for replacement detection, and
+structured maintenance commands honor the resolved global output format.
 
 ## Notes
 

--- a/specs/cli/requirements.md
+++ b/specs/cli/requirements.md
@@ -110,3 +110,14 @@ Acceptance Criteria
 - Other commands retain their established canonical-root dispatch behavior.
 - A symlink/junction replacement after capability retention remains observable to checked
   traversal and cannot be hidden by dispatcher canonicalization.
+
+### REQ-cli-007
+
+The root CLI SHALL forward the resolved global output format to compact and archive-tasks handlers.
+
+Acceptance Criteria
+
+- `--json` and `--format json` dispatch the same `OutputFormat::Json` value.
+- `--format markdown` dispatches `OutputFormat::Markdown`.
+- No human banner is emitted before the structured renderer.
+

--- a/specs/cli/requirements.md
+++ b/specs/cli/requirements.md
@@ -110,13 +110,3 @@ Acceptance Criteria
 - Other commands retain their established canonical-root dispatch behavior.
 - A symlink/junction replacement after capability retention remains observable to checked
   traversal and cannot be hidden by dispatcher canonicalization.
-
-### REQ-cli-007
-
-The root CLI SHALL forward the resolved global output format to compact and archive-tasks handlers.
-
-Acceptance Criteria
-
-- `--json` and `--format json` dispatch the same `OutputFormat::Json` value.
-- `--format markdown` dispatches `OutputFormat::Markdown`.
-- No human banner is emitted before the structured renderer.

--- a/specs/cli/requirements.md
+++ b/specs/cli/requirements.md
@@ -17,13 +17,14 @@ spec: cli.spec.md
 - As a team lead, I want `specsync hooks install` to set up agent instructions for Claude, Cursor, and Copilot so that AI assistants respect our specs automatically
 - As a developer, I want `specsync add-spec <name>` to scaffold a single spec with companion files so that I can add documentation incrementally
 - As a developer or agent, I want one `specsync change` namespace for the complete verified SDD lifecycle so that delivery state and next actions remain predictable
+- As an automation author, I want the root dispatcher to honor JSON and Markdown formats for compact/archive maintenance commands instead of silently printing text
 
 ## Acceptance Criteria
 
 - No subcommand defaults to `check`
 - Exit code 0 on success, 1 on errors (or warnings in strict mode, or coverage below threshold)
-- `--json` suppresses all ANSI color codes and outputs valid JSON
-- `--format markdown` produces output suitable for PR comments
+- Commands that advertise JSON output suppress all ANSI color codes and emit one valid document
+- Commands that advertise Markdown output produce content suitable for PR comments
 - `--root <path>` allows running against a different project directory
 - All domain logic is delegated to library modules — `main.rs` is purely a dispatcher and the clap grammar lives in `src/cli.rs`
 - `--fix` only modifies spec files, never source code
@@ -31,6 +32,7 @@ spec: cli.spec.md
 - `generate` accepts no provider/model options and delegates only to the deterministic generator
 - A panic in any subcommand is caught and reported as a "please report it" bug message rather than a raw backtrace
 - `change` dispatches every lifecycle operation through the shared domain engine and preserves structured JSON output
+- `compact` and `archive-tasks` receive the resolved global `OutputFormat`; `--json` is equivalent to `--format json`
 
 ## Constraints
 
@@ -109,3 +111,12 @@ Acceptance Criteria
 - A symlink/junction replacement after capability retention remains observable to checked
   traversal and cannot be hidden by dispatcher canonicalization.
 
+### REQ-cli-007
+
+The root CLI SHALL forward the resolved global output format to compact and archive-tasks handlers.
+
+Acceptance Criteria
+
+- `--json` and `--format json` dispatch the same `OutputFormat::Json` value.
+- `--format markdown` dispatches `OutputFormat::Markdown`.
+- No human banner is emitted before the structured renderer.

--- a/specs/cli/tasks.md
+++ b/specs/cli/tasks.md
@@ -23,6 +23,7 @@ spec: cli.spec.md
 - [x] Forward explicit MCP write authorization and fail closed on server-root startup errors
 - [x] Preserve requested roots for MCP and coverage-gating retained-capability traversal
 - [x] Keep generate writes bound to the retained root after checked coverage returns
+- [x] Forward global output format to `compact` and `archive-tasks` and cover JSON shorthand/Markdown dispatch end to end
 
 ## Gaps
 

--- a/specs/cli/testing.md
+++ b/specs/cli/testing.md
@@ -17,6 +17,8 @@ spec: cli.spec.md
 | `tests/integration.rs` | cargo test --test integration require_coverage_on_coverage_subcommand | End-to-end fixture: `require_coverage_on_coverage_subcommand` |
 | `tests/integration.rs` | cargo test --test integration strict_on_coverage_subcommand | End-to-end fixture: `strict_on_coverage_subcommand` |
 | `tests/integration.rs` | cargo test --test integration toml_config_is_loaded | End-to-end fixture: `toml_config_is_loaded` |
+| `tests/integration/commands.rs` | `fledge run test -- compact_` | Compact text/JSON/Markdown routing, `--json` equivalence, and no-write dry runs |
+| `tests/integration/commands.rs` | `fledge run test -- archive_tasks_` | Archive-tasks text/JSON/Markdown routing, `--json` equivalence, and no-write dry runs |
 
 ## Behavioral Verification
 
@@ -24,7 +26,8 @@ spec: cli.spec.md
 |------|-----------------|--------|-----------------|
 | Default subcommand | the user runs `specsync` with no subcommand | the CLI parses arguments | the `check` command executes |
 | Strict mode with warnings | specs have undocumented exports (warnings but no errors) | `specsync check --strict` is run | the process exits with code 1 |
-| JSON output | `--json` flag is passed | any command runs | output is valid JSON with no ANSI escape codes |
+| JSON output | `--json` is passed | a structured-output command runs | output is valid JSON with no ANSI escape codes |
+| Compact/archive structured output | a fixture has compactable entries or completed tasks | run text, `--format json`, `--json`, and `--format markdown` variants | each handler receives the resolved format; structured stdout is parse-clean and dry-run safe |
 | Init idempotency | `specsync.json` already exists in the project root | `specsync init` is run | prints "specsync.json already exists" and returns without modifying it |
 | Coverage threshold | file coverage is 80% | `specsync check --require-coverage 90` is run | the process exits with code 1 and prints the unspecced files |
 | Deterministic generate | uncovered modules exist | `specsync generate` is run | local template specs and companions are created |
@@ -46,6 +49,7 @@ spec: cli.spec.md
 | Failed to write spec file | Prints error to stderr and exits 1 | Keep or add a focused assertion before changing this behavior |
 | Failed to write `specsync-registry.toml` | Prints error to stderr and exits 1 | Keep or add a focused assertion before changing this behavior |
 | No spec files found (non-generate commands) | Prints guidance message and exits 0 | Keep or add a focused assertion before changing this behavior |
+| Format silently ignored | Compact/archive JSON and Markdown requests must not fall through to terminal text | `compact_json_formats_are_clean_truthful_and_equivalent`, `archive_tasks_json_formats_are_clean_truthful_and_equivalent`, Markdown counterparts |
 
 ## Reviewer Checklist
 

--- a/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
+++ b/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_archive_tasks
-version: 6
+version: 7
 status: stable
 files:
   - src/commands/archive_tasks.rs
@@ -28,9 +28,18 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 
 ## Invariants
 
-1. Delegates entirely to `archive::archive_tasks()` for the actual archiving logic
+1. Delegates entirely to `archive::archive_tasks()` for planning and transactional archival
 2. Dry-run mode prints affected files but makes no writes
 3. Gracefully handles empty results (no completed tasks to archive)
+4. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent.
+5. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary.
+6. Structured dry-run output distinguishes `would_change: true` from `applied: false`.
+7. Structured paths retain `PathBuf` identity until rendering: Windows separators become `/`, while literal Unix backslashes remain literal
+8. JSON exposes `complete`, `partial`, and explicit planned/succeeded/rolled-back/failed operation arrays
+9. Any incomplete report is fully rendered before the command exits 1; `applied` is never true for an incomplete invocation
+10. Markdown/GitHub paths use one code element: dynamic-backtick spans normally and entity-safe HTML code for literal-pipe paths, plus visible escapes for control and bidirectional-control characters; every legal Unix backslash parity remains unchanged
+11. Text output uses correct task/tasks and file/files labels
+12. Text paths and filesystem errors visibly escape control and bidirectional-control characters
 
 ## Behavioral Examples
 
@@ -92,3 +101,4 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 | 2026-07-26 | Fix #417 structured output: parse-clean JSON, Markdown/GitHub tables, shorthand equivalence, and explicit dry-run truth |
 | 2026-04-09 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-27 | CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str: Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output |

--- a/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
+++ b/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
@@ -37,7 +37,7 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 7. Structured paths retain `PathBuf` identity until rendering: Windows separators become `/`, while literal Unix backslashes remain literal
 8. JSON exposes `complete`, `partial`, and explicit planned/succeeded/rolled-back/failed operation arrays
 9. Any incomplete report is fully rendered before the command exits 1; `applied` is never true for an incomplete invocation
-10. Markdown/GitHub paths use dynamic-backtick code spans, escaped table pipes, visible escapes for control and bidirectional-control characters, and unchanged legal Unix backslashes
+10. Markdown/GitHub paths use one code element: dynamic-backtick spans normally and entity-safe HTML code for literal-pipe paths, plus visible escapes for control and bidirectional-control characters; every legal Unix backslash parity remains unchanged
 11. Text output uses correct task/tasks and file/files labels
 12. Text paths and filesystem errors visibly escape control and bidirectional-control characters
 
@@ -95,7 +95,7 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 
 | Date | Change |
 |------|--------|
-| 2026-07-26 | Preserve legal Unix backslashes through Markdown/GitHub code-span rendering |
+| 2026-07-26 | Preserve every legal Unix backslash parity, including backslash-before-pipe paths, through one safe Markdown/GitHub code cell |
 | 2026-07-26 | Add truthful typed failure output, exit-1 incomplete results, safe path rendering, and singular/plural text |
 | 2026-07-26 | Normalize structured result paths to portable `/` separators on Windows |
 | 2026-07-26 | Fix #417 structured output: parse-clean JSON, Markdown/GitHub tables, shorthand equivalence, and explicit dry-run truth |

--- a/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
+++ b/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_archive_tasks
-version: 2
+version: 5
 status: stable
 files:
   - src/commands/archive_tasks.rs
@@ -9,6 +9,7 @@ tracks: []
 depends_on:
   - specs/archive/archive.spec.md
   - specs/config/config.spec.md
+  - specs/types/types.spec.md
 ---
 
 # Cmd Archive Tasks
@@ -23,27 +24,48 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `cmd_archive_tasks` | `root: &Path, dry_run: bool` | `()` | Archive completed tasks from all spec companion tasks.md files |
+| `cmd_archive_tasks` | `root: &Path, dry_run: bool, format: OutputFormat` | `()` | Archive completed tasks and render text, JSON, or Markdown results |
 
 ## Invariants
 
-1. Delegates entirely to `archive::archive_tasks()` for the actual archiving logic
+1. Delegates entirely to `archive::archive_tasks()` for planning and transactional archival
 2. Dry-run mode prints affected files but makes no writes
 3. Gracefully handles empty results (no completed tasks to archive)
+4. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent
+5. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary
+6. Structured dry-run output distinguishes `would_change: true` from `applied: false`
+7. Structured paths retain `PathBuf` identity until rendering: Windows separators become `/`, while literal Unix backslashes remain literal
+8. JSON exposes `complete`, `partial`, and explicit planned/succeeded/rolled-back/failed operation arrays
+9. Any incomplete report is fully rendered before the command exits 1; `applied` is never true for an incomplete invocation
+10. Markdown/GitHub paths use dynamic-backtick code spans, escaped table pipes, and visible escapes for control and bidirectional-control characters
+11. Text output uses correct task/tasks and file/files labels
+12. Text paths and filesystem errors visibly escape control and bidirectional-control characters
 
 ## Behavioral Examples
 
 ### Scenario: Tasks archived successfully
 
 - **Given** tasks.md has 3 checked items (`- [x]`)
-- **When** `cmd_archive_tasks(root, false)` is called
-- **Then** checked items move to `## Done` section and count is printed
+- **When** `cmd_archive_tasks(root, false, OutputFormat::Text)` is called
+- **Then** checked items move to the `## Archive` section and count is printed
 
 ### Scenario: Dry run
 
 - **Given** tasks.md has completed items
-- **When** `cmd_archive_tasks(root, true)` is called
+- **When** `cmd_archive_tasks(root, true, OutputFormat::Text)` is called
 - **Then** prints what would be archived without modifying files
+
+### Scenario: Machine-readable dry run
+
+- **Given** tasks.md has completed items
+- **When** `cmd_archive_tasks` runs with JSON format and `dry_run = true`
+- **Then** stdout is one valid JSON document with `would_change: true`, `applied: false`, and no file is modified
+
+### Scenario: Apply cannot read one candidate
+
+- **Given** one valid archive candidate and one malformed tasks.md file
+- **When** `cmd_archive_tasks` runs in apply mode
+- **Then** stdout reports the plan and structured read failure, all destinations remain unchanged, and the process exits 1
 
 ## Error Cases
 
@@ -51,6 +73,7 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 |-----------|----------|
 | No tasks.md files found | Prints "nothing to archive" |
 | No completed tasks | Prints "nothing to archive" |
+| Incomplete plan, stage, publish, or rollback | Renders the selected format with `complete: false`/failure details and exits 1 |
 
 ## Dependencies
 
@@ -60,6 +83,7 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 |--------|-------------|
 | archive | `archive_tasks` |
 | config | `load_config` |
+| types | `OutputFormat` |
 
 ### Consumed By
 
@@ -71,5 +95,8 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Add truthful typed failure output, exit-1 incomplete results, safe path rendering, and singular/plural text |
+| 2026-07-26 | Normalize structured result paths to portable `/` separators on Windows |
+| 2026-07-26 | Fix #417 structured output: parse-clean JSON, Markdown/GitHub tables, shorthand equivalence, and explicit dry-run truth |
 | 2026-04-09 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
+++ b/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_archive_tasks
-version: 5
+version: 6
 status: stable
 files:
   - src/commands/archive_tasks.rs
@@ -37,7 +37,7 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 7. Structured paths retain `PathBuf` identity until rendering: Windows separators become `/`, while literal Unix backslashes remain literal
 8. JSON exposes `complete`, `partial`, and explicit planned/succeeded/rolled-back/failed operation arrays
 9. Any incomplete report is fully rendered before the command exits 1; `applied` is never true for an incomplete invocation
-10. Markdown/GitHub paths use dynamic-backtick code spans, escaped table pipes, and visible escapes for control and bidirectional-control characters
+10. Markdown/GitHub paths use dynamic-backtick code spans, escaped table pipes, visible escapes for control and bidirectional-control characters, and unchanged legal Unix backslashes
 11. Text output uses correct task/tasks and file/files labels
 12. Text paths and filesystem errors visibly escape control and bidirectional-control characters
 
@@ -95,6 +95,7 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Preserve legal Unix backslashes through Markdown/GitHub code-span rendering |
 | 2026-07-26 | Add truthful typed failure output, exit-1 incomplete results, safe path rendering, and singular/plural text |
 | 2026-07-26 | Normalize structured result paths to portable `/` separators on Windows |
 | 2026-07-26 | Fix #417 structured output: parse-clean JSON, Markdown/GitHub tables, shorthand equivalence, and explicit dry-run truth |

--- a/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
+++ b/specs/cmd_archive_tasks/cmd_archive_tasks.spec.md
@@ -28,18 +28,9 @@ Implements the `specsync archive-tasks` command. Moves completed tasks (checked 
 
 ## Invariants
 
-1. Delegates entirely to `archive::archive_tasks()` for planning and transactional archival
+1. Delegates entirely to `archive::archive_tasks()` for the actual archiving logic
 2. Dry-run mode prints affected files but makes no writes
 3. Gracefully handles empty results (no completed tasks to archive)
-4. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent
-5. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary
-6. Structured dry-run output distinguishes `would_change: true` from `applied: false`
-7. Structured paths retain `PathBuf` identity until rendering: Windows separators become `/`, while literal Unix backslashes remain literal
-8. JSON exposes `complete`, `partial`, and explicit planned/succeeded/rolled-back/failed operation arrays
-9. Any incomplete report is fully rendered before the command exits 1; `applied` is never true for an incomplete invocation
-10. Markdown/GitHub paths use one code element: dynamic-backtick spans normally and entity-safe HTML code for literal-pipe paths, plus visible escapes for control and bidirectional-control characters; every legal Unix backslash parity remains unchanged
-11. Text output uses correct task/tasks and file/files labels
-12. Text paths and filesystem errors visibly escape control and bidirectional-control characters
 
 ## Behavioral Examples
 

--- a/specs/cmd_archive_tasks/context.md
+++ b/specs/cmd_archive_tasks/context.md
@@ -4,9 +4,14 @@ spec: cmd_archive_tasks.spec.md
 
 ## Key Decisions
 
-- Thin command wrapper: load config, resolve `specs_dir`, call `archive::archive_tasks`, format output. No domain logic lives here.
-- Dry-run is passed straight through to the delegate; this module only flips the printed verb ("would archive" vs "archived") and prints the banner.
+- Thin command wrapper: load config, resolve `specs_dir`, call `archive::archive_tasks`, render the typed report, and map incompleteness to exit 1. No task parsing or filesystem mutation logic lives here.
+- Dry-run is passed straight through to the delegate; rendering uses the report plan while keeping `applied` false.
 - Empty result is treated as a success case ("No completed tasks to archive.") with an early return — not an error.
+- `OutputFormat::Json` produces one document with planned/succeeded/rolled-back/failed arrays plus `would_change`, `applied`, `complete`, and `partial`.
+- `OutputFormat::Markdown` and `Github` share a PR-suitable renderer with dynamic code-span delimiters and sanitized table cells.
+- Paths stay as `PathBuf` values until rendering. Only Windows separators are normalized; a legal Unix backslash is preserved.
+- Text rendering passes paths and filesystem errors through the same visible control/bidirectional escaping used by structured diagnostics.
+- Failure reports are rendered and stdout is flushed before exit 1.
 
 ## Files to Read First
 
@@ -16,8 +21,10 @@ spec: cmd_archive_tasks.spec.md
 
 ## Current Status
 
-Implemented and stable. The delegate `archive` module is well unit-tested; the wrapper itself has no inline tests (output formatting only).
+Text, JSON/`--json`, Markdown/GitHub, adversarial paths, and fail-closed exit behavior are covered; the delegate independently proves the transactional filesystem boundaries.
 
 ## Notes
 
-- `ArchiveResult.tasks_path` is already a repo-relative string produced by the delegate; the wrapper prints it verbatim.
+- `ArchiveResult.tasks_path` is a repo-relative `PathBuf`; structured renderers normalize separators only on Windows while text preserves terminal-native output.
+- The delegate moves completed items into `## Archive`; the command wrapper only reports that result.
+- Markdown table paths escape pipes, use a delimiter longer than every contained backtick run, and visibly encode line/control/bidirectional controls.

--- a/specs/cmd_archive_tasks/context.md
+++ b/specs/cmd_archive_tasks/context.md
@@ -8,7 +8,7 @@ spec: cmd_archive_tasks.spec.md
 - Dry-run is passed straight through to the delegate; rendering uses the report plan while keeping `applied` false.
 - Empty result is treated as a success case ("No completed tasks to archive.") with an early return — not an error.
 - `OutputFormat::Json` produces one document with planned/succeeded/rolled-back/failed arrays plus `would_change`, `applied`, `complete`, and `partial`.
-- `OutputFormat::Markdown` and `Github` share a PR-suitable renderer with dynamic code-span delimiters and sanitized table cells.
+- `OutputFormat::Markdown` and `Github` share a PR-suitable renderer with dynamic code-span delimiters, sanitized table cells, and unchanged legal Unix backslashes.
 - Paths stay as `PathBuf` values until rendering. Only Windows separators are normalized; a legal Unix backslash is preserved.
 - Text rendering passes paths and filesystem errors through the same visible control/bidirectional escaping used by structured diagnostics.
 - Failure reports are rendered and stdout is flushed before exit 1.
@@ -21,7 +21,7 @@ spec: cmd_archive_tasks.spec.md
 
 ## Current Status
 
-Text, JSON/`--json`, Markdown/GitHub, adversarial paths, and fail-closed exit behavior are covered; the delegate independently proves the transactional filesystem boundaries.
+Text, JSON/`--json`, Markdown/GitHub, adversarial paths, literal Unix backslashes, and fail-closed exit behavior are covered; the delegate independently proves the transactional filesystem boundaries.
 
 ## Notes
 

--- a/specs/cmd_archive_tasks/context.md
+++ b/specs/cmd_archive_tasks/context.md
@@ -8,7 +8,7 @@ spec: cmd_archive_tasks.spec.md
 - Dry-run is passed straight through to the delegate; rendering uses the report plan while keeping `applied` false.
 - Empty result is treated as a success case ("No completed tasks to archive.") with an early return — not an error.
 - `OutputFormat::Json` produces one document with planned/succeeded/rolled-back/failed arrays plus `would_change`, `applied`, `complete`, and `partial`.
-- `OutputFormat::Markdown` and `Github` share a PR-suitable renderer with dynamic code-span delimiters, sanitized table cells, and unchanged legal Unix backslashes.
+- `OutputFormat::Markdown` and `Github` share a PR-suitable renderer with one code element per path: dynamic-backtick spans normally and entity-safe HTML code for literal-pipe paths, with unchanged legal Unix backslashes.
 - Paths stay as `PathBuf` values until rendering. Only Windows separators are normalized; a legal Unix backslash is preserved.
 - Text rendering passes paths and filesystem errors through the same visible control/bidirectional escaping used by structured diagnostics.
 - Failure reports are rendered and stdout is flushed before exit 1.
@@ -27,4 +27,4 @@ Text, JSON/`--json`, Markdown/GitHub, adversarial paths, literal Unix backslashe
 
 - `ArchiveResult.tasks_path` is a repo-relative `PathBuf`; structured renderers normalize separators only on Windows while text preserves terminal-native output.
 - The delegate moves completed items into `## Archive`; the command wrapper only reports that result.
-- Markdown table paths escape pipes, use a delimiter longer than every contained backtick run, and visibly encode line/control/bidirectional controls.
+- Markdown table paths entity-encode table pipes when needed, otherwise use a delimiter longer than every contained backtick run, and visibly encode line/control/bidirectional controls.

--- a/specs/cmd_archive_tasks/requirements.md
+++ b/specs/cmd_archive_tasks/requirements.md
@@ -4,23 +4,38 @@ spec: cmd_archive_tasks.spec.md
 
 ## User Stories
 
-- As a developer, I want completed (`- [x]`) tasks moved out of each companion `tasks.md` into a `## Done` section so active task lists stay focused on outstanding work
+- As a developer, I want completed (`- [x]`) tasks moved out of each companion `tasks.md` into a `## Archive` section so active task lists stay focused on outstanding work
 - As a maintainer, I want a `--dry-run` preview so I can see which files and how many tasks would be archived before committing to a write
-- As a script author, I want a clear summary line ("Archived N task(s) across M file(s)", or "No completed tasks to archive.") so the result is easy to read or assert on
+- As a script author, I want a grammatically correct summary line ("Archived 1 task across 1 file", "Archived N tasks across M files", or "No completed tasks to archive.") so the result is easy to read or assert on
+- As an automation author, I want equivalent `--format json` and `--json` output so archive results are safely parseable
+- As a reviewer, I want `--format markdown` output with a result table suitable for a PR comment
+- As a CI operator, I want incomplete operations to render their structured failures and exit 1 so partial or inconclusive archival cannot pass
+- As a user with unusual legal filenames, I want every output format to preserve path identity without Markdown row/code-span injection
 
 ## Acceptance Criteria
 
-- `cmd_archive_tasks(root, dry_run)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
+- `cmd_archive_tasks(root, dry_run, format)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
 - When `dry_run` is true, an informational banner ("Dry run — no files will be modified") prints and no files are written; per-file lines read "would archive"
 - When `dry_run` is false, completed tasks are moved and per-file lines read "archived"
 - When the delegate returns no results, prints "No completed tasks to archive." and returns without a summary
 - Each affected file prints its relative `tasks_path` and `archived_count`; a trailing summary reports the summed task count across the affected file count
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-file results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- JSON separates planned, succeeded, rolled-back, and failed operations and exposes truthful `complete` and `partial` booleans
+- Incomplete apply results render before exit 1 and never report `applied: true`
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit equivalent headings, optional dry-run notices, result/failure tables, and truthful singular/plural summaries
+- Structured Windows paths use `/` separators; legal Unix backslashes remain literal
+- Markdown/GitHub paths cannot inject rows or break code spans through pipes, backtick runs, line/control characters, or bidirectional controls
+- Text output uses task/tasks and file/files according to the actual counts
+- Text paths and errors visibly encode line/control and bidirectional-control characters rather than emitting terminal-control content
 
 ## Constraints
 
 - Pure orchestration wrapper: all task-parsing/rewriting logic lives in `archive::archive_tasks`; this module only loads config and formats output
-- Must not panic on missing/unreadable `tasks.md` files — the underlying module skips them gracefully
-- Output uses `colored` for status glyphs (`ℹ`, `✓`)
+- Must not panic or falsely succeed on missing/unreadable `tasks.md` files — the underlying report retains structured failures
+- Text output uses `colored` for status glyphs (`ℹ`, `✓`); structured output contains no ANSI formatting
+- The command must flush the rendered failure report before exiting 1
 
 ## Out of Scope
 
@@ -30,12 +45,21 @@ spec: cmd_archive_tasks.spec.md
 
 ### REQ-cmd-archive-tasks-001
 
-The archive-tasks command SHALL delegate task archival safely and SHALL distinguish dry-run, no-op, per-file, and summary output.
+The archive-tasks command SHALL delegate task archival safely and SHALL render truthful dry-run, success, partial, rollback, and failure outcomes.
 
 Acceptance Criteria
-- `cmd_archive_tasks(root, dry_run)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
+- `cmd_archive_tasks(root, dry_run, format)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
 - When `dry_run` is true, an informational banner ("Dry run — no files will be modified") prints and no files are written; per-file lines read "would archive"
 - When `dry_run` is false, completed tasks are moved and per-file lines read "archived"
 - When the delegate returns no results, prints "No completed tasks to archive." and returns without a summary
 - Each affected file prints its relative `tasks_path` and `archived_count`; a trailing summary reports the summed task count across the affected file count
-
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-file results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- JSON separates planned, succeeded, rolled-back, and failed operations and exposes truthful `complete` and `partial` booleans
+- Incomplete apply results render before exit 1 and never report `applied: true`
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit equivalent headings, optional dry-run notices, result/failure tables, and truthful singular/plural summaries
+- Structured Windows paths use `/` separators; legal Unix backslashes remain literal
+- Markdown/GitHub paths cannot inject rows or break code spans through pipes, backtick runs, line/control characters, or bidirectional controls
+- Text output uses task/tasks and file/files according to the actual counts
+- Text paths and errors visibly encode line/control and bidirectional-control characters rather than emitting terminal-control content

--- a/specs/cmd_archive_tasks/requirements.md
+++ b/specs/cmd_archive_tasks/requirements.md
@@ -45,11 +45,22 @@ spec: cmd_archive_tasks.spec.md
 
 ### REQ-cmd-archive-tasks-001
 
-The archive-tasks command SHALL delegate task archival safely and SHALL distinguish dry-run, no-op, per-file, and summary output.
+The archive-tasks command SHALL delegate task archival safely and SHALL render truthful dry-run, success, partial, rollback, and failure outcomes.
 
 Acceptance Criteria
-- `cmd_archive_tasks(root, dry_run)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
+- `cmd_archive_tasks(root, dry_run, format)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
 - When `dry_run` is true, an informational banner ("Dry run — no files will be modified") prints and no files are written; per-file lines read "would archive"
 - When `dry_run` is false, completed tasks are moved and per-file lines read "archived"
 - When the delegate returns no results, prints "No completed tasks to archive." and returns without a summary
 - Each affected file prints its relative `tasks_path` and `archived_count`; a trailing summary reports the summed task count across the affected file count
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-file results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- JSON separates planned, succeeded, rolled-back, and failed operations and exposes truthful `complete` and `partial` booleans
+- Incomplete apply results render before exit 1 and never report `applied: true`
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit equivalent headings, optional dry-run notices, result/failure tables, and truthful singular/plural summaries
+- Structured Windows paths use `/` separators; legal Unix backslashes remain literal
+- Markdown/GitHub paths cannot inject rows or break their single code element through pipes, backtick runs, line/control characters, or bidirectional controls
+- Text output uses task/tasks and file/files according to the actual counts
+- Text paths and errors visibly encode line/control and bidirectional-control characters rather than emitting terminal-control content
+

--- a/specs/cmd_archive_tasks/requirements.md
+++ b/specs/cmd_archive_tasks/requirements.md
@@ -45,21 +45,11 @@ spec: cmd_archive_tasks.spec.md
 
 ### REQ-cmd-archive-tasks-001
 
-The archive-tasks command SHALL delegate task archival safely and SHALL render truthful dry-run, success, partial, rollback, and failure outcomes.
+The archive-tasks command SHALL delegate task archival safely and SHALL distinguish dry-run, no-op, per-file, and summary output.
 
 Acceptance Criteria
-- `cmd_archive_tasks(root, dry_run, format)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
+- `cmd_archive_tasks(root, dry_run)` loads config, resolves `config.specs_dir` under `root`, and delegates archiving to `archive::archive_tasks(root, &specs_dir, dry_run)`
 - When `dry_run` is true, an informational banner ("Dry run — no files will be modified") prints and no files are written; per-file lines read "would archive"
 - When `dry_run` is false, completed tasks are moved and per-file lines read "archived"
 - When the delegate returns no results, prints "No completed tasks to archive." and returns without a summary
 - Each affected file prints its relative `tasks_path` and `archived_count`; a trailing summary reports the summed task count across the affected file count
-- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-file results
-- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
-- JSON separates planned, succeeded, rolled-back, and failed operations and exposes truthful `complete` and `partial` booleans
-- Incomplete apply results render before exit 1 and never report `applied: true`
-- `--json` is byte-equivalent to `--format json`
-- Markdown and GitHub modes emit equivalent headings, optional dry-run notices, result/failure tables, and truthful singular/plural summaries
-- Structured Windows paths use `/` separators; legal Unix backslashes remain literal
-- Markdown/GitHub paths cannot inject rows or break their single code element through pipes, backtick runs, line/control characters, or bidirectional controls
-- Text output uses task/tasks and file/files according to the actual counts
-- Text paths and errors visibly encode line/control and bidirectional-control characters rather than emitting terminal-control content

--- a/specs/cmd_archive_tasks/requirements.md
+++ b/specs/cmd_archive_tasks/requirements.md
@@ -26,7 +26,7 @@ spec: cmd_archive_tasks.spec.md
 - `--json` is byte-equivalent to `--format json`
 - Markdown and GitHub modes emit equivalent headings, optional dry-run notices, result/failure tables, and truthful singular/plural summaries
 - Structured Windows paths use `/` separators; legal Unix backslashes remain literal
-- Markdown/GitHub paths cannot inject rows or break code spans through pipes, backtick runs, line/control characters, or bidirectional controls
+- Markdown/GitHub paths render as one safe code element and cannot inject rows through pipes, backtick runs, line/control characters, or bidirectional controls
 - Text output uses task/tasks and file/files according to the actual counts
 - Text paths and errors visibly encode line/control and bidirectional-control characters rather than emitting terminal-control content
 
@@ -60,6 +60,6 @@ Acceptance Criteria
 - `--json` is byte-equivalent to `--format json`
 - Markdown and GitHub modes emit equivalent headings, optional dry-run notices, result/failure tables, and truthful singular/plural summaries
 - Structured Windows paths use `/` separators; legal Unix backslashes remain literal
-- Markdown/GitHub paths cannot inject rows or break code spans through pipes, backtick runs, line/control characters, or bidirectional controls
+- Markdown/GitHub paths cannot inject rows or break their single code element through pipes, backtick runs, line/control characters, or bidirectional controls
 - Text output uses task/tasks and file/files according to the actual counts
 - Text paths and errors visibly encode line/control and bidirectional-control characters rather than emitting terminal-control content

--- a/specs/cmd_archive_tasks/tasks.md
+++ b/specs/cmd_archive_tasks/tasks.md
@@ -22,6 +22,7 @@ spec: cmd_archive_tasks.spec.md
 - [x] Replace task(s)/file(s) placeholders with truthful singular/plural labels
 - [x] Sanitize text paths and errors against control and bidirectional terminal injection
 - [x] Add explicit GitHub-format and structured zero-write failure integration coverage
+- [x] Preserve legal Unix backslashes through Markdown/GitHub code-span rendering
 
 ## Review Status
 

--- a/specs/cmd_archive_tasks/tasks.md
+++ b/specs/cmd_archive_tasks/tasks.md
@@ -22,7 +22,7 @@ spec: cmd_archive_tasks.spec.md
 - [x] Replace task(s)/file(s) placeholders with truthful singular/plural labels
 - [x] Sanitize text paths and errors against control and bidirectional terminal injection
 - [x] Add explicit GitHub-format and structured zero-write failure integration coverage
-- [x] Preserve legal Unix backslashes through Markdown/GitHub code-span rendering
+- [x] Preserve every legal Unix backslash parity, including backslash-before-pipe paths, through Markdown/GitHub code rendering
 
 ## Review Status
 

--- a/specs/cmd_archive_tasks/tasks.md
+++ b/specs/cmd_archive_tasks/tasks.md
@@ -4,9 +4,7 @@ spec: cmd_archive_tasks.spec.md
 
 ## Tasks
 
-## Post-5.0 Test Debt
-
-- [ ] Add an integration test that drives `archive-tasks` end-to-end through the CLI (the delegate `archive` module is unit-tested, but the wrapper's output/`--dry-run` formatting is not)
+(none open)
 
 ## Done
 
@@ -14,6 +12,16 @@ spec: cmd_archive_tasks.spec.md
 - [x] Requirements and acceptance criteria documented
 - [x] Verified wrapper delegates to `archive::archive_tasks` and matches the empty-result / dry-run / write paths
 - [x] Confirmed delegate logic is covered by `archive` inline tests (`test_archive_completed_tasks`, `test_archive_no_completed`, `test_archive_preserves_existing`)
+- [x] Add text, JSON/`--json`, and Markdown end-to-end dry-run coverage
+- [x] Emit parse-clean structured output with explicit `would_change` and `applied` truth
+- [x] Normalize JSON and Markdown paths to portable separators and cover Windows-style inputs
+- [x] Render typed planned, succeeded, rolled-back, and failed operation collections
+- [x] Exit 1 after rendering incomplete operations without claiming `applied: true`
+- [x] Preserve literal Unix backslashes while normalizing Windows separators
+- [x] Harden Markdown/GitHub paths against pipes, backtick runs, controls, and bidirectional injection
+- [x] Replace task(s)/file(s) placeholders with truthful singular/plural labels
+- [x] Sanitize text paths and errors against control and bidirectional terminal injection
+- [x] Add explicit GitHub-format and structured zero-write failure integration coverage
 
 ## Review Status
 

--- a/specs/cmd_archive_tasks/testing.md
+++ b/specs/cmd_archive_tasks/testing.md
@@ -6,19 +6,25 @@ spec: cmd_archive_tasks.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/archive_tasks.rs` | cargo test commands::archive_tasks | Command wrapper has no inline tests (output formatting only); cover `cmd_archive_tasks` end-to-end before risky changes |
-| `src/archive.rs` (delegate logic) | cargo test archive | `test_archive_completed_tasks`, `test_archive_no_completed`, `test_archive_preserves_existing` |
+| `tests/integration/commands.rs` | `fledge run test -- archive_tasks_` | Text dry-run, JSON shorthand equivalence, Markdown/GitHub structure, exit-1 failure schema, and no-write guarantees |
+| `src/commands/archive_tasks.rs` | `fledge run test -- commands::archive_tasks::tests` | Pluralization, platform-aware separators, dynamic code spans, text/Markdown control and bidi sanitization, and JSON escaping |
+| `src/archive.rs` (delegate logic) | `fledge run test -- archive::tests` | Parsing plus plan/stage/publish/rollback transaction boundaries |
 
 ## Coverage Gaps
 
-- No end-to-end CLI test asserts the wrapper's stdout (per-file lines, "would archive" vs "archived", the summary line, or the "No completed tasks to archive." path). Add one before changing user-visible output.
+(none for issue #417)
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Tasks archived successfully | a companion `tasks.md` has checked items (`- [x]`) | `cmd_archive_tasks(root, false)` is called | checked items move to `## Done`; per-file line + summary printed |
-| Dry run | `tasks.md` has completed items | `cmd_archive_tasks(root, true)` is called | prints "Dry run" banner and "would archive" lines, modifies no files |
+| Tasks archived successfully | a companion `tasks.md` has checked items (`- [x]`) | `cmd_archive_tasks(root, false, Text)` is called | checked items move to `## Archive`; per-file line + summary printed |
+| Text dry run | `tasks.md` has completed items | run with `--dry-run` | prints "Dry run" banner and "would archive" lines, modifies no files |
+| JSON dry run | `tasks.md` has completed items | run with `--format json` and `--json` | both emit the same valid ANSI-free document; `would_change` is true and `applied` is false |
+| Markdown/GitHub dry run | `tasks.md` has completed items | run with `--format markdown` and `--format github` | both emit a heading, notice, table, and truthful summary; neither modifies files |
+| Incomplete apply | one candidate is valid and another is non-UTF-8 | run JSON apply | exits 1 with `complete: false`, no succeeded operations, a read failure, and zero file changes |
+| Platform-aware structured paths | Windows separators or a Unix literal backslash | render JSON or Markdown | Windows uses `/`; Unix preserves the literal backslash |
+| Adversarial Markdown path | path contains pipes, backtick runs, line/control, or bidi characters | render Markdown/GitHub | one intact row with a dynamic code span and visible safe escapes |
 
 ## Regression Matrix
 
@@ -26,11 +32,16 @@ spec: cmd_archive_tasks.spec.md
 |------|-------------------|-----------------|
 | No `tasks.md` files / no completed tasks (empty result) | Prints "No completed tasks to archive." and returns, no summary | Keep or add a focused assertion before changing this behavior |
 | Multiple affected files | Summary sums `archived_count` across all results and reports the file count | Keep or add a focused assertion before changing this behavior |
+| Structured stdout contamination | JSON must be exactly one parseable document with no banner or ANSI bytes | `archive_tasks_json_formats_are_clean_truthful_and_equivalent` |
+| Incomplete mutation | Failure must exit 1 after rendering; `applied` false; no success on preflight/stage failure | `archive_tasks_apply_failure_exits_one_and_reports_zero_writes` and archive transaction unit tests |
+| Host-native path separators | Windows separators normalize without corrupting Unix identities | cfg-specific `structured_output_*` unit tests and structured CLI assertions |
+| Markdown path injection | Pipes, backticks, controls, and bidi controls cannot create rows or malformed spans | `markdown_paths_use_safe_dynamic_code_spans` |
+| Terminal diagnostic injection | Text paths/errors visibly encode controls and bidi characters | `text_paths_and_errors_visibly_escape_control_and_bidi_characters` |
 
 ## Reviewer Checklist
 
 - Run `cargo run -- archive-tasks --help` and confirm the help text still names the documented flags and behavior.
-- Run `cargo test archive` when changing the delegate; run `cargo test commands::archive_tasks` when changing the wrapper.
+- Run `fledge run test -- archive::tests` when changing the delegate; run `fledge run test -- commands::archive_tasks::tests` when changing the wrapper.
 - Reproduce one Behavioral Verification row with a temporary project fixture before changing user-visible output.
 - If an output string changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_archive_tasks/testing.md
+++ b/specs/cmd_archive_tasks/testing.md
@@ -35,7 +35,7 @@ spec: cmd_archive_tasks.spec.md
 | Structured stdout contamination | JSON must be exactly one parseable document with no banner or ANSI bytes | `archive_tasks_json_formats_are_clean_truthful_and_equivalent` |
 | Incomplete mutation | Failure must exit 1 after rendering; `applied` false; no success on preflight/stage failure | `archive_tasks_apply_failure_exits_one_and_reports_zero_writes` and archive transaction unit tests |
 | Host-native path separators | Windows separators normalize without corrupting Unix identities | cfg-specific `structured_output_*` unit tests and structured CLI assertions |
-| Markdown path injection | Pipes, backticks, controls, and bidi controls cannot create rows or malformed spans | `markdown_paths_use_safe_dynamic_code_spans` |
+| Markdown path injection | Pipes, backticks, controls, and bidi controls cannot create rows or malformed spans; Unix backslashes remain literal | `markdown_paths_use_safe_dynamic_code_spans`, `markdown_paths_preserve_literal_unix_backslashes` |
 | Terminal diagnostic injection | Text paths/errors visibly encode controls and bidi characters | `text_paths_and_errors_visibly_escape_control_and_bidi_characters` |
 
 ## Reviewer Checklist

--- a/specs/cmd_archive_tasks/testing.md
+++ b/specs/cmd_archive_tasks/testing.md
@@ -7,7 +7,7 @@ spec: cmd_archive_tasks.spec.md
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
 | `tests/integration/commands.rs` | `fledge run test -- archive_tasks_` | Text dry-run, JSON shorthand equivalence, Markdown/GitHub structure, exit-1 failure schema, and no-write guarantees |
-| `src/commands/archive_tasks.rs` | `fledge run test -- commands::archive_tasks::tests` | Pluralization, platform-aware separators, dynamic code spans, text/Markdown control and bidi sanitization, and JSON escaping |
+| `src/commands/archive_tasks.rs` | `fledge run test -- commands::archive_tasks::tests` | Pluralization, platform-aware separators, one-element code rendering, backslash/pipe composition, text/Markdown control and bidi sanitization, and JSON escaping |
 | `src/archive.rs` (delegate logic) | `fledge run test -- archive::tests` | Parsing plus plan/stage/publish/rollback transaction boundaries |
 
 ## Coverage Gaps
@@ -24,7 +24,7 @@ spec: cmd_archive_tasks.spec.md
 | Markdown/GitHub dry run | `tasks.md` has completed items | run with `--format markdown` and `--format github` | both emit a heading, notice, table, and truthful summary; neither modifies files |
 | Incomplete apply | one candidate is valid and another is non-UTF-8 | run JSON apply | exits 1 with `complete: false`, no succeeded operations, a read failure, and zero file changes |
 | Platform-aware structured paths | Windows separators or a Unix literal backslash | render JSON or Markdown | Windows uses `/`; Unix preserves the literal backslash |
-| Adversarial Markdown path | path contains pipes, backtick runs, line/control, or bidi characters | render Markdown/GitHub | one intact row with a dynamic code span and visible safe escapes |
+| Adversarial Markdown path | path contains pipes, backtick runs, line/control, or bidi characters | render Markdown/GitHub | one intact row with one code element and visible safe escapes |
 
 ## Regression Matrix
 
@@ -35,7 +35,7 @@ spec: cmd_archive_tasks.spec.md
 | Structured stdout contamination | JSON must be exactly one parseable document with no banner or ANSI bytes | `archive_tasks_json_formats_are_clean_truthful_and_equivalent` |
 | Incomplete mutation | Failure must exit 1 after rendering; `applied` false; no success on preflight/stage failure | `archive_tasks_apply_failure_exits_one_and_reports_zero_writes` and archive transaction unit tests |
 | Host-native path separators | Windows separators normalize without corrupting Unix identities | cfg-specific `structured_output_*` unit tests and structured CLI assertions |
-| Markdown path injection | Pipes, backticks, controls, and bidi controls cannot create rows or malformed spans; Unix backslashes remain literal | `markdown_paths_use_safe_dynamic_code_spans`, `markdown_paths_preserve_literal_unix_backslashes` |
+| Markdown path injection | Pipes, backticks, controls, and bidi controls cannot create rows or malformed code elements; every Unix backslash parity, including backslash-before-pipe, remains literal | `markdown_paths_use_safe_dynamic_code_spans`, `markdown_paths_preserve_literal_unix_backslashes`, `markdown_paths_preserve_backslash_before_pipe_in_one_table_cell` |
 | Terminal diagnostic injection | Text paths/errors visibly encode controls and bidi characters | `text_paths_and_errors_visibly_escape_control_and_bidi_characters` |
 
 ## Reviewer Checklist

--- a/specs/cmd_compact/cmd_compact.spec.md
+++ b/specs/cmd_compact/cmd_compact.spec.md
@@ -36,7 +36,7 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 6. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary
 7. Structured dry-run output distinguishes `would_change: true` from `applied: false`
 8. JSON and Markdown project paths use `/` separators on Windows while preserving literal Unix backslashes
-9. Markdown/GitHub paths use sanitized variable-length code spans that cannot inject table rows or duplicate legal Unix backslashes
+9. Markdown/GitHub paths use one sanitized code element: variable-length Markdown spans normally and entity-safe HTML code when a literal pipe is present, so no table row can be injected and every legal Unix backslash is preserved
 10. JSON exposes `complete`, `partial`, planned/succeeded/failed operations, structured errors, and never sets `applied: true` for incomplete work
 11. Any compact failure is rendered before the command exits 1
 
@@ -82,7 +82,7 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 
 | Date | Change |
 |------|--------|
-| 2026-07-26 | Preserve literal Unix backslashes in rendered Markdown/GitHub and add truthful late-publish partial JSON/Markdown evidence |
+| 2026-07-26 | Preserve every Unix backslash parity, including backslash-before-pipe paths, in one rendered Markdown/GitHub code cell and add truthful late-publish partial JSON/Markdown evidence |
 | 2026-07-26 | Harden #417 result truth: correct spec pluralization, platform-aware paths, safe Markdown code spans, structured failures, and nonzero incomplete outcomes |
 | 2026-07-26 | Normalize structured result paths to portable `/` separators on Windows |
 | 2026-07-26 | Fix #417 structured output: parse-clean JSON, Markdown/GitHub tables, shorthand equivalence, and explicit dry-run truth |

--- a/specs/cmd_compact/cmd_compact.spec.md
+++ b/specs/cmd_compact/cmd_compact.spec.md
@@ -31,14 +31,6 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 1. Delegates to `compact::compact_changelogs()`
 2. `--keep N` controls how many entries to retain (default 10)
 3. Dry-run shows what would change without writing
-4. Per-spec and aggregate output use correct singular/plural labels and exclude the generated summary from the kept count
-5. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent
-6. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary
-7. Structured dry-run output distinguishes `would_change: true` from `applied: false`
-8. JSON and Markdown project paths use `/` separators on Windows while preserving literal Unix backslashes
-9. Markdown/GitHub paths use one sanitized code element: variable-length Markdown spans normally and entity-safe HTML code when a literal pipe is present, so no table row can be injected and every legal Unix backslash is preserved
-10. JSON exposes `complete`, `partial`, planned/succeeded/failed operations, structured errors, and never sets `applied: true` for incomplete work
-11. Any compact failure is rendered before the command exits 1
 
 ## Behavioral Examples
 

--- a/specs/cmd_compact/cmd_compact.spec.md
+++ b/specs/cmd_compact/cmd_compact.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_compact
-version: 6
+version: 7
 status: stable
 files:
   - src/commands/compact.rs
@@ -36,7 +36,7 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 6. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary
 7. Structured dry-run output distinguishes `would_change: true` from `applied: false`
 8. JSON and Markdown project paths use `/` separators on Windows while preserving literal Unix backslashes
-9. Markdown/GitHub paths use sanitized variable-length code spans that cannot inject table rows
+9. Markdown/GitHub paths use sanitized variable-length code spans that cannot inject table rows or duplicate legal Unix backslashes
 10. JSON exposes `complete`, `partial`, planned/succeeded/failed operations, structured errors, and never sets `applied: true` for incomplete work
 11. Any compact failure is rendered before the command exits 1
 
@@ -82,6 +82,7 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Preserve literal Unix backslashes in rendered Markdown/GitHub and add truthful late-publish partial JSON/Markdown evidence |
 | 2026-07-26 | Harden #417 result truth: correct spec pluralization, platform-aware paths, safe Markdown code spans, structured failures, and nonzero incomplete outcomes |
 | 2026-07-26 | Normalize structured result paths to portable `/` separators on Windows |
 | 2026-07-26 | Fix #417 structured output: parse-clean JSON, Markdown/GitHub tables, shorthand equivalence, and explicit dry-run truth |

--- a/specs/cmd_compact/cmd_compact.spec.md
+++ b/specs/cmd_compact/cmd_compact.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_compact
-version: 7
+version: 8
 status: stable
 files:
   - src/commands/compact.rs
@@ -31,6 +31,15 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 1. Delegates to `compact::compact_changelogs()`
 2. `--keep N` controls how many entries to retain (default 10)
 3. Dry-run shows what would change without writing
+4. Per-spec and aggregate output use correct singular/plural labels and exclude the generated
+   summary from the kept count.
+5. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent.
+6. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary.
+7. Structured dry-run output distinguishes `would_change: true` from `applied: false`.
+8. JSON and Markdown project paths use `/` separators on Windows while preserving literal Unix backslashes
+9. Markdown/GitHub paths use one sanitized code element: variable-length Markdown spans normally and entity-safe HTML code when a literal pipe is present, so no table row can be injected and every legal Unix backslash is preserved
+10. JSON exposes `complete`, `partial`, planned/succeeded/failed operations, structured errors, and never sets `applied: true` for incomplete work
+11. Any compact failure is rendered before the command exits 1
 
 ## Behavioral Examples
 
@@ -81,3 +90,4 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 | 2026-07-26 | Fix #417 text reporting: truthful kept counts, correct singular/plural labels, and end-to-end dry-run/idempotence coverage |
 | 2026-04-09 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-27 | CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str: Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output |

--- a/specs/cmd_compact/cmd_compact.spec.md
+++ b/specs/cmd_compact/cmd_compact.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_compact
-version: 2
+version: 6
 status: stable
 files:
   - src/commands/compact.rs
@@ -9,6 +9,7 @@ tracks: []
 depends_on:
   - specs/compact/compact.spec.md
   - specs/config/config.spec.md
+  - specs/types/types.spec.md
 ---
 
 # Cmd Compact
@@ -23,13 +24,21 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `cmd_compact` | `root: &Path, keep: usize, dry_run: bool` | `()` | Compact changelog entries across all spec files |
+| `cmd_compact` | `root: &Path, keep: usize, dry_run: bool, format: OutputFormat` | `()` | Compact changelog entries and render text, JSON, or Markdown results |
 
 ## Invariants
 
 1. Delegates to `compact::compact_changelogs()`
 2. `--keep N` controls how many entries to retain (default 10)
 3. Dry-run shows what would change without writing
+4. Per-spec and aggregate output use correct singular/plural labels and exclude the generated summary from the kept count
+5. JSON is one parseable, ANSI-free document; `--json` and `--format json` are equivalent
+6. Markdown and GitHub formats render a heading, dry-run notice, result table, and truthful summary
+7. Structured dry-run output distinguishes `would_change: true` from `applied: false`
+8. JSON and Markdown project paths use `/` separators on Windows while preserving literal Unix backslashes
+9. Markdown/GitHub paths use sanitized variable-length code spans that cannot inject table rows
+10. JSON exposes `complete`, `partial`, planned/succeeded/failed operations, structured errors, and never sets `applied: true` for incomplete work
+11. Any compact failure is rendered before the command exits 1
 
 ## Behavioral Examples
 
@@ -39,12 +48,19 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 - **When** `cmd_compact` runs
 - **Then** 15 oldest entries removed, 10 newest kept
 
+### Scenario: Machine-readable dry run
+
+- **Given** a spec has excess changelog entries
+- **When** `cmd_compact` runs with JSON format and `dry_run = true`
+- **Then** stdout is one valid JSON document with `would_change: true`, `applied: false`, and no file is modified
+
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
 | No specs with changelogs | Prints "nothing to compact" |
 | Fewer entries than keep | File unchanged |
+| Any read, parse, stage, or publish failure | Renders a structured incomplete result and exits 1 |
 
 ## Dependencies
 
@@ -54,6 +70,7 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 |--------|-------------|
 | compact | `compact_changelogs` |
 | config | `load_config` |
+| types | `OutputFormat` |
 
 ### Consumed By
 
@@ -65,5 +82,9 @@ Implements the `specsync compact` command. Trims old entries from spec changelog
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Harden #417 result truth: correct spec pluralization, platform-aware paths, safe Markdown code spans, structured failures, and nonzero incomplete outcomes |
+| 2026-07-26 | Normalize structured result paths to portable `/` separators on Windows |
+| 2026-07-26 | Fix #417 structured output: parse-clean JSON, Markdown/GitHub tables, shorthand equivalence, and explicit dry-run truth |
+| 2026-07-26 | Fix #417 text reporting: truthful kept counts, correct singular/plural labels, and end-to-end dry-run/idempotence coverage |
 | 2026-04-09 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/cmd_compact/context.md
+++ b/specs/cmd_compact/context.md
@@ -12,7 +12,7 @@ spec: cmd_compact.spec.md
 - `OutputFormat::Json` produces one document and expresses dry-run truth through separate `would_change` and `applied` booleans.
 - `OutputFormat::Markdown` and `Github` share the PR-suitable table renderer; text-like formats preserve the established terminal output.
 - Structured renderers normalize Windows separators to `/` without corrupting literal Unix backslashes.
-- Markdown/GitHub uses sanitized dynamic-backtick code spans without doubling legal Unix backslashes; JSON retains machine-readable paths and reports complete/partial operation truth.
+- Markdown/GitHub uses one sanitized code element: dynamic-backtick spans for ordinary paths and entity-safe HTML code for literal-pipe paths, preserving every legal Unix backslash parity; JSON retains machine-readable paths and reports complete/partial operation truth.
 - The command renders the full typed compact report and exits 1 when any operation fails.
 
 ## Files to Read First
@@ -28,4 +28,4 @@ Text, JSON/`--json`, Markdown/GitHub, hostile structured paths, literal Unix bac
 ## Notes
 
 - `CompactResult.spec_path` is repo-relative; Windows separators normalize while Unix literal backslashes survive.
-- Markdown table paths sanitize controls/bidi characters, escape pipes, and use a delimiter longer than every embedded backtick run.
+- Markdown table paths sanitize controls/bidi characters, entity-encode table pipes when needed, and otherwise use a delimiter longer than every embedded backtick run.

--- a/specs/cmd_compact/context.md
+++ b/specs/cmd_compact/context.md
@@ -8,6 +8,12 @@ spec: cmd_compact.spec.md
 - `--keep` is passed straight through; the wrapper only flips the printed verb ("would compact" vs "compacted") and prints the banner.
 - Empty result is a success case ("No changelogs need compaction (all within limit).") with an early return — not an error.
 - Per-spec output reports both `removed` and the surviving `compacted_entries` count so reviewers can sanity-check the keep limit.
+- Singular/plural labels derive from each reported count; the kept count is ordinary rows only.
+- `OutputFormat::Json` produces one document and expresses dry-run truth through separate `would_change` and `applied` booleans.
+- `OutputFormat::Markdown` and `Github` share the PR-suitable table renderer; text-like formats preserve the established terminal output.
+- Structured renderers normalize Windows separators to `/` without corrupting literal Unix backslashes.
+- Markdown/GitHub uses sanitized dynamic-backtick code spans; JSON retains machine-readable paths and reports complete/partial operation truth.
+- The command renders the full typed compact report and exits 1 when any operation fails.
 
 ## Files to Read First
 
@@ -17,8 +23,9 @@ spec: cmd_compact.spec.md
 
 ## Current Status
 
-Implemented and stable. The `compact` delegate is unit-tested (trim, no-op when under limit, three-column tables); the wrapper itself has no inline tests (output formatting only).
+Text, JSON/`--json`, Markdown/GitHub, hostile structured paths, failure truth, dry-run, and repeated-run behavior are covered end to end for issue #417.
 
 ## Notes
 
-- `CompactResult.spec_path` is already repo-relative; the wrapper prints it verbatim.
+- `CompactResult.spec_path` is repo-relative; Windows separators normalize while Unix literal backslashes survive.
+- Markdown table paths sanitize controls/bidi characters, escape pipes, and use a delimiter longer than every embedded backtick run.

--- a/specs/cmd_compact/context.md
+++ b/specs/cmd_compact/context.md
@@ -12,7 +12,7 @@ spec: cmd_compact.spec.md
 - `OutputFormat::Json` produces one document and expresses dry-run truth through separate `would_change` and `applied` booleans.
 - `OutputFormat::Markdown` and `Github` share the PR-suitable table renderer; text-like formats preserve the established terminal output.
 - Structured renderers normalize Windows separators to `/` without corrupting literal Unix backslashes.
-- Markdown/GitHub uses sanitized dynamic-backtick code spans; JSON retains machine-readable paths and reports complete/partial operation truth.
+- Markdown/GitHub uses sanitized dynamic-backtick code spans without doubling legal Unix backslashes; JSON retains machine-readable paths and reports complete/partial operation truth.
 - The command renders the full typed compact report and exits 1 when any operation fails.
 
 ## Files to Read First
@@ -23,7 +23,7 @@ spec: cmd_compact.spec.md
 
 ## Current Status
 
-Text, JSON/`--json`, Markdown/GitHub, hostile structured paths, failure truth, dry-run, and repeated-run behavior are covered end to end for issue #417.
+Text, JSON/`--json`, Markdown/GitHub, hostile structured paths, literal Unix backslashes, deterministic late-publish partial truth, dry-run, and repeated-run behavior are covered end to end for issue #417.
 
 ## Notes
 

--- a/specs/cmd_compact/requirements.md
+++ b/specs/cmd_compact/requirements.md
@@ -6,22 +6,34 @@ spec: cmd_compact.spec.md
 
 - As a maintainer, I want old spec changelog entries trimmed so the `## Change Log` table in each spec stays readable and only keeps the most recent N rows
 - As a maintainer, I want a `--dry-run` preview so I can see how many entries would be removed (and from which specs) before writing
-- As a script author, I want a clear summary ("Compacted N entries across M spec(s)", or "No changelogs need compaction (all within limit).") so the result is easy to read or assert on
+- As a script author, I want a grammatically correct summary ("Compacted N entries across M specs", or "No changelogs need compaction (all within limit).") so the result is easy to read or assert on
+- As an automation author, I want equivalent `--format json` and `--json` output so compaction results are safely parseable
+- As a reviewer, I want `--format markdown` output with a result table suitable for a PR comment
 
 ## Acceptance Criteria
 
-- `cmd_compact(root, keep, dry_run)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
+- `cmd_compact(root, keep, dry_run, format)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
 - `--keep N` controls how many changelog entries to retain per spec
 - When `dry_run` is true, a banner prints, no files are written, and per-spec lines read "would compact"
 - When `dry_run` is false, entries are removed and per-spec lines read "compacted"
 - When the delegate returns no results, prints "No changelogs need compaction (all within limit)." and returns without a summary
 - Each affected spec prints its relative `spec_path`, the `removed` count, and the kept (`compacted_entries`) count; the trailing summary sums removed entries across affected specs
+- A count of one uses `entry`; all other counts use `entries`
+- The kept count excludes the generated compaction summary row
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-spec results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit a heading, optional dry-run notice, result table, and truthful singular/plural summary
+- JSON and Markdown result paths use `/` separators on Windows while preserving literal Unix backslashes
+- Markdown/GitHub path cells use sanitized variable-length code spans and cannot inject rows through pipes, backticks, controls, or bidi formatting
+- JSON reports complete/partial state and planned/succeeded/failed operation counts; an incomplete apply never claims `applied: true`
+- The command exits 1 after rendering any read, parse, stage, or publication failure
 
 ## Constraints
 
 - Pure orchestration wrapper: changelog parsing/trimming lives in `compact::compact_changelogs`; this module only loads config and formats output
-- Must not panic on missing/unreadable specs — the underlying module skips them gracefully
-- Output uses `colored` for status glyphs (`ℹ`, `✓`)
+- Must not panic on missing/unreadable specs — the typed delegate report surfaces them as failures
+- Text output uses `colored` for status glyphs (`ℹ`, `✓`); structured output contains no ANSI formatting
 
 ## Out of Scope
 
@@ -34,10 +46,19 @@ spec: cmd_compact.spec.md
 The compact command SHALL delegate deterministic changelog compaction and SHALL preserve dry-run and summary behavior.
 
 Acceptance Criteria
-- `cmd_compact(root, keep, dry_run)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
+- `cmd_compact(root, keep, dry_run, format)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
 - `--keep N` controls how many changelog entries to retain per spec
 - When `dry_run` is true, a banner prints, no files are written, and per-spec lines read "would compact"
 - When `dry_run` is false, entries are removed and per-spec lines read "compacted"
 - When the delegate returns no results, prints "No changelogs need compaction (all within limit)." and returns without a summary
 - Each affected spec prints its relative `spec_path`, the `removed` count, and the kept (`compacted_entries`) count; the trailing summary sums removed entries across affected specs
-
+- A count of one uses `entry`; all other counts use `entries`
+- The kept count excludes the generated compaction summary row
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-spec results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit a heading, optional dry-run notice, result table, and truthful singular/plural summary
+- JSON and Markdown result paths use `/` separators on Windows while preserving literal Unix backslashes
+- Markdown/GitHub paths are sanitized and rendered with safe variable-length code spans
+- JSON exposes complete/partial state, operation counts, and structured errors
+- Any incomplete apply renders before exiting 1 and never claims `applied: true`

--- a/specs/cmd_compact/requirements.md
+++ b/specs/cmd_compact/requirements.md
@@ -25,7 +25,7 @@ spec: cmd_compact.spec.md
 - `--json` is byte-equivalent to `--format json`
 - Markdown and GitHub modes emit a heading, optional dry-run notice, result table, and truthful singular/plural summary
 - JSON and Markdown result paths use `/` separators on Windows while preserving literal Unix backslashes
-- Markdown/GitHub path cells use sanitized variable-length code spans and cannot inject rows through pipes, backticks, controls, or bidi formatting
+- Markdown/GitHub path cells use one sanitized code element (a variable-length Markdown span or entity-safe HTML code for literal-pipe paths) and cannot inject rows through pipes, backticks, controls, or bidi formatting
 - JSON reports complete/partial state and planned/succeeded/failed operation counts; an incomplete apply never claims `applied: true`
 - The command exits 1 after rendering any read, parse, stage, or publication failure
 
@@ -59,6 +59,6 @@ Acceptance Criteria
 - `--json` is byte-equivalent to `--format json`
 - Markdown and GitHub modes emit a heading, optional dry-run notice, result table, and truthful singular/plural summary
 - JSON and Markdown result paths use `/` separators on Windows while preserving literal Unix backslashes
-- Markdown/GitHub paths are sanitized and rendered with safe variable-length code spans
+- Markdown/GitHub paths are sanitized and rendered as one safe code element while preserving every legal Unix backslash parity
 - JSON exposes complete/partial state, operation counts, and structured errors
 - Any incomplete apply renders before exiting 1 and never claims `applied: true`

--- a/specs/cmd_compact/requirements.md
+++ b/specs/cmd_compact/requirements.md
@@ -46,9 +46,20 @@ spec: cmd_compact.spec.md
 The compact command SHALL delegate deterministic changelog compaction and SHALL preserve dry-run and summary behavior.
 
 Acceptance Criteria
-- `cmd_compact(root, keep, dry_run)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
+- `cmd_compact(root, keep, dry_run, format)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
 - `--keep N` controls how many changelog entries to retain per spec
 - When `dry_run` is true, a banner prints, no files are written, and per-spec lines read "would compact"
 - When `dry_run` is false, entries are removed and per-spec lines read "compacted"
 - When the delegate returns no results, prints "No changelogs need compaction (all within limit)." and returns without a summary
 - Each affected spec prints its relative `spec_path`, the `removed` count, and the kept (`compacted_entries`) count; the trailing summary sums removed entries across affected specs
+- A count of one uses `entry`; all other counts use `entries`
+- The kept count excludes the generated compaction summary row
+- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-spec results
+- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
+- `--json` is byte-equivalent to `--format json`
+- Markdown and GitHub modes emit a heading, optional dry-run notice, result table, and truthful singular/plural summary
+- JSON and Markdown result paths use `/` separators on Windows while preserving literal Unix backslashes
+- Markdown/GitHub paths are sanitized and rendered as one safe code element while preserving every legal Unix backslash parity
+- JSON exposes complete/partial state, operation counts, and structured errors
+- Any incomplete apply renders before exiting 1 and never claims `applied: true`
+

--- a/specs/cmd_compact/requirements.md
+++ b/specs/cmd_compact/requirements.md
@@ -46,19 +46,9 @@ spec: cmd_compact.spec.md
 The compact command SHALL delegate deterministic changelog compaction and SHALL preserve dry-run and summary behavior.
 
 Acceptance Criteria
-- `cmd_compact(root, keep, dry_run, format)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
+- `cmd_compact(root, keep, dry_run)` loads config, resolves `config.specs_dir`, and delegates to `compact::compact_changelogs(root, &specs_dir, keep, dry_run)`
 - `--keep N` controls how many changelog entries to retain per spec
 - When `dry_run` is true, a banner prints, no files are written, and per-spec lines read "would compact"
 - When `dry_run` is false, entries are removed and per-spec lines read "compacted"
 - When the delegate returns no results, prints "No changelogs need compaction (all within limit)." and returns without a summary
 - Each affected spec prints its relative `spec_path`, the `removed` count, and the kept (`compacted_entries`) count; the trailing summary sums removed entries across affected specs
-- A count of one uses `entry`; all other counts use `entries`
-- The kept count excludes the generated compaction summary row
-- JSON mode emits one ANSI-free document with command, dry-run, `would_change`, `applied`, aggregate counts, and per-spec results
-- In dry-run JSON, `would_change` reflects selected changes while `applied` remains false
-- `--json` is byte-equivalent to `--format json`
-- Markdown and GitHub modes emit a heading, optional dry-run notice, result table, and truthful singular/plural summary
-- JSON and Markdown result paths use `/` separators on Windows while preserving literal Unix backslashes
-- Markdown/GitHub paths are sanitized and rendered as one safe code element while preserving every legal Unix backslash parity
-- JSON exposes complete/partial state, operation counts, and structured errors
-- Any incomplete apply renders before exiting 1 and never claims `applied: true`

--- a/specs/cmd_compact/tasks.md
+++ b/specs/cmd_compact/tasks.md
@@ -19,7 +19,7 @@ spec: cmd_compact.spec.md
 - [x] Preserve literal Unix backslashes and render adversarial Markdown/GitHub paths safely
 - [x] Render typed complete/partial failures and exit nonzero without false `applied` success
 - [x] Use correct singular/plural labels for aggregate spec counts
-- [x] Preserve literal Unix backslashes through Markdown/GitHub rendering
+- [x] Preserve every literal Unix backslash parity, including backslash-before-pipe paths, through Markdown/GitHub rendering
 - [x] Prove late-publish partial counts and errors in parseable JSON and Markdown
 
 ## Review Status

--- a/specs/cmd_compact/tasks.md
+++ b/specs/cmd_compact/tasks.md
@@ -19,6 +19,8 @@ spec: cmd_compact.spec.md
 - [x] Preserve literal Unix backslashes and render adversarial Markdown/GitHub paths safely
 - [x] Render typed complete/partial failures and exit nonzero without false `applied` success
 - [x] Use correct singular/plural labels for aggregate spec counts
+- [x] Preserve literal Unix backslashes through Markdown/GitHub rendering
+- [x] Prove late-publish partial counts and errors in parseable JSON and Markdown
 
 ## Review Status
 

--- a/specs/cmd_compact/tasks.md
+++ b/specs/cmd_compact/tasks.md
@@ -4,9 +4,7 @@ spec: cmd_compact.spec.md
 
 ## Tasks
 
-## Post-5.0 Test Debt
-
-- [ ] Add an end-to-end CLI test that runs `compact --keep N` against a fixture spec and asserts the per-spec lines, summary, and `--dry-run` no-write behavior
+(none open)
 
 ## Done
 
@@ -14,6 +12,13 @@ spec: cmd_compact.spec.md
 - [x] Requirements and acceptance criteria documented
 - [x] Verified wrapper delegates to `compact::compact_changelogs` and matches the empty-result / dry-run / write paths
 - [x] Confirmed the trimming logic is covered by `compact` inline tests (`test_compact_changelog`, `test_compact_no_change_needed`, `test_compact_three_column_table`)
+- [x] Add an end-to-end CLI test that runs `compact --keep N` against a fixture spec and asserts the per-spec lines, summary, `--dry-run` no-write behavior, and byte-identical second run
+- [x] Add parse-clean JSON/`--json` equivalence and Markdown/GitHub output with truthful dry-run fields
+- [x] Add focused text, JSON, and Markdown CLI integration coverage for issue #417
+- [x] Normalize JSON and Markdown paths to portable separators and cover Windows-style inputs
+- [x] Preserve literal Unix backslashes and render adversarial Markdown/GitHub paths safely
+- [x] Render typed complete/partial failures and exit nonzero without false `applied` success
+- [x] Use correct singular/plural labels for aggregate spec counts
 
 ## Review Status
 

--- a/specs/cmd_compact/testing.md
+++ b/specs/cmd_compact/testing.md
@@ -7,6 +7,7 @@ spec: cmd_compact.spec.md
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
 | `tests/integration/commands.rs` | `fledge run test -- compact_` | Text dry-run/idempotence, JSON shorthand equivalence and portable paths, Markdown structure, newline preservation |
+| `src/commands/compact.rs` | `fledge run test -- commands::compact::tests` | Unix backslash identity, hostile dynamic spans, and truthful late-publish partial JSON/Markdown |
 | `src/compact.rs` (delegate logic) | `fledge run test -- compact::tests` | Core and #417 regression matrix |
 
 ## Coverage Gaps
@@ -35,8 +36,8 @@ spec: cmd_compact.spec.md
 | Multiple affected specs | Summary sums `removed` across results and reports the spec count | Keep or add a focused assertion before changing this behavior |
 | Structured stdout contamination | JSON must be exactly one parseable document with no banner or ANSI bytes | `compact_json_formats_are_clean_truthful_and_equivalent` |
 | Host-native path separators | Normalize actual Windows separators without aliasing Unix filename bytes | cfg-specific portable-path tests and structured CLI assertions |
-| Markdown path injection | Pipes/backticks/controls cannot create rows or break code spans | `markdown_code_span_sanitizes_paths_and_uses_safe_delimiters` |
-| Incomplete operations | Render valid structured output, exit 1, and never claim complete application | focused failure integration fixture |
+| Markdown path injection | Pipes/backticks/controls cannot create rows or break code spans; Unix backslashes remain literal | `markdown_code_span_sanitizes_paths_and_uses_safe_delimiters`, `markdown_code_span_preserves_literal_unix_backslashes` |
+| Incomplete operations | Render valid structured output, exit 1, and never claim complete application | focused failure integration fixture, `partial_publish_reports_are_truthful_in_json_and_markdown` |
 
 ## Reviewer Checklist
 

--- a/specs/cmd_compact/testing.md
+++ b/specs/cmd_compact/testing.md
@@ -6,12 +6,12 @@ spec: cmd_compact.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/compact.rs` | cargo test commands::compact | Command wrapper has no inline tests (output formatting only); cover `cmd_compact` end-to-end before risky changes |
-| `src/compact.rs` (delegate logic) | cargo test compact | `test_compact_changelog`, `test_compact_no_change_needed`, `test_compact_three_column_table` |
+| `tests/integration/commands.rs` | `fledge run test -- compact_` | Text dry-run/idempotence, JSON shorthand equivalence and portable paths, Markdown structure, newline preservation |
+| `src/compact.rs` (delegate logic) | `fledge run test -- compact::tests` | Core and #417 regression matrix |
 
 ## Coverage Gaps
 
-- No end-to-end CLI test asserts the wrapper's stdout (per-spec lines, "would compact" vs "compacted", the summary, or the "No changelogs need compaction…" path). Add one before changing user-visible output.
+(none for issue #417)
 
 ## Behavioral Verification
 
@@ -19,6 +19,12 @@ spec: cmd_compact.spec.md
 |------|-----------------|--------|-----------------|
 | Compact changelogs | a spec's `## Change Log` has 25 entries, `--keep 10` | `cmd_compact(root, 10, false)` | 15 oldest entries removed, 10 newest kept; per-spec line + summary printed |
 | Dry run | a spec exceeds the keep limit | `cmd_compact(root, 10, true)` | prints "Dry run" banner + "would compact" lines, modifies no files |
+| JSON dry run | a spec exceeds the keep limit | run with `--format json` and `--json` | both emit the same valid ANSI-free document; `would_change` is true and `applied` is false |
+| Markdown dry run | a spec exceeds the keep limit | run with `--format markdown` | emits a heading, notice, table, and truthful summary; modifies no files |
+| Windows structured paths | the delegate returns a Windows path | render JSON or Markdown | output uses portable `/` separators |
+| Unix literal backslash | a legal Unix filename contains `\` | render structured output | path identity is preserved |
+| Hostile Markdown path | a path contains pipes, backtick runs, controls, or bidi marks | render Markdown/GitHub | one sanitized code span remains inside one table cell |
+| Incomplete apply | any read/parse/stage/publish operation fails | render JSON | exit 1; `complete: false`, truthful counts/errors, and no false `applied` |
 
 ## Regression Matrix
 
@@ -27,11 +33,16 @@ spec: cmd_compact.spec.md
 | No specs need compaction (all within limit) | Prints "No changelogs need compaction (all within limit)." and returns, no summary | Keep or add a focused assertion before changing this behavior |
 | Fewer entries than `--keep` | Spec unchanged, not reported | Keep or add a focused assertion before changing this behavior |
 | Multiple affected specs | Summary sums `removed` across results and reports the spec count | Keep or add a focused assertion before changing this behavior |
+| Structured stdout contamination | JSON must be exactly one parseable document with no banner or ANSI bytes | `compact_json_formats_are_clean_truthful_and_equivalent` |
+| Host-native path separators | Normalize actual Windows separators without aliasing Unix filename bytes | cfg-specific portable-path tests and structured CLI assertions |
+| Markdown path injection | Pipes/backticks/controls cannot create rows or break code spans | `markdown_code_span_sanitizes_paths_and_uses_safe_delimiters` |
+| Incomplete operations | Render valid structured output, exit 1, and never claim complete application | focused failure integration fixture |
 
 ## Reviewer Checklist
 
 - Run `cargo run -- compact --help` and confirm the help text still names the documented flags (`--keep`, `--dry-run`).
 - Run `cargo test compact` when changing the delegate; run `cargo test commands::compact` when changing the wrapper.
+- Run `fledge run test -- compact_` for the unit and end-to-end issue #417 matrix.
 - Reproduce one Behavioral Verification row with a temporary spec fixture before changing user-visible output.
 - If an output string changes, update the matching Regression Matrix row and test assertion in the same commit.
 - Run the release checks for this module: `fledge run fmt`, `fledge run lint`, `fledge run test`, `fledge spec check --strict`, `fledge run build`.

--- a/specs/cmd_compact/testing.md
+++ b/specs/cmd_compact/testing.md
@@ -24,7 +24,7 @@ spec: cmd_compact.spec.md
 | Markdown dry run | a spec exceeds the keep limit | run with `--format markdown` | emits a heading, notice, table, and truthful summary; modifies no files |
 | Windows structured paths | the delegate returns a Windows path | render JSON or Markdown | output uses portable `/` separators |
 | Unix literal backslash | a legal Unix filename contains `\` | render structured output | path identity is preserved |
-| Hostile Markdown path | a path contains pipes, backtick runs, controls, or bidi marks | render Markdown/GitHub | one sanitized code span remains inside one table cell |
+| Hostile Markdown path | a path contains pipes, backtick runs, controls, or bidi marks | render Markdown/GitHub | one sanitized code element remains inside one table cell |
 | Incomplete apply | any read/parse/stage/publish operation fails | render JSON | exit 1; `complete: false`, truthful counts/errors, and no false `applied` |
 
 ## Regression Matrix
@@ -36,7 +36,7 @@ spec: cmd_compact.spec.md
 | Multiple affected specs | Summary sums `removed` across results and reports the spec count | Keep or add a focused assertion before changing this behavior |
 | Structured stdout contamination | JSON must be exactly one parseable document with no banner or ANSI bytes | `compact_json_formats_are_clean_truthful_and_equivalent` |
 | Host-native path separators | Normalize actual Windows separators without aliasing Unix filename bytes | cfg-specific portable-path tests and structured CLI assertions |
-| Markdown path injection | Pipes/backticks/controls cannot create rows or break code spans; Unix backslashes remain literal | `markdown_code_span_sanitizes_paths_and_uses_safe_delimiters`, `markdown_code_span_preserves_literal_unix_backslashes` |
+| Markdown path injection | Pipes/backticks/controls cannot create rows or break code elements; every Unix backslash parity, including backslash-before-pipe, remains literal | `markdown_code_span_sanitizes_paths_and_uses_safe_delimiters`, `markdown_code_span_preserves_literal_unix_backslashes`, `markdown_code_span_preserves_backslash_before_pipe_in_one_table_cell` |
 | Incomplete operations | Render valid structured output, exit 1, and never claim complete application | focused failure integration fixture, `partial_publish_reports_are_truthful_in_json_and_markdown` |
 
 ## Reviewer Checklist

--- a/specs/compact/compact.spec.md
+++ b/specs/compact/compact.spec.md
@@ -36,20 +36,13 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 ## Invariants
 
-1. Only an exact `## Change Log` H2 outside fenced and indented code is processed
-2. Only the first contiguous, width-valid table outside fenced and indented code in the section is compacted; later tables are preserved
+1. Only specs with a `## Change Log` section containing a markdown table are processed
+2. Table header and separator rows (first two `|`-prefixed lines) are always preserved
 3. The last `keep` data rows are preserved; earlier rows are summarized
 4. Summary row contains the date range of compacted entries and their count
 5. If a changelog has fewer than `keep + 1` entries, no compaction occurs
 6. `dry_run: true` returns results without modifying files
 7. Handles both 2-column and 3+ column tables with appropriate summary format
-8. Re-running compaction with the same `keep` value is byte-for-byte idempotent
-9. Escaped table pipes, code-span pipes, every original LF/CRLF line terminator, and the original final-newline state are preserved
-10. Only rows carrying the exact `<!-- specsync:compact:v1 -->` provenance marker are folded as prior summaries
-11. Multiple marked summaries, malformed table widths, and fixed-width count overflow fail closed
-12. Apply mode preflights every replacement and stages same-directory temporary files before publication
-13. Staging failures retain every planned result/count with zero writes; late publish failures retain all results and report exact partial progress
-14. Indented pipe code terminates table data, indented separators fail before writes, and a generated summary is valid only as the first data row
 
 ## Behavioral Examples
 

--- a/specs/compact/compact.spec.md
+++ b/specs/compact/compact.spec.md
@@ -1,6 +1,6 @@
 ---
 module: compact
-version: 5
+version: 6
 status: stable
 files:
   - src/compact.rs
@@ -36,18 +36,19 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 ## Invariants
 
-1. Only specs with a `## Change Log` section containing a markdown table are processed
-2. Only the first contiguous, width-valid table in the section is compacted; later tables are preserved
+1. Only an exact `## Change Log` H2 outside fenced and indented code is processed
+2. Only the first contiguous, width-valid table outside fenced and indented code in the section is compacted; later tables are preserved
 3. The last `keep` data rows are preserved; earlier rows are summarized
 4. Summary row contains the date range of compacted entries and their count
 5. If a changelog has fewer than `keep + 1` entries, no compaction occurs
 6. `dry_run: true` returns results without modifying files
 7. Handles both 2-column and 3+ column tables with appropriate summary format
 8. Re-running compaction with the same `keep` value is byte-for-byte idempotent
-9. Escaped table pipes, code-span pipes, and every original LF/CRLF line terminator are preserved
+9. Escaped table pipes, code-span pipes, every original LF/CRLF line terminator, and the original final-newline state are preserved
 10. Only rows carrying the exact `<!-- specsync:compact:v1 -->` provenance marker are folded as prior summaries
 11. Multiple marked summaries, malformed table widths, and fixed-width count overflow fail closed
 12. Apply mode preflights every replacement and stages same-directory temporary files before publication
+13. Staging failures retain every planned result/count with zero writes; late publish failures retain all results and report exact partial progress
 
 ## Behavioral Examples
 
@@ -103,6 +104,7 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Close adversarial #417 gaps: ignore fenced/prefix headings, preserve keep-zero EOF bytes, retain complete plan counts on staging failure, and characterize late partial publication |
 | 2026-07-26 | Harden #417 after adversarial review: provenance-mark summaries, preserve exact line endings, parse contiguous tables safely, reject ambiguity/overflow, and report staged atomic-write failures |
 | 2026-07-26 | Fix #417: make summary folding idempotent and exact, preserve escaped pipes and trailing newlines, and report truthful counts |
 | 2026-04-10 | Populated requirements.md with user stories, acceptance criteria, constraints, and out-of-scope items |

--- a/specs/compact/compact.spec.md
+++ b/specs/compact/compact.spec.md
@@ -1,6 +1,6 @@
 ---
 module: compact
-version: 6
+version: 7
 status: stable
 files:
   - src/compact.rs
@@ -49,6 +49,7 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 11. Multiple marked summaries, malformed table widths, and fixed-width count overflow fail closed
 12. Apply mode preflights every replacement and stages same-directory temporary files before publication
 13. Staging failures retain every planned result/count with zero writes; late publish failures retain all results and report exact partial progress
+14. Indented pipe code terminates table data, indented separators fail before writes, and a generated summary is valid only as the first data row
 
 ## Behavioral Examples
 
@@ -82,6 +83,7 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 |-----------|----------|
 | Spec file unreadable | Records a structured failure, exits nonzero at the command boundary, and performs no writes |
 | Multiple marked summaries or malformed table | Records a parse failure and performs no writes |
+| Indented separator or reordered generated summary | Records a parse failure and performs no writes |
 | Staging failure | Records the failing path/operation and performs no writes |
 | Late atomic publish failure | Reports an incomplete/partial outcome and never claims complete success |
 | No changelog section found | Spec is silently skipped |
@@ -104,6 +106,7 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Stop before indented pipe-code and reject indented separators or reordered generated summaries before mutation |
 | 2026-07-26 | Close adversarial #417 gaps: ignore fenced/prefix headings, preserve keep-zero EOF bytes, retain complete plan counts on staging failure, and characterize late partial publication |
 | 2026-07-26 | Harden #417 after adversarial review: provenance-mark summaries, preserve exact line endings, parse contiguous tables safely, reject ambiguity/overflow, and report staged atomic-write failures |
 | 2026-07-26 | Fix #417: make summary folding idempotent and exact, preserve escaped pipes and trailing newlines, and report truthful counts |

--- a/specs/compact/compact.spec.md
+++ b/specs/compact/compact.spec.md
@@ -1,6 +1,6 @@
 ---
 module: compact
-version: 3
+version: 5
 status: stable
 files:
   - src/compact.rs
@@ -22,23 +22,30 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `compact_changelogs` | `root: &Path, specs_dir: &Path, keep: usize, dry_run: bool` | `Vec<CompactResult>` | Compact changelog tables in all spec files, keeping the last `keep` entries |
+| `compact_changelogs` | `root: &Path, specs_dir: &Path, keep: usize, dry_run: bool` | `CompactReport` | Plan, stage, and compact changelog tables while reporting every failure |
 
 ### Exported Structs
 
 | Type | Description |
 |------|-------------|
-| `CompactResult` | Result of compacting one spec — contains `spec_path: String`, `original_entries: usize`, `compacted_entries: usize`, `removed: usize` |
+| `CompactResult` | Planned result for one spec, including truthful counts and whether publication was applied |
+| `CompactFailure` | Structured path, operation, and error for a failed read, parse, stage, or publish |
+| `CompactReport` | Invocation outcome with planned/succeeded counts, results, failures, and complete/partial predicates |
 
 ## Invariants
 
 1. Only specs with a `## Change Log` section containing a markdown table are processed
-2. Table header and separator rows (first two `|`-prefixed lines) are always preserved
+2. Only the first contiguous, width-valid table in the section is compacted; later tables are preserved
 3. The last `keep` data rows are preserved; earlier rows are summarized
 4. Summary row contains the date range of compacted entries and their count
 5. If a changelog has fewer than `keep + 1` entries, no compaction occurs
 6. `dry_run: true` returns results without modifying files
 7. Handles both 2-column and 3+ column tables with appropriate summary format
+8. Re-running compaction with the same `keep` value is byte-for-byte idempotent
+9. Escaped table pipes, code-span pipes, and every original LF/CRLF line terminator are preserved
+10. Only rows carrying the exact `<!-- specsync:compact:v1 -->` provenance marker are folded as prior summaries
+11. Multiple marked summaries, malformed table widths, and fixed-width count overflow fail closed
+12. Apply mode preflights every replacement and stages same-directory temporary files before publication
 
 ## Behavioral Examples
 
@@ -46,7 +53,13 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 - **Given** a spec with 20 changelog entries and `keep = 5`
 - **When** `compact_changelogs` is called
-- **Then** the first 15 entries are replaced with a single summary row like `| 2025-01-01 — 2026-03-15 | 15 entries compacted |`
+- **Then** the first 15 entries are replaced with one marked summary row ending in `Compacted: 15 entries <!-- specsync:compact:v1 -->`
+
+### Scenario: Re-run an already compacted changelog
+
+- **Given** a changelog has one generated compaction summary and the latest five ordinary rows
+- **When** `compact_changelogs` runs again with `keep = 5`
+- **Then** no rows are removed and the file remains byte-for-byte unchanged
 
 ### Scenario: Short changelog (no compaction needed)
 
@@ -64,7 +77,10 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 | Condition | Behavior |
 |-----------|----------|
-| Spec file unreadable | Prints error in bold red, continues processing other files |
+| Spec file unreadable | Records a structured failure, exits nonzero at the command boundary, and performs no writes |
+| Multiple marked summaries or malformed table | Records a parse failure and performs no writes |
+| Staging failure | Records the failing path/operation and performs no writes |
+| Late atomic publish failure | Reports an incomplete/partial outcome and never claims complete success |
 | No changelog section found | Spec is silently skipped |
 
 ## Dependencies
@@ -85,6 +101,8 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Harden #417 after adversarial review: provenance-mark summaries, preserve exact line endings, parse contiguous tables safely, reject ambiguity/overflow, and report staged atomic-write failures |
+| 2026-07-26 | Fix #417: make summary folding idempotent and exact, preserve escaped pipes and trailing newlines, and report truthful counts |
 | 2026-04-10 | Populated requirements.md with user stories, acceptance criteria, constraints, and out-of-scope items |
 | 2026-04-06 | Initial spec for v3.3.0 |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/compact/compact.spec.md
+++ b/specs/compact/compact.spec.md
@@ -1,6 +1,6 @@
 ---
 module: compact
-version: 7
+version: 8
 status: stable
 files:
   - src/compact.rs
@@ -36,13 +36,20 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 
 ## Invariants
 
-1. Only specs with a `## Change Log` section containing a markdown table are processed
-2. Table header and separator rows (first two `|`-prefixed lines) are always preserved
+1. Only an exact `## Change Log` H2 outside fenced and indented code is processed
+2. Only the first contiguous, width-valid table outside fenced and indented code in the section is compacted; later tables are preserved
 3. The last `keep` data rows are preserved; earlier rows are summarized
 4. Summary row contains the date range of compacted entries and their count
 5. If a changelog has fewer than `keep + 1` entries, no compaction occurs
 6. `dry_run: true` returns results without modifying files
 7. Handles both 2-column and 3+ column tables with appropriate summary format
+8. Re-running compaction with the same `keep` value is byte-for-byte idempotent.
+9. Escaped table pipes, code-span pipes, every original LF/CRLF line terminator, and the original final-newline state are preserved
+10. Only rows carrying the exact `<!-- specsync:compact:v1 -->` provenance marker are folded as prior summaries
+11. Multiple marked summaries, malformed table widths, and fixed-width count overflow fail closed
+12. Apply mode preflights every replacement and stages same-directory temporary files before publication
+13. Staging failures retain every planned result/count with zero writes; late publish failures retain all results and report exact partial progress
+14. Indented pipe code terminates table data, indented separators fail before writes, and a generated summary is valid only as the first data row
 
 ## Behavioral Examples
 
@@ -106,3 +113,4 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 | 2026-04-10 | Populated requirements.md with user stories, acceptance criteria, constraints, and out-of-scope items |
 | 2026-04-06 | Initial spec for v3.3.0 |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-27 | CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str: Make issue 417 changelog compaction idempotent and provide truthful portable structured maintenance output |

--- a/specs/compact/compact.spec.md
+++ b/specs/compact/compact.spec.md
@@ -23,6 +23,8 @@ Reduces changelog table size in spec files by keeping only the last N entries an
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `compact_changelogs` | `root: &Path, specs_dir: &Path, keep: usize, dry_run: bool` | `CompactReport` | Plan, stage, and compact changelog tables while reporting every failure |
+| `complete` | `&self` | `bool` | Whether the invocation recorded no failures |
+| `partial` | `&self` | `bool` | Whether an incomplete apply published at least one planned replacement |
 
 ### Exported Structs
 

--- a/specs/compact/context.md
+++ b/specs/compact/context.md
@@ -5,21 +5,26 @@ spec: compact.spec.md
 ## Key Decisions
 
 - **String slicing, not markdown parsing**: `compact_spec_changelog` finds the `## Change Log` marker, computes the section end (next `## ` heading or EOF), and rewrites only that slice. The rest of the file is copied byte-for-byte.
-- **First two table lines are structural**: any `|`-prefixed line counts toward the table; the first two are treated as header + separator and always kept, the rest are data rows.
+- **One contiguous validated table**: the first pipe table is validated against its header width; a later table after prose/blank separation is not changelog data.
 - **Keep-last semantics**: the most recent `keep` rows survive; older rows collapse into one summary row inserted at the position of the first removed row.
-- **Column-aware summary**: column count comes from the first data row; 3+ column tables get a `—` placeholder for the interior column so the markdown table stays aligned.
+- **Provenance-bound summary ownership**: a generated summary carries `<!-- specsync:compact:v1 -->`; unmarked lookalikes remain user history and duplicate marked summaries fail closed.
+- **Idempotent summary folding**: prior generated counts are accumulated, the original range start is retained, and a no-excess re-run returns the original bytes.
+- **Escape/code-span-aware columns**: only odd backslash runs escape pipes, code-span pipes remain cell content, and 3+ column tables get `—` placeholders.
+- **Byte-preserving reconstruction**: inclusive source lines retain each untouched LF/CRLF terminator, including mixed-ending files.
+- **Preflight before publication**: reads, parsing, permissions, and same-directory temporary-file staging complete before any atomic replacement is published; the typed report carries incomplete/partial failures.
 - **No-op filtering**: `compact_spec_changelog` still returns a `CompactResult` when nothing is removed, but `compact_changelogs` drops those (only `removed > 0` is surfaced and written).
 
 ## Files to Read First
 
-- `src/compact.rs` — entire module: `compact_changelogs` (driver), `compact_spec_changelog` (core rewrite), `extract_first_cell`, and the `CompactResult` struct.
+- `src/compact.rs` — entire module: `compact_changelogs` (driver), `compact_spec_changelog` (core rewrite), summary metadata/cell parsing helpers, and the `CompactResult` struct.
 
 ## Current Status
 
-Stable and complete. Public API is `compact_changelogs` plus the `CompactResult` struct. Invoked by the `cmd_compact` subcommand.
+Issue #417's core behavior includes adversarial ownership, parsing, line-ending, overflow, and atomic-write regressions. Structured rendering is covered in the owning command modules.
 
 ## Notes
 
 - Depends on `validator::find_spec_files`.
-- `dry_run` short-circuits the `fs::write` only; results are still collected.
-- Summary row format: `| <first> — <last> | Compacted: <N> entries |` (with an extra `—` cell for wider tables).
+- Dry-run returns the complete plan without staging or publishing writes.
+- Summary rows end with `<!-- specsync:compact:v1 -->` and use `—` cells for wider tables.
+- Rewriting preserves every untouched line and its exact terminator.

--- a/specs/compact/context.md
+++ b/specs/compact/context.md
@@ -4,14 +4,14 @@ spec: compact.spec.md
 
 ## Key Decisions
 
-- **String slicing, not markdown parsing**: `compact_spec_changelog` finds the `## Change Log` marker, computes the section end (next `## ` heading or EOF), and rewrites only that slice. The rest of the file is copied byte-for-byte.
-- **One contiguous validated table**: the first pipe table is validated against its header width; a later table after prose/blank separation is not changelog data.
+- **Fence-aware section slicing**: `compact_spec_changelog` recognizes only an exact `## Change Log` H2 outside fenced/indented code, computes the next real H2/EOF boundary, and rewrites only that slice. The rest of the file is copied byte-for-byte.
+- **One contiguous validated table**: the first unfenced pipe table is validated against its header width; fenced examples and later tables after prose/blank separation are not changelog data.
 - **Keep-last semantics**: the most recent `keep` rows survive; older rows collapse into one summary row inserted at the position of the first removed row.
 - **Provenance-bound summary ownership**: a generated summary carries `<!-- specsync:compact:v1 -->`; unmarked lookalikes remain user history and duplicate marked summaries fail closed.
 - **Idempotent summary folding**: prior generated counts are accumulated, the original range start is retained, and a no-excess re-run returns the original bytes.
 - **Escape/code-span-aware columns**: only odd backslash runs escape pipes, code-span pipes remain cell content, and 3+ column tables get `—` placeholders.
-- **Byte-preserving reconstruction**: inclusive source lines retain each untouched LF/CRLF terminator, including mixed-ending files.
-- **Preflight before publication**: reads, parsing, permissions, and same-directory temporary-file staging complete before any atomic replacement is published; the typed report carries incomplete/partial failures.
+- **Byte-preserving reconstruction**: inclusive source lines retain each untouched LF/CRLF terminator, including mixed-ending files and the no-final-newline state when `keep = 0`.
+- **Preflight before publication**: reads, parsing, permissions, and same-directory temporary-file staging complete before any atomic replacement is published; every planned result remains visible on staging failure and the typed report records exact late-publish partial progress.
 - **No-op filtering**: `compact_spec_changelog` still returns a `CompactResult` when nothing is removed, but `compact_changelogs` drops those (only `removed > 0` is surfaced and written).
 
 ## Files to Read First
@@ -20,7 +20,7 @@ spec: compact.spec.md
 
 ## Current Status
 
-Issue #417's core behavior includes adversarial ownership, parsing, line-ending, overflow, and atomic-write regressions. Structured rendering is covered in the owning command modules.
+Issue #417's core behavior includes adversarial ownership, fenced-heading/table isolation, parsing, EOF/line-ending fidelity, overflow, complete staging counts, and deterministic partial-publication regressions. Structured rendering is covered in the owning command modules.
 
 ## Notes
 

--- a/specs/compact/context.md
+++ b/specs/compact/context.md
@@ -5,9 +5,10 @@ spec: compact.spec.md
 ## Key Decisions
 
 - **Fence-aware section slicing**: `compact_spec_changelog` recognizes only an exact `## Change Log` H2 outside fenced/indented code, computes the next real H2/EOF boundary, and rewrites only that slice. The rest of the file is copied byte-for-byte.
-- **One contiguous validated table**: the first unfenced pipe table is validated against its header width; fenced examples and later tables after prose/blank separation are not changelog data.
+- **One contiguous validated table**: the first unfenced pipe table is validated against its header width; fenced examples, indented pipe-code, and later tables after prose/blank separation are not changelog data. An indented separator is malformed.
 - **Keep-last semantics**: the most recent `keep` rows survive; older rows collapse into one summary row inserted at the position of the first removed row.
 - **Provenance-bound summary ownership**: a generated summary carries `<!-- specsync:compact:v1 -->`; unmarked lookalikes remain user history and duplicate marked summaries fail closed.
+- **Canonical summary position**: generated summaries must be the first data row; reordered marked state is rejected before reconstruction so EOF-byte preservation cannot concatenate retained rows.
 - **Idempotent summary folding**: prior generated counts are accumulated, the original range start is retained, and a no-excess re-run returns the original bytes.
 - **Escape/code-span-aware columns**: only odd backslash runs escape pipes, code-span pipes remain cell content, and 3+ column tables get `—` placeholders.
 - **Byte-preserving reconstruction**: inclusive source lines retain each untouched LF/CRLF terminator, including mixed-ending files and the no-final-newline state when `keep = 0`.
@@ -20,7 +21,7 @@ spec: compact.spec.md
 
 ## Current Status
 
-Issue #417's core behavior includes adversarial ownership, fenced-heading/table isolation, parsing, EOF/line-ending fidelity, overflow, complete staging counts, and deterministic partial-publication regressions. Structured rendering is covered in the owning command modules.
+Issue #417's core behavior includes adversarial ownership, fenced/indented heading and table isolation, canonical summary position, EOF/line-ending fidelity, overflow, complete staging counts, and deterministic partial-publication regressions. Structured rendering is covered in the owning command modules.
 
 ## Notes
 

--- a/specs/compact/requirements.md
+++ b/specs/compact/requirements.md
@@ -53,7 +53,15 @@ Acceptance Criteria
 - The first two `|`-prefixed lines in the section (header + separator) are always preserved
 - The last `keep` ordinary data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
 - The summary row reads `| <first_date> — <last_date> | Compacted: <N> entries |` for 2-column tables, and inserts a `—` placeholder for the middle column(s) on 3+ column tables
-- Column count is detected from the first data row (`| count - 1`)
+- A generated summary row is recognized only when its first cell contains a non-empty `start — end` range, every interior cell is `—`, and its final cell contains a grammatically-correct fixed-width count plus the exact `<!-- specsync:compact:v1 -->` marker
+- When new ordinary rows require another compaction, prior generated summary counts are accumulated and the original range start is retained
+- Multiple marked summaries fail closed instead of being summed
+- Column count and cells are parsed from one contiguous table without treating odd-backslash escaped pipes or code-span pipes as delimiters
 - If `total <= keep`, no rows are removed (`removed == 0`) and the spec is not written; such results are filtered out by `compact_changelogs`
 - `dry_run: true` collects `CompactResult` values but never writes files
 - Only results where `removed > 0` are returned from `compact_changelogs`
+- Re-running with no excess ordinary rows leaves the file byte-for-byte unchanged, including exact LF/CRLF terminators
+- `CompactResult.compacted_entries` reports ordinary entries retained and excludes the generated summary row
+- Count overflow, malformed widths, and ambiguous generated state fail closed
+- Preflight or staging failure writes nothing, and every incomplete apply is represented in the typed report
+

--- a/specs/compact/requirements.md
+++ b/specs/compact/requirements.md
@@ -53,14 +53,7 @@ Acceptance Criteria
 - The first two `|`-prefixed lines in the section (header + separator) are always preserved
 - The last `keep` ordinary data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
 - The summary row reads `| <first_date> — <last_date> | Compacted: <N> entries |` for 2-column tables, and inserts a `—` placeholder for the middle column(s) on 3+ column tables
-- A generated summary row is recognized only when its first cell contains a non-empty `start — end` range, every interior cell is `—`, and its final cell contains a grammatically-correct fixed-width count plus the exact `<!-- specsync:compact:v1 -->` marker
-- When new ordinary rows require another compaction, prior generated summary counts are accumulated and the original range start is retained
-- Multiple marked summaries fail closed instead of being summed
-- Column count and cells are parsed from one contiguous table without treating odd-backslash escaped pipes or code-span pipes as delimiters
+- Column count is detected from the first data row (`| count - 1`)
 - If `total <= keep`, no rows are removed (`removed == 0`) and the spec is not written; such results are filtered out by `compact_changelogs`
 - `dry_run: true` collects `CompactResult` values but never writes files
 - Only results where `removed > 0` are returned from `compact_changelogs`
-- Re-running with no excess ordinary rows leaves the file byte-for-byte unchanged, including exact LF/CRLF terminators
-- `CompactResult.compacted_entries` reports ordinary entries retained and excludes the generated summary row
-- Count overflow, malformed widths, and ambiguous generated state fail closed
-- Preflight or staging failure writes nothing, and every incomplete apply is represented in the typed report

--- a/specs/compact/requirements.md
+++ b/specs/compact/requirements.md
@@ -7,31 +7,40 @@ spec: compact.spec.md
 - As a maintainer of long-lived specs, I want old changelog rows collapsed into one summary line so that the `## Change Log` table stays readable
 - As a CI operator, I want a `--dry-run` mode so that I can preview which specs would change before writing anything
 - As a developer, I want compaction to keep the most recent N entries verbatim so that recent history is never lost
+- As a maintainer, I want repeated compaction to be byte-for-byte idempotent so generated summaries never destroy their original count or range
 
 ## Acceptance Criteria
 
 - `compact_changelogs(root, specs_dir, keep, dry_run)` walks every spec found by `find_spec_files` and compacts each spec's `## Change Log` table
 - The `## Change Log` section ends at the next `## ` heading or EOF; only that slice is rewritten
 - The first two `|`-prefixed lines in the section (header + separator) are always preserved
-- The last `keep` data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
+- The last `keep` ordinary data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
 - The summary row reads `| <first_date> — <last_date> | Compacted: <N> entries |` for 2-column tables, and inserts a `—` placeholder for the middle column(s) on 3+ column tables
-- Column count is detected from the first data row (`| count - 1`)
+- A generated summary row is recognized only when its first cell contains a non-empty `start — end` range, every interior cell is `—`, and its final cell has the exact grammatically-correct count plus `<!-- specsync:compact:v1 -->` provenance marker
+- When new ordinary rows require another compaction, prior generated summary counts are accumulated and the original range start is retained
+- Multiple marked summaries fail closed instead of being summed
+- Column count and cells are parsed from the first contiguous table without treating odd-backslash escaped pipes or code-span pipes as delimiters; even backslash runs do not escape delimiters
 - If `total <= keep`, no rows are removed (`removed == 0`) and the spec is not written; such results are filtered out by `compact_changelogs`
 - `dry_run: true` collects `CompactResult` values but never writes files
 - Only results where `removed > 0` are returned from `compact_changelogs`
+- Re-running with no excess ordinary rows leaves the file byte-for-byte unchanged, including every LF/CRLF terminator
+- `CompactResult.compacted_entries` reports ordinary entries retained and excludes the generated summary row
+- Counts use fixed-width checked arithmetic and overflow fails closed
+- All reads/parses and same-directory replacement staging complete before publication; preflight failure writes nothing
+- The returned report identifies planned, succeeded, and failed operations so incomplete apply work cannot be reported as success
 
 ## Constraints
 
 - Operates on the raw markdown text via string slicing; no markdown AST
 - A spec is only touched if it contains a `## Change Log` marker; otherwise silently skipped
 - Date range is taken from the first cell of the first/last removed rows (`extract_first_cell`)
-- Write failures print a bold-red `error:` line to stderr and continue with the next spec
+- Command rendering reports structured failures and exits nonzero for every incomplete apply
 
 ## Out of Scope
 
 - Compacting any section other than `## Change Log`
 - Parsing or validating individual changelog dates
-- Merging or de-duplicating changelog content beyond counting removed rows
+- Merging or de-duplicating ordinary changelog content beyond folding tool-generated summary rows
 - Restoring previously compacted entries
 
 ### REQ-compact-001
@@ -42,10 +51,16 @@ Acceptance Criteria
 - `compact_changelogs(root, specs_dir, keep, dry_run)` walks every spec found by `find_spec_files` and compacts each spec's `## Change Log` table
 - The `## Change Log` section ends at the next `## ` heading or EOF; only that slice is rewritten
 - The first two `|`-prefixed lines in the section (header + separator) are always preserved
-- The last `keep` data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
+- The last `keep` ordinary data rows are kept verbatim; the earlier `total - keep` rows are replaced by a single summary row
 - The summary row reads `| <first_date> — <last_date> | Compacted: <N> entries |` for 2-column tables, and inserts a `—` placeholder for the middle column(s) on 3+ column tables
-- Column count is detected from the first data row (`| count - 1`)
+- A generated summary row is recognized only when its first cell contains a non-empty `start — end` range, every interior cell is `—`, and its final cell contains a grammatically-correct fixed-width count plus the exact `<!-- specsync:compact:v1 -->` marker
+- When new ordinary rows require another compaction, prior generated summary counts are accumulated and the original range start is retained
+- Multiple marked summaries fail closed instead of being summed
+- Column count and cells are parsed from one contiguous table without treating odd-backslash escaped pipes or code-span pipes as delimiters
 - If `total <= keep`, no rows are removed (`removed == 0`) and the spec is not written; such results are filtered out by `compact_changelogs`
 - `dry_run: true` collects `CompactResult` values but never writes files
 - Only results where `removed > 0` are returned from `compact_changelogs`
-
+- Re-running with no excess ordinary rows leaves the file byte-for-byte unchanged, including exact LF/CRLF terminators
+- `CompactResult.compacted_entries` reports ordinary entries retained and excludes the generated summary row
+- Count overflow, malformed widths, and ambiguous generated state fail closed
+- Preflight or staging failure writes nothing, and every incomplete apply is represented in the typed report

--- a/specs/compact/tasks.md
+++ b/specs/compact/tasks.md
@@ -17,6 +17,15 @@ spec: compact.spec.md
 - [x] Filter out results where `removed == 0`
 - [x] Bold-red error on write failure, continue with remaining specs
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+- [x] Make generated summary folding byte-for-byte idempotent and preserve the original count/range
+- [x] Preserve escaped pipes, exact table width, and trailing-newline state
+- [x] Prevent user-authored `Compacted:` prose from being mistaken for generated state
+- [x] Add focused unit and end-to-end CLI regressions for issue #417
+- [x] Complete issue #417 structured command output in the owning `cmd_compact`, `cmd_archive_tasks`, and CLI modules
+- [x] Add provenance-bound summary ownership and reject duplicate generated summaries
+- [x] Preserve CRLF/mixed line endings and parse escaped/code-span pipes with correct backslash parity
+- [x] Add checked fixed-width summary counts, keep-zero coverage, and first-contiguous-table isolation
+- [x] Preflight and stage compact replacements before publication with typed incomplete/partial reporting
 
 ## Review Status
 

--- a/specs/compact/tasks.md
+++ b/specs/compact/tasks.md
@@ -29,6 +29,8 @@ spec: compact.spec.md
 - [x] Ignore fenced/indented changelog examples and prefix headings such as `## Change Logger`
 - [x] Preserve a missing final newline for LF and CRLF files when `keep = 0`
 - [x] Retain complete planned counts on staging failure and characterize deterministic late-publish partial results
+- [x] Stop before indented pipe-code and fail closed on indented separators
+- [x] Reject reordered generated summaries before no-final-newline reconstruction
 
 ## Review Status
 

--- a/specs/compact/tasks.md
+++ b/specs/compact/tasks.md
@@ -26,6 +26,9 @@ spec: compact.spec.md
 - [x] Preserve CRLF/mixed line endings and parse escaped/code-span pipes with correct backslash parity
 - [x] Add checked fixed-width summary counts, keep-zero coverage, and first-contiguous-table isolation
 - [x] Preflight and stage compact replacements before publication with typed incomplete/partial reporting
+- [x] Ignore fenced/indented changelog examples and prefix headings such as `## Change Logger`
+- [x] Preserve a missing final newline for LF and CRLF files when `keep = 0`
+- [x] Retain complete planned counts on staging failure and characterize deterministic late-publish partial results
 
 ## Review Status
 

--- a/specs/compact/testing.md
+++ b/specs/compact/testing.md
@@ -6,7 +6,7 @@ spec: compact.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/compact.rs` | `fledge run test -- compact::tests` | Core trimming plus exact unfenced H2/table selection, marked ownership, duplicate rejection, fixed-width overflow, backslash parity/code spans, contiguous tables, exact CRLF/EOF preservation, keep-zero, staging all-or-none, late partial publication, and idempotence |
+| `src/compact.rs` | `fledge run test -- compact::tests` | Core trimming plus exact unfenced/unindented H2/table selection, canonical summary position, marked ownership, duplicate rejection, fixed-width overflow, backslash parity/code spans, exact CRLF/EOF preservation, keep-zero, staging all-or-none, late partial publication, and idempotence |
 | `tests/integration/commands.rs` | `fledge run test -- compact_` | CLI dry-run no-write behavior, output counts, newline preservation, and byte-identical second run |
 
 ## Coverage Gaps
@@ -29,6 +29,8 @@ spec: compact.spec.md
 |------|-------------------|-----------------|
 | Read/parse/stage failure | Typed failure, nonzero command outcome, zero writes, and complete planned counts before publication | `compact_preflight_failure_prevents_all_writes` plus command JSON failure fixture |
 | Fenced table or prefix heading | Ignore fenced/indented examples and `## Change Logger`; compact only the exact real H2 table | `compact_ignores_fenced_tables_and_change_logger_prefixes` |
+| Indented pipe code or separator | Stop data parsing before indented code; reject an indented separator with zero writes | `compact_stops_before_indented_pipe_code`, `compact_indented_separator_fails_before_writing` |
+| Reordered generated summary | Reject marked state outside the first data row without changing unterminated source bytes | `compact_rejects_reordered_unterminated_owned_summary_without_writing` |
 | No changelog section found | Spec is silently skipped | Keep or add a focused assertion before changing this behavior |
 | Unmarked row exactly resembles a summary | Preserve it as ordinary history; never fold it as generated state | `compact_preserves_exact_shape_user_row_without_marker` |
 | Duplicate generated summaries | Refuse ambiguous folding | `compact_rejects_multiple_marked_summaries` |

--- a/specs/compact/testing.md
+++ b/specs/compact/testing.md
@@ -6,11 +6,12 @@ spec: compact.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/compact.rs` | cargo test compact:: | `test_compact_changelog`, `test_compact_no_change_needed`, `test_compact_three_column_table` |
+| `src/compact.rs` | `fledge run test -- compact::tests` | Core trimming plus marked ownership, duplicate rejection, fixed-width overflow, backslash parity/code spans, contiguous tables, exact CRLF preservation, keep-zero, staging all-or-none, and idempotence |
+| `tests/integration/commands.rs` | `fledge run test -- compact_` | CLI dry-run no-write behavior, output counts, newline preservation, and byte-identical second run |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Short changelog (no compaction needed)" before changing user-visible CLI output, generated files, or error handling in compact.
+(none for issue #417; command rendering is covered by the `cmd_compact`, `cmd_archive_tasks`, and CLI module test matrices)
 
 ## Behavioral Verification
 
@@ -19,13 +20,20 @@ spec: compact.spec.md
 | Compact a long changelog | a spec with 20 changelog entries and `keep = 5` | `compact_changelogs` is called | the first 15 entries are replaced with a single summary row of the form `\| <first_date> — <last_date> \| Compacted: 15 entries \|` |
 | Short changelog (no compaction needed) | a spec with 3 changelog entries and `keep = 5` | `compact_changelogs` is called | the spec is skipped (not included in results) |
 | Dry run | specs with long changelogs | `compact_changelogs(root, specs_dir, 5, true)` is called | returns `CompactResult` entries but does not modify any files |
+| Repeat compaction | a generated summary plus exactly `keep` ordinary rows | run compaction again | file bytes and summary metadata remain unchanged |
+| New rows after compaction | a generated summary plus more than `keep` ordinary rows | run compaction again | old and new removed counts are folded and the original range start survives |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Spec file unreadable | Prints error in bold red, continues processing other files | Keep or add a focused assertion before changing this behavior |
+| Read/parse/stage failure | Typed failure, nonzero command outcome, and zero writes before publication | `compact_preflight_failure_prevents_all_writes` plus command JSON failure fixture |
 | No changelog section found | Spec is silently skipped | Keep or add a focused assertion before changing this behavior |
+| Unmarked row exactly resembles a summary | Preserve it as ordinary history; never fold it as generated state | `compact_preserves_exact_shape_user_row_without_marker` |
+| Duplicate generated summaries | Refuse ambiguous folding | `compact_rejects_multiple_marked_summaries` |
+| Escaped/code-span pipe | Honor backslash parity and code delimiters | `split_cells_honors_backslash_parity_and_code_spans`, `compact_handles_escaped_pipes_in_cells` |
+| CRLF or mixed endings | Preserve every untouched terminator | `compact_preserves_crlf_and_mixed_line_endings` |
+| Count overflow | Return an error rather than panic or wrap | `compact_rejects_summary_count_overflow` |
 
 ## Reviewer Checklist
 

--- a/specs/compact/testing.md
+++ b/specs/compact/testing.md
@@ -6,7 +6,7 @@ spec: compact.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/compact.rs` | `fledge run test -- compact::tests` | Core trimming plus marked ownership, duplicate rejection, fixed-width overflow, backslash parity/code spans, contiguous tables, exact CRLF preservation, keep-zero, staging all-or-none, and idempotence |
+| `src/compact.rs` | `fledge run test -- compact::tests` | Core trimming plus exact unfenced H2/table selection, marked ownership, duplicate rejection, fixed-width overflow, backslash parity/code spans, contiguous tables, exact CRLF/EOF preservation, keep-zero, staging all-or-none, late partial publication, and idempotence |
 | `tests/integration/commands.rs` | `fledge run test -- compact_` | CLI dry-run no-write behavior, output counts, newline preservation, and byte-identical second run |
 
 ## Coverage Gaps
@@ -27,13 +27,15 @@ spec: compact.spec.md
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Read/parse/stage failure | Typed failure, nonzero command outcome, and zero writes before publication | `compact_preflight_failure_prevents_all_writes` plus command JSON failure fixture |
+| Read/parse/stage failure | Typed failure, nonzero command outcome, zero writes, and complete planned counts before publication | `compact_preflight_failure_prevents_all_writes` plus command JSON failure fixture |
+| Fenced table or prefix heading | Ignore fenced/indented examples and `## Change Logger`; compact only the exact real H2 table | `compact_ignores_fenced_tables_and_change_logger_prefixes` |
 | No changelog section found | Spec is silently skipped | Keep or add a focused assertion before changing this behavior |
 | Unmarked row exactly resembles a summary | Preserve it as ordinary history; never fold it as generated state | `compact_preserves_exact_shape_user_row_without_marker` |
 | Duplicate generated summaries | Refuse ambiguous folding | `compact_rejects_multiple_marked_summaries` |
 | Escaped/code-span pipe | Honor backslash parity and code delimiters | `split_cells_honors_backslash_parity_and_code_spans`, `compact_handles_escaped_pipes_in_cells` |
-| CRLF or mixed endings | Preserve every untouched terminator | `compact_preserves_crlf_and_mixed_line_endings` |
+| CRLF or mixed endings | Preserve every untouched terminator and no-final-newline state under `keep=0` | `compact_preserves_crlf_and_mixed_line_endings`, `compact_keep_zero_preserves_missing_final_newline_for_lf_and_crlf` |
 | Count overflow | Return an error rather than panic or wrap | `compact_rejects_summary_count_overflow` |
+| Late publish failure | Preserve exact result/affected counts and report partial progress without false success | `compact_publish_failure_reports_partial_results_and_exact_counts`, `partial_publish_reports_are_truthful_in_json_and_markdown` |
 
 ## Reviewer Checklist
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,62 +1,370 @@
-use colored::Colorize;
-use std::fs;
-use std::path::Path;
+use std::collections::HashSet;
+use std::fs::{self, Permissions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 use crate::validator::find_spec_files;
 
-/// Result of archiving tasks in a single tasks.md file.
+/// A task archival operation selected for one companion `tasks.md` file.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ArchiveResult {
-    pub tasks_path: String,
+    pub tasks_path: PathBuf,
     pub archived_count: usize,
 }
 
-/// Archive completed tasks across all companion tasks.md files.
-/// Moves `- [x]` items to an `## Archive` section at the bottom.
-pub fn archive_tasks(root: &Path, specs_dir: &Path, dry_run: bool) -> Vec<ArchiveResult> {
-    let spec_files = find_spec_files(specs_dir);
-    let mut results = Vec::new();
+/// The filesystem phase that failed while preparing or applying an archive operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArchiveOperation {
+    Inspect,
+    Read,
+    Preflight,
+    Stage,
+    Publish,
+    Rollback,
+}
 
-    for spec_path in &spec_files {
-        // Find the companion tasks.md in the same directory
-        let spec_dir = match spec_path.parent() {
-            Some(d) => d,
-            None => continue,
+impl ArchiveOperation {
+    /// Stable machine-readable name for structured command output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Inspect => "inspect",
+            Self::Read => "read",
+            Self::Preflight => "preflight",
+            Self::Stage => "stage",
+            Self::Publish => "publish",
+            Self::Rollback => "rollback",
+        }
+    }
+}
+
+/// A structured failure for one filesystem phase and companion path.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArchiveFailure {
+    pub tasks_path: PathBuf,
+    pub operation: ArchiveOperation,
+    pub error: String,
+}
+
+/// Complete plan and execution outcome for an archive-tasks invocation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArchiveReport {
+    pub dry_run: bool,
+    pub planned: Vec<ArchiveResult>,
+    pub succeeded: Vec<ArchiveResult>,
+    pub rolled_back: Vec<ArchiveResult>,
+    pub failed: Vec<ArchiveFailure>,
+}
+
+impl ArchiveReport {
+    /// Whether every selected operation was either previewed or applied successfully.
+    pub fn is_complete(&self) -> bool {
+        self.failed.is_empty() && (self.dry_run || self.succeeded.len() == self.planned.len())
+    }
+
+    /// Whether at least one destination remains changed after an incomplete apply.
+    pub fn is_partial(&self) -> bool {
+        !self.dry_run && !self.is_complete() && !self.succeeded.is_empty()
+    }
+
+    /// Whether a complete non-empty apply was published.
+    pub fn applied(&self) -> bool {
+        !self.dry_run && self.is_complete() && !self.succeeded.is_empty()
+    }
+
+    /// Total number of tasks selected by the plan.
+    pub fn planned_tasks(&self) -> usize {
+        self.planned
+            .iter()
+            .map(|result| result.archived_count)
+            .sum()
+    }
+
+    /// Total number of tasks left archived after execution.
+    pub fn succeeded_tasks(&self) -> usize {
+        self.succeeded
+            .iter()
+            .map(|result| result.archived_count)
+            .sum()
+    }
+}
+
+#[derive(Clone)]
+struct PlannedArchive {
+    result: ArchiveResult,
+    absolute_path: PathBuf,
+    original_content: Vec<u8>,
+    replacement_content: Vec<u8>,
+    permissions: Permissions,
+}
+
+struct StagedArchive {
+    plan: PlannedArchive,
+    temporary: tempfile::NamedTempFile,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct FailureInjection {
+    stage_index: Option<usize>,
+    publish_index: Option<usize>,
+    rollback_index: Option<usize>,
+}
+
+/// Archive completed tasks across all companion tasks.md files.
+///
+/// The invocation first plans and validates every operation, then stages every replacement in
+/// its destination directory before publishing any file. Planning or staging failures therefore
+/// leave all destination files untouched. A late publication failure is reported and previously
+/// published replacements are rolled back when that can be done safely.
+pub fn archive_tasks(root: &Path, specs_dir: &Path, dry_run: bool) -> ArchiveReport {
+    archive_tasks_with_failures(root, specs_dir, dry_run, FailureInjection::default())
+}
+
+fn archive_tasks_with_failures(
+    root: &Path,
+    specs_dir: &Path,
+    dry_run: bool,
+    failure_injection: FailureInjection,
+) -> ArchiveReport {
+    let (plans, failures) = plan_archive_operations(root, specs_dir);
+    let mut report = ArchiveReport {
+        dry_run,
+        planned: plans.iter().map(|plan| plan.result.clone()).collect(),
+        succeeded: Vec::new(),
+        rolled_back: Vec::new(),
+        failed: failures,
+    };
+
+    if dry_run || !report.failed.is_empty() || plans.is_empty() {
+        return report;
+    }
+
+    let mut staged = Vec::with_capacity(plans.len());
+    for (index, plan) in plans.into_iter().enumerate() {
+        if failure_injection.stage_index == Some(index) {
+            report.failed.push(ArchiveFailure {
+                tasks_path: plan.result.tasks_path,
+                operation: ArchiveOperation::Stage,
+                error: "injected staging failure".to_string(),
+            });
+            return report;
+        }
+
+        match stage_archive(plan) {
+            Ok(operation) => staged.push(operation),
+            Err(failure) => {
+                report.failed.push(failure);
+                return report;
+            }
+        }
+    }
+
+    let mut published = Vec::new();
+    for (index, operation) in staged.into_iter().enumerate() {
+        if failure_injection.publish_index == Some(index) {
+            report.failed.push(ArchiveFailure {
+                tasks_path: operation.plan.result.tasks_path.clone(),
+                operation: ArchiveOperation::Publish,
+                error: "injected publication failure".to_string(),
+            });
+            rollback_published(&mut report, published, failure_injection.rollback_index);
+            return report;
+        }
+
+        let StagedArchive { plan, temporary } = operation;
+        match temporary.persist(&plan.absolute_path) {
+            Ok(file) => {
+                drop(file);
+                report.succeeded.push(plan.result.clone());
+                published.push(plan);
+            }
+            Err(error) => {
+                report.failed.push(ArchiveFailure {
+                    tasks_path: plan.result.tasks_path,
+                    operation: ArchiveOperation::Publish,
+                    error: error.error.to_string(),
+                });
+                rollback_published(&mut report, published, failure_injection.rollback_index);
+                return report;
+            }
+        }
+    }
+
+    report
+}
+
+fn plan_archive_operations(
+    root: &Path,
+    specs_dir: &Path,
+) -> (Vec<PlannedArchive>, Vec<ArchiveFailure>) {
+    let mut plans = Vec::new();
+    let mut failures = Vec::new();
+    let mut seen_tasks_paths = HashSet::new();
+
+    for spec_path in find_spec_files(specs_dir) {
+        let Some(spec_dir) = spec_path.parent() else {
+            continue;
         };
         let tasks_path = spec_dir.join("tasks.md");
-        if !tasks_path.exists() {
+        if !seen_tasks_paths.insert(tasks_path.clone()) {
             continue;
         }
 
-        let content = match fs::read_to_string(&tasks_path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
-        let rel_path = tasks_path
-            .strip_prefix(root)
-            .unwrap_or(&tasks_path)
-            .to_string_lossy()
-            .to_string();
-
-        if let Some((new_content, count)) = archive_completed_tasks(&content)
-            && count > 0
-        {
-            if !dry_run && let Err(e) = fs::write(&tasks_path, &new_content) {
-                eprintln!(
-                    "{} Failed to write {}: {e}",
-                    "error:".red().bold(),
-                    rel_path
-                );
+        let report_path = relative_report_path(root, &tasks_path);
+        let metadata = match fs::symlink_metadata(&tasks_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                failures.push(ArchiveFailure {
+                    tasks_path: report_path,
+                    operation: ArchiveOperation::Inspect,
+                    error: error.to_string(),
+                });
                 continue;
             }
-            results.push(ArchiveResult {
-                tasks_path: rel_path,
-                archived_count: count,
+        };
+
+        if metadata.file_type().is_symlink() {
+            failures.push(ArchiveFailure {
+                tasks_path: report_path,
+                operation: ArchiveOperation::Preflight,
+                error: "refusing to replace a symbolic-link tasks file".to_string(),
+            });
+            continue;
+        }
+        if !metadata.is_file() {
+            failures.push(ArchiveFailure {
+                tasks_path: report_path,
+                operation: ArchiveOperation::Preflight,
+                error: "tasks path is not a regular file".to_string(),
+            });
+            continue;
+        }
+
+        let original_content = match fs::read(&tasks_path) {
+            Ok(content) => content,
+            Err(error) => {
+                failures.push(ArchiveFailure {
+                    tasks_path: report_path,
+                    operation: ArchiveOperation::Read,
+                    error: error.to_string(),
+                });
+                continue;
+            }
+        };
+        let content = match std::str::from_utf8(&original_content) {
+            Ok(content) => content,
+            Err(error) => {
+                failures.push(ArchiveFailure {
+                    tasks_path: report_path,
+                    operation: ArchiveOperation::Read,
+                    error: format!("tasks file is not valid UTF-8: {error}"),
+                });
+                continue;
+            }
+        };
+
+        if let Some((replacement_content, archived_count)) = archive_completed_tasks(content)
+            && archived_count > 0
+        {
+            plans.push(PlannedArchive {
+                result: ArchiveResult {
+                    tasks_path: report_path,
+                    archived_count,
+                },
+                absolute_path: tasks_path,
+                original_content,
+                replacement_content: replacement_content.into_bytes(),
+                permissions: metadata.permissions(),
             });
         }
     }
 
-    results
+    (plans, failures)
+}
+
+fn relative_report_path(root: &Path, tasks_path: &Path) -> PathBuf {
+    tasks_path
+        .strip_prefix(root)
+        .unwrap_or(tasks_path)
+        .to_path_buf()
+}
+
+fn stage_archive(plan: PlannedArchive) -> Result<StagedArchive, ArchiveFailure> {
+    let temporary = stage_replacement(
+        &plan.absolute_path,
+        &plan.replacement_content,
+        &plan.permissions,
+    )
+    .map_err(|error| ArchiveFailure {
+        tasks_path: plan.result.tasks_path.clone(),
+        operation: ArchiveOperation::Stage,
+        error: error.to_string(),
+    })?;
+
+    Ok(StagedArchive { plan, temporary })
+}
+
+fn stage_replacement(
+    destination: &Path,
+    content: &[u8],
+    permissions: &Permissions,
+) -> io::Result<tempfile::NamedTempFile> {
+    let parent = destination.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "archive destination has no parent directory",
+        )
+    })?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".specsync-archive-")
+        .tempfile_in(parent)?;
+    temporary.as_file_mut().write_all(content)?;
+    temporary.as_file_mut().flush()?;
+    fs::set_permissions(temporary.path(), permissions.clone())?;
+    temporary.as_file_mut().sync_all()?;
+    Ok(temporary)
+}
+
+fn rollback_published(
+    report: &mut ArchiveReport,
+    published: Vec<PlannedArchive>,
+    injected_failure_index: Option<usize>,
+) {
+    let mut rollback_failed_paths = HashSet::new();
+
+    for (index, plan) in published.into_iter().rev().enumerate() {
+        let rollback_result = if injected_failure_index == Some(index) {
+            Err(io::Error::other("injected rollback failure"))
+        } else {
+            stage_replacement(
+                &plan.absolute_path,
+                &plan.original_content,
+                &plan.permissions,
+            )
+            .and_then(|temporary| {
+                temporary
+                    .persist(&plan.absolute_path)
+                    .map(drop)
+                    .map_err(|error| error.error)
+            })
+        };
+
+        match rollback_result {
+            Ok(()) => report.rolled_back.push(plan.result),
+            Err(error) => {
+                rollback_failed_paths.insert(plan.result.tasks_path.clone());
+                report.failed.push(ArchiveFailure {
+                    tasks_path: plan.result.tasks_path,
+                    operation: ArchiveOperation::Rollback,
+                    error: error.to_string(),
+                });
+            }
+        }
+    }
+
+    report
+        .succeeded
+        .retain(|result| rollback_failed_paths.contains(&result.tasks_path));
 }
 
 /// Archive completed tasks in a tasks.md file.
@@ -213,5 +521,181 @@ Nothing here.
         assert_eq!(count, 1);
         assert!(new_content.contains("- [x] Previously archived"));
         assert!(new_content.contains("- [x] New done task"));
+    }
+
+    fn write_archive_fixture(root: &Path, module: &str, tasks: &[u8]) -> PathBuf {
+        let module_dir = root.join("specs").join(module);
+        fs::create_dir_all(&module_dir).unwrap();
+        fs::write(module_dir.join(format!("{module}.spec.md")), "# fixture\n").unwrap();
+        let tasks_path = module_dir.join("tasks.md");
+        fs::write(&tasks_path, tasks).unwrap();
+        tasks_path
+    }
+
+    // Requirement evidence: REQ-archive-001.
+    #[test]
+    fn planning_failure_prevents_all_destination_writes() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let first = write_archive_fixture(root, "first", b"## Tasks\n\n- [x] done\n");
+        let invalid = write_archive_fixture(root, "invalid", b"## Tasks\n\n- [x] \xFF\n");
+        let first_before = fs::read(&first).unwrap();
+        let invalid_before = fs::read(&invalid).unwrap();
+
+        let report = archive_tasks(root, &root.join("specs"), false);
+
+        assert!(!report.is_complete());
+        assert!(!report.applied());
+        assert!(report.succeeded.is_empty());
+        assert_eq!(report.planned.len(), 1);
+        assert_eq!(report.failed.len(), 1);
+        assert_eq!(report.failed[0].operation, ArchiveOperation::Read);
+        assert_eq!(fs::read(first).unwrap(), first_before);
+        assert_eq!(fs::read(invalid).unwrap(), invalid_before);
+    }
+
+    #[test]
+    fn all_failed_planning_is_incomplete_without_selected_work() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let invalid = write_archive_fixture(root, "invalid", b"## Tasks\n\n- [x] \xFF\n");
+        let invalid_before = fs::read(&invalid).unwrap();
+
+        let report = archive_tasks(root, &root.join("specs"), false);
+
+        assert!(!report.is_complete());
+        assert!(!report.is_partial());
+        assert!(!report.applied());
+        assert!(report.planned.is_empty());
+        assert!(report.succeeded.is_empty());
+        assert_eq!(report.failed.len(), 1);
+        assert_eq!(report.failed[0].operation, ArchiveOperation::Read);
+        assert_eq!(fs::read(invalid).unwrap(), invalid_before);
+    }
+
+    #[test]
+    fn middle_staging_failure_prevents_all_destination_writes() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let first = write_archive_fixture(root, "first", b"## Tasks\n\n- [x] first\n");
+        let second = write_archive_fixture(root, "second", b"## Tasks\n\n- [x] second\n");
+        let first_before = fs::read(&first).unwrap();
+        let second_before = fs::read(&second).unwrap();
+
+        let report = archive_tasks_with_failures(
+            root,
+            &root.join("specs"),
+            false,
+            FailureInjection {
+                stage_index: Some(1),
+                ..FailureInjection::default()
+            },
+        );
+
+        assert!(!report.is_complete());
+        assert!(report.succeeded.is_empty());
+        assert_eq!(report.failed[0].operation, ArchiveOperation::Stage);
+        assert_eq!(fs::read(first).unwrap(), first_before);
+        assert_eq!(fs::read(second).unwrap(), second_before);
+    }
+
+    #[test]
+    fn middle_publish_failure_rolls_back_prior_replacements() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let first = write_archive_fixture(root, "first", b"## Tasks\n\n- [x] first\n");
+        let second = write_archive_fixture(root, "second", b"## Tasks\n\n- [x] second\n");
+        let first_before = fs::read(&first).unwrap();
+        let second_before = fs::read(&second).unwrap();
+
+        let report = archive_tasks_with_failures(
+            root,
+            &root.join("specs"),
+            false,
+            FailureInjection {
+                publish_index: Some(1),
+                ..FailureInjection::default()
+            },
+        );
+
+        assert!(!report.is_complete());
+        assert!(!report.is_partial());
+        assert!(!report.applied());
+        assert!(report.succeeded.is_empty());
+        assert_eq!(report.rolled_back.len(), 1);
+        assert_eq!(report.failed[0].operation, ArchiveOperation::Publish);
+        assert_eq!(fs::read(first).unwrap(), first_before);
+        assert_eq!(fs::read(second).unwrap(), second_before);
+    }
+
+    #[test]
+    fn rollback_failure_exposes_the_remaining_partial_apply() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let first = write_archive_fixture(root, "first", b"## Tasks\n\n- [x] first\n");
+        let second = write_archive_fixture(root, "second", b"## Tasks\n\n- [x] second\n");
+        let first_before = fs::read(&first).unwrap();
+        let second_before = fs::read(&second).unwrap();
+
+        let report = archive_tasks_with_failures(
+            root,
+            &root.join("specs"),
+            false,
+            FailureInjection {
+                publish_index: Some(1),
+                rollback_index: Some(0),
+                ..FailureInjection::default()
+            },
+        );
+
+        assert!(!report.is_complete());
+        assert!(report.is_partial());
+        assert!(!report.applied());
+        assert_eq!(report.succeeded.len(), 1);
+        assert!(report.rolled_back.is_empty());
+        assert_eq!(report.failed.len(), 2);
+        assert_eq!(report.failed[0].operation, ArchiveOperation::Publish);
+        assert_eq!(report.failed[1].operation, ArchiveOperation::Rollback);
+        assert_ne!(fs::read(first).unwrap(), first_before);
+        assert_eq!(fs::read(second).unwrap(), second_before);
+    }
+
+    #[test]
+    fn dry_run_and_apply_share_the_same_plan() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let tasks_path =
+            write_archive_fixture(root, "work", b"## Tasks\n\n- [x] done\n- [ ] open\n");
+        let before = fs::read(&tasks_path).unwrap();
+
+        let preview = archive_tasks(root, &root.join("specs"), true);
+        assert!(preview.is_complete());
+        assert!(!preview.applied());
+        assert_eq!(fs::read(&tasks_path).unwrap(), before);
+
+        let applied = archive_tasks(root, &root.join("specs"), false);
+        assert!(applied.is_complete());
+        assert!(applied.applied());
+        assert_eq!(preview.planned, applied.planned);
+        assert_eq!(applied.succeeded, applied.planned);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_preserves_original_unix_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path();
+        let tasks_path = write_archive_fixture(root, "work", b"## Tasks\n\n- [x] done\n");
+        fs::set_permissions(&tasks_path, Permissions::from_mode(0o640)).unwrap();
+
+        let report = archive_tasks(root, &root.join("specs"), false);
+
+        assert!(report.applied());
+        assert_eq!(
+            fs::metadata(tasks_path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
     }
 }

--- a/src/commands/archive_tasks.rs
+++ b/src/commands/archive_tasks.rs
@@ -356,9 +356,7 @@ fn safe_diagnostic(value: &str) -> String {
 }
 
 fn markdown_table_cell(value: &str) -> String {
-    safe_diagnostic(value)
-        .replace('\\', "\\\\")
-        .replace('|', "\\|")
+    safe_diagnostic(value).replace('|', "\\|")
 }
 
 fn markdown_code_span(value: &str) -> String {
@@ -440,6 +438,19 @@ mod tests {
             1,
             "adversarial path injected a Markdown row"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn markdown_paths_preserve_literal_unix_backslashes() {
+        let path = PathBuf::from(r"specs/\\server\share/tasks.md");
+        let markdown = render_markdown(&report_for(path, 1, true));
+
+        assert!(
+            markdown.contains(r"`specs/\\server\share/tasks.md`"),
+            "{markdown}"
+        );
+        assert!(!markdown.contains(r"`specs/\\\\server\\share/tasks.md`"));
     }
 
     #[test]

--- a/src/commands/archive_tasks.rs
+++ b/src/commands/archive_tasks.rs
@@ -356,11 +356,15 @@ fn safe_diagnostic(value: &str) -> String {
 }
 
 fn markdown_table_cell(value: &str) -> String {
-    safe_diagnostic(value).replace('|', "\\|")
+    markdown_html_text(&safe_diagnostic(value))
 }
 
 fn markdown_code_span(value: &str) -> String {
-    let value = markdown_table_cell(value);
+    let value = safe_diagnostic(value);
+    if value.contains('|') {
+        return format!("<code>{}</code>", markdown_html_text(&value));
+    }
+
     let longest_backtick_run = value
         .split(|character| character != '`')
         .map(str::len)
@@ -372,6 +376,15 @@ fn markdown_code_span(value: &str) -> String {
     } else {
         format!("{delimiter}{value}{delimiter}")
     }
+}
+
+fn markdown_html_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('\\', "&#92;")
+        .replace('|', "&#124;")
 }
 
 #[cfg(test)]
@@ -422,14 +435,15 @@ mod tests {
 
     #[test]
     fn markdown_paths_use_safe_dynamic_code_spans() {
-        let path = PathBuf::from("specs/pipe|ticks``\n\u{0007}\u{202E}/tasks.md");
+        let path = PathBuf::from("specs/pipe|ticks``</code>&\n\u{0007}\u{202E}/tasks.md");
         let markdown = render_markdown(&report_for(path, 1, true));
 
-        assert!(markdown.contains("\\|"));
-        assert!(markdown.contains("\\u{000A}"));
-        assert!(markdown.contains("\\u{0007}"));
-        assert!(markdown.contains("\\u{202E}"));
-        assert!(markdown.contains("```"));
+        assert!(markdown.contains("&#124;"));
+        assert!(markdown.contains("&lt;/code&gt;&amp;"));
+        assert!(markdown.contains("&#92;u{000A}"));
+        assert!(markdown.contains("&#92;u{0007}"));
+        assert!(markdown.contains("&#92;u{202E}"));
+        assert!(markdown.contains("<code>"));
         assert_eq!(
             markdown
                 .lines()
@@ -451,6 +465,25 @@ mod tests {
             "{markdown}"
         );
         assert!(!markdown.contains(r"`specs/\\\\server\\share/tasks.md`"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn markdown_paths_preserve_backslash_before_pipe_in_one_table_cell() {
+        let path = PathBuf::from(r"specs/a\|b/tasks.md");
+        let markdown = render_markdown(&report_for(path, 1, true));
+
+        assert!(
+            markdown.contains(r"<code>specs/a&#92;&#124;b/tasks.md</code>"),
+            "{markdown}"
+        );
+        assert_eq!(
+            markdown
+                .lines()
+                .filter(|line| line.contains("Would archive") && line.starts_with('|'))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src/commands/archive_tasks.rs
+++ b/src/commands/archive_tasks.rs
@@ -1,43 +1,493 @@
 use colored::Colorize;
+use std::fmt::Write as _;
+use std::io::{self, Write as _};
 use std::path::Path;
+use std::process;
 
 use crate::archive;
 use crate::config::load_config;
+use crate::types;
 
-pub fn cmd_archive_tasks(root: &Path, dry_run: bool) {
+pub fn cmd_archive_tasks(root: &Path, dry_run: bool, format: types::OutputFormat) {
     let config = load_config(root);
     let specs_dir = root.join(&config.specs_dir);
+    let report = archive::archive_tasks(root, &specs_dir, dry_run);
 
-    if dry_run {
-        println!("{} Dry run — no files will be modified\n", "ℹ".cyan());
+    let output = match format {
+        types::OutputFormat::Json => render_json(&report),
+        types::OutputFormat::Markdown | types::OutputFormat::Github => render_markdown(&report),
+        types::OutputFormat::Text | types::OutputFormat::Table | types::OutputFormat::Csv => {
+            render_text(&report)
+        }
+    };
+    print!("{output}");
+
+    if !report.is_complete() {
+        // `process::exit` does not run normal destructors, so flush the already-rendered report
+        // before returning the documented findings/inconclusive exit code.
+        let _ = io::stdout().flush();
+        process::exit(1);
+    }
+}
+
+fn render_text(report: &archive::ArchiveReport) -> String {
+    let mut output = String::new();
+    if report.dry_run {
+        writeln!(
+            output,
+            "{} Dry run — no files will be modified\n",
+            "ℹ".cyan()
+        )
+        .expect("writing to a String cannot fail");
     }
 
-    let results = archive::archive_tasks(root, &specs_dir, dry_run);
-
-    if results.is_empty() {
-        println!("{}", "No completed tasks to archive.".green());
-        return;
+    if report.planned.is_empty() && report.failed.is_empty() {
+        writeln!(output, "{}", "No completed tasks to archive.".green())
+            .expect("writing to a String cannot fail");
+        return output;
     }
 
-    for r in &results {
-        let verb = if dry_run { "would archive" } else { "archived" };
-        println!(
-            "  {} {} — {verb} {} task(s)",
+    let visible_results = if report.dry_run {
+        &report.planned
+    } else {
+        &report.succeeded
+    };
+    for result in visible_results {
+        let verb = if report.dry_run {
+            "would archive"
+        } else {
+            "archived"
+        };
+        writeln!(
+            output,
+            "  {} {} — {verb} {} {}",
             "✓".green(),
-            r.tasks_path,
-            r.archived_count,
+            safe_diagnostic(&result.tasks_path.to_string_lossy()),
+            result.archived_count,
+            plural(result.archived_count, "task", "tasks"),
+        )
+        .expect("writing to a String cannot fail");
+    }
+
+    if !report.dry_run && !report.is_complete() {
+        for planned in report.planned.iter().filter(|planned| {
+            !report
+                .succeeded
+                .iter()
+                .any(|succeeded| succeeded.tasks_path == planned.tasks_path)
+        }) {
+            writeln!(
+                output,
+                "  {} {} — planned {} {}, not applied",
+                "○".yellow(),
+                safe_diagnostic(&planned.tasks_path.to_string_lossy()),
+                planned.archived_count,
+                plural(planned.archived_count, "task", "tasks"),
+            )
+            .expect("writing to a String cannot fail");
+        }
+    }
+
+    for failure in &report.failed {
+        writeln!(
+            output,
+            "  {} {} — {} failed: {}",
+            "✗".red(),
+            safe_diagnostic(&failure.tasks_path.to_string_lossy()),
+            failure.operation.as_str(),
+            safe_diagnostic(&failure.error),
+        )
+        .expect("writing to a String cannot fail");
+    }
+
+    if !report.rolled_back.is_empty() {
+        writeln!(
+            output,
+            "\nRolled back {} {} after a publication failure.",
+            report.rolled_back.len(),
+            plural(report.rolled_back.len(), "file", "files"),
+        )
+        .expect("writing to a String cannot fail");
+    }
+
+    if report.is_complete() {
+        let tasks = report.planned_tasks();
+        writeln!(
+            output,
+            "\n{} {} {} across {} {}",
+            if report.dry_run {
+                "Would archive"
+            } else {
+                "Archived"
+            },
+            tasks,
+            plural(tasks, "task", "tasks"),
+            report.planned.len(),
+            plural(report.planned.len(), "file", "files"),
+        )
+        .expect("writing to a String cannot fail");
+    } else {
+        writeln!(
+            output,
+            "\nArchive incomplete: {} {} planned, {} {} archived; {} {} failed.",
+            report.planned_tasks(),
+            plural(report.planned_tasks(), "task", "tasks"),
+            report.succeeded_tasks(),
+            plural(report.succeeded_tasks(), "task", "tasks"),
+            report.failed.len(),
+            plural(report.failed.len(), "operation", "operations"),
+        )
+        .expect("writing to a String cannot fail");
+    }
+
+    output
+}
+
+fn render_json(report: &archive::ArchiveReport) -> String {
+    let render_result = |result: &archive::ArchiveResult, action: &str| {
+        serde_json::json!({
+            "tasks_path": portable_output_path(&result.tasks_path),
+            "operation": "archive",
+            "action": action,
+            "tasks_affected": result.archived_count,
+        })
+    };
+    let planned_action = if report.dry_run {
+        "would_archive"
+    } else {
+        "planned"
+    };
+    let planned: Vec<_> = report
+        .planned
+        .iter()
+        .map(|result| render_result(result, planned_action))
+        .collect();
+    let succeeded: Vec<_> = report
+        .succeeded
+        .iter()
+        .map(|result| render_result(result, "archived"))
+        .collect();
+    let rolled_back: Vec<_> = report
+        .rolled_back
+        .iter()
+        .map(|result| render_result(result, "rolled_back"))
+        .collect();
+    let failed: Vec<_> = report
+        .failed
+        .iter()
+        .map(|failure| {
+            serde_json::json!({
+                "tasks_path": portable_output_path(&failure.tasks_path),
+                "operation": failure.operation.as_str(),
+                "error": failure.error,
+            })
+        })
+        .collect();
+    let results = if report.dry_run {
+        planned.clone()
+    } else {
+        succeeded.clone()
+    };
+
+    let output = serde_json::json!({
+        "command": "archive-tasks",
+        "dry_run": report.dry_run,
+        "would_change": !report.planned.is_empty(),
+        "applied": report.applied(),
+        "complete": report.is_complete(),
+        "partial": report.is_partial(),
+        "tasks_affected": if report.dry_run {
+            report.planned_tasks()
+        } else {
+            report.succeeded_tasks()
+        },
+        "files_affected": results.len(),
+        "tasks_planned": report.planned_tasks(),
+        "tasks_succeeded": report.succeeded_tasks(),
+        "files_planned": report.planned.len(),
+        "files_succeeded": report.succeeded.len(),
+        "planned": planned,
+        "succeeded": succeeded,
+        "rolled_back": rolled_back,
+        "failed": failed,
+        "results": results,
+    });
+    format!(
+        "{}\n",
+        serde_json::to_string_pretty(&output).expect("archive report is JSON serializable")
+    )
+}
+
+fn render_markdown(report: &archive::ArchiveReport) -> String {
+    let mut output = String::from("## SpecSync Archive Tasks Results\n\n");
+    if report.dry_run {
+        output.push_str("> Dry run — no files will be modified.\n\n");
+    }
+
+    if report.planned.is_empty() && report.failed.is_empty() {
+        output.push_str("No completed tasks to archive.\n");
+        return output;
+    }
+
+    let visible_results = if report.dry_run {
+        &report.planned
+    } else {
+        &report.succeeded
+    };
+    if !visible_results.is_empty() {
+        output.push_str("| Tasks file | Action | Tasks affected |\n");
+        output.push_str("|------------|--------|---------------:|\n");
+        let action = if report.dry_run {
+            "Would archive"
+        } else {
+            "Archived"
+        };
+        for result in visible_results {
+            writeln!(
+                output,
+                "| {} | {action} | {} |",
+                markdown_code_span(&portable_output_path(&result.tasks_path)),
+                result.archived_count,
+            )
+            .expect("writing to a String cannot fail");
+        }
+        output.push('\n');
+    }
+
+    if !report.failed.is_empty() {
+        output.push_str("| Tasks file | Failed operation | Error |\n");
+        output.push_str("|------------|------------------|-------|\n");
+        for failure in &report.failed {
+            writeln!(
+                output,
+                "| {} | {} | {} |",
+                markdown_code_span(&portable_output_path(&failure.tasks_path)),
+                failure.operation.as_str(),
+                markdown_table_cell(&failure.error),
+            )
+            .expect("writing to a String cannot fail");
+        }
+        output.push('\n');
+    }
+
+    if !report.rolled_back.is_empty() {
+        writeln!(
+            output,
+            "> Rolled back {} {} after a publication failure.\n",
+            report.rolled_back.len(),
+            plural(report.rolled_back.len(), "file", "files"),
+        )
+        .expect("writing to a String cannot fail");
+    }
+
+    if report.is_complete() {
+        let tasks = report.planned_tasks();
+        writeln!(
+            output,
+            "**Summary:** {} {tasks} {} across {} {}.",
+            if report.dry_run {
+                "Would archive"
+            } else {
+                "Archived"
+            },
+            plural(tasks, "task", "tasks"),
+            report.planned.len(),
+            plural(report.planned.len(), "file", "files"),
+        )
+        .expect("writing to a String cannot fail");
+    } else {
+        writeln!(
+            output,
+            "**Summary:** Archive incomplete — {} {} planned, {} {} archived; {} {} failed.",
+            report.planned_tasks(),
+            plural(report.planned_tasks(), "task", "tasks"),
+            report.succeeded_tasks(),
+            plural(report.succeeded_tasks(), "task", "tasks"),
+            report.failed.len(),
+            plural(report.failed.len(), "operation", "operations"),
+        )
+        .expect("writing to a String cannot fail");
+    }
+
+    output
+}
+
+fn plural<'a>(count: usize, singular: &'a str, plural: &'a str) -> &'a str {
+    if count == 1 { singular } else { plural }
+}
+
+fn portable_output_path(value: &Path) -> String {
+    let rendered = value.to_string_lossy().into_owned();
+    #[cfg(windows)]
+    {
+        rendered.replace('\\', "/")
+    }
+    #[cfg(not(windows))]
+    {
+        rendered
+    }
+}
+
+fn is_unsafe_diagnostic_character(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{061c}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+        )
+}
+
+fn safe_diagnostic(value: &str) -> String {
+    let mut safe = String::with_capacity(value.len());
+    for character in value.chars() {
+        if is_unsafe_diagnostic_character(character) {
+            write!(&mut safe, "\\u{{{:04X}}}", character as u32)
+                .expect("writing to a String cannot fail");
+        } else {
+            safe.push(character);
+        }
+    }
+    safe
+}
+
+fn markdown_table_cell(value: &str) -> String {
+    safe_diagnostic(value)
+        .replace('\\', "\\\\")
+        .replace('|', "\\|")
+}
+
+fn markdown_code_span(value: &str) -> String {
+    let value = markdown_table_cell(value);
+    let longest_backtick_run = value
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    let delimiter = "`".repeat(longest_backtick_run + 1);
+    if value.starts_with('`') || value.ends_with('`') {
+        format!("{delimiter} {value} {delimiter}")
+    } else {
+        format!("{delimiter}{value}{delimiter}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn report_for(path: PathBuf, count: usize, dry_run: bool) -> archive::ArchiveReport {
+        let result = archive::ArchiveResult {
+            tasks_path: path,
+            archived_count: count,
+        };
+        archive::ArchiveReport {
+            dry_run,
+            planned: vec![result.clone()],
+            succeeded: if dry_run { Vec::new() } else { vec![result] },
+            rolled_back: Vec::new(),
+            failed: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn text_uses_truthful_singular_and_plural_labels() {
+        let singular = render_text(&report_for(PathBuf::from("specs/one/tasks.md"), 1, true));
+        assert!(singular.contains("would archive 1 task"));
+        assert!(singular.contains("Would archive 1 task across 1 file"));
+        assert!(!singular.contains("task(s)"));
+        assert!(!singular.contains("file(s)"));
+
+        let plural = render_text(&report_for(PathBuf::from("specs/many/tasks.md"), 2, false));
+        assert!(plural.contains("archived 2 tasks"));
+        assert!(plural.contains("Archived 2 tasks across 1 file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn structured_output_preserves_literal_unix_backslashes() {
+        let path = Path::new(r"specs/literal\name/tasks.md");
+        assert_eq!(portable_output_path(path), r"specs/literal\name/tasks.md");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn structured_output_normalizes_windows_separators() {
+        let path = Path::new(r"specs\work\tasks.md");
+        assert_eq!(portable_output_path(path), "specs/work/tasks.md");
+    }
+
+    #[test]
+    fn markdown_paths_use_safe_dynamic_code_spans() {
+        let path = PathBuf::from("specs/pipe|ticks``\n\u{0007}\u{202E}/tasks.md");
+        let markdown = render_markdown(&report_for(path, 1, true));
+
+        assert!(markdown.contains("\\|"));
+        assert!(markdown.contains("\\u{000A}"));
+        assert!(markdown.contains("\\u{0007}"));
+        assert!(markdown.contains("\\u{202E}"));
+        assert!(markdown.contains("```"));
+        assert_eq!(
+            markdown
+                .lines()
+                .filter(|line| line.contains("Would archive") && line.starts_with('|'))
+                .count(),
+            1,
+            "adversarial path injected a Markdown row"
         );
     }
 
-    let total: usize = results.iter().map(|r| r.archived_count).sum();
-    println!(
-        "\n{} {} task(s) across {} file(s)",
-        if dry_run {
-            "Would archive".to_string()
-        } else {
-            "Archived".to_string()
-        },
-        total,
-        results.len()
-    );
+    #[test]
+    fn json_safely_escapes_control_characters_in_paths_and_errors() {
+        let result = archive::ArchiveResult {
+            tasks_path: PathBuf::from("specs/new\nline/tasks.md"),
+            archived_count: 1,
+        };
+        let report = archive::ArchiveReport {
+            dry_run: false,
+            planned: vec![result],
+            succeeded: Vec::new(),
+            rolled_back: Vec::new(),
+            failed: vec![archive::ArchiveFailure {
+                tasks_path: PathBuf::from("specs/fail/tasks.md"),
+                operation: archive::ArchiveOperation::Publish,
+                error: "bad\nwrite".to_string(),
+            }],
+        };
+
+        let json = render_json(&report);
+        assert!(json.contains("new\\nline"));
+        assert!(json.contains("bad\\nwrite"));
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["complete"], false);
+        assert_eq!(parsed["partial"], false);
+        assert_eq!(parsed["applied"], false);
+        assert_eq!(parsed["failed"][0]["operation"], "publish");
+    }
+
+    #[test]
+    fn text_paths_and_errors_visibly_escape_control_and_bidi_characters() {
+        let report = archive::ArchiveReport {
+            dry_run: false,
+            planned: Vec::new(),
+            succeeded: Vec::new(),
+            rolled_back: Vec::new(),
+            failed: vec![archive::ArchiveFailure {
+                tasks_path: PathBuf::from("specs/new\n\u{202E}line/tasks.md"),
+                operation: archive::ArchiveOperation::Read,
+                error: "bad\u{0007}\nread".to_string(),
+            }],
+        };
+
+        let text = render_text(&report);
+        assert!(text.contains("new\\u{000A}\\u{202E}line"));
+        assert!(text.contains("bad\\u{0007}\\u{000A}read"));
+        assert!(!text.contains('\u{0007}'));
+        assert!(!text.contains('\u{202E}'));
+    }
 }

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -104,6 +104,10 @@ fn print_text(report: &compact::CompactReport, dry_run: bool) {
 }
 
 fn print_json(report: &compact::CompactReport, keep: usize, dry_run: bool) {
+    println!("{}", render_json(report, keep, dry_run));
+}
+
+fn render_json(report: &compact::CompactReport, keep: usize, dry_run: bool) -> String {
     let entries_affected: usize = report.results.iter().map(|result| result.removed).sum();
     let entries_applied: usize = report
         .results
@@ -162,23 +166,36 @@ fn print_json(report: &compact::CompactReport, keep: usize, dry_run: bool) {
         "results": rendered_results,
         "errors": failures,
     });
-    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    serde_json::to_string_pretty(&output).unwrap()
 }
 
 fn print_markdown(report: &compact::CompactReport, dry_run: bool) {
-    println!("## SpecSync Compact Results\n");
+    print!("{}", render_markdown(report, dry_run));
+}
+
+fn render_markdown(report: &compact::CompactReport, dry_run: bool) -> String {
+    let mut output = String::new();
+    writeln!(&mut output, "## SpecSync Compact Results\n")
+        .expect("writing to a String cannot fail");
     if dry_run {
-        println!("> Dry run — no files will be modified.\n");
+        writeln!(&mut output, "> Dry run — no files will be modified.\n")
+            .expect("writing to a String cannot fail");
     }
 
     if report.results.is_empty() && report.failures.is_empty() {
-        println!("No changelogs need compaction (all within limit).");
-        return;
+        writeln!(
+            &mut output,
+            "No changelogs need compaction (all within limit)."
+        )
+        .expect("writing to a String cannot fail");
+        return output;
     }
 
     if !report.results.is_empty() {
-        println!("| Spec | Action | Entries affected | Kept |");
-        println!("|------|--------|-----------------:|-----:|");
+        writeln!(&mut output, "| Spec | Action | Entries affected | Kept |")
+            .expect("writing to a String cannot fail");
+        writeln!(&mut output, "|------|--------|-----------------:|-----:|")
+            .expect("writing to a String cannot fail");
         for result in &report.results {
             let action = if dry_run {
                 "Would compact"
@@ -187,25 +204,31 @@ fn print_markdown(report: &compact::CompactReport, dry_run: bool) {
             } else {
                 "Not applied"
             };
-            println!(
+            writeln!(
+                &mut output,
                 "| {} | {action} | {} | {} |",
                 markdown_code_span(&portable_output_path(&result.spec_path)),
                 result.removed,
                 result.compacted_entries,
-            );
+            )
+            .expect("writing to a String cannot fail");
         }
     }
 
     if !report.failures.is_empty() {
-        println!("\n| Failed path | Operation | Error |");
-        println!("|-------------|-----------|-------|");
+        writeln!(&mut output, "\n| Failed path | Operation | Error |")
+            .expect("writing to a String cannot fail");
+        writeln!(&mut output, "|-------------|-----------|-------|")
+            .expect("writing to a String cannot fail");
         for failure in &report.failures {
-            println!(
+            writeln!(
+                &mut output,
                 "| {} | {} | {} |",
                 markdown_code_span(&portable_output_path(&failure.spec_path)),
                 markdown_cell(failure.operation),
                 markdown_cell(&failure.message),
-            );
+            )
+            .expect("writing to a String cannot fail");
         }
     }
 
@@ -217,7 +240,8 @@ fn print_markdown(report: &compact::CompactReport, dry_run: bool) {
     } else {
         "Planned"
     };
-    println!(
+    writeln!(
+        &mut output,
         "\n**Summary:** {action} {entries_affected} {} across {} {}.",
         if entries_affected == 1 {
             "entry"
@@ -230,7 +254,9 @@ fn print_markdown(report: &compact::CompactReport, dry_run: bool) {
         } else {
             "specs"
         },
-    );
+    )
+    .expect("writing to a String cannot fail");
+    output
 }
 
 fn is_unsafe_diagnostic_character(character: char) -> bool {
@@ -261,9 +287,7 @@ fn safe_diagnostic(value: &str) -> String {
 }
 
 fn markdown_cell(value: &str) -> String {
-    safe_diagnostic(value)
-        .replace('\\', "\\\\")
-        .replace('|', "\\|")
+    safe_diagnostic(value).replace('|', "\\|")
 }
 
 fn markdown_code_span(value: &str) -> String {
@@ -294,7 +318,8 @@ fn portable_output_path(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{markdown_code_span, portable_output_path};
+    use super::{markdown_code_span, portable_output_path, render_json, render_markdown};
+    use crate::compact::{CompactFailure, CompactReport, CompactResult};
 
     #[cfg(windows)]
     #[test]
@@ -318,8 +343,64 @@ mod tests {
     fn markdown_code_span_sanitizes_paths_and_uses_safe_delimiters() {
         assert_eq!(
             markdown_code_span("bad`name|row\n.spec.md"),
-            "``bad`name\\|row\\\\u{000A}.spec.md``"
+            "``bad`name\\|row\\u{000A}.spec.md``"
         );
         assert_eq!(markdown_code_span("``edge"), "``` ``edge ```");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn markdown_code_span_preserves_literal_unix_backslashes() {
+        assert_eq!(
+            markdown_code_span(r"specs/\\server\share/history.spec.md"),
+            r"`specs/\\server\share/history.spec.md`"
+        );
+    }
+
+    #[test]
+    fn partial_publish_reports_are_truthful_in_json_and_markdown() {
+        let report = CompactReport {
+            results: vec![
+                CompactResult {
+                    spec_path: "specs/a/a.spec.md".to_string(),
+                    original_entries: 4,
+                    compacted_entries: 2,
+                    removed: 2,
+                    applied: true,
+                },
+                CompactResult {
+                    spec_path: "specs/b/b.spec.md".to_string(),
+                    original_entries: 4,
+                    compacted_entries: 2,
+                    removed: 2,
+                    applied: false,
+                },
+            ],
+            failures: vec![CompactFailure {
+                spec_path: "specs/b/b.spec.md".to_string(),
+                operation: "publish",
+                message: "publication failed".to_string(),
+            }],
+            planned: 2,
+            succeeded: 1,
+        };
+
+        let json: serde_json::Value = serde_json::from_str(&render_json(&report, 2, false))
+            .expect("partial JSON must be parseable");
+        assert_eq!(json["complete"], false);
+        assert_eq!(json["partial"], true);
+        assert_eq!(json["applied"], false);
+        assert_eq!(json["entries_affected"], 4);
+        assert_eq!(json["entries_applied"], 2);
+        assert_eq!(json["specs_affected"], 2);
+        assert_eq!(json["operations"]["planned"], 2);
+        assert_eq!(json["operations"]["succeeded"], 1);
+        assert_eq!(json["errors"][0]["operation"], "publish");
+
+        let markdown = render_markdown(&report, false);
+        assert!(markdown.contains("| `specs/a/a.spec.md` | Compacted | 2 | 2 |"));
+        assert!(markdown.contains("| `specs/b/b.spec.md` | Not applied | 2 | 2 |"));
+        assert!(markdown.contains("| `specs/b/b.spec.md` | publish | publication failed |"));
+        assert!(markdown.contains("**Summary:** Planned 4 entries across 2 specs."));
     }
 }

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -1,20 +1,40 @@
 use colored::Colorize;
+use std::fmt::Write as _;
+use std::io::{self, Write as _};
 use std::path::Path;
+use std::process;
 
 use crate::compact;
 use crate::config::load_config;
+use crate::types;
 
-pub fn cmd_compact(root: &Path, keep: usize, dry_run: bool) {
+pub fn cmd_compact(root: &Path, keep: usize, dry_run: bool, format: types::OutputFormat) {
     let config = load_config(root);
     let specs_dir = root.join(&config.specs_dir);
+    let report = compact::compact_changelogs(root, &specs_dir, keep, dry_run);
 
+    match format {
+        types::OutputFormat::Json => print_json(&report, keep, dry_run),
+        types::OutputFormat::Markdown | types::OutputFormat::Github => {
+            print_markdown(&report, dry_run)
+        }
+        types::OutputFormat::Text | types::OutputFormat::Table | types::OutputFormat::Csv => {
+            print_text(&report, dry_run)
+        }
+    }
+
+    if !report.complete() {
+        let _ = io::stdout().flush();
+        process::exit(1);
+    }
+}
+
+fn print_text(report: &compact::CompactReport, dry_run: bool) {
     if dry_run {
         println!("{} Dry run — no files will be modified\n", "ℹ".cyan());
     }
 
-    let results = compact::compact_changelogs(root, &specs_dir, keep, dry_run);
-
-    if results.is_empty() {
+    if report.results.is_empty() && report.failures.is_empty() {
         println!(
             "{}",
             "No changelogs need compaction (all within limit).".green()
@@ -22,30 +42,284 @@ pub fn cmd_compact(root: &Path, keep: usize, dry_run: bool) {
         return;
     }
 
-    for r in &results {
+    for result in &report.results {
         let verb = if dry_run {
             "would compact"
-        } else {
+        } else if result.applied {
             "compacted"
+        } else {
+            "not applied"
         };
         println!(
-            "  {} {} — {verb} {} entries (kept {})",
-            "✓".green(),
-            r.spec_path,
-            r.removed,
-            r.compacted_entries,
+            "  {} {} — {verb} {} {} (kept {})",
+            if dry_run || result.applied {
+                "✓".green()
+            } else {
+                "✗".red()
+            },
+            safe_diagnostic(&result.spec_path),
+            result.removed,
+            if result.removed == 1 {
+                "entry"
+            } else {
+                "entries"
+            },
+            result.compacted_entries,
         );
     }
 
-    let total_removed: usize = results.iter().map(|r| r.removed).sum();
+    for failure in &report.failures {
+        eprintln!(
+            "{} {} ({}): {}",
+            "error:".red().bold(),
+            safe_diagnostic(&failure.spec_path),
+            failure.operation,
+            safe_diagnostic(&failure.message)
+        );
+    }
+
+    let total_removed: usize = report.results.iter().map(|result| result.removed).sum();
     println!(
-        "\n{} {} entries across {} spec(s)",
+        "\n{} {} {} across {} {}",
         if dry_run {
             "Would compact".to_string()
-        } else {
+        } else if report.complete() {
             "Compacted".to_string()
+        } else {
+            "Planned".to_string()
         },
         total_removed,
-        results.len()
+        if total_removed == 1 {
+            "entry"
+        } else {
+            "entries"
+        },
+        report.results.len(),
+        if report.results.len() == 1 {
+            "spec"
+        } else {
+            "specs"
+        }
     );
+}
+
+fn print_json(report: &compact::CompactReport, keep: usize, dry_run: bool) {
+    let entries_affected: usize = report.results.iter().map(|result| result.removed).sum();
+    let entries_applied: usize = report
+        .results
+        .iter()
+        .filter(|result| result.applied)
+        .map(|result| result.removed)
+        .sum();
+    let rendered_results: Vec<serde_json::Value> = report
+        .results
+        .iter()
+        .map(|result| {
+            serde_json::json!({
+                "spec_path": portable_output_path(&result.spec_path),
+                "action": if dry_run {
+                    "would_compact"
+                } else if result.applied {
+                    "compacted"
+                } else {
+                    "not_applied"
+                },
+                "applied": result.applied,
+                "original_entries": result.original_entries,
+                "kept_entries": result.compacted_entries,
+                "entries_affected": result.removed,
+            })
+        })
+        .collect();
+    let failures: Vec<serde_json::Value> = report
+        .failures
+        .iter()
+        .map(|failure| {
+            serde_json::json!({
+                "spec_path": portable_output_path(&failure.spec_path),
+                "operation": failure.operation,
+                "error": failure.message,
+            })
+        })
+        .collect();
+    let would_change = report.planned > 0;
+    let output = serde_json::json!({
+        "command": "compact",
+        "dry_run": dry_run,
+        "keep": keep,
+        "would_change": would_change,
+        "applied": would_change && !dry_run && report.complete() && report.succeeded == report.planned,
+        "complete": report.complete(),
+        "partial": report.partial(),
+        "operations": {
+            "planned": report.planned,
+            "succeeded": report.succeeded,
+            "failed": report.failures.len(),
+        },
+        "entries_affected": entries_affected,
+        "entries_applied": entries_applied,
+        "specs_affected": report.results.len(),
+        "results": rendered_results,
+        "errors": failures,
+    });
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}
+
+fn print_markdown(report: &compact::CompactReport, dry_run: bool) {
+    println!("## SpecSync Compact Results\n");
+    if dry_run {
+        println!("> Dry run — no files will be modified.\n");
+    }
+
+    if report.results.is_empty() && report.failures.is_empty() {
+        println!("No changelogs need compaction (all within limit).");
+        return;
+    }
+
+    if !report.results.is_empty() {
+        println!("| Spec | Action | Entries affected | Kept |");
+        println!("|------|--------|-----------------:|-----:|");
+        for result in &report.results {
+            let action = if dry_run {
+                "Would compact"
+            } else if result.applied {
+                "Compacted"
+            } else {
+                "Not applied"
+            };
+            println!(
+                "| {} | {action} | {} | {} |",
+                markdown_code_span(&portable_output_path(&result.spec_path)),
+                result.removed,
+                result.compacted_entries,
+            );
+        }
+    }
+
+    if !report.failures.is_empty() {
+        println!("\n| Failed path | Operation | Error |");
+        println!("|-------------|-----------|-------|");
+        for failure in &report.failures {
+            println!(
+                "| {} | {} | {} |",
+                markdown_code_span(&portable_output_path(&failure.spec_path)),
+                markdown_cell(failure.operation),
+                markdown_cell(&failure.message),
+            );
+        }
+    }
+
+    let entries_affected: usize = report.results.iter().map(|result| result.removed).sum();
+    let action = if dry_run {
+        "Would compact"
+    } else if report.complete() {
+        "Compacted"
+    } else {
+        "Planned"
+    };
+    println!(
+        "\n**Summary:** {action} {entries_affected} {} across {} {}.",
+        if entries_affected == 1 {
+            "entry"
+        } else {
+            "entries"
+        },
+        report.results.len(),
+        if report.results.len() == 1 {
+            "spec"
+        } else {
+            "specs"
+        },
+    );
+}
+
+fn is_unsafe_diagnostic_character(character: char) -> bool {
+    character.is_control()
+        || matches!(
+            character,
+            '\u{061c}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+        )
+}
+
+fn safe_diagnostic(value: &str) -> String {
+    let mut safe = String::with_capacity(value.len());
+    for character in value.chars() {
+        if is_unsafe_diagnostic_character(character) {
+            write!(&mut safe, "\\u{{{:04X}}}", character as u32)
+                .expect("writing to a String cannot fail");
+        } else {
+            safe.push(character);
+        }
+    }
+    safe
+}
+
+fn markdown_cell(value: &str) -> String {
+    safe_diagnostic(value)
+        .replace('\\', "\\\\")
+        .replace('|', "\\|")
+}
+
+fn markdown_code_span(value: &str) -> String {
+    let value = markdown_cell(value);
+    let longest_backtick_run = value
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    let delimiter = "`".repeat(longest_backtick_run + 1);
+    if value.starts_with('`') || value.ends_with('`') {
+        format!("{delimiter} {value} {delimiter}")
+    } else {
+        format!("{delimiter}{value}{delimiter}")
+    }
+}
+
+fn portable_output_path(value: &str) -> String {
+    #[cfg(windows)]
+    {
+        value.replace('\\', "/")
+    }
+    #[cfg(not(windows))]
+    {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{markdown_code_span, portable_output_path};
+
+    #[cfg(windows)]
+    #[test]
+    fn structured_output_paths_use_portable_separators() {
+        assert_eq!(
+            portable_output_path(r"specs\history\history.spec.md"),
+            "specs/history/history.spec.md"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn structured_output_paths_preserve_literal_backslashes_on_unix() {
+        assert_eq!(
+            portable_output_path(r"specs/history\literal/history.spec.md"),
+            r"specs/history\literal/history.spec.md"
+        );
+    }
+
+    #[test]
+    fn markdown_code_span_sanitizes_paths_and_uses_safe_delimiters() {
+        assert_eq!(
+            markdown_code_span("bad`name|row\n.spec.md"),
+            "``bad`name\\|row\\\\u{000A}.spec.md``"
+        );
+        assert_eq!(markdown_code_span("``edge"), "``` ``edge ```");
+    }
 }

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -287,11 +287,15 @@ fn safe_diagnostic(value: &str) -> String {
 }
 
 fn markdown_cell(value: &str) -> String {
-    safe_diagnostic(value).replace('|', "\\|")
+    markdown_html_text(&safe_diagnostic(value))
 }
 
 fn markdown_code_span(value: &str) -> String {
-    let value = markdown_cell(value);
+    let value = safe_diagnostic(value);
+    if value.contains('|') {
+        return format!("<code>{}</code>", markdown_html_text(&value));
+    }
+
     let longest_backtick_run = value
         .split(|character| character != '`')
         .map(str::len)
@@ -303,6 +307,15 @@ fn markdown_code_span(value: &str) -> String {
     } else {
         format!("{delimiter}{value}{delimiter}")
     }
+}
+
+fn markdown_html_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('\\', "&#92;")
+        .replace('|', "&#124;")
 }
 
 fn portable_output_path(value: &str) -> String {
@@ -343,7 +356,11 @@ mod tests {
     fn markdown_code_span_sanitizes_paths_and_uses_safe_delimiters() {
         assert_eq!(
             markdown_code_span("bad`name|row\n.spec.md"),
-            "``bad`name\\|row\\u{000A}.spec.md``"
+            "<code>bad`name&#124;row&#92;u{000A}.spec.md</code>"
+        );
+        assert_eq!(
+            markdown_code_span("bad</code>&|row.spec.md"),
+            "<code>bad&lt;/code&gt;&amp;&#124;row.spec.md</code>"
         );
         assert_eq!(markdown_code_span("``edge"), "``` ``edge ```");
     }
@@ -354,6 +371,15 @@ mod tests {
         assert_eq!(
             markdown_code_span(r"specs/\\server\share/history.spec.md"),
             r"`specs/\\server\share/history.spec.md`"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn markdown_code_span_preserves_backslash_before_pipe_in_one_table_cell() {
+        assert_eq!(
+            markdown_code_span(r"specs/a\|b/history.spec.md"),
+            r"<code>specs/a&#92;&#124;b/history.spec.md</code>"
         );
     }
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -211,6 +211,9 @@ fn compact_spec_changelog(
     let Some(separator) = lines.get(separator_index) else {
         return Err("Change Log table is missing its separator row".to_string());
     };
+    if is_indented_code(separator.content) {
+        return Err("Change Log table separator cannot be indented code".to_string());
+    }
     let separator_cells = split_cells(separator.content.trim());
     if separator_cells.len() != header_cells.len()
         || !separator_cells.iter().all(|cell| is_separator_cell(cell))
@@ -226,6 +229,9 @@ fn compact_spec_changelog(
     // the section are prose and must remain byte-for-byte untouched.
     let mut data_rows: Vec<(usize, &str)> = Vec::new();
     for (index, line) in lines.iter().enumerate().skip(separator_index + 1) {
+        if is_indented_code(line.content) {
+            break;
+        }
         let trimmed = line.content.trim();
         if !trimmed.starts_with('|') {
             break;
@@ -250,6 +256,15 @@ fn compact_spec_changelog(
     if summary_rows.len() > 1 {
         return Err(
             "Change Log contains multiple SpecSync compaction summaries; refusing ambiguous folding"
+                .to_string(),
+        );
+    }
+    if summary_rows
+        .first()
+        .is_some_and(|(index, _)| *index != separator_index + 1)
+    {
+        return Err(
+            "SpecSync compaction summary must be the first Change Log data row; refusing reordered generated state"
                 .to_string(),
         );
     }
@@ -1009,6 +1024,81 @@ Test module.
         assert!(new_content.contains("| nested-1 | Nested one |"));
         assert!(new_content.contains("| 2026-01-03 | Third |"));
         assert!(!new_content.contains("| 2026-01-01 | First |"));
+    }
+
+    #[test]
+    fn compact_stops_before_indented_pipe_code() {
+        let content = concat!(
+            "## Change Log\n\n",
+            "| Date | Change |\n",
+            "|------|--------|\n",
+            "| 2026-01-01 | First |\n",
+            "| 2026-01-02 | Second |\n",
+            "    | example | indented code |\n",
+            "| not-table | prose after code |\n",
+        );
+
+        let (new_content, result) = compact_spec_changelog(content, "t.spec.md", 1)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.original_entries, 2);
+        assert_eq!(result.removed, 1);
+        assert!(new_content.contains("    | example | indented code |\n"));
+        assert!(new_content.contains("| not-table | prose after code |\n"));
+    }
+
+    #[test]
+    fn compact_indented_separator_fails_before_writing() {
+        let temporary = tempfile::tempdir().unwrap();
+        let specs = temporary.path().join("specs");
+        fs::create_dir_all(specs.join("broken")).unwrap();
+        let path = specs.join("broken/broken.spec.md");
+        let content = concat!(
+            "## Change Log\n\n",
+            "| Date | Change |\n",
+            "    |------|--------|\n",
+            "| 2026-01-01 | First |\n",
+            "| 2026-01-02 | Second |\n",
+        );
+        fs::write(&path, content).unwrap();
+
+        let report = compact_changelogs(temporary.path(), &specs, 1, false);
+
+        assert!(!report.complete());
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].operation, "parse");
+        assert!(report.failures[0].message.contains("indented code"));
+        assert_eq!(fs::read_to_string(path).unwrap(), content);
+    }
+
+    #[test]
+    fn compact_rejects_reordered_unterminated_owned_summary_without_writing() {
+        let temporary = tempfile::tempdir().unwrap();
+        let specs = temporary.path().join("specs");
+        fs::create_dir_all(specs.join("broken")).unwrap();
+        let path = specs.join("broken/broken.spec.md");
+        let content = format!(
+            "## Change Log\n\n| Date | Change |\n|------|--------|\n\
+             | 2026-01-01 | First |\n\
+             | 2026-01-02 | Second |\n\
+             | 2025-01-01 — 2025-01-31 | Compacted: 2 entries {SUMMARY_MARKER} |"
+        );
+        fs::write(&path, &content).unwrap();
+
+        let report = compact_changelogs(temporary.path(), &specs, 1, false);
+
+        assert!(!report.complete());
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].operation, "parse");
+        assert!(
+            report.failures[0]
+                .message
+                .contains("first Change Log data row")
+        );
+        assert_eq!(fs::read_to_string(path).unwrap(), content);
     }
 
     #[test]

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -7,7 +7,7 @@ use crate::validator::find_spec_files;
 const SUMMARY_MARKER: &str = "<!-- specsync:compact:v1 -->";
 
 /// Result of compacting a single spec's changelog.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CompactResult {
     pub spec_path: String,
     #[allow(dead_code)]
@@ -48,6 +48,12 @@ struct CompactPlan {
     result: CompactResult,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct FailureInjection {
+    stage_index: Option<usize>,
+    publish_index: Option<usize>,
+}
+
 /// Compact changelog entries across all specs.
 /// Keeps the last `keep` entries and summarizes older ones.
 pub fn compact_changelogs(
@@ -55,6 +61,16 @@ pub fn compact_changelogs(
     specs_dir: &Path,
     keep: usize,
     dry_run: bool,
+) -> CompactReport {
+    compact_changelogs_with_failures(root, specs_dir, keep, dry_run, FailureInjection::default())
+}
+
+fn compact_changelogs_with_failures(
+    root: &Path,
+    specs_dir: &Path,
+    keep: usize,
+    dry_run: bool,
+    failure_injection: FailureInjection,
 ) -> CompactReport {
     let spec_files = find_spec_files(specs_dir);
     let mut plans = Vec::new();
@@ -92,9 +108,10 @@ pub fn compact_changelogs(
     }
 
     let planned = plans.len();
+    let planned_results: Vec<_> = plans.iter().map(|plan| plan.result.clone()).collect();
     if dry_run || !failures.is_empty() {
         return CompactReport {
-            results: plans.into_iter().map(|plan| plan.result).collect(),
+            results: planned_results,
             failures,
             planned,
             succeeded: 0,
@@ -102,7 +119,16 @@ pub fn compact_changelogs(
     }
 
     let mut staged = Vec::with_capacity(planned);
-    for plan in plans {
+    for (index, plan) in plans.into_iter().enumerate() {
+        if failure_injection.stage_index == Some(index) {
+            failures.push(CompactFailure {
+                spec_path: plan.result.spec_path.clone(),
+                operation: "stage",
+                message: "injected staging failure".to_string(),
+            });
+            continue;
+        }
+
         match stage_replacement(&plan.path, plan.replacement.as_bytes()) {
             Ok(temporary) => staged.push((temporary, plan)),
             Err(error) => failures.push(CompactFailure {
@@ -115,7 +141,7 @@ pub fn compact_changelogs(
 
     if !failures.is_empty() {
         return CompactReport {
-            results: staged.into_iter().map(|(_, plan)| plan.result).collect(),
+            results: planned_results,
             failures,
             planned,
             succeeded: 0,
@@ -124,7 +150,17 @@ pub fn compact_changelogs(
 
     let mut results = Vec::with_capacity(planned);
     let mut succeeded = 0usize;
-    for (temporary, mut plan) in staged {
+    for (index, (temporary, mut plan)) in staged.into_iter().enumerate() {
+        if failure_injection.publish_index == Some(index) {
+            failures.push(CompactFailure {
+                spec_path: plan.result.spec_path.clone(),
+                operation: "publish",
+                message: "injected publication failure".to_string(),
+            });
+            results.push(plan.result);
+            continue;
+        }
+
         match temporary.persist(&plan.path) {
             Ok(_) => {
                 plan.result.applied = true;
@@ -157,25 +193,14 @@ fn compact_spec_changelog(
     rel_path: &str,
     keep: usize,
 ) -> Result<Option<(String, CompactResult)>, String> {
-    // Find the ## Change Log section
-    let changelog_marker = "## Change Log";
-    let Some(cl_start) = content.find(changelog_marker) else {
+    // Locate an exact level-two heading outside fenced and indented code.
+    let Some((cl_start, section_end)) = changelog_section_bounds(content) else {
         return Ok(None);
     };
 
-    // Find where this section ends (next ## heading or EOF)
-    let after_header = cl_start + changelog_marker.len();
-    let section_end = content[after_header..]
-        .find("\n## ")
-        .map(|p| after_header + p)
-        .unwrap_or(content.len());
-
     let section = &content[cl_start..section_end];
     let lines = source_lines(section);
-    let Some(header_index) = lines
-        .iter()
-        .position(|line| line.content.trim().starts_with('|'))
-    else {
+    let Some(header_index) = first_table_header_index(&lines) else {
         return Ok(None);
     };
     let header_cells = split_cells(lines[header_index].content.trim());
@@ -289,6 +314,12 @@ fn compact_spec_changelog(
         .map(|(i, _)| *i)
         .collect();
     let insert_at = remove_indices.iter().min().copied();
+    let summary_ending = remove_indices
+        .iter()
+        .max()
+        .and_then(|index| lines.get(*index))
+        .map(|line| line.ending)
+        .unwrap_or("");
 
     // Reconstruct from inclusive source lines so every untouched line keeps
     // its original LF/CRLF terminator (including mixed-ending files).
@@ -297,7 +328,7 @@ fn compact_spec_changelog(
         if remove_indices.contains(&i) {
             if Some(i) == insert_at {
                 new_section.push_str(&summary_row);
-                new_section.push_str(line.ending);
+                new_section.push_str(summary_ending);
             }
             // Skip this line (it was compacted / an outdated summary)
         } else {
@@ -320,6 +351,123 @@ fn compact_spec_changelog(
             applied: false,
         },
     )))
+}
+
+#[derive(Clone, Copy)]
+struct MarkdownFence {
+    marker: char,
+    length: usize,
+}
+
+fn changelog_section_bounds(content: &str) -> Option<(usize, usize)> {
+    let mut offset = 0usize;
+    let mut start = None;
+    let mut fence = None;
+
+    for line in source_lines(content) {
+        if update_markdown_fence(line.content, &mut fence) {
+            offset += line.raw.len();
+            continue;
+        }
+        if fence.is_some() || is_indented_code(line.content) {
+            offset += line.raw.len();
+            continue;
+        }
+
+        if start.is_none() {
+            if exact_h2_text(line.content) == Some("Change Log") {
+                start = Some(offset);
+            }
+        } else if exact_h2_text(line.content).is_some() {
+            return Some((start?, offset));
+        }
+
+        offset += line.raw.len();
+    }
+
+    start.map(|section_start| (section_start, content.len()))
+}
+
+fn first_table_header_index(lines: &[SourceLine<'_>]) -> Option<usize> {
+    let mut fence = None;
+    for (index, line) in lines.iter().enumerate().skip(1) {
+        if update_markdown_fence(line.content, &mut fence) {
+            continue;
+        }
+        if fence.is_some() || is_indented_code(line.content) {
+            continue;
+        }
+        if line.content.trim().starts_with('|') {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn exact_h2_text(line: &str) -> Option<&str> {
+    let indent = line
+        .chars()
+        .take_while(|character| *character == ' ')
+        .count();
+    if indent > 3 {
+        return None;
+    }
+    let heading = line.get(indent..)?.trim_end();
+    let text = heading.strip_prefix("## ")?;
+    if text.starts_with('#') || text.is_empty() {
+        return None;
+    }
+    Some(text)
+}
+
+fn is_indented_code(line: &str) -> bool {
+    line.starts_with("    ") || line.starts_with('\t')
+}
+
+/// Update fenced-code state and report whether this line is a fence delimiter.
+fn update_markdown_fence(line: &str, fence: &mut Option<MarkdownFence>) -> bool {
+    let indent = line
+        .chars()
+        .take_while(|character| *character == ' ')
+        .count();
+    if indent > 3 {
+        return false;
+    }
+    let rest = match line.get(indent..) {
+        Some(rest) => rest,
+        None => return false,
+    };
+    let Some(marker) = rest
+        .chars()
+        .next()
+        .filter(|marker| matches!(marker, '`' | '~'))
+    else {
+        return false;
+    };
+    let length = rest
+        .chars()
+        .take_while(|character| *character == marker)
+        .count();
+    if length < 3 {
+        return false;
+    }
+
+    match *fence {
+        Some(active) if active.marker == marker && length >= active.length => {
+            let trailing = rest.get(length..).unwrap_or("");
+            if trailing.trim().is_empty() {
+                *fence = None;
+                true
+            } else {
+                false
+            }
+        }
+        Some(_) => false,
+        None => {
+            *fence = Some(MarkdownFence { marker, length });
+            true
+        }
+    }
 }
 
 /// Whether a changelog table row is a spec-sync compaction summary row.
@@ -820,6 +968,50 @@ Test module.
     }
 
     #[test]
+    fn compact_ignores_fenced_tables_and_change_logger_prefixes() {
+        let content = concat!(
+            "```markdown\n",
+            "## Change Log\n\n",
+            "| Date | Change |\n",
+            "|------|--------|\n",
+            "| example-1 | Example one |\n",
+            "| example-2 | Example two |\n",
+            "| example-3 | Example three |\n",
+            "```\n\n",
+            "## Change Logger\n\n",
+            "| Date | Change |\n",
+            "|------|--------|\n",
+            "| logger-1 | Logger one |\n",
+            "| logger-2 | Logger two |\n",
+            "| logger-3 | Logger three |\n\n",
+            "## Change Log\n\n",
+            "```markdown\n",
+            "| Date | Change |\n",
+            "|------|--------|\n",
+            "| nested-1 | Nested one |\n",
+            "| nested-2 | Nested two |\n",
+            "| nested-3 | Nested three |\n",
+            "```\n\n",
+            "| Date | Change |\n",
+            "|------|--------|\n",
+            "| 2026-01-01 | First |\n",
+            "| 2026-01-02 | Second |\n",
+            "| 2026-01-03 | Third |\n",
+        );
+
+        let (new_content, result) = compact_spec_changelog(content, "t.spec.md", 1)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.removed, 2);
+        assert!(new_content.contains("| example-1 | Example one |"));
+        assert!(new_content.contains("| logger-1 | Logger one |"));
+        assert!(new_content.contains("| nested-1 | Nested one |"));
+        assert!(new_content.contains("| 2026-01-03 | Third |"));
+        assert!(!new_content.contains("| 2026-01-01 | First |"));
+    }
+
+    #[test]
     fn compact_supports_keep_zero() {
         let (new_content, result) = compact_spec_changelog(&changelog_21(), "t.spec.md", 0)
             .unwrap()
@@ -829,6 +1021,29 @@ Test module.
         assert_eq!(result.compacted_entries, 0);
         assert_eq!(new_content.matches(SUMMARY_MARKER).count(), 1);
         assert!(!new_content.contains("| 2026-01-21 | Change number 21 |"));
+    }
+
+    #[test]
+    fn compact_keep_zero_preserves_missing_final_newline_for_lf_and_crlf() {
+        for line_ending in ["\n", "\r\n"] {
+            let content = [
+                "## Change Log",
+                "",
+                "| Date | Change |",
+                "|------|--------|",
+                "| 2026-01-01 | First |",
+                "| 2026-01-02 | Second |",
+            ]
+            .join(line_ending);
+
+            let (new_content, result) = compact_spec_changelog(&content, "t.spec.md", 0)
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(result.removed, 2);
+            assert!(!new_content.ends_with('\n'), "{new_content:?}");
+            assert_eq!(new_content.matches(SUMMARY_MARKER).count(), 1);
+        }
     }
 
     #[test]
@@ -866,8 +1081,68 @@ Test module.
         let report = compact_changelogs(temporary.path(), &specs, 5, false);
 
         assert!(!report.complete());
+        assert_eq!(report.planned, 2);
         assert_eq!(report.succeeded, 0);
+        assert_eq!(report.results.len(), 2);
+        assert_eq!(
+            report
+                .results
+                .iter()
+                .map(|result| result.removed)
+                .sum::<usize>(),
+            32
+        );
         assert_eq!(fs::read_to_string(&first).unwrap(), content);
+        assert_eq!(fs::read_to_string(&second).unwrap(), content);
+    }
+
+    #[test]
+    fn compact_publish_failure_reports_partial_results_and_exact_counts() {
+        let temporary = tempfile::tempdir().unwrap();
+        let specs = temporary.path().join("specs");
+        fs::create_dir_all(specs.join("a")).unwrap();
+        fs::create_dir_all(specs.join("b")).unwrap();
+        let first = specs.join("a/a.spec.md");
+        let second = specs.join("b/b.spec.md");
+        let content = changelog_21();
+        fs::write(&first, &content).unwrap();
+        fs::write(&second, &content).unwrap();
+
+        let report = compact_changelogs_with_failures(
+            temporary.path(),
+            &specs,
+            5,
+            false,
+            FailureInjection {
+                stage_index: None,
+                publish_index: Some(1),
+            },
+        );
+
+        assert!(!report.complete());
+        assert!(report.partial());
+        assert_eq!(report.planned, 2);
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(report.results.len(), 2);
+        assert_eq!(
+            report
+                .results
+                .iter()
+                .map(|result| result.removed)
+                .sum::<usize>(),
+            32
+        );
+        assert_eq!(
+            report
+                .results
+                .iter()
+                .filter(|result| result.applied)
+                .count(),
+            1
+        );
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].operation, "publish");
+        assert_ne!(fs::read_to_string(&first).unwrap(), content);
         assert_eq!(fs::read_to_string(&second).unwrap(), content);
     }
 }

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -1,16 +1,51 @@
-use colored::Colorize;
 use std::fs;
-use std::path::Path;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 use crate::validator::find_spec_files;
 
+const SUMMARY_MARKER: &str = "<!-- specsync:compact:v1 -->";
+
 /// Result of compacting a single spec's changelog.
+#[derive(Debug)]
 pub struct CompactResult {
     pub spec_path: String,
     #[allow(dead_code)]
     pub original_entries: usize,
     pub compacted_entries: usize,
     pub removed: usize,
+    pub applied: bool,
+}
+
+/// A failed compact read, parse, staging, or publish operation.
+pub struct CompactFailure {
+    pub spec_path: String,
+    pub operation: &'static str,
+    pub message: String,
+}
+
+/// Complete outcome of a repository-wide compact invocation.
+pub struct CompactReport {
+    pub results: Vec<CompactResult>,
+    pub failures: Vec<CompactFailure>,
+    pub planned: usize,
+    pub succeeded: usize,
+}
+
+impl CompactReport {
+    pub fn complete(&self) -> bool {
+        self.failures.is_empty()
+    }
+
+    pub fn partial(&self) -> bool {
+        self.succeeded > 0 && self.succeeded < self.planned
+    }
+}
+
+struct CompactPlan {
+    path: PathBuf,
+    replacement: String,
+    result: CompactResult,
 }
 
 /// Compact changelog entries across all specs.
@@ -20,38 +55,99 @@ pub fn compact_changelogs(
     specs_dir: &Path,
     keep: usize,
     dry_run: bool,
-) -> Vec<CompactResult> {
+) -> CompactReport {
     let spec_files = find_spec_files(specs_dir);
-    let mut results = Vec::new();
+    let mut plans = Vec::new();
+    let mut failures = Vec::new();
 
     for spec_path in &spec_files {
+        let rel_path = relative_display_path(root, spec_path);
         let content = match fs::read_to_string(spec_path) {
             Ok(c) => c,
-            Err(_) => continue,
-        };
-
-        let rel_path = spec_path
-            .strip_prefix(root)
-            .unwrap_or(spec_path)
-            .to_string_lossy()
-            .to_string();
-
-        if let Some((new_content, result)) = compact_spec_changelog(&content, &rel_path, keep)
-            && result.removed > 0
-        {
-            if !dry_run && let Err(e) = fs::write(spec_path, &new_content) {
-                eprintln!(
-                    "{} Failed to write {}: {e}",
-                    "error:".red().bold(),
-                    rel_path
-                );
+            Err(error) => {
+                failures.push(CompactFailure {
+                    spec_path: rel_path,
+                    operation: "read",
+                    message: error.to_string(),
+                });
                 continue;
             }
-            results.push(result);
+        };
+
+        match compact_spec_changelog(&content, &rel_path, keep) {
+            Ok(Some((replacement, result))) if result.removed > 0 => {
+                plans.push(CompactPlan {
+                    path: spec_path.clone(),
+                    replacement,
+                    result,
+                });
+            }
+            Ok(_) => {}
+            Err(message) => failures.push(CompactFailure {
+                spec_path: rel_path,
+                operation: "parse",
+                message,
+            }),
         }
     }
 
-    results
+    let planned = plans.len();
+    if dry_run || !failures.is_empty() {
+        return CompactReport {
+            results: plans.into_iter().map(|plan| plan.result).collect(),
+            failures,
+            planned,
+            succeeded: 0,
+        };
+    }
+
+    let mut staged = Vec::with_capacity(planned);
+    for plan in plans {
+        match stage_replacement(&plan.path, plan.replacement.as_bytes()) {
+            Ok(temporary) => staged.push((temporary, plan)),
+            Err(error) => failures.push(CompactFailure {
+                spec_path: plan.result.spec_path.clone(),
+                operation: "stage",
+                message: error.to_string(),
+            }),
+        }
+    }
+
+    if !failures.is_empty() {
+        return CompactReport {
+            results: staged.into_iter().map(|(_, plan)| plan.result).collect(),
+            failures,
+            planned,
+            succeeded: 0,
+        };
+    }
+
+    let mut results = Vec::with_capacity(planned);
+    let mut succeeded = 0usize;
+    for (temporary, mut plan) in staged {
+        match temporary.persist(&plan.path) {
+            Ok(_) => {
+                plan.result.applied = true;
+                succeeded += 1;
+                results.push(plan.result);
+            }
+            Err(error) => {
+                failures.push(CompactFailure {
+                    spec_path: plan.result.spec_path.clone(),
+                    operation: "publish",
+                    message: error.error.to_string(),
+                });
+                results.push(plan.result);
+            }
+        }
+    }
+
+    CompactReport {
+        results,
+        failures,
+        planned,
+        succeeded,
+    }
 }
 
 /// Compact the changelog in a single spec file's content.
@@ -60,10 +156,12 @@ fn compact_spec_changelog(
     content: &str,
     rel_path: &str,
     keep: usize,
-) -> Option<(String, CompactResult)> {
+) -> Result<Option<(String, CompactResult)>, String> {
     // Find the ## Change Log section
     let changelog_marker = "## Change Log";
-    let cl_start = content.find(changelog_marker)?;
+    let Some(cl_start) = content.find(changelog_marker) else {
+        return Ok(None);
+    };
 
     // Find where this section ends (next ## heading or EOF)
     let after_header = cl_start + changelog_marker.len();
@@ -73,107 +171,309 @@ fn compact_spec_changelog(
         .unwrap_or(content.len());
 
     let section = &content[cl_start..section_end];
-    let lines: Vec<&str> = section.lines().collect();
-
-    // Find table rows: lines starting with | that are not header/separator.
-    // The first two table lines are always header + separator; data rows follow.
-    let mut header_lines: Vec<usize> = Vec::new();
-    let mut data_rows: Vec<(usize, &str)> = Vec::new();
-    let mut table_line_count = 0usize;
-
-    for (i, line) in lines.iter().enumerate() {
-        let trimmed = line.trim();
-        if !trimmed.starts_with('|') {
-            continue;
-        }
-        table_line_count += 1;
-        // First two table lines are header row and separator row
-        if table_line_count <= 2 {
-            header_lines.push(i);
-            continue;
-        }
-        // Data row
-        data_rows.push((i, trimmed));
+    let lines = source_lines(section);
+    let Some(header_index) = lines
+        .iter()
+        .position(|line| line.content.trim().starts_with('|'))
+    else {
+        return Ok(None);
+    };
+    let header_cells = split_cells(lines[header_index].content.trim());
+    if header_cells.len() < 2 {
+        return Err("Change Log table header must contain at least two columns".to_string());
+    }
+    let separator_index = header_index + 1;
+    let Some(separator) = lines.get(separator_index) else {
+        return Err("Change Log table is missing its separator row".to_string());
+    };
+    let separator_cells = split_cells(separator.content.trim());
+    if separator_cells.len() != header_cells.len()
+        || !separator_cells.iter().all(|cell| is_separator_cell(cell))
+    {
+        return Err(format!(
+            "Change Log separator has {} columns; expected {}",
+            separator_cells.len(),
+            header_cells.len()
+        ));
     }
 
-    let total = data_rows.len();
+    // Only the first contiguous table is the changelog table. Later tables in
+    // the section are prose and must remain byte-for-byte untouched.
+    let mut data_rows: Vec<(usize, &str)> = Vec::new();
+    for (index, line) in lines.iter().enumerate().skip(separator_index + 1) {
+        let trimmed = line.content.trim();
+        if !trimmed.starts_with('|') {
+            break;
+        }
+        let cells = split_cells(trimmed);
+        if cells.len() != header_cells.len() {
+            return Err(format!(
+                "Change Log row {} has {} columns; expected {}",
+                index + 1,
+                cells.len(),
+                header_cells.len()
+            ));
+        }
+        data_rows.push((index, trimmed));
+    }
+
+    // #417: recognize our OWN compaction summary rows so a re-run replaces
+    // (folds) them instead of re-compacting them as ordinary entries — the
+    // accumulated count and range survive, making compact idempotent.
+    let (summary_rows, entries): (Vec<_>, Vec<_>) =
+        data_rows.into_iter().partition(|(_, l)| is_summary_row(l));
+    if summary_rows.len() > 1 {
+        return Err(
+            "Change Log contains multiple SpecSync compaction summaries; refusing ambiguous folding"
+                .to_string(),
+        );
+    }
+
+    let old_count = summary_rows
+        .iter()
+        .filter_map(|(_, row)| summary_metadata(row))
+        .map(|(count, _)| count)
+        .next()
+        .unwrap_or(0);
+    let old_range_start = summary_rows
+        .iter()
+        .find_map(|(_, row)| summary_metadata(row).map(|(_, start)| start));
+
+    let total = entries.len();
     if total <= keep {
-        return Some((
+        return Ok(Some((
             content.to_string(),
             CompactResult {
                 spec_path: rel_path.to_string(),
                 original_entries: total,
                 compacted_entries: total,
                 removed: 0,
+                applied: false,
             },
-        ));
+        )));
     }
 
     // Keep the last `keep` entries, summarize the rest
     let to_remove = total - keep;
-    let removed_rows = &data_rows[..to_remove];
+    let removed_rows = &entries[..to_remove];
 
-    // Extract date range from removed entries
-    let first_date = extract_first_cell(removed_rows.first().map(|(_, l)| *l).unwrap_or(""));
+    // Fold any previous summary into the new one: counts add, the range keeps
+    // its original start and extends to the newest compacted entry.
+    let new_count = old_count
+        .checked_add(to_remove as u64)
+        .ok_or_else(|| "SpecSync compaction summary count overflowed u64".to_string())?;
+    let first_date = old_range_start
+        .unwrap_or_else(|| extract_first_cell(removed_rows.first().map(|(_, l)| *l).unwrap_or("")));
     let last_date = extract_first_cell(removed_rows.last().map(|(_, l)| *l).unwrap_or(""));
 
-    // Detect column count from first data row
-    let col_count = data_rows
-        .first()
-        .map(|(_, l)| l.matches('|').count().saturating_sub(1))
-        .unwrap_or(2);
+    let col_count = header_cells.len();
 
-    let summary_row = if col_count >= 3 {
-        format!("| {first_date} — {last_date} | — | Compacted: {to_remove} entries |")
-    } else {
-        format!("| {first_date} — {last_date} | Compacted: {to_remove} entries |")
+    let summary_row = {
+        let mut cells: Vec<String> = Vec::with_capacity(col_count);
+        cells.push(format!("{first_date} — {last_date}"));
+        for _ in 0..col_count.saturating_sub(2) {
+            cells.push("—".to_string());
+        }
+        cells.push(format!(
+            "Compacted: {new_count} {} {SUMMARY_MARKER}",
+            if new_count == 1 { "entry" } else { "entries" }
+        ));
+        format!("| {} |", cells.join(" | "))
     };
 
-    // Build the indices to remove
-    let remove_indices: std::collections::HashSet<usize> =
-        removed_rows.iter().map(|(i, _)| *i).collect();
+    // Remove the compacted entries AND any previous summary row; insert the
+    // new summary at the earliest removed position.
+    let remove_indices: std::collections::HashSet<usize> = removed_rows
+        .iter()
+        .chain(summary_rows.iter())
+        .map(|(i, _)| *i)
+        .collect();
+    let insert_at = remove_indices.iter().min().copied();
 
-    // Reconstruct the section
-    let mut new_lines: Vec<String> = Vec::new();
-    let mut inserted_summary = false;
-
+    // Reconstruct from inclusive source lines so every untouched line keeps
+    // its original LF/CRLF terminator (including mixed-ending files).
+    let mut new_section = String::with_capacity(section.len());
     for (i, line) in lines.iter().enumerate() {
         if remove_indices.contains(&i) {
-            if !inserted_summary {
-                new_lines.push(summary_row.clone());
-                inserted_summary = true;
+            if Some(i) == insert_at {
+                new_section.push_str(&summary_row);
+                new_section.push_str(line.ending);
             }
-            // Skip this line (it was compacted)
+            // Skip this line (it was compacted / an outdated summary)
         } else {
-            new_lines.push(line.to_string());
+            new_section.push_str(line.raw);
         }
     }
 
-    let new_section = new_lines.join("\n");
     let mut new_content = String::new();
     new_content.push_str(&content[..cl_start]);
     new_content.push_str(&new_section);
     new_content.push_str(&content[section_end..]);
 
-    Some((
+    Ok(Some((
         new_content,
         CompactResult {
             spec_path: rel_path.to_string(),
             original_entries: total,
-            compacted_entries: keep + 1, // kept + summary
+            compacted_entries: keep, // entries actually kept (summary row excluded)
             removed: to_remove,
+            applied: false,
         },
-    ))
+    )))
+}
+
+/// Whether a changelog table row is a spec-sync compaction summary row.
+fn is_summary_row(row: &str) -> bool {
+    summary_metadata(row).is_some()
+}
+
+/// Parse the metadata that uniquely identifies a spec-sync summary row.
+///
+/// Requiring both a non-empty range and an exact `Compacted: N entry|entries`
+/// final cell prevents ordinary user-authored changelog text beginning with
+/// `Compacted:` from being deleted as if it were tool-owned state.
+fn summary_metadata(row: &str) -> Option<(u64, String)> {
+    let cells = split_cells(row);
+    if cells.len() < 2 || cells[1..cells.len() - 1].iter().any(|cell| cell != "—") {
+        return None;
+    }
+    let (range_start, range_end) = cells.first()?.split_once(" — ")?;
+    let range_start = range_start.trim();
+    if range_start.is_empty() || range_end.trim().is_empty() {
+        return None;
+    }
+
+    let mut summary_parts = cells
+        .last()?
+        .trim()
+        .strip_suffix(SUMMARY_MARKER)?
+        .trim_end()
+        .strip_prefix("Compacted: ")?
+        .split_whitespace();
+    let count: u64 = summary_parts.next()?.parse().ok()?;
+    let label = summary_parts.next()?;
+    if (count == 1 && label != "entry")
+        || (count != 1 && label != "entries")
+        || summary_parts.next().is_some()
+    {
+        return None;
+    }
+
+    Some((count, range_start.to_string()))
+}
+
+/// Split a markdown table row into cells, honoring odd escaped backslash runs
+/// and Markdown code spans containing pipes.
+fn split_cells(row: &str) -> Vec<String> {
+    let inner = row.trim();
+    let mut cells = Vec::new();
+    let mut cur = String::new();
+    let chars: Vec<char> = inner.chars().collect();
+    let mut index = usize::from(chars.first() == Some(&'|'));
+    let mut code_delimiter = None;
+    let mut backslash_run = 0usize;
+
+    while index < chars.len() {
+        let ch = chars[index];
+        if ch == '`' {
+            let start = index;
+            while index < chars.len() && chars[index] == '`' {
+                index += 1;
+            }
+            let run = index - start;
+            match code_delimiter {
+                Some(delimiter) if delimiter == run => code_delimiter = None,
+                None => code_delimiter = Some(run),
+                _ => {}
+            }
+            cur.extend(std::iter::repeat_n('`', run));
+            backslash_run = 0;
+            continue;
+        }
+
+        if ch == '|' && code_delimiter.is_none() && backslash_run.is_multiple_of(2) {
+            cells.push(cur.trim().to_string());
+            cur.clear();
+            backslash_run = 0;
+            index += 1;
+            continue;
+        }
+
+        cur.push(ch);
+        backslash_run = if ch == '\\' { backslash_run + 1 } else { 0 };
+        index += 1;
+    }
+
+    if !cur.trim().is_empty() {
+        cells.push(cur.trim().to_string());
+    }
+    cells
 }
 
 /// Extract the first cell value from a markdown table row.
 fn extract_first_cell(row: &str) -> String {
-    let parts: Vec<&str> = row.split('|').collect();
-    if parts.len() >= 2 {
-        parts[1].trim().to_string()
-    } else {
-        "?".to_string()
+    split_cells(row)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| "?".to_string())
+}
+
+struct SourceLine<'a> {
+    raw: &'a str,
+    content: &'a str,
+    ending: &'a str,
+}
+
+fn source_lines(source: &str) -> Vec<SourceLine<'_>> {
+    source
+        .split_inclusive('\n')
+        .map(|raw| {
+            let without_lf = raw.strip_suffix('\n').unwrap_or(raw);
+            let content = without_lf.strip_suffix('\r').unwrap_or(without_lf);
+            SourceLine {
+                raw,
+                content,
+                ending: &raw[content.len()..],
+            }
+        })
+        .collect()
+}
+
+fn is_separator_cell(cell: &str) -> bool {
+    let trimmed = cell.trim().trim_matches(':');
+    trimmed.len() >= 3 && trimmed.chars().all(|character| character == '-')
+}
+
+fn relative_display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}
+
+fn stage_replacement(path: &Path, replacement: &[u8]) -> io::Result<tempfile::NamedTempFile> {
+    let metadata = fs::metadata(path)?;
+    if metadata.permissions().readonly() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "target is read-only",
+        ));
     }
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "target has no parent directory",
+        )
+    })?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".specsync-compact-")
+        .tempfile_in(parent)?;
+    temporary.write_all(replacement)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .as_file_mut()
+        .set_permissions(metadata.permissions())?;
+    Ok(temporary)
 }
 
 #[cfg(test)]
@@ -205,7 +505,9 @@ Test module.
 | 2026-03-01 | Fifth |
 "#;
 
-        let (new_content, result) = compact_spec_changelog(content, "test.spec.md", 3).unwrap();
+        let (new_content, result) = compact_spec_changelog(content, "test.spec.md", 3)
+            .unwrap()
+            .unwrap();
         assert_eq!(result.original_entries, 5);
         assert_eq!(result.removed, 2);
         assert!(new_content.contains("Compacted: 2 entries"));
@@ -223,7 +525,9 @@ Test module.
 | 2026-03-01 | Only entry |
 "#;
 
-        let (_, result) = compact_spec_changelog(content, "test.spec.md", 5).unwrap();
+        let (_, result) = compact_spec_changelog(content, "test.spec.md", 5)
+            .unwrap()
+            .unwrap();
         assert_eq!(result.removed, 0);
     }
 
@@ -238,9 +542,332 @@ Test module.
 | 2026-03-01 | carol | Third |
 "#;
 
-        let (new_content, result) = compact_spec_changelog(content, "test.spec.md", 1).unwrap();
+        let (new_content, result) = compact_spec_changelog(content, "test.spec.md", 1)
+            .unwrap()
+            .unwrap();
         assert_eq!(result.removed, 2);
         assert!(new_content.contains("| — |")); // compacted author column
         assert!(new_content.contains("Compacted: 2 entries"));
+    }
+
+    // ── #417 regressions ────────────────────────────────────────────
+
+    fn changelog_21() -> String {
+        let mut s = String::from("## Change Log\n\n| Date | Change |\n|------|--------|\n");
+        for i in 1..=21 {
+            s.push_str(&format!("| 2026-01-{i:02} | Change number {i} |\n"));
+        }
+        s
+    }
+
+    #[test]
+    fn compact_is_idempotent() {
+        // #417 core regression: re-running compact must not re-compact its own
+        // summary row — count and range survive, nothing changes.
+        let (once, r1) = compact_spec_changelog(&changelog_21(), "t.spec.md", 5)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r1.removed, 16);
+        assert!(once.contains("Compacted: 16 entries"));
+        assert!(once.contains("| 2026-01-01 — 2026-01-16 |"));
+
+        let (twice, r2) = compact_spec_changelog(&once, "t.spec.md", 5)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r2.removed, 0, "second run must be a no-op");
+        assert_eq!(once, twice, "second run must not change the file");
+    }
+
+    #[test]
+    fn compact_folds_existing_summary_when_more_entries_arrive() {
+        let (once, _) = compact_spec_changelog(&changelog_21(), "t.spec.md", 5)
+            .unwrap()
+            .unwrap();
+        // Two new entries land, pushing past --keep 5 again.
+        let extended = once.replace(
+            "| 2026-01-21 | Change number 21 |",
+            "| 2026-01-21 | Change number 21 |\n| 2026-01-22 | Change number 22 |\n| 2026-01-23 | Change number 23 |",
+        );
+        let (twice, r2) = compact_spec_changelog(&extended, "t.spec.md", 5)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r2.removed, 2);
+        assert!(twice.contains("Compacted: 18 entries"), "{twice}");
+        assert!(twice.contains("| 2026-01-01 — 2026-01-18 |"), "{twice}");
+        // Exactly one summary row.
+        assert_eq!(twice.matches("Compacted: ").count(), 1, "{twice}");
+    }
+
+    #[test]
+    fn compact_preserves_trailing_newline() {
+        let content = changelog_21();
+        assert!(content.ends_with('\n'));
+        let (new_content, _) = compact_spec_changelog(&content, "t.spec.md", 5)
+            .unwrap()
+            .unwrap();
+        assert!(new_content.ends_with('\n'), "trailing newline stripped");
+    }
+
+    #[test]
+    fn compact_summary_row_matches_four_column_table() {
+        let mut content = String::from(
+            "## Change Log\n\n| Date | PR | Author | Change |\n|------|----|--------|--------|\n",
+        );
+        for i in 1..=8 {
+            content.push_str(&format!("| 2026-01-{i:02} | #{i} | dev | Change {i} |\n"));
+        }
+        let (new_content, _) = compact_spec_changelog(&content, "t.spec.md", 3)
+            .unwrap()
+            .unwrap();
+        let summary = new_content
+            .lines()
+            .find(|l| l.contains("Compacted: "))
+            .unwrap();
+        assert_eq!(split_cells(summary).len(), 4, "malformed row: {summary}");
+    }
+
+    #[test]
+    fn compact_handles_escaped_pipes_in_cells() {
+        let mut content = String::from("## Change Log\n\n| Date | Change |\n|------|--------|\n");
+        for i in 1..=6 {
+            content.push_str(&format!("| 2026-01-{i:02} | Change {i} |\n"));
+        }
+        content.push_str("| 2026-02-01 | Uses a \\| b syntax |\n");
+        let (new_content, r) = compact_spec_changelog(&content, "t.spec.md", 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.removed, 5);
+        assert!(
+            new_content.contains("Uses a \\| b syntax"),
+            "escaped-pipe cell truncated/dropped:\n{new_content}"
+        );
+        assert!(
+            new_content.contains("2026-01-01 — 2026-01-05"),
+            "{new_content}"
+        );
+    }
+
+    #[test]
+    fn split_cells_preserves_one_escaped_pipe() {
+        let cells = split_cells("| 2026-01-01 | Uses a \\| b syntax |");
+        assert_eq!(cells, ["2026-01-01", "Uses a \\| b syntax"]);
+    }
+
+    #[test]
+    fn compact_does_not_treat_user_text_as_a_summary_row() {
+        let mut content = String::from("## Change Log\n\n| Date | Change |\n|------|--------|\n");
+        for i in 1..=6 {
+            content.push_str(&format!("| 2026-01-{i:02} | Change {i} |\n"));
+        }
+        content.push_str("| 2026-01-07 | Compacted: manual migration notes |\n");
+
+        let (new_content, result) = compact_spec_changelog(&content, "t.spec.md", 2)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.removed, 5);
+        assert!(
+            new_content.contains("| 2026-01-07 | Compacted: manual migration notes |"),
+            "a user-authored recent row was mistaken for a tool summary:\n{new_content}"
+        );
+    }
+
+    #[test]
+    fn compact_requires_summary_placeholders_in_wide_tables() {
+        let mut content = String::from(
+            "## Change Log\n\n| Date | Author | Change |\n|------|--------|--------|\n",
+        );
+        for i in 1..=6 {
+            content.push_str(&format!("| 2026-01-{i:02} | dev | Change {i} |\n"));
+        }
+        content.push_str("| 2026-01-01 — 2026-01-07 | maintainer | Compacted: 2 entries |\n");
+
+        let (new_content, result) = compact_spec_changelog(&content, "t.spec.md", 2)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.removed, 5);
+        assert!(
+            new_content.contains("| 2026-01-01 — 2026-01-07 | maintainer | Compacted: 2 entries |"),
+            "a user-authored wide row was mistaken for a tool summary:\n{new_content}"
+        );
+    }
+
+    #[test]
+    fn compact_uses_singular_for_one_entry() {
+        let content = changelog_21();
+        let (new_content, r) = compact_spec_changelog(&content, "t.spec.md", 20)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.removed, 1);
+        assert!(
+            new_content.contains(&format!("Compacted: 1 entry {SUMMARY_MARKER} |")),
+            "{new_content}"
+        );
+        assert!(!new_content.contains("1 entries"));
+    }
+
+    #[test]
+    fn compact_reports_kept_entries_not_summary_row() {
+        // #417: --keep 5 used to report "(kept 6)" because the summary row was
+        // counted as a kept entry.
+        let (_, r) = compact_spec_changelog(&changelog_21(), "t.spec.md", 5)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.compacted_entries, 5);
+    }
+
+    #[test]
+    fn compact_preserves_exact_shape_user_row_without_marker() {
+        let mut content = String::from("## Change Log\n\n| Date | Change |\n|------|--------|\n");
+        for i in 1..=6 {
+            content.push_str(&format!("| 2026-01-{i:02} | Change {i} |\n"));
+        }
+        content.push_str("| 2025-01-01 — 2025-01-31 | Compacted: 2 entries |\n");
+
+        let (new_content, result) = compact_spec_changelog(&content, "t.spec.md", 2)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.removed, 5);
+        assert!(
+            new_content.contains("| 2025-01-01 — 2025-01-31 | Compacted: 2 entries |"),
+            "an unmarked user row was claimed as tool state:\n{new_content}"
+        );
+        assert!(new_content.contains(SUMMARY_MARKER));
+    }
+
+    #[test]
+    fn compact_rejects_multiple_marked_summaries() {
+        let marker = SUMMARY_MARKER;
+        let content = format!(
+            "## Change Log\n\n| Date | Change |\n|------|--------|\n\
+             | 2026-01-01 — 2026-01-02 | Compacted: 2 entries {marker} |\n\
+             | 2026-01-03 — 2026-01-04 | Compacted: 2 entries {marker} |\n\
+             | 2026-01-05 | Fifth |\n"
+        );
+
+        let error = compact_spec_changelog(&content, "t.spec.md", 0).unwrap_err();
+        assert!(error.contains("multiple SpecSync compaction summaries"));
+    }
+
+    #[test]
+    fn compact_preserves_crlf_and_mixed_line_endings() {
+        let content = concat!(
+            "## Change Log\r\n",
+            "\r\n",
+            "| Date | Change |\r\n",
+            "|------|--------|\r\n",
+            "| 2026-01-01 | First |\r\n",
+            "| 2026-01-02 | Second |\n",
+            "| 2026-01-03 | Third |\r\n",
+            "\r\n",
+            "## Next\r\n",
+            "untouched\n",
+        );
+
+        let (new_content, _) = compact_spec_changelog(content, "t.spec.md", 1)
+            .unwrap()
+            .unwrap();
+
+        assert!(new_content.starts_with("## Change Log\r\n\r\n"));
+        assert!(new_content.contains(SUMMARY_MARKER));
+        assert!(new_content.contains("| 2026-01-03 | Third |\r\n\r\n## Next\r\nuntouched\n"));
+        assert!(!new_content.contains("| 2026-01-02 | Second |\n"));
+    }
+
+    #[test]
+    fn split_cells_honors_backslash_parity_and_code_spans() {
+        assert_eq!(
+            split_cells(r"| date | one \| pipe |"),
+            ["date", r"one \| pipe"]
+        );
+        assert_eq!(
+            split_cells(r"| date | two \\| columns |"),
+            ["date", r"two \\", "columns"]
+        );
+        assert_eq!(
+            split_cells("| date | `code | pipe` |"),
+            ["date", "`code | pipe`"]
+        );
+        assert_eq!(
+            split_cells("| date | ``code ` | pipe`` |"),
+            ["date", "``code ` | pipe``"]
+        );
+    }
+
+    #[test]
+    fn compact_ignores_secondary_tables_after_changelog_table() {
+        let content = concat!(
+            "## Change Log\n\n",
+            "| Date | Change |\n",
+            "|------|--------|\n",
+            "| 2026-01-01 | First |\n",
+            "| 2026-01-02 | Second |\n",
+            "| 2026-01-03 | Third |\n",
+            "\n",
+            "| Key | Value |\n",
+            "|-----|-------|\n",
+            "| A | B |\n",
+        );
+
+        let (new_content, result) = compact_spec_changelog(content, "t.spec.md", 1)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.removed, 2);
+        assert!(new_content.contains("| Key | Value |\n|-----|-------|\n| A | B |\n"));
+    }
+
+    #[test]
+    fn compact_supports_keep_zero() {
+        let (new_content, result) = compact_spec_changelog(&changelog_21(), "t.spec.md", 0)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.removed, 21);
+        assert_eq!(result.compacted_entries, 0);
+        assert_eq!(new_content.matches(SUMMARY_MARKER).count(), 1);
+        assert!(!new_content.contains("| 2026-01-21 | Change number 21 |"));
+    }
+
+    #[test]
+    fn compact_rejects_summary_count_overflow() {
+        let content = format!(
+            "## Change Log\n\n| Date | Change |\n|------|--------|\n\
+             | 2026-01-01 — 2026-01-02 | Compacted: {} entries {} |\n\
+             | 2026-01-03 | Third |\n",
+            u64::MAX,
+            SUMMARY_MARKER
+        );
+
+        let error = compact_spec_changelog(&content, "t.spec.md", 0).unwrap_err();
+        assert!(error.contains("overflowed u64"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn compact_preflight_failure_prevents_all_writes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temporary = tempfile::tempdir().unwrap();
+        let specs = temporary.path().join("specs");
+        fs::create_dir_all(specs.join("a")).unwrap();
+        fs::create_dir_all(specs.join("b")).unwrap();
+        let first = specs.join("a/a.spec.md");
+        let second = specs.join("b/b.spec.md");
+        let content = changelog_21();
+        fs::write(&first, &content).unwrap();
+        fs::write(&second, &content).unwrap();
+        let mut permissions = fs::metadata(&second).unwrap().permissions();
+        permissions.set_mode(0o444);
+        fs::set_permissions(&second, permissions).unwrap();
+
+        let report = compact_changelogs(temporary.path(), &specs, 5, false);
+
+        assert!(!report.complete());
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(fs::read_to_string(&first).unwrap(), content);
+        assert_eq!(fs::read_to_string(&second).unwrap(), content);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,9 +198,11 @@ fn run() {
         Command::Diff { base } => commands::diff::cmd_diff(&root, &base, format),
         Command::Hooks { action } => commands::hooks::cmd_hooks(&root, action),
         Command::Agents { action } => commands::agents::cmd_agents(&root, action),
-        Command::Compact { keep, dry_run } => commands::compact::cmd_compact(&root, keep, dry_run),
+        Command::Compact { keep, dry_run } => {
+            commands::compact::cmd_compact(&root, keep, dry_run, format)
+        }
         Command::ArchiveTasks { dry_run } => {
-            commands::archive_tasks::cmd_archive_tasks(&root, dry_run)
+            commands::archive_tasks::cmd_archive_tasks(&root, dry_run, format)
         }
         Command::View { role, spec } => commands::view::cmd_view(&root, &role, spec.as_deref()),
         Command::Merge { dry_run, all } => commands::merge::cmd_merge(&root, dry_run, all, format),

--- a/tests/integration/commands.rs
+++ b/tests/integration/commands.rs
@@ -4383,8 +4383,8 @@ fn generate_json_no_specs_emits_valid_json() {
 }
 
 // ─── compact: idempotent files and truthful text output ───────────────
-// Requirement evidence: REQ-cli-007, REQ-cmd-archive-tasks-001,
-// REQ-cmd-compact-001, and REQ-compact-001.
+// Requirement evidence: REQ-cli-007, REQ-archive-001,
+// REQ-cmd-archive-tasks-001, REQ-cmd-compact-001, and REQ-compact-001.
 
 fn setup_compact_project(tmp: &TempDir) -> std::path::PathBuf {
     let root = tmp.path().to_path_buf();

--- a/tests/integration/commands.rs
+++ b/tests/integration/commands.rs
@@ -4382,6 +4382,416 @@ fn generate_json_no_specs_emits_valid_json() {
     );
 }
 
+// ─── compact: idempotent files and truthful text output ───────────────
+// Requirement evidence: REQ-cli-007, REQ-cmd-archive-tasks-001,
+// REQ-cmd-compact-001, and REQ-compact-001.
+
+fn setup_compact_project(tmp: &TempDir) -> std::path::PathBuf {
+    let root = tmp.path().to_path_buf();
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src/history")).unwrap();
+    fs::write(
+        root.join("src/history/mod.ts"),
+        "export function record() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/history")).unwrap();
+
+    let mut spec = valid_spec("history", &["src/history/mod.ts"]);
+    for day in 1..=4 {
+        spec.push_str(&format!(
+            "| 2026-07-{day:02} | maintainer | Change {day} |\n"
+        ));
+    }
+    fs::write(root.join("specs/history/history.spec.md"), spec).unwrap();
+    root
+}
+
+#[test]
+fn compact_dry_run_reports_counts_without_writing() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_compact_project(&tmp);
+    let spec_path = root.join("specs/history/history.spec.md");
+    let before = fs::read(&spec_path).unwrap();
+
+    specsync()
+        .args(["compact", "--keep", "2", "--dry-run", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Dry run — no files will be modified",
+        ))
+        .stdout(predicate::str::contains("would compact 2 entries (kept 2)"))
+        .stdout(predicate::str::contains(
+            "Would compact 2 entries across 1 spec",
+        ));
+
+    assert_eq!(fs::read(spec_path).unwrap(), before);
+}
+
+#[test]
+fn compact_cli_is_idempotent_and_preserves_trailing_newline() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_compact_project(&tmp);
+    let spec_path = root.join("specs/history/history.spec.md");
+
+    specsync()
+        .args(["compact", "--keep", "2", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("compacted 2 entries (kept 2)"))
+        .stdout(predicate::str::contains(
+            "Compacted 2 entries across 1 spec",
+        ));
+
+    let once = fs::read(&spec_path).unwrap();
+    assert!(
+        once.ends_with(b"\n"),
+        "compact stripped the trailing newline"
+    );
+
+    specsync()
+        .args(["compact", "--keep", "2", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No changelogs need compaction (all within limit).",
+        ));
+
+    assert_eq!(
+        fs::read(spec_path).unwrap(),
+        once,
+        "the second compact run changed the file"
+    );
+}
+
+#[test]
+fn compact_json_formats_are_clean_truthful_and_equivalent() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_compact_project(&tmp);
+    let spec_path = root.join("specs/history/history.spec.md");
+    let before = fs::read(&spec_path).unwrap();
+    let mut outputs = Vec::new();
+
+    for format_args in [vec!["--format", "json"], vec!["--json"]] {
+        let output = specsync()
+            .args(["compact", "--keep", "2", "--dry-run"])
+            .args(format_args)
+            .arg("--root")
+            .arg(&root)
+            .assert()
+            .success()
+            .get_output()
+            .clone();
+        assert!(
+            !output.stdout.contains(&0x1b),
+            "JSON stdout contained an ANSI escape"
+        );
+        outputs.push(
+            serde_json::from_slice::<serde_json::Value>(&output.stdout)
+                .expect("compact JSON stdout must be one valid document"),
+        );
+    }
+
+    assert_eq!(outputs[0], outputs[1], "--json must match --format json");
+    let result = &outputs[0];
+    assert_eq!(result["command"], "compact");
+    assert_eq!(result["dry_run"], true);
+    assert_eq!(result["would_change"], true);
+    assert_eq!(result["applied"], false);
+    assert_eq!(result["complete"], true);
+    assert_eq!(result["partial"], false);
+    assert_eq!(result["operations"]["planned"], 1);
+    assert_eq!(result["operations"]["succeeded"], 0);
+    assert_eq!(result["operations"]["failed"], 0);
+    assert_eq!(result["entries_affected"], 2);
+    assert_eq!(result["specs_affected"], 1);
+    assert_eq!(
+        result["results"][0]["spec_path"],
+        "specs/history/history.spec.md"
+    );
+    assert_eq!(result["results"][0]["action"], "would_compact");
+    assert_eq!(result["results"][0]["kept_entries"], 2);
+    assert_eq!(fs::read(spec_path).unwrap(), before);
+}
+
+#[test]
+fn compact_markdown_and_github_are_structured_and_preserve_dry_run() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_compact_project(&tmp);
+    let spec_path = root.join("specs/history/history.spec.md");
+    let before = fs::read(&spec_path).unwrap();
+
+    for format in ["markdown", "github"] {
+        specsync()
+            .args(["compact", "--keep", "2", "--dry-run", "--format", format])
+            .arg("--root")
+            .arg(&root)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("## SpecSync Compact Results"))
+            .stdout(predicate::str::contains(
+                "> Dry run — no files will be modified.",
+            ))
+            .stdout(predicate::str::contains(
+                "| Spec | Action | Entries affected | Kept |",
+            ))
+            .stdout(predicate::str::contains(
+                "| `specs/history/history.spec.md` | Would compact | 2 | 2 |",
+            ))
+            .stdout(predicate::str::contains(
+                "**Summary:** Would compact 2 entries across 1 spec.",
+            ));
+    }
+
+    assert_eq!(fs::read(spec_path).unwrap(), before);
+}
+
+#[test]
+fn compact_parse_failure_exits_one_with_valid_json_and_zero_writes() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_compact_project(&tmp);
+    let valid_path = root.join("specs/history/history.spec.md");
+    let valid_before = fs::read(&valid_path).unwrap();
+
+    fs::create_dir_all(root.join("src/broken")).unwrap();
+    fs::write(
+        root.join("src/broken/mod.ts"),
+        "export function broken() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/broken")).unwrap();
+    let broken_path = root.join("specs/broken/broken.spec.md");
+    let broken = valid_spec("broken", &["src/broken/mod.ts"])
+        .replace("|------|--------|--------|", "|------|--------|");
+    fs::write(&broken_path, &broken).unwrap();
+
+    let output = specsync()
+        .args(["compact", "--keep", "2", "--format", "json", "--root"])
+        .arg(&root)
+        .assert()
+        .failure()
+        .code(1)
+        .get_output()
+        .clone();
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("failure stdout must remain valid JSON");
+
+    assert_eq!(report["complete"], false);
+    assert_eq!(report["partial"], false);
+    assert_eq!(report["applied"], false);
+    assert_eq!(report["operations"]["planned"], 1);
+    assert_eq!(report["operations"]["succeeded"], 0);
+    assert_eq!(report["operations"]["failed"], 1);
+    assert_eq!(report["errors"][0]["operation"], "parse");
+    assert_eq!(fs::read(valid_path).unwrap(), valid_before);
+    assert_eq!(fs::read_to_string(broken_path).unwrap(), broken);
+}
+
+#[cfg(unix)]
+#[test]
+fn compact_json_preserves_an_actual_unix_backslash_filename() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src/history")).unwrap();
+    fs::write(
+        root.join("src/history/mod.ts"),
+        "export function record() {}\n",
+    )
+    .unwrap();
+    let spec_dir = root.join(r"specs/history\literal");
+    fs::create_dir_all(&spec_dir).unwrap();
+    let mut spec = valid_spec("history", &["src/history/mod.ts"]);
+    for day in 1..=3 {
+        spec.push_str(&format!(
+            "| 2026-07-{day:02} | maintainer | Change {day} |\n"
+        ));
+    }
+    fs::write(spec_dir.join("history.spec.md"), spec).unwrap();
+
+    let output = specsync()
+        .args(["compact", "--keep", "1", "--dry-run", "--format", "json"])
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(
+        report["results"][0]["spec_path"],
+        r"specs/history\literal/history.spec.md"
+    );
+}
+
+// ─── archive-tasks: text and structured output ───────────────────────
+
+fn setup_archive_tasks_project(tmp: &TempDir) -> std::path::PathBuf {
+    let root = tmp.path().to_path_buf();
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src/work")).unwrap();
+    fs::write(root.join("src/work/mod.ts"), "export function work() {}\n").unwrap();
+    fs::create_dir_all(root.join("specs/work")).unwrap();
+    fs::write(
+        root.join("specs/work/work.spec.md"),
+        valid_spec("work", &["src/work/mod.ts"]),
+    )
+    .unwrap();
+    fs::write(
+        root.join("specs/work/tasks.md"),
+        "---\nspec: work.spec.md\n---\n\n## Tasks\n\n- [x] Done one\n- [ ] Still open\n- [X] Done two\n",
+    )
+    .unwrap();
+    root
+}
+
+#[test]
+fn archive_tasks_text_dry_run_reports_without_writing() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_archive_tasks_project(&tmp);
+    let tasks_path = root.join("specs/work/tasks.md");
+    let before = fs::read(&tasks_path).unwrap();
+
+    specsync()
+        .args(["archive-tasks", "--dry-run", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Dry run — no files will be modified",
+        ))
+        .stdout(predicate::str::contains("would archive 2 tasks"))
+        .stdout(predicate::str::contains(
+            "Would archive 2 tasks across 1 file",
+        ));
+
+    assert_eq!(fs::read(tasks_path).unwrap(), before);
+}
+
+#[test]
+fn archive_tasks_json_formats_are_clean_truthful_and_equivalent() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_archive_tasks_project(&tmp);
+    let tasks_path = root.join("specs/work/tasks.md");
+    let before = fs::read(&tasks_path).unwrap();
+    let mut outputs = Vec::new();
+
+    for format_args in [vec!["--format", "json"], vec!["--json"]] {
+        let output = specsync()
+            .args(["archive-tasks", "--dry-run"])
+            .args(format_args)
+            .arg("--root")
+            .arg(&root)
+            .assert()
+            .success()
+            .get_output()
+            .clone();
+        assert!(
+            !output.stdout.contains(&0x1b),
+            "JSON stdout contained an ANSI escape"
+        );
+        outputs.push(
+            serde_json::from_slice::<serde_json::Value>(&output.stdout)
+                .expect("archive-tasks JSON stdout must be one valid document"),
+        );
+    }
+
+    assert_eq!(outputs[0], outputs[1], "--json must match --format json");
+    let result = &outputs[0];
+    assert_eq!(result["command"], "archive-tasks");
+    assert_eq!(result["dry_run"], true);
+    assert_eq!(result["would_change"], true);
+    assert_eq!(result["applied"], false);
+    assert_eq!(result["tasks_affected"], 2);
+    assert_eq!(result["files_affected"], 1);
+    assert_eq!(result["results"][0]["tasks_path"], "specs/work/tasks.md");
+    assert_eq!(result["results"][0]["action"], "would_archive");
+    assert_eq!(result["results"][0]["tasks_affected"], 2);
+    assert_eq!(fs::read(tasks_path).unwrap(), before);
+}
+
+#[test]
+fn archive_tasks_markdown_is_structured_and_preserves_dry_run() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_archive_tasks_project(&tmp);
+    let tasks_path = root.join("specs/work/tasks.md");
+    let before = fs::read(&tasks_path).unwrap();
+
+    for format in ["markdown", "github"] {
+        specsync()
+            .args(["archive-tasks", "--dry-run", "--format", format, "--root"])
+            .arg(&root)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "## SpecSync Archive Tasks Results",
+            ))
+            .stdout(predicate::str::contains(
+                "> Dry run — no files will be modified.",
+            ))
+            .stdout(predicate::str::contains(
+                "| Tasks file | Action | Tasks affected |",
+            ))
+            .stdout(predicate::str::contains(
+                "| `specs/work/tasks.md` | Would archive | 2 |",
+            ))
+            .stdout(predicate::str::contains(
+                "**Summary:** Would archive 2 tasks across 1 file.",
+            ));
+    }
+
+    assert_eq!(fs::read(tasks_path).unwrap(), before);
+}
+
+#[test]
+fn archive_tasks_apply_failure_exits_one_and_reports_zero_writes() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_archive_tasks_project(&tmp);
+    let valid_tasks = root.join("specs/work/tasks.md");
+    let valid_before = fs::read(&valid_tasks).unwrap();
+
+    fs::create_dir_all(root.join("src/invalid")).unwrap();
+    fs::write(
+        root.join("src/invalid/mod.ts"),
+        "export function invalid() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/invalid")).unwrap();
+    fs::write(
+        root.join("specs/invalid/invalid.spec.md"),
+        valid_spec("invalid", &["src/invalid/mod.ts"]),
+    )
+    .unwrap();
+    let invalid_tasks = root.join("specs/invalid/tasks.md");
+    fs::write(&invalid_tasks, b"## Tasks\n\n- [x] invalid \xFF\n").unwrap();
+    let invalid_before = fs::read(&invalid_tasks).unwrap();
+
+    let output = specsync()
+        .args(["archive-tasks", "--format", "json", "--root"])
+        .arg(&root)
+        .assert()
+        .failure()
+        .code(1)
+        .get_output()
+        .clone();
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("failure stdout must remain valid JSON");
+
+    assert_eq!(report["complete"], false);
+    assert_eq!(report["partial"], false);
+    assert_eq!(report["applied"], false);
+    assert_eq!(report["files_planned"], 1);
+    assert_eq!(report["files_succeeded"], 0);
+    assert_eq!(report["failed"][0]["operation"], "read");
+    assert_eq!(fs::read(valid_tasks).unwrap(), valid_before);
+    assert_eq!(fs::read(invalid_tasks).unwrap(), invalid_before);
+}
+
 // ─── hooks install: claude-code-hook must not clobber user settings ──────
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #417 completely for `compact` and the related `archive-tasks` output path.

- Makes changelog compaction idempotent with an explicit provenance marker and cumulative summary handling.
- Preserves exact LF, CRLF, mixed-ending, trailing-newline, and no-final-newline bytes.
- Parses Markdown tables without truncating escaped pipes or code-span pipes and emits the exact original table width.
- Fails closed without writes for malformed, duplicate, overflowed, indented-separator, or reordered marked-summary state.
- Reports truthful compacted/kept counts and singular/plural labels.
- Honors text, JSON, Markdown, and GitHub formats for both commands with valid structured output and no ANSI leakage.
- Uses plan/stage/publish/rollback transactions so planning or staging failures write nothing and late publish failures are reported truthfully.
- Safely renders unusual paths, including literal Unix backslashes, backslash-before-pipe names, backticks, HTML characters, control characters, and bidi controls.

## Lifecycle and review

- SpecSync change: `CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str`
- Definition approved by the user at digest `4cb1f669e6892906b7ed9d78d872de1eb133de0725ceac4ef262ff7451d99984`.
- Two independent reviewer agents checked every issue-body acceptance row plus adversarial security, compatibility, and regression behavior.
- No unresolved high- or medium-severity findings remain.
- The old PR history was replaced with an eight-commit dependency-ordered lifecycle history based directly on current `main`.

## Verification

- `fledge lanes run verify`
  - 2,002 unit tests passed
  - 329 integration tests passed
  - release build passed
- `specsync check --strict --require-coverage 100 --force`
  - 62/62 specs passed
  - 105/105 files covered
  - 110,054/110,054 LOC covered
- Private `CorvidLabs/spec-sync-sandbox` disposable-clone replay
  - first compact/archive apply succeeded
  - second run was a byte-identical no-op
  - JSON stayed parseable
  - rendered Markdown preserved adversarial path names in one table cell
- Signed Attest provenance recorded at 0.95 confidence with tests passed and human definition approval.
- Augur returned `review` at risk 40 and did not return `BLOCK`.

## Test plan

- [x] Characterization and targeted unit/integration regressions
- [x] Warm/cold and first-run/second-run behavior
- [x] LF/CRLF/mixed/no-final-newline fixtures
- [x] Escaped pipes, code spans, malformed tables, and reordered summaries
- [x] Transaction planning/staging/publish/rollback failure injection
- [x] Text/JSON/Markdown/GitHub output and exit semantics
- [x] Private sandbox replay
- [x] Full local verification and independent agent review
- [ ] GitHub CI
- [ ] Fresh lifecycle verification and explicit closing approval
