### PR TITLE
fix(merge): resolve spec conflicts losslessly and truthfully

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 65,
-  "id": "CHG-0065-make-issue-417-changelog-compaction-idempotent-and-provide-truthful-portable-str",
+  "sequence": 66,
+  "id": "CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/approvals.json
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/approvals.json
@@ -1,0 +1,26 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1785166976,
+      "digest": "e10d425b05d3061b7415a5efbfc1573cbeb05915284a5161356d77e2475c89db",
+      "note": "User approved exact definition digest 1e45a62bfcb107964fb658d21ad950b38da6f00f9313a1f1799edb017be9316b."
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1785171716,
+      "digest": "d404d9063fcdb5806509c0d628ae79d1fc7115dd7243176138bc96bf167064b2",
+      "note": "User reapproved exact definition digest 1e45a62bfcb107964fb658d21ad950b38da6f00f9313a1f1799edb017be9316b after lifecycle synchronization and independent acceptance/adversarial review."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "0xLeif",
+      "timestamp": 1785173714,
+      "digest": "4d91fc33c838f4ecfa161a6b0609029692b6397058e4d6ad996ce046d2c602a2",
+      "note": "User approved closing CHG-0066 after fresh verification on 2026-07-27."
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/change.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/change.md
@@ -1,0 +1,32 @@
+---
+id: CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base
+state: accepted
+type: bug_fix
+base_commit: a55a744a97b46f5c01068d6fe4433990d4fef942
+---
+
+# Make issue 427 spec merge resolution lossless and truthful by parsing diff3 bases, preserving both side labels, selecting the maximum numeric version, unioning list fields, leaving conflicting table rows and scalar fields unresolved, and preserving all-or-nothing writes
+
+## Intent
+
+Make issue 427 spec merge resolution lossless and truthful by parsing diff3 bases, preserving both side labels, selecting the maximum numeric version, unioning list fields, leaving conflicting table rows and scalar fields unresolved, and preserving all-or-nothing writes
+
+## Affected Canonical Specs
+
+- `merge`
+
+## Acceptance Criteria
+
+- Diff3 base regions are excluded from resolved output and diagnostics report both ours and incoming labels.
+- Frontmatter list values are unioned and sorted while version uses the maximum numeric value.
+- Conflicting same-key table rows and divergent or non-numeric scalar fields remain unresolved.
+- One-sided scalar fields, YAML null-versus-list disagreements, table headers or separators inside or immediately after a hunk, and nested frontmatter mappings remain unresolved.
+- Only exact standard conflict markers are accepted; malformed, orphan, duplicate, nested, incomplete, and lookalike markers remain manual.
+- Reconstructed output must contain valid YAML frontmatter without duplicate keys and must retain every required field, a valid status, and non-empty files.
+- Unreadable all-files candidates remain explicit Manual findings and failed Git discovery is a safe no-op.
+- CRLF line endings and final-newline form are preserved.
+- Any unresolved region prevents every write to the file; diagnostics never claim HEAD won when incoming content was selected and distinguish dry-run candidates from persisted resolutions.
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/context.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/context.md
@@ -1,0 +1,39 @@
+---
+change: CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base
+artifact: context
+---
+
+# Context
+
+## Baseline Behavior Before CHG-0066
+
+The baseline merge implementation used side-precedence shortcuts for scalar fields and generic
+table rows. It did not model a diff3 base region as a distinct input, and some status messages
+could attribute incoming content to HEAD.
+
+## Decision
+
+Use conservative, content-aware resolution. Known lossless shapes may resolve automatically;
+any ambiguous, malformed, orphan, nested, or lossy-parser-boundary region makes the entire file
+manual and prevents writes. Candidate frontmatter is checked for YAML validity, duplicate keys,
+required fields, valid status, and non-empty files. This matches the repository's safety
+invariant and the delivery plan approved for issue #427.
+
+## Scope
+
+- Implementation: `src/merge.rs`
+- CLI integration coverage: `tests/integration/commands.rs`
+- Canonical contract and companions: `specs/merge/`
+- No CLI flags or exported Rust symbol names change.
+
+## Delivery
+
+Reconstruct PR #448 from current `main` so the unsafe intermediate implementation is not replayed.
+The final PR metadata must describe all-or-nothing persistence, not partial writes.
+
+Independent acceptance and adversarial reviews found additional pre-existing paths through which
+headers, nested YAML, malformed markers, or one-sided scalars could be rewritten. CHG-0066 treats
+those findings as blockers and includes their regression coverage. A second adversarial pass also
+identified header-only hunks, YAML null-versus-empty-list coercion, missing-frontmatter writes, and
+premature `Auto-resolvable` wording after persistence; all four paths now have explicit regression
+coverage and passed fresh independent adversarial confirmation.

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/deltas/merge.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/deltas/merge.md
@@ -1,0 +1,27 @@
+## MODIFIED
+
+### REQUIREMENT REQ-merge-001
+
+The merge engine SHALL resolve only lossless known conflict shapes and SHALL leave ambiguous files untouched with an explicit result.
+
+Acceptance Criteria
+- Frontmatter list fields (`files`, `db_tables`, `depends_on`) are unioned and sorted alphabetically when both sides have conflicting values
+- Numeric frontmatter `version` fields use `max(ours, theirs)`, accept supported quoted/commented unsigned scalars, and never regress
+- Divergent or one-sided non-version frontmatter scalars, nonnumeric versions, and equal numeric versions with different scalar syntax require manual resolution
+- Nested mappings, YAML null-versus-list disagreements, and unsupported frontmatter shapes inside a hunk require manual resolution
+- Changelog table rows are merged chronologically by date, with deduplication by full row content
+- Generic markdown tables union distinct data rows and deduplicate identical rows by first cell; divergent rows with the same key, headers/separators inside the hunk, or a conflicted header whose separator immediately follows the hunk require manual resolution
+- Prose section conflicts (like `## Purpose` body text) are never auto-resolved and preserve conflict markers
+- `all_files: false` uses `git diff --diff-filter=U` to find only git-conflicted files
+- `all_files: true` scans all `.spec.md` files for every conflict-marker family regardless of git state and retains unreadable candidates as explicit findings
+- `dry_run: true` returns resolution results without writing any changes to disk
+- Unreadable spec files are marked as `Manual` with the read error included in details
+- If `git diff` fails in git mode (`all_files: false`), `detect_conflicted_specs` returns no files (the run is a safe no-op); explicit `all_files: true` is the way to scan everything
+- Only exact standard opener/base/separator/closer forms are accepted; orphan, nested, duplicate, incomplete, and lookalike markers require manual resolution
+- Diff3 base sections are excluded from auto-resolution input and preserved verbatim when a hunk remains manual
+- Resolution details name both marker labels and the applied strategy or manual-resolution reason, use `Auto-resolvable` for candidates, and use `Auto-resolved` only after successful persistence
+- A file is written only when every hunk resolves safely and the resulting output contains valid frontmatter
+- Post-resolution YAML errors, duplicate keys, missing required fields, invalid status, or empty files leave the original file unchanged
+- Uniform CRLF/LF style and final-newline presence are preserved
+- Results include `spec_path`, `status` (`Resolved` | `Manual` | `Clean`), and `details` for each file
+- Human-readable output uses colored formatting to distinguish status types

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/design.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/design.md
@@ -1,0 +1,34 @@
+---
+change: CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base
+artifact: design
+---
+
+# Design
+
+## Region Model
+
+Parse conflict input into clean segments and typed conflict regions. A region retains ours,
+optional diff3 base, incoming, and both labels. Only exact standard marker forms are accepted.
+Missing delimiters and orphan, duplicate, nested, incomplete, or lookalike markers produce a
+manual result with truthful outer labels.
+
+## Resolution Rules
+
+- Ignore the base section as an output candidate; use it only to identify diff3 structure.
+- Union and deterministically sort supported frontmatter lists.
+- Parse versions numerically and choose the maximum.
+- Resolve identical scalar/table values; keep divergent values manual.
+- Merge changelog rows only when the union is lossless.
+- Keep one-sided scalars, table headers/separators, and nested YAML mappings manual.
+
+## Persistence
+
+Build the candidate output in memory, validate its frontmatter with the checked YAML parser and
+canonical required-field/status rules, and write only if every region resolved. A manual region,
+parse error, duplicate key, or validation error returns details while retaining the original
+bytes.
+
+## Diagnostics
+
+Preserve raw side labels and report which values were retained or why resolution stopped.
+Messages must not call incoming content HEAD or otherwise invert side identity.

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/docs.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/docs.md
@@ -1,0 +1,21 @@
+---
+change: CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base
+artifact: docs
+---
+
+# Docs
+
+## Canonical Documentation
+
+Update `specs/merge/merge.spec.md` and its companions to describe diff3 parsing, maximum numeric
+versions, lossless list unions, conservative row/scalar handling, and all-or-nothing writes.
+
+## Pull Request
+
+Rewrite PR #448's title and body so they do not claim partial resolutions are persisted. Include
+the issue #427 closure, targeted test matrix, lifecycle evidence, and full verification results.
+
+## Release Notes
+
+No new CLI surface is introduced. Note the compatibility change that ambiguous merge conflicts
+now remain manual instead of selecting an arbitrary side.

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/requirements.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/requirements.md
@@ -1,0 +1,29 @@
+---
+change: CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base
+artifact: requirements
+---
+
+# Requirements
+
+## Problem
+
+Issue #427 demonstrates that the merge engine can misinterpret diff3 base regions, choose the
+wrong scalar or table value, and describe the selected side inaccurately. A partly resolvable
+file must not be rewritten because doing so can destroy the user's unresolved conflict context.
+
+## Required Outcomes
+
+- Parse standard two-way and diff3 conflict regions without treating base-ancestor bytes as an
+  editable side.
+- Preserve both side labels in truthful diagnostics.
+- Union supported list fields and select the maximum numeric frontmatter version.
+- Leave same-key table disagreements and divergent or non-numeric scalar fields unresolved.
+- Reject malformed regions and reconstructed frontmatter that fails canonical parsing.
+- Preserve CRLF and final-newline form.
+- Perform an all-or-nothing write: one manual region leaves the complete original file unchanged.
+
+## Compatibility
+
+- Existing lossless changelog and list-field resolutions remain automatic.
+- Public Rust exports remain unchanged.
+- Ambiguous cases become conservative manual results instead of silently choosing content.

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/state.json
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/state.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "id": "CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base",
+  "slug": "make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base",
+  "title": "Make issue 427 spec merge resolution lossless and truthful by parsing diff3 bases, preserving both side labels, selecting the maximum numeric version, unioning list fields, leaving conflicting table rows and scalar fields unresolved, and preserving all-or-nothing writes",
+  "description": "Make issue 427 spec merge resolution lossless and truthful by parsing diff3 bases, preserving both side labels, selecting the maximum numeric version, unioning list fields, leaving conflicting table rows and scalar fields unresolved, and preserving all-or-nothing writes",
+  "kind": "bug_fix",
+  "state": "accepted",
+  "canonical_applied": true,
+  "base_commit": "a55a744a97b46f5c01068d6fe4433990d4fef942",
+  "created_at": 1785164618,
+  "updated_at": 1785173714,
+  "affected_specs": [
+    "merge"
+  ],
+  "affected_paths": [
+    "src/merge.rs",
+    "tests/integration/commands.rs",
+    "specs/merge/merge.spec.md",
+    "specs/merge/requirements.md",
+    "specs/merge/context.md",
+    "specs/merge/tasks.md",
+    "specs/merge/testing.md",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Diff3 base regions are excluded from resolved output and diagnostics report both ours and incoming labels.",
+    "Frontmatter list values are unioned and sorted while version uses the maximum numeric value.",
+    "Conflicting same-key table rows and divergent or non-numeric scalar fields remain unresolved.",
+    "One-sided scalar fields, YAML null-versus-list disagreements, table headers or separators inside or immediately after a hunk, and nested frontmatter mappings remain unresolved.",
+    "Only exact standard conflict markers are accepted; malformed, orphan, duplicate, nested, incomplete, and lookalike markers remain manual.",
+    "Reconstructed output must contain valid YAML frontmatter without duplicate keys and must retain every required field, a valid status, and non-empty files.",
+    "Unreadable all-files candidates remain explicit Manual findings and failed Git discovery is a safe no-op.",
+    "CRLF line endings and final-newline form are preserved.",
+    "Any unresolved region prevents every write to the file; diagnostics never claim HEAD won when incoming content was selected and distinguish dry-run candidates from persisted resolutions."
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "design",
+    "requirements",
+    "docs"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/tasks.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/tasks.md
@@ -1,0 +1,19 @@
+---
+change: CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Capture failing characterizations for every issue #427 behavior.
+- [x] Implement diff3-aware parsing and truthful side labels.
+- [x] Implement lossless frontmatter and table resolution rules.
+- [x] Enforce malformed-input rejection and all-or-nothing writes.
+- [x] Update the merge canonical spec and companions.
+- [x] Run targeted merge, full repository, format, lint, diff, and sandbox-testbed checks.
+- [x] Complete independent acceptance and adversarial implementation reviews and resolve every high/medium finding.
+- [x] Synchronize the machine definition, semantic delta, and canonical companions for the final digest-bound approval.
+
+Lifecycle verification, PR publication, and closing approval follow this completed implementation
+checklist and are recorded in the verification and approval ledgers rather than as pre-verification
+tasks.

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/testing.md
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/testing.md
@@ -1,0 +1,39 @@
+---
+change: CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base
+artifact: testing
+---
+
+# Testing
+
+## Characterization
+
+- Reproduce a diff3 region whose base bytes must not appear in resolved output.
+- Reproduce divergent same-key table rows and scalar fields that previously selected one side.
+- Reproduce a mixed file containing one resolvable region and one manual region, then compare the
+  complete file byte-for-byte before and after.
+
+## Targeted Regression Coverage
+
+- `REQ-merge-001` maps to the focused merge tests below and requires a passing lifecycle
+  verification manifest before acceptance.
+- Two-way and diff3 parser behavior, including both labels.
+- Numeric version maximum and supported list unions.
+- Table-row and scalar conflicts remaining manual.
+- Exact marker grammar plus malformed, orphan, duplicate, nested, incomplete, and lookalike forms.
+- Table headers with the separator inside or immediately after the hunk, nested mappings,
+  null-versus-empty-list disagreements, one-sided scalars, missing frontmatter, and invalid
+  reconstructed frontmatter.
+- Unreadable all-files candidates and failed Git discovery.
+- CRLF input and files both with and without a final newline.
+- Dry-run and real-run all-or-nothing persistence.
+- Human output side attribution, `Auto-resolvable` dry-run wording, and `Auto-resolved` wording
+  only after a successful write. Structured JSON dry-run schema is owned by issue #420.
+
+## Required Gates
+
+- `cargo test merge::`
+- `fledge lanes run verify`
+- Full repository lane
+- Strict 100% spec coverage and score at least 80
+- `fledge trust verify`
+- Independent acceptance-row review and adversarial regression review

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/verification-attempts.json
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/verification-attempts.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1785173533,
+      "commit": "a55a744a97b46f5c01068d6fe4433990d4fef942",
+      "contract_digest": "d404d9063fcdb5806509c0d628ae79d1fc7115dd7243176138bc96bf167064b2",
+      "workspace_digest": "81024c8642326adb7589a2df12e566c1f075fa0a05f48a6e1b37e8b6e4bd532a",
+      "passed": true,
+      "commands": [
+        {
+          "command": "ruby --version",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-merge-001"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/verification.json
+++ b/.specsync/changes/CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base/verification.json
@@ -1,0 +1,118 @@
+{
+  "timestamp": 1785173533,
+  "commit": "a55a744a97b46f5c01068d6fe4433990d4fef942",
+  "contract_digest": "d404d9063fcdb5806509c0d628ae79d1fc7115dd7243176138bc96bf167064b2",
+  "workspace_digest": "81024c8642326adb7589a2df12e566c1f075fa0a05f48a6e1b37e8b6e4bd532a",
+  "acceptance_input_digest": "7b9355ccd647acc01d7d7b27f7243de457f6990c3f8455500cfa2649450c0e48",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".specsync/change-sequence.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "45523c7134f70e74510046b95b973f2ffaa789c25f1aa708ef54e2ab3210e875",
+        "entry_digest": "f103065b54960e22a4ac0079e96f5c62212b7cf0d4d8795203f048fd57e41625",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "specs/merge/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "cb3f6b555078e2ef1712175a8ef6159886e5b7f99c5602b0a2fc8065a9fdac4c",
+        "entry_digest": "542caf695ac74e989deae4b2d1a6e663205a374f7149bad9b40d3b17e4faaedb",
+        "owners": [
+          "merge"
+        ]
+      },
+      {
+        "path": "specs/merge/merge.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "a80436c400b0119f909701cb032f940202e5289ba97c7de46c8d892bb1d472d0",
+        "entry_digest": "b5d1981e83697c1bc30c1f99dadf755ae107b6dc5ad73165f1580b2921daf4cb",
+        "owners": [
+          "merge"
+        ]
+      },
+      {
+        "path": "specs/merge/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "e59b90bb4645ce4794816a65e1e964391148635aa035c9ef17e5f2e7a6b809b2",
+        "entry_digest": "01da34609b66b7bdd28eb8a9887581d312154152e342a5070b32d77dd14f6067",
+        "owners": [
+          "merge"
+        ]
+      },
+      {
+        "path": "specs/merge/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "ed11ca9310158ea60b163bbcb73bdbed08857db9c560c17cb4d21ab33d191ae2",
+        "entry_digest": "eb86c4bfaa14cdeeeb6f4e46a5006a1e4039095cd18fded6db2dcb400aae166a",
+        "owners": [
+          "merge"
+        ]
+      },
+      {
+        "path": "specs/merge/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "9ed7a262eda7a0635540e4056fc83bd2367e9819ea751607b7b3da33b0bb7a89",
+        "entry_digest": "032f1e9a6811695cbb45317b0d3b86d8a540ccb8d0d13207b947d28627866035",
+        "owners": [
+          "merge"
+        ]
+      },
+      {
+        "path": "src/merge.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0b2772c48657a13065e95d5b18e219f963cdd5a5a15e0faec5cc84f5bce32aac",
+        "entry_digest": "bc36738e005ab14f8ab4cdf23125d8fe9403d03ca61b144dd6339a6ea33846de",
+        "owners": [
+          "merge"
+        ]
+      },
+      {
+        "path": "tests/integration/commands.rs",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "772d4d70a119f249ab77f5523ece48ea9b9b534434d2d9ebce441e8ee791b098",
+        "entry_digest": "958fedd68e513726a0285909a0ce30a3f0b0ab7123cee098239abf657058cbc0",
+        "owners": [
+          "@exact:test"
+        ]
+      }
+    ]
+  },
+  "passed": true,
+  "commands": [
+    {
+      "command": "ruby --version",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-merge-001"
+  ]
+}

--- a/specs/merge/context.md
+++ b/specs/merge/context.md
@@ -4,10 +4,12 @@ spec: merge.spec.md
 
 ## Key Decisions
 
-- **Section-aware strategies**: `resolve_conflict` dispatches on the enclosing section (last `## ` heading, computed via `detect_section` from text emitted so far). Frontmatter (before any heading) unions lists and takes theirs for scalars; `## Change Log` merges rows chronologically; any section that is *pure table rows* gets a key-based table merge; everything else (prose) is left for manual resolution.
-- **Region parsing, not regex**: `parse_conflict_regions` walks lines, peeling `<<<<<<< / ======= / >>>>>>>` blocks into `ours`/`theirs` strings and a `marker_label`. Clean text between blocks is preserved verbatim.
-- **Zero-dependency YAML**: `parse_yaml_fields` handles the project's simple key/scalar and key/list subset directly rather than pulling in a YAML crate. List keys `files`, `db_tables`, `depends_on` are unioned and sorted.
-- **Theirs-wins precedence**: for scalar frontmatter fields and generic-table row collisions, the incoming (theirs) value overrides ours, treating the merged-in branch as the newer change.
+- **Section-aware strategies**: `resolve_conflict` dispatches on the enclosing section (last `## ` heading, computed via `detect_section` from text emitted so far). Frontmatter (before any heading) unions known lists, takes the maximum numeric version, and rejects ambiguous scalars; `## Change Log` merges rows chronologically; any section that is *pure table rows* gets a lossless key-based union; everything else (prose) is left for manual resolution.
+- **Exact region parsing, not regex precedence**: `parse_conflict_regions` accepts exact `<<<<<<< / ||||||| / ======= / >>>>>>>` forms and separates HEAD, base, and incoming regions. Base content is excluded from auto-resolution inputs; orphan, nested, duplicate, incomplete, and lookalike markers keep the complete file manual.
+- **Conservative YAML subset plus checked validation**: `parse_yaml_fields` distinguishes null scalars from empty lists and handles only top-level key/scalar and known-list shapes. Nested mappings remain manual. Every candidate output must contain frontmatter and is checked by the shared YAML parser for duplicate keys and by canonical required-field/status rules.
+- **No ambiguous winner**: numeric versions use the maximum value and known frontmatter lists are unioned. Divergent or one-sided non-version scalars, nonnumeric versions, same-key table rows, and table header/separator hunks remain manual; no branch is silently selected.
+- **All-or-nothing persistence**: a file is written only after every hunk resolves and frontmatter validates. Auto-resolvable hunks are reported but not persisted when any hunk remains manual.
+- **Truthful persistence wording**: dry-run candidates remain `Auto-resolvable`; details become `Auto-resolved` only after the complete file is successfully written.
 - **Conservative fallbacks**: when `git diff` fails in git mode, `detect_conflicted_specs` returns an empty list (no specs processed); unreadable files become `Manual`; a still-conflicted result keeps its markers.
 
 ## Files to Read First
@@ -16,10 +18,10 @@ spec: merge.spec.md
 
 ## Current Status
 
-Stable and complete. Public API: `merge_specs`, `has_conflict_markers`, `print_results`, `results_to_json`, plus `MergeResult`/`MergeStatus`. Invoked by the `cmd_merge` subcommand.
+CHG-0066 implementation is under verification after independent acceptance and adversarial review. Public API remains `merge_specs`, `has_conflict_markers`, `print_results`, `results_to_json`, plus `MergeResult`/`MergeStatus`.
 
 ## Notes
 
-- Depends on `parser::parse_frontmatter` (post-resolution validation) and `validator::find_spec_files` (all-files scan).
+- Depends on `parser::parse_frontmatter` and `parse_checked_issue_references` for post-resolution structural/YAML validation and `validator::find_spec_files` for all-files scan.
 - Changelog sorting assumes ISO `YYYY-MM-DD` dates so lexicographic order is chronological.
 - `print_results` skips `Clean` entries; `results_to_json` includes all three statuses.

--- a/specs/merge/merge.spec.md
+++ b/specs/merge/merge.spec.md
@@ -1,6 +1,6 @@
 ---
 module: merge
-version: 3
+version: 5
 status: stable
 files:
   - src/merge.rs
@@ -15,7 +15,7 @@ depends_on:
 
 ## Purpose
 
-Detects and auto-resolves git merge conflicts in spec files using context-aware strategies. Different resolution algorithms are applied based on the section type — YAML frontmatter fields are unioned, changelog tables are merged chronologically, and generic tables are deduplicated by first cell.
+Detects and conservatively auto-resolves git merge conflicts in spec files using context-aware strategies. Only lossless conflict shapes are resolved: known YAML lists are unioned, numeric versions take the maximum value, changelog tables are merged chronologically, and non-conflicting generic table rows are unioned. Ambiguous content leaves the entire file untouched.
 
 ## Public API
 
@@ -24,7 +24,7 @@ Detects and auto-resolves git merge conflicts in spec files using context-aware 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
 | `merge_specs` | `root: &Path, specs_dir: &Path, dry_run: bool, all_files: bool` | `Vec<MergeResult>` | Scan for conflicted specs and attempt auto-resolution |
-| `has_conflict_markers` | `content: &str` | `bool` | Check if content contains `<<<<<<< ` conflict markers |
+| `has_conflict_markers` | `content: &str` | `bool` | Check for opener, base, separator, or closer marker families, including malformed/orphan forms |
 | `print_results` | `results: &[MergeResult], dry_run: bool` | `()` | Print human-readable resolution summary with colored output |
 | `results_to_json` | `results: &[MergeResult]` | `String` | Format results as JSON with path, status, and details |
 
@@ -39,9 +39,9 @@ Detects and auto-resolves git merge conflicts in spec files using context-aware 
 
 | Context | Strategy |
 |---------|----------|
-| Frontmatter (YAML) | Lists (`files`, `db_tables`, `depends_on`) are unioned and sorted; scalars use theirs (latest) |
-| `## Change Log` table | Rows merged chronologically by date cell; deduplicated by full row content |
-| Generic markdown table | Rows merged by first cell (symbol name); theirs wins on conflicts; deduplicated |
+| Frontmatter (YAML) | Lists (`files`, `db_tables`, `depends_on`) are unioned and sorted; numeric `version` uses max; divergent or one-sided scalars, null-versus-list disagreements, nested mappings, and unsupported shapes require manual resolution |
+| `## Change Log` table | Data rows merge chronologically by date and deduplicate by full row; a header/separator inside the hunk or a header whose separator immediately follows the hunk requires manual resolution |
+| Generic markdown table | Distinct data rows are unioned and identical duplicate keys are deduplicated; divergent duplicate-key rows or a header/separator inside or immediately after the hunk require manual resolution |
 | Prose / section body | No auto-resolution — conflict markers preserved for manual intervention |
 
 ## Invariants
@@ -49,12 +49,18 @@ Detects and auto-resolves git merge conflicts in spec files using context-aware 
 1. `all_files: false` uses `git diff --diff-filter=U` to find only git-conflicted files
 2. `all_files: true` scans all spec files for conflict markers regardless of git state
 3. Frontmatter list fields are unioned (not replaced) and sorted alphabetically
-4. Frontmatter scalar fields use "theirs wins" strategy (latest change takes precedence)
+4. Numeric frontmatter `version` values use `max(ours, theirs)`; nonnumeric versions and divergent or one-sided other scalars require manual resolution
 5. Changelog rows are sorted by first cell (ISO date) — lexicographic sorting works correctly
 6. Prose conflicts are never auto-resolved — always marked as `Manual`
-7. Post-resolution, frontmatter is re-validated; warnings printed if invalid
+7. Every post-resolution candidate must contain frontmatter with valid YAML, no duplicate keys, all required fields, a valid status, and non-empty files; failures are `Manual` and are not written
 8. `dry_run: true` returns results without writing resolved content to disk
 9. Custom YAML parser handles simple key-value and list fields without external YAML library
+10. Only exact standard marker forms are accepted; diff3 base sections are parsed but never treated as either branch's content
+11. A file is written only when every conflict hunk is safely resolved and the resulting frontmatter is valid
+12. Resolution details name both conflict-marker labels and the applied strategy or manual-resolution reason; candidate hunks say `Auto-resolvable` until a file is actually persisted
+13. Orphan, duplicate, nested, incomplete, and malformed marker families make the complete file manual
+14. Table headers/separators, including a conflicted header immediately followed by a clean separator, and nested frontmatter mappings are never reconstructed by the lossy subset parsers
+15. Uniform CRLF/LF form and final-newline presence are preserved
 
 ## Behavioral Examples
 
@@ -76,6 +82,18 @@ Detects and auto-resolves git merge conflicts in spec files using context-aware 
 - **When** `merge_specs` encounters the conflict
 - **Then** conflict markers are preserved, status is `Manual`
 
+### Scenario: Divergent Public API row requires manual resolution
+
+- **Given** both sides contain the same Public API symbol with different row content
+- **When** `merge_specs` encounters the conflict
+- **Then** neither row is selected, the original file remains unchanged, and the result names both sides and the ambiguity
+
+### Scenario: Diff3 conflict
+
+- **Given** a safely mergeable table conflict includes a `||||||| base` section
+- **When** `merge_specs` resolves the conflict
+- **Then** only the HEAD and incoming rows are unioned and no base marker or base row appears in the output
+
 ### Scenario: Dry run
 
 - **Given** conflicted spec files exist
@@ -87,8 +105,11 @@ Detects and auto-resolves git merge conflicts in spec files using context-aware 
 | Condition | Behavior |
 |-----------|----------|
 | Spec file unreadable | Marked as `Manual` with read error in details |
-| `git diff` command fails | Falls back to scanning all files for conflict markers |
-| Post-resolution frontmatter invalid | Warning printed; file is still written with resolved content |
+| `git diff` command fails | Returns no files in git mode; explicit `all_files: true` is required for a scan |
+| Post-resolution frontmatter invalid | Marked `Manual`; original file remains unchanged |
+| Malformed or incomplete conflict block | Marked `Manual`; original block and file remain unchanged |
+| Orphan, nested, duplicate, or non-standard marker | Marked `Manual`; no partial write occurs |
+| Table header/separator or nested YAML mapping inside a hunk | Marked `Manual`; original bytes remain authoritative |
 
 ## Dependencies
 
@@ -96,7 +117,7 @@ Detects and auto-resolves git merge conflicts in spec files using context-aware 
 
 | Module | What is used |
 |--------|-------------|
-| parser | `parse_frontmatter` for post-resolution validation |
+| parser | `parse_frontmatter` plus checked YAML/duplicate-key validation for post-resolution safety |
 | validator | `find_spec_files` to locate all spec files when `all_files: true` |
 
 ### Consumed By
@@ -109,6 +130,8 @@ Detects and auto-resolves git merge conflicts in spec files using context-aware 
 
 | Date | Change |
 |------|--------|
+| 2026-07-27 | Issue #427 / CHG-0066: parse exact diff3 markers, use numeric max for versions, reject ambiguous rows/scalars and lossy table/YAML shapes, validate reconstructed frontmatter, report both sides accurately, and preserve all-or-nothing writes |
 | 2026-04-10 | Populated requirements.md with user stories, acceptance criteria, constraints, and out-of-scope items |
 | 2026-04-06 | Initial spec for v3.3.0 |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-27 | CHG-0066-make-issue-427-spec-merge-resolution-lossless-and-truthful-by-parsing-diff3-base: Make issue 427 spec merge resolution lossless and truthful by parsing diff3 bases, preserving both side labels, selecting the maximum numeric version, unioning list fields, leaving conflicting table rows and scalar fields unresolved, and preserving all-or-nothing writes |

--- a/specs/merge/requirements.md
+++ b/specs/merge/requirements.md
@@ -16,33 +16,40 @@ spec: merge.spec.md
 ## Acceptance Criteria
 
 - Frontmatter list fields (`files`, `db_tables`, `depends_on`) are unioned and sorted alphabetically when both sides have conflicting values
-- Frontmatter scalar fields (like `version`, `status`) use "theirs wins" strategy (latest change takes precedence)
+- Numeric frontmatter `version` fields use `max(ours, theirs)`, accept supported quoted/commented unsigned scalars, and never regress
+- Divergent or one-sided non-version frontmatter scalars, nonnumeric versions, and equal numeric versions with different scalar syntax require manual resolution
+- Nested mappings, YAML null-versus-list disagreements, and unsupported frontmatter shapes inside a hunk require manual resolution
 - Changelog table rows are merged chronologically by date, with deduplication by full row content
-- Generic markdown tables are merged by first cell (symbol name), with "theirs wins" on conflicts and deduplication
+- Generic markdown tables union distinct data rows and deduplicate identical rows by first cell; divergent rows with the same key, headers/separators inside the hunk, or a conflicted header whose separator immediately follows the hunk require manual resolution
 - Prose section conflicts (like `## Purpose` body text) are never auto-resolved and preserve conflict markers
 - `all_files: false` uses `git diff --diff-filter=U` to find only git-conflicted files
-- `all_files: true` scans all `.spec.md` files for conflict markers regardless of git state
+- `all_files: true` scans all `.spec.md` files for every conflict-marker family regardless of git state and retains unreadable candidates as explicit findings
 - `dry_run: true` returns resolution results without writing any changes to disk
 - Unreadable spec files are marked as `Manual` with the read error included in details
 - If `git diff` fails in git mode (`all_files: false`), `detect_conflicted_specs` returns no files (the run is a safe no-op); explicit `all_files: true` is the way to scan everything
-- Post-resolution frontmatter validation warnings are printed but don't prevent file writes
+- Only exact standard opener/base/separator/closer forms are accepted; orphan, nested, duplicate, incomplete, and lookalike markers require manual resolution
+- Diff3 base sections are excluded from auto-resolution input and preserved verbatim when a hunk remains manual
+- Resolution details name both marker labels and the applied strategy or manual-resolution reason, use `Auto-resolvable` for candidates, and use `Auto-resolved` only after successful persistence
+- A file is written only when every hunk resolves safely and the resulting output contains valid frontmatter
+- Post-resolution YAML errors, duplicate keys, missing required fields, invalid status, or empty files leave the original file unchanged
+- Uniform CRLF/LF style and final-newline presence are preserved
 - Results include `spec_path`, `status` (`Resolved` | `Manual` | `Clean`), and `details` for each file
 - Human-readable output uses colored formatting to distinguish status types
 
 ## Constraints
 
-- Must not depend on external YAML libraries — uses custom parser for simple key-value and list fields
+- Auto-resolution uses a custom parser for its simple top-level key/scalar and known-list subset; candidate output uses the shared checked YAML parser
 - Prose sections must never be auto-resolved to prevent loss of important description changes
 - Changelog sorting relies on ISO date format (YYYY-MM-DD) for lexicographic ordering
 - Resolution strategies are context-aware and cannot be overridden per-file
-- Conflict marker detection looks for standard git markers: `<<<<<<< `, `=======`, `>>>>>>> `
+- Conflict parsing accepts exact standard git markers plus diff3 `||||||| base` sections and fails closed on every marker-like deviation
 - Must handle both Windows (`\r\n`) and Unix (`\n`) line endings in conflicted files
 - Post-resolution validation must use the same frontmatter parser as the main `parser` module
 
 ## Out of Scope
 
 - Interactive merge conflict resolution (TUI or prompts)
-- Three-way merge with base ancestor analysis
+- Semantic three-way reconciliation using the base ancestor (diff3 base text is parsed only to keep it out of branch inputs)
 - Custom resolution strategies per-project or per-file
 - Resolving conflicts in non-spec files (`.rs`, `.md` without spec frontmatter)
 - Automatic git add/commit after resolution
@@ -55,16 +62,23 @@ The merge engine SHALL resolve only lossless known conflict shapes and SHALL lea
 
 Acceptance Criteria
 - Frontmatter list fields (`files`, `db_tables`, `depends_on`) are unioned and sorted alphabetically when both sides have conflicting values
-- Frontmatter scalar fields (like `version`, `status`) use "theirs wins" strategy (latest change takes precedence)
+- Numeric frontmatter `version` fields use `max(ours, theirs)`, accept supported quoted/commented unsigned scalars, and never regress
+- Divergent or one-sided non-version frontmatter scalars, nonnumeric versions, and equal numeric versions with different scalar syntax require manual resolution
+- Nested mappings, YAML null-versus-list disagreements, and unsupported frontmatter shapes inside a hunk require manual resolution
 - Changelog table rows are merged chronologically by date, with deduplication by full row content
-- Generic markdown tables are merged by first cell (symbol name), with "theirs wins" on conflicts and deduplication
+- Generic markdown tables union distinct data rows and deduplicate identical rows by first cell; divergent rows with the same key, headers/separators inside the hunk, or a conflicted header whose separator immediately follows the hunk require manual resolution
 - Prose section conflicts (like `## Purpose` body text) are never auto-resolved and preserve conflict markers
 - `all_files: false` uses `git diff --diff-filter=U` to find only git-conflicted files
-- `all_files: true` scans all `.spec.md` files for conflict markers regardless of git state
+- `all_files: true` scans all `.spec.md` files for every conflict-marker family regardless of git state and retains unreadable candidates as explicit findings
 - `dry_run: true` returns resolution results without writing any changes to disk
 - Unreadable spec files are marked as `Manual` with the read error included in details
 - If `git diff` fails in git mode (`all_files: false`), `detect_conflicted_specs` returns no files (the run is a safe no-op); explicit `all_files: true` is the way to scan everything
-- Post-resolution frontmatter validation warnings are printed but don't prevent file writes
+- Only exact standard opener/base/separator/closer forms are accepted; orphan, nested, duplicate, incomplete, and lookalike markers require manual resolution
+- Diff3 base sections are excluded from auto-resolution input and preserved verbatim when a hunk remains manual
+- Resolution details name both marker labels and the applied strategy or manual-resolution reason, use `Auto-resolvable` for candidates, and use `Auto-resolved` only after successful persistence
+- A file is written only when every hunk resolves safely and the resulting output contains valid frontmatter
+- Post-resolution YAML errors, duplicate keys, missing required fields, invalid status, or empty files leave the original file unchanged
+- Uniform CRLF/LF style and final-newline presence are preserved
 - Results include `spec_path`, `status` (`Resolved` | `Manual` | `Clean`), and `details` for each file
 - Human-readable output uses colored formatting to distinguish status types
 

--- a/specs/merge/tasks.md
+++ b/specs/merge/tasks.md
@@ -4,7 +4,9 @@ spec: merge.spec.md
 
 ## Tasks
 
-(none open)
+- [ ] Complete CHG-0066 full repository, strict spec, score, trust, and sandbox verification.
+- [x] Complete fresh independent acceptance/adversarial review after the hardening fixes.
+- [ ] Correct PR #448 metadata, obtain closing approval, merge, and archive CHG-0066.
 
 ## Done
 
@@ -13,11 +15,11 @@ spec: merge.spec.md
 - [x] `detect_conflicted_specs` via `git diff --name-only --diff-filter=U`
 - [x] `parse_conflict_regions` splitting content into clean text and ours/theirs conflict blocks
 - [x] `detect_section` context detection (last `## ` heading) to choose a strategy
-- [x] Frontmatter conflict resolution: list union+sort, scalar "theirs wins"
+- [x] Frontmatter conflict resolution: known list union+sort, numeric version max, ambiguous scalars manual
 - [x] Changelog conflict resolution: chronological merge, dedup by full row
-- [x] Generic table conflict resolution: dedup by first cell, "theirs wins"
+- [x] Generic table conflict resolution: union distinct keys, deduplicate identical rows, ambiguous duplicate keys manual
 - [x] Prose conflicts left as `Manual` with markers preserved
-- [x] Post-resolution frontmatter validation warning
+- [x] Post-resolution frontmatter validation blocks writes of invalid output
 - [x] `print_results` (colored text) and `results_to_json` output formats
 - [x] Custom zero-dep YAML field parser (`parse_yaml_fields`)
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)

--- a/specs/merge/testing.md
+++ b/specs/merge/testing.md
@@ -6,11 +6,12 @@ spec: merge.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/merge.rs` | cargo test merge:: | `test_has_conflict_markers`, `test_parse_conflict_regions`, `test_resolve_changelog_conflict`, `test_resolve_table_conflict`, `test_resolve_frontmatter_conflict`, `test_full_spec_conflict_resolution`, `test_manual_fallback_for_prose`, `test_parse_yaml_fields`, `test_is_pure_table_rows` |
+| `src/merge.rs` | `fledge run test -- merge::` | Issue #427 regressions for all supported list unions, numeric version syntax/max, divergent and one-sided scalars, exact/malformed/orphan/nested markers, header-only and separator hunks, null/list type preservation, nested YAML, required frontmatter, CRLF/final newline, accurate details, dry-run, and all-or-nothing writes |
+| `tests/integration/commands.rs` | `fledge run test -- merge_issue_427` | CLI dry-run and real-run diff3/version behavior, persisted-resolution wording, and byte-identical mixed-manual persistence |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Auto-resolve frontmatter list conflict" before changing user-visible CLI output, generated files, or error handling in merge.
+- Structured JSON dry-run schema is owned by issue #420 and its reporting PR; CHG-0066 keeps the existing public JSON shape.
 
 ## Behavioral Verification
 
@@ -19,15 +20,27 @@ spec: merge.spec.md
 | Auto-resolve frontmatter list conflict | ours has `files: [a.rs, b.rs]` and theirs has `files: [b.rs, c.rs]` | `merge_specs` resolves the conflict | result is `files: [a.rs, b.rs, c.rs]` (union, sorted) |
 | Auto-resolve changelog conflict | ours added a `2026-03-20` entry, theirs added a `2026-03-25` entry | `merge_specs` resolves the conflict | both entries appear in chronological order, status is `Resolved` |
 | Prose conflict requires manual resolution | both sides modified the `## Purpose` section text | `merge_specs` encounters the conflict | conflict markers are preserved, status is `Manual` |
+| Divergent API row | both sides modify the same Public API symbol differently | `merge_specs` encounters the conflict | status is `Manual`, both labels and the ambiguity are reported, and the file is unchanged |
+| Diff3 table conflict | a lossless row union includes a `||||||| base` section | `merge_specs` resolves the conflict | HEAD and incoming rows remain; base marker/content does not leak |
 | Dry run | conflicted spec files exist | `merge_specs(root, specs_dir, true, false)` is called | returns `MergeResult` entries with resolution details but does not modify files |
+| Malformed marker or lossy parser boundary | orphan/nested/lookalike marker, table header/separator, null/list disagreement, nested YAML, or missing frontmatter appears | `merge_specs` encounters the file | status is `Manual` and disk bytes are unchanged |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Spec file unreadable | Marked as `Manual` with read error in details | Keep or add a focused assertion before changing this behavior |
-| `git diff` command fails (`all_files: false`) | `detect_conflicted_specs` returns an empty list — no specs are processed (no auto-fallback to scanning all files) | Keep or add a focused assertion before changing this behavior |
-| Post-resolution frontmatter invalid | `"Warning: resolved file has invalid frontmatter"` added to details; file is still written with resolved content | Keep or add a focused assertion before changing this behavior |
+| Spec file unreadable | Marked as `Manual` with read error in details | `all_files_reports_unreadable_specs_as_manual` |
+| `git diff` command fails (`all_files: false`) | `detect_conflicted_specs` returns an empty list — no specs are processed (no auto-fallback to scanning all files) | `git_discovery_failure_is_a_safe_noop` |
+| Post-resolution frontmatter invalid | Marked `Manual`; original file remains unchanged | `duplicate_or_invalid_frontmatter_suppresses_otherwise_resolvable_writes` |
+| Post-resolution frontmatter missing | Marked `Manual`; original file remains unchanged | `missing_frontmatter_prevents_resolvable_body_write` |
+| Partially resolvable file | Report auto-resolvable and manual hunk counts; preserve the original file byte-for-byte | `partial_resolution_preview_keeps_all_or_nothing_write_boundary`, `merge_specs_leaves_partially_resolvable_file_untouched` |
+| Malformed conflict block | Marked `Manual`; no write | `malformed_conflict_block_is_never_auto_resolved` |
+| CRLF diff3 input | Fully resolved output uses CRLF without lone LF bytes | `resolved_diff3_file_preserves_crlf_line_endings` |
+| Missing final newline | Fully resolved output remains unterminated | `fully_resolved_file_preserves_missing_final_newline` |
+| Orphan/nested/lookalike markers | Marked `Manual`; on-disk file stays byte-identical | `orphan_marker_families_after_a_valid_hunk_block_every_write`, `nested_marker_diagnostics_keep_the_outer_side_labels`, `diff3_marker_requires_exact_seven_pipes_and_label_separator` |
+| Header/separator or nested YAML in hunk | Marked `Manual`; no lossy reconstruction | `table_hunks_containing_headers_or_separators_remain_manual`, `table_header_only_hunks_remain_manual_and_byte_identical`, `nested_frontmatter_mapping_is_not_flattened` |
+| YAML null versus empty list | Marked `Manual`; neither type is rewritten as the other | `unknown_empty_scalar_and_empty_list_are_not_equivalent` |
+| Dry-run versus persisted wording | Preview details say `Auto-resolvable`; successful real writes say `Auto-resolved` | `merge_resolves_interior_field_conflict`, `merge_issue_427_diff3_max_version_and_dry_run_are_lossless` |
 
 ## Reviewer Checklist
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::Path;
 use std::process;
 
-use crate::parser::parse_frontmatter;
+use crate::parser::{parse_checked_issue_references, parse_frontmatter};
 use crate::validator::find_spec_files;
 
 /// Result of merging a single spec file.
@@ -37,10 +37,11 @@ pub fn merge_specs(
         let spec_files = find_spec_files(specs_dir);
         spec_files
             .into_iter()
-            .filter(|p| {
-                fs::read_to_string(p)
-                    .map(|c| has_conflict_markers(&c))
-                    .unwrap_or(false)
+            .filter(|path| match fs::read_to_string(path) {
+                Ok(content) => has_conflict_markers(&content),
+                // Keep unreadable candidates so the main loop emits an explicit
+                // Manual result instead of silently dropping them.
+                Err(_) => true,
             })
             .collect::<Vec<_>>()
     } else {
@@ -63,18 +64,25 @@ pub fn merge_specs(
             }
         };
 
-        let (resolved, result) = resolve_spec_conflicts(&content, &rel_path(root, spec_path));
+        let (resolved, mut result, should_write) =
+            resolve_spec_conflicts(&content, &rel_path(root, spec_path));
 
-        if !dry_run
-            && let MergeStatus::Resolved = &result.status
-            && let Err(e) = fs::write(spec_path, &resolved)
-        {
-            results.push(MergeResult {
-                spec_path: rel_path(root, spec_path),
-                status: MergeStatus::Manual,
-                details: vec![format!("Cannot write file: {e}")],
-            });
-            continue;
+        // Preserve all-or-nothing writes: an ambiguous hunk leaves the complete
+        // original file untouched, even when other hunks are auto-resolvable.
+        if !dry_run && should_write {
+            if let Err(e) = fs::write(spec_path, &resolved) {
+                results.push(MergeResult {
+                    spec_path: rel_path(root, spec_path),
+                    status: MergeStatus::Manual,
+                    details: vec![format!("Cannot write file: {e}")],
+                });
+                continue;
+            }
+            for detail in &mut result.details {
+                if let Some(suffix) = detail.strip_prefix("Auto-resolvable") {
+                    *detail = format!("Auto-resolved{suffix}");
+                }
+            }
         }
 
         results.push(result);
@@ -85,7 +93,7 @@ pub fn merge_specs(
 
 /// Check whether content contains git conflict markers.
 pub fn has_conflict_markers(content: &str) -> bool {
-    content.contains("\n<<<<<<< ") || content.starts_with("<<<<<<< ")
+    content.lines().any(is_conflict_marker_like)
 }
 
 /// Use `git status` to find spec files with merge conflicts.
@@ -96,8 +104,9 @@ fn detect_conflicted_specs(root: &Path, specs_dir: &Path) -> Vec<std::path::Path
         .output();
 
     let output = match output {
-        Ok(o) => o,
+        Ok(output) if output.status.success() => output,
         Err(_) => return Vec::new(),
+        Ok(_) => return Vec::new(),
     };
 
     let specs_rel = specs_dir
@@ -113,23 +122,32 @@ fn detect_conflicted_specs(root: &Path, specs_dir: &Path) -> Vec<std::path::Path
 }
 
 /// Resolve conflicts in a single spec file.
-/// Returns (resolved_content, merge_result).
-fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
+/// Returns (resolved_content, merge_result, should_write).
+///
+/// `should_write` is true only when every hunk was resolved and the output
+/// passed the frontmatter safety net. Ambiguous files remain byte-for-byte
+/// untouched.
+fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult, bool) {
     let mut details = Vec::new();
     let mut all_resolved = true;
+    let mut auto_count = 0usize;
+    let mut manual_count = 0usize;
 
     // Split the file into regions: clean text and conflict blocks
     let regions = parse_conflict_regions(content);
 
     let mut output = String::new();
 
-    for region in &regions {
+    for (index, region) in regions.iter().enumerate() {
         match region {
             Region::Clean(text) => output.push_str(text),
             Region::Conflict {
                 ours,
                 theirs,
                 marker_label,
+                theirs_label,
+                raw,
+                well_formed,
             } => {
                 // Determine what section this conflict is in. We are still inside
                 // the leading frontmatter block until its closing `---` — i.e.
@@ -137,49 +155,93 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
                 let section = detect_section(&output);
                 let in_frontmatter = output.lines().filter(|l| l.trim() == "---").count() < 2;
 
-                match resolve_conflict(ours, theirs, &section, in_frontmatter) {
-                    Resolution::Auto(merged) => {
+                let next_clean_starts_with_separator = regions
+                    .get(index + 1)
+                    .and_then(|region| match region {
+                        Region::Clean(text) => Some(text),
+                        Region::Conflict { .. } => None,
+                    })
+                    .is_some_and(|text| clean_region_starts_with_table_separator(text));
+
+                let resolution = if !*well_formed {
+                    Resolution::Manual("malformed or incomplete conflict markers")
+                } else if !in_frontmatter && next_clean_starts_with_separator {
+                    Resolution::Manual("conflict includes a table header")
+                } else {
+                    resolve_conflict(ours, theirs, &section, in_frontmatter)
+                };
+
+                match resolution {
+                    Resolution::Auto(merged, strategy) => {
+                        auto_count += 1;
                         details.push(format!(
-                            "Auto-resolved in {}: {}",
+                            "Auto-resolvable in {} ({} ↔ {}): {}",
                             section.as_deref().unwrap_or("unknown section"),
-                            marker_label
+                            marker_label,
+                            if theirs_label.is_empty() {
+                                "incoming"
+                            } else {
+                                theirs_label
+                            },
+                            strategy
                         ));
                         output.push_str(&merged);
                     }
-                    Resolution::Manual => {
+                    Resolution::Manual(reason) => {
+                        manual_count += 1;
                         details.push(format!(
-                            "Manual resolution needed in {}: {}",
+                            "Manual resolution needed in {} ({} ↔ {}): {}",
                             section.as_deref().unwrap_or("unknown section"),
-                            marker_label
+                            marker_label,
+                            if theirs_label.is_empty() {
+                                "incoming"
+                            } else {
+                                theirs_label
+                            },
+                            reason
                         ));
                         all_resolved = false;
-                        // Preserve the conflict markers
-                        output.push_str(&format!(
-                            "<<<<<<< {marker_label}\n{ours}=======\n{theirs}>>>>>>> {marker_label}\n"
-                        ));
+                        // Preserve the original conflict block verbatim (markers,
+                        // diff3 base section and all) — nothing is lost.
+                        output.push_str(raw);
                     }
                 }
             }
         }
     }
 
-    // Safety net for frontmatter validity: if the input had frontmatter but the
-    // assembled output no longer parses as frontmatter OR parses to one that lost
-    // its `module`, refuse — downgrade to Manual so the caller (which writes only
-    // on `Resolved`) leaves the ORIGINAL file untouched. (This guards frontmatter
-    // structure; body/row preservation is handled upstream by only auto-merging
-    // pure field/table hunks, never prose- or section-carrying ones.)
-    let had_frontmatter = content.lines().any(|l| l.trim() == "---");
+    // Safety net for frontmatter validity: if the assembled output does not parse
+    // as a complete spec frontmatter block, refuse to persist ANYTHING so the
+    // caller leaves the ORIGINAL
+    // file untouched. (This guards frontmatter structure; body/row preservation is
+    // handled upstream by only auto-merging pure field/table hunks, never prose- or
+    // section-carrying ones.)
     let resolved_frontmatter_ok = parse_frontmatter(&output)
-        .map(|parsed| parsed.frontmatter.module.is_some())
-        .unwrap_or(false);
-    if all_resolved && !output.is_empty() && had_frontmatter && !resolved_frontmatter_ok {
+        .map(|parsed| {
+            parsed.frontmatter.module.is_some()
+                && parsed.frontmatter.version.is_some()
+                && parsed.frontmatter.status.is_some()
+                && parsed.frontmatter.parsed_status().is_some()
+                && !parsed.frontmatter.files.is_empty()
+        })
+        .unwrap_or(false)
+        && parse_checked_issue_references(&output).is_ok();
+    let mut should_write = all_resolved && auto_count > 0;
+    if !output.is_empty() && !resolved_frontmatter_ok {
         all_resolved = false;
+        should_write = false;
         details.push(
             "Resolved content would have invalid or empty frontmatter — left for \
              manual resolution; the original file was not modified"
                 .to_string(),
         );
+    }
+
+    if manual_count > 0 && auto_count > 0 {
+        details.push(format!(
+            "{auto_count} hunk(s) are auto-resolvable, but {manual_count} hunk(s) need \
+             manual resolution; the file was left unchanged (all-or-nothing)"
+        ));
     }
 
     let status = if !all_resolved {
@@ -190,6 +252,8 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
         MergeStatus::Resolved
     };
 
+    let output = restore_input_line_endings(content, output);
+
     (
         output,
         MergeResult {
@@ -197,7 +261,22 @@ fn resolve_spec_conflicts(content: &str, path: &str) -> (String, MergeResult) {
             status,
             details,
         },
+        should_write,
     )
+}
+
+fn restore_input_line_endings(input: &str, mut output: String) -> String {
+    if !input.ends_with('\n') && output.ends_with('\n') {
+        output.pop();
+    }
+
+    let newline_count = input.bytes().filter(|byte| *byte == b'\n').count();
+    let crlf_count = input.match_indices("\r\n").count();
+    if newline_count > 0 && newline_count == crlf_count {
+        output.replace('\n', "\r\n")
+    } else {
+        output
+    }
 }
 
 enum Region {
@@ -205,18 +284,31 @@ enum Region {
     Conflict {
         ours: String,
         theirs: String,
+        /// Label on the `<<<<<<<` marker (ours side, usually `HEAD`).
         marker_label: String,
+        /// Label on the `>>>>>>>` marker (the incoming side).
+        theirs_label: String,
+        /// The complete original conflict block, markers included — re-emitted
+        /// verbatim when the hunk needs manual resolution so nothing (including
+        /// diff3 base sections) is lost or rewritten.
+        raw: String,
+        /// Whether the block contained exactly one separator and a closing marker.
+        well_formed: bool,
     },
 }
 
 /// Parse content into clean regions and conflict blocks.
+///
+/// Handles `merge.conflictStyle diff3` hunks: the `||||||| base` section is
+/// captured (in `raw`) but excluded from `ours`/`theirs`, so auto-resolution
+/// never leaks base content or the `|||||||` marker into the output.
 fn parse_conflict_regions(content: &str) -> Vec<Region> {
     let mut regions = Vec::new();
     let mut clean_buf = String::new();
     let mut lines = content.lines().peekable();
 
     while let Some(line) = lines.next() {
-        if let Some(label) = line.strip_prefix("<<<<<<< ") {
+        if let Some(label) = conflict_opener_label(line) {
             // Flush clean buffer
             if !clean_buf.is_empty() {
                 regions.push(Region::Clean(clean_buf.clone()));
@@ -224,19 +316,60 @@ fn parse_conflict_regions(content: &str) -> Vec<Region> {
             }
 
             let marker_label = label.to_string();
+            let mut raw = format!("{line}\n");
             let mut ours = String::new();
             let mut theirs = String::new();
+            let mut theirs_label = String::new();
+            let mut in_base = false;
             let mut in_theirs = false;
+            let mut saw_base = false;
+            let mut saw_separator = false;
+            let mut saw_end = false;
+            let mut malformed = false;
+            let mut nested_depth = 0usize;
 
             for inner_line in lines.by_ref() {
-                if inner_line == "=======" {
+                raw.push_str(inner_line);
+                raw.push('\n');
+
+                if conflict_opener_label(inner_line).is_some() {
+                    malformed = true;
+                    nested_depth += 1;
+                    continue;
+                }
+                if nested_depth > 0 {
+                    if conflict_closer_label(inner_line).is_some() {
+                        nested_depth -= 1;
+                    }
+                    continue;
+                }
+
+                if is_diff3_base_marker(inner_line) {
+                    if saw_base || saw_separator || in_theirs {
+                        malformed = true;
+                    }
+                    saw_base = true;
+                    in_base = true;
+                } else if inner_line == "=======" {
+                    if saw_separator {
+                        malformed = true;
+                    }
+                    saw_separator = true;
+                    in_base = false;
                     in_theirs = true;
-                } else if inner_line.starts_with(">>>>>>> ") {
+                } else if let Some(label) = conflict_closer_label(inner_line) {
+                    if !saw_separator {
+                        malformed = true;
+                    }
+                    theirs_label = label.to_string();
+                    saw_end = true;
                     break;
+                } else if is_conflict_marker_like(inner_line) {
+                    malformed = true;
                 } else if in_theirs {
                     theirs.push_str(inner_line);
                     theirs.push('\n');
-                } else {
+                } else if !in_base {
                     ours.push_str(inner_line);
                     ours.push('\n');
                 }
@@ -246,6 +379,22 @@ fn parse_conflict_regions(content: &str) -> Vec<Region> {
                 ours,
                 theirs,
                 marker_label,
+                theirs_label,
+                raw,
+                well_formed: saw_separator && saw_end && !malformed,
+            });
+        } else if is_conflict_marker_like(line) {
+            if !clean_buf.is_empty() {
+                regions.push(Region::Clean(clean_buf.clone()));
+                clean_buf.clear();
+            }
+            regions.push(Region::Conflict {
+                ours: String::new(),
+                theirs: String::new(),
+                marker_label: "unavailable".to_string(),
+                theirs_label: "unavailable".to_string(),
+                raw: format!("{line}\n"),
+                well_formed: false,
             });
         } else {
             clean_buf.push_str(line);
@@ -260,6 +409,28 @@ fn parse_conflict_regions(content: &str) -> Vec<Region> {
     regions
 }
 
+fn conflict_opener_label(line: &str) -> Option<&str> {
+    line.strip_prefix("<<<<<<< ")
+        .filter(|label| !label.is_empty() && !label.starts_with('<'))
+}
+
+fn conflict_closer_label(line: &str) -> Option<&str> {
+    line.strip_prefix(">>>>>>> ")
+        .filter(|label| !label.is_empty() && !label.starts_with('>'))
+}
+
+fn is_diff3_base_marker(line: &str) -> bool {
+    line.strip_prefix("||||||| ")
+        .is_some_and(|label| !label.is_empty() && !label.starts_with('|'))
+}
+
+fn is_conflict_marker_like(line: &str) -> bool {
+    line.starts_with("<<<<<<<")
+        || line.starts_with("|||||||")
+        || line.starts_with("=======")
+        || line.starts_with(">>>>>>>")
+}
+
 /// Detect which markdown section the cursor is currently in,
 /// based on the content already emitted.
 fn detect_section(content_so_far: &str) -> Option<String> {
@@ -272,8 +443,10 @@ fn detect_section(content_so_far: &str) -> Option<String> {
 }
 
 enum Resolution {
-    Auto(String),
-    Manual,
+    /// (merged content, human-readable description of WHICH side/strategy won
+    /// — reported so the log never claims HEAD won when it didn't, #427)
+    Auto(String, &'static str),
+    Manual(&'static str),
 }
 
 /// Try to auto-resolve a conflict based on section context.
@@ -303,7 +476,10 @@ fn resolve_conflict(
     // resolution instead.
     let pure_rows = is_pure_table_rows(ours) && is_pure_table_rows(theirs);
     match section_name {
-        _ if !pure_rows => Resolution::Manual,
+        _ if !pure_rows => Resolution::Manual("conflict contains prose or non-table content"),
+        _ if contains_table_separator(ours) || contains_table_separator(theirs) => {
+            Resolution::Manual("conflict includes a table header separator")
+        }
         "Change Log" => resolve_changelog_conflict(ours, theirs),
         _ => resolve_table_conflict(ours, theirs),
     }
@@ -316,13 +492,26 @@ fn is_pure_table_rows(text: &str) -> bool {
         .all(|l| l.trim_start().starts_with('|'))
 }
 
+fn contains_table_separator(text: &str) -> bool {
+    text.lines().any(|line| is_table_separator_row(line.trim()))
+}
+
+fn clean_region_starts_with_table_separator(text: &str) -> bool {
+    text.lines()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(|line| is_table_separator_row(line.trim()))
+}
+
 /// Merge changelog table rows by date (union, sorted chronologically).
 fn resolve_changelog_conflict(ours: &str, theirs: &str) -> Resolution {
     let our_rows = parse_table_rows(ours);
     let their_rows = parse_table_rows(theirs);
 
     if our_rows.is_empty() && their_rows.is_empty() {
-        return Resolution::Manual;
+        return Resolution::Manual("no changelog rows could be parsed");
+    }
+    if our_rows.is_empty() || their_rows.is_empty() {
+        return Resolution::Manual("one side deleted all changelog rows");
     }
 
     // Deduplicate by full row content, preserve chronological order
@@ -345,7 +534,10 @@ fn resolve_changelog_conflict(ours: &str, theirs: &str) -> Resolution {
         .collect::<Vec<_>>()
         .join("\n");
 
-    Resolution::Auto(format!("{merged}\n"))
+    Resolution::Auto(
+        format!("{merged}\n"),
+        "union of both sides, sorted chronologically",
+    )
 }
 
 /// Merge generic table rows (union, deduplicated by first cell / key).
@@ -354,20 +546,29 @@ fn resolve_table_conflict(ours: &str, theirs: &str) -> Resolution {
     let their_rows = parse_table_rows(theirs);
 
     if our_rows.is_empty() && their_rows.is_empty() {
-        return Resolution::Manual;
+        return Resolution::Manual("no table rows could be parsed");
+    }
+    if our_rows.is_empty() || their_rows.is_empty() {
+        return Resolution::Manual("one side deleted all table rows");
     }
 
-    // Deduplicate by first cell (e.g., symbol name)
-    let mut seen = HashMap::new();
+    // Union rows by first cell (e.g., symbol name), but never choose a winner
+    // when both sides changed the same key differently. Such a choice would
+    // silently discard one branch's API contract.
+    let mut seen: HashMap<String, String> = HashMap::new();
     let mut order = Vec::new();
 
     for row in our_rows.iter().chain(their_rows.iter()) {
         let key = extract_first_cell(row);
-        if !seen.contains_key(&key) {
-            order.push(key.clone());
+        let normalized = row.trim_end();
+        if let Some(existing) = seen.get(&key) {
+            if existing != normalized {
+                return Resolution::Manual("same table key has divergent row content");
+            }
+            continue;
         }
-        // Theirs wins on conflict (latest change takes precedence)
-        seen.insert(key, row.trim_end().to_string());
+        order.push(key.clone());
+        seen.insert(key, normalized.to_string());
     }
 
     let merged = order
@@ -377,7 +578,10 @@ fn resolve_table_conflict(ours: &str, theirs: &str) -> Resolution {
         .collect::<Vec<_>>()
         .join("\n");
 
-    Resolution::Auto(format!("{merged}\n"))
+    Resolution::Auto(
+        format!("{merged}\n"),
+        "union of both sides; identical duplicate rows deduplicated",
+    )
 }
 
 /// Whether a conflict-hunk side is ONLY interior frontmatter fields that
@@ -405,6 +609,12 @@ fn is_frontmatter_only(text: &str) -> bool {
             // Only safe when an owning list key was opened earlier in THIS hunk.
             return under_list_key;
         }
+        // Indented mappings are valid YAML extensions, but this deliberately
+        // small resolver would flatten them into top-level fields. Leave them
+        // untouched instead of changing their meaning.
+        if line.len() != line.trim_start().len() {
+            return false;
+        }
         // `key: value` with a spaceless key (a `---` fence has no colon → rejected).
         match line.find(':') {
             Some(c) => {
@@ -413,8 +623,9 @@ fn is_frontmatter_only(text: &str) -> bool {
                     return false;
                 }
                 let value = line[c + 1..].trim();
-                // An empty (or `[]`) value opens a list the parser attaches items to.
-                under_list_key = value.is_empty() || value == "[]";
+                // Only a block-style empty value can own following `- item`
+                // lines. An inline `[]` is already complete.
+                under_list_key = value.is_empty();
                 true
             }
             None => false,
@@ -424,7 +635,8 @@ fn is_frontmatter_only(text: &str) -> bool {
 
 /// Merge frontmatter YAML fields.
 /// Lists (files, depends_on, db_tables) are unioned.
-/// Scalars: theirs wins if different.
+/// Numeric versions take the maximum value. Other scalar conflicts are
+/// ambiguous and require manual resolution.
 fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
     // Only auto-merge when BOTH sides are pure interior frontmatter fields (no
     // `---` fence, heading, or body in the hunk). A plain `git merge` of specs
@@ -433,7 +645,7 @@ fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
     // fields alone, reconstructing those fences is error-prone (dropped body,
     // doubled fences). So we don't try — such hunks are left for manual resolution.
     if !is_frontmatter_only(ours) || !is_frontmatter_only(theirs) {
-        return Resolution::Manual;
+        return Resolution::Manual("frontmatter hunk contains unsupported content");
     }
 
     // Parse both sides as YAML-like key-value pairs
@@ -441,7 +653,10 @@ fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
     let their_fields = parse_yaml_fields(theirs);
 
     if our_fields.is_empty() && their_fields.is_empty() {
-        return Resolution::Manual;
+        return Resolution::Manual("no frontmatter fields could be parsed");
+    }
+    if has_duplicate_yaml_keys(&our_fields) || has_duplicate_yaml_keys(&their_fields) {
+        return Resolution::Manual("frontmatter contains duplicate keys");
     }
 
     let list_keys: HashSet<&str> = ["files", "db_tables", "depends_on"].into_iter().collect();
@@ -479,8 +694,8 @@ fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
                 if list_keys.contains(key.as_str()) =>
             {
                 // Union the lists
-                let mut combined = a.clone();
-                for item in b {
+                let mut combined = Vec::new();
+                for item in a.iter().chain(b.iter()) {
                     if !combined.contains(item) {
                         combined.push(item.clone());
                     }
@@ -495,12 +710,57 @@ fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
                     }
                 }
             }
-            (_, Some(val)) => {
-                // Theirs wins for scalars (or if only theirs has it)
+            (Some(YamlValue::Scalar(a)), Some(YamlValue::Scalar(b))) if key == "version" => {
+                // #427: version must never regress on merge — take max(), not
+                // blindly "theirs" (which could be the older number).
+                match (
+                    parse_numeric_version_scalar(a),
+                    parse_numeric_version_scalar(b),
+                ) {
+                    (Ok(x), Ok(y)) => {
+                        let selected = match x.cmp(&y) {
+                            std::cmp::Ordering::Greater => a,
+                            std::cmp::Ordering::Less => b,
+                            std::cmp::Ordering::Equal if a == b => a,
+                            std::cmp::Ordering::Equal => {
+                                return Resolution::Manual(
+                                    "equal version values use different scalar syntax",
+                                );
+                            }
+                        };
+                        merged_lines.push(format!("{key}: {selected}"));
+                    }
+                    _ => {
+                        return Resolution::Manual("version values are not both unsigned integers");
+                    }
+                }
+            }
+            (Some(YamlValue::Scalar(a)), Some(YamlValue::Scalar(b))) => {
+                if a != b {
+                    return Resolution::Manual("frontmatter scalar values differ");
+                }
+                merged_lines.push(format_yaml_field(key, &YamlValue::Scalar(a.clone())));
+            }
+            (Some(YamlValue::List(a)), Some(YamlValue::List(b))) => {
+                if a != b {
+                    return Resolution::Manual("unsupported frontmatter list values differ");
+                }
+                merged_lines.push(format_yaml_field(key, &YamlValue::List(a.clone())));
+            }
+            (Some(YamlValue::Null), Some(YamlValue::Null)) => {
+                merged_lines.push(format_yaml_field(key, &YamlValue::Null));
+            }
+            (Some(_), Some(_)) => {
+                return Resolution::Manual("frontmatter field types differ");
+            }
+            (None, Some(val @ YamlValue::List(_))) if list_keys.contains(key.as_str()) => {
                 merged_lines.push(format_yaml_field(key, val));
             }
-            (Some(val), None) => {
+            (Some(val @ YamlValue::List(_)), None) if list_keys.contains(key.as_str()) => {
                 merged_lines.push(format_yaml_field(key, val));
+            }
+            (None, Some(_)) | (Some(_), None) => {
+                return Resolution::Manual("frontmatter field exists on only one side");
             }
             (None, None) => {}
         }
@@ -510,13 +770,44 @@ fn resolve_frontmatter_conflict(ours: &str, theirs: &str) -> Resolution {
     // surrounding clean regions (guaranteed: `is_frontmatter_only` rejects any hunk
     // that contains a fence), so we never reconstruct or double a delimiter.
     let body = merged_lines.join("\n");
-    Resolution::Auto(format!("{body}\n"))
+    Resolution::Auto(
+        format!("{body}\n"),
+        "known lists unioned; version = max(both sides); equal scalars preserved",
+    )
+}
+
+fn parse_numeric_version_scalar(raw: &str) -> Result<u64, ()> {
+    let raw = raw.trim();
+    let value = if let Some(quote) = raw
+        .chars()
+        .next()
+        .filter(|character| *character == '\'' || *character == '"')
+    {
+        let remainder = &raw[quote.len_utf8()..];
+        let close = remainder.find(quote).ok_or(())?;
+        let suffix = &remainder[close + quote.len_utf8()..];
+        if !suffix.trim().is_empty() && !suffix.trim_start().starts_with('#') {
+            return Err(());
+        }
+        &remainder[..close]
+    } else {
+        let comment = raw.find(" #").unwrap_or(raw.len());
+        &raw[..comment]
+    };
+
+    value.trim().parse::<u64>().map_err(|_| ())
 }
 
 #[derive(Clone, Debug)]
 enum YamlValue {
     Scalar(String),
     List(Vec<String>),
+    Null,
+}
+
+fn has_duplicate_yaml_keys(fields: &[(String, YamlValue)]) -> bool {
+    let mut seen = HashSet::new();
+    fields.iter().any(|(key, _)| !seen.insert(key))
 }
 
 /// Simple YAML field parser (handles our zero-dep YAML subset).
@@ -541,14 +832,21 @@ fn parse_yaml_fields(text: &str) -> Vec<(String, YamlValue)> {
 
             // Flush previous
             if let Some(prev_key) = current_key.take() {
-                fields.push((prev_key, YamlValue::List(current_list.clone())));
+                let value = if current_list.is_empty() {
+                    YamlValue::Null
+                } else {
+                    YamlValue::List(current_list.clone())
+                };
+                fields.push((prev_key, value));
                 current_list.clear();
             }
 
             let value = line[colon_pos + 1..].trim();
-            if value.is_empty() || value == "[]" {
+            if value.is_empty() {
                 current_key = Some(key.to_string());
                 current_list.clear();
+            } else if value == "[]" {
+                fields.push((key.to_string(), YamlValue::List(Vec::new())));
             } else {
                 fields.push((key.to_string(), YamlValue::Scalar(value.to_string())));
             }
@@ -556,7 +854,12 @@ fn parse_yaml_fields(text: &str) -> Vec<(String, YamlValue)> {
     }
 
     if let Some(prev_key) = current_key.take() {
-        fields.push((prev_key, YamlValue::List(current_list)));
+        let value = if current_list.is_empty() {
+            YamlValue::Null
+        } else {
+            YamlValue::List(current_list)
+        };
+        fields.push((prev_key, value));
     }
 
     fields
@@ -573,6 +876,7 @@ fn format_yaml_field(key: &str, value: &YamlValue) -> String {
             }
             lines.join("\n")
         }
+        YamlValue::Null => format!("{key}:"),
     }
 }
 
@@ -731,10 +1035,13 @@ mod tests {
                 ours,
                 theirs,
                 marker_label,
+                theirs_label,
+                ..
             } => {
                 assert_eq!(ours, "ours line\n");
                 assert_eq!(theirs, "theirs line\n");
                 assert_eq!(marker_label, "HEAD");
+                assert_eq!(theirs_label, "branch");
             }
             _ => panic!("expected Conflict"),
         }
@@ -750,7 +1057,7 @@ mod tests {
         let theirs = "| 2026-01-01 | Added auth |\n| 2026-01-10 | Added signup |\n";
 
         match resolve_changelog_conflict(ours, theirs) {
-            Resolution::Auto(merged) => {
+            Resolution::Auto(merged, _) => {
                 assert!(merged.contains("Added auth"));
                 assert!(merged.contains("Fixed login"));
                 assert!(merged.contains("Added signup"));
@@ -761,23 +1068,34 @@ mod tests {
                 assert!(lines[1].contains("2026-01-10"));
                 assert!(lines[2].contains("2026-01-15"));
             }
-            Resolution::Manual => panic!("expected auto resolution"),
+            Resolution::Manual(reason) => panic!("expected auto resolution: {reason}"),
         }
     }
 
     #[test]
     fn test_resolve_table_conflict() {
         let ours = "| `createAuth` | config: Config | Auth | Creates auth |\n";
-        let theirs = "| `createAuth` | config: Config | Auth | Updated desc |\n| `validateToken` | token: string | bool | Validates |\n";
+        let theirs = "| `validateToken` | token: string | bool | Validates |\n";
 
         match resolve_table_conflict(ours, theirs) {
-            Resolution::Auto(merged) => {
+            Resolution::Auto(merged, _) => {
+                assert!(merged.contains("createAuth"));
                 assert!(merged.contains("validateToken"));
-                // theirs wins for createAuth
-                assert!(merged.contains("Updated desc"));
-                assert!(!merged.contains("Creates auth"));
             }
-            Resolution::Manual => panic!("expected auto resolution"),
+            Resolution::Manual(reason) => panic!("expected auto resolution: {reason}"),
+        }
+    }
+
+    #[test]
+    fn divergent_table_rows_require_manual_resolution() {
+        let ours = "| `createAuth` | config: Config | Auth | Creates auth |\n";
+        let theirs = "| `createAuth` | config: Config | Auth | Updated desc |\n";
+
+        match resolve_table_conflict(ours, theirs) {
+            Resolution::Manual(reason) => {
+                assert!(reason.contains("divergent row content"), "{reason}");
+            }
+            Resolution::Auto(merged, _) => panic!("must not discard a row: {merged}"),
         }
     }
 
@@ -788,7 +1106,7 @@ mod tests {
         let theirs = "module: auth\nversion: 3\nfiles:\n  - src/auth.ts\n  - src/signup.ts\ndepends_on: []\n";
 
         match resolve_frontmatter_conflict(ours, theirs) {
-            Resolution::Auto(merged) => {
+            Resolution::Auto(merged, _) => {
                 // Theirs wins for scalar (version)
                 assert!(merged.contains("version: 3"));
                 // Lists are unioned
@@ -796,7 +1114,7 @@ mod tests {
                 assert!(merged.contains("src/login.ts"));
                 assert!(merged.contains("src/signup.ts"));
             }
-            Resolution::Manual => panic!("expected auto resolution"),
+            Resolution::Manual(reason) => panic!("expected auto resolution: {reason}"),
         }
     }
 
@@ -841,10 +1159,10 @@ Auth module.
 >>>>>>> feature-branch
 "#;
 
-        let (resolved, result) = resolve_spec_conflicts(content, "specs/auth/auth.spec.md");
+        let (resolved, result, _) = resolve_spec_conflicts(content, "specs/auth/auth.spec.md");
         assert!(matches!(result.status, MergeStatus::Resolved));
         assert!(!has_conflict_markers(&resolved));
-        // Frontmatter: version 3 (theirs wins), files unioned
+        // Frontmatter: maximum version is 3, files are unioned
         assert!(resolved.contains("version: 3"));
         assert!(resolved.contains("src/login.ts"));
         assert!(resolved.contains("src/signup.ts"));
@@ -882,7 +1200,8 @@ depends_on: []
 >>>>>>> branch
 # Minimal
 ";
-        let (resolved, result) = resolve_spec_conflicts(content, "specs/minimal/minimal.spec.md");
+        let (resolved, result, _) =
+            resolve_spec_conflicts(content, "specs/minimal/minimal.spec.md");
         assert_eq!(
             result.status,
             MergeStatus::Manual,
@@ -919,7 +1238,7 @@ version: 3
 >>>>>>> feature
 # Body
 ";
-        let (resolved, result) = resolve_spec_conflicts(content, "specs/a/a.spec.md");
+        let (resolved, result, _) = resolve_spec_conflicts(content, "specs/a/a.spec.md");
         assert_eq!(
             result.status,
             MergeStatus::Manual,
@@ -970,7 +1289,7 @@ depends_on: []
 Theirs purpose.
 >>>>>>> feature
 ";
-        let (resolved, result) = resolve_spec_conflicts(content, "specs/alpha/alpha.spec.md");
+        let (resolved, result, _) = resolve_spec_conflicts(content, "specs/alpha/alpha.spec.md");
         assert_eq!(
             result.status,
             MergeStatus::Manual,
@@ -1020,7 +1339,7 @@ TODO: rewrite the auth flow
 
 The module.
 ";
-        let (resolved, result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        let (resolved, result, _) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
         assert_eq!(
             result.status,
             MergeStatus::Manual,
@@ -1061,7 +1380,7 @@ depends_on: []
 ---
 # M
 ";
-        let (resolved, result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        let (resolved, result, _) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
         assert_eq!(
             result.status,
             MergeStatus::Manual,
@@ -1110,7 +1429,7 @@ Run the migration script before deploying.
 Run it after.
 >>>>>>> feature
 ";
-        let (resolved, result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        let (resolved, result, _) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
         assert_eq!(
             result.status,
             MergeStatus::Manual,
@@ -1162,7 +1481,7 @@ depends_on: []
 | --quiet | Quiet mode |
 >>>>>>> feature
 ";
-        let (resolved, _result) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        let (resolved, _result, _) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
         assert!(
             !has_conflict_markers(&resolved),
             "should auto-resolve:\n{resolved}"
@@ -1177,7 +1496,7 @@ depends_on: []
     #[test]
     fn test_manual_fallback_for_prose() {
         let content = "## Purpose\n\n<<<<<<< HEAD\nThis is our purpose description.\n=======\nThis is their different purpose.\n>>>>>>> branch\n";
-        let (resolved, result) = resolve_spec_conflicts(content, "test.spec.md");
+        let (resolved, result, _) = resolve_spec_conflicts(content, "test.spec.md");
         // Prose conflicts should remain for manual resolution
         assert!(matches!(result.status, MergeStatus::Manual));
         assert!(has_conflict_markers(&resolved));
@@ -1197,5 +1516,642 @@ depends_on: []
         assert!(is_pure_table_rows("| a | b |\n| c | d |\n"));
         assert!(!is_pure_table_rows("some text\n| a | b |\n"));
         assert!(is_pure_table_rows("| a | b |\n\n| c | d |\n"));
+    }
+
+    // ── #427 regressions ────────────────────────────────────────────
+
+    const OPEN_HEAD: &str = concat!("<<<<", "<<< HEAD\n");
+    const OPEN_OUTER: &str = concat!("<<<<", "<<< outer-ours\n");
+    const OPEN_INNER: &str = concat!("<<<<", "<<< inner-ours\n");
+    const BASE_MARKER: &str = concat!("||||", "||| base\n");
+    const SEPARATOR: &str = concat!("===", "====\n");
+    const CLOSE_SIDE: &str = concat!(">>>>", ">>> side\n");
+    const CLOSE_OUTER: &str = concat!(">>>>", ">>> outer-incoming\n");
+    const CLOSE_INNER: &str = concat!(">>>>", ">>> inner-incoming\n");
+
+    #[test]
+    fn divergent_api_row_detail_names_both_sides_and_requires_manual_resolution() {
+        // #427: never claim HEAD won while selecting incoming content. Divergent
+        // rows are ambiguous, so neither side may be selected.
+        let content = format!(
+            "---\nmodule: m\nversion: 1\n---\n# M\n\n## Public API\n\n\
+             | Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | MAIN description. |\n\
+             {SEPARATOR}| `a` | SIDE description. |\n{CLOSE_SIDE}"
+        );
+        let (resolved, result, should_write) =
+            resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Manual);
+        assert!(!should_write);
+        let detail = &result.details[0];
+        assert!(detail.contains("HEAD"), "{detail}");
+        assert!(detail.contains("side"), "{detail}");
+        assert!(detail.contains("divergent row content"), "{detail}");
+        assert!(resolved.contains("MAIN description."), "{resolved}");
+        assert!(resolved.contains("SIDE description."), "{resolved}");
+        assert!(has_conflict_markers(&resolved));
+    }
+
+    #[test]
+    fn lossless_table_union_detail_names_both_sides_and_strategy() {
+        let content = concat!(
+            "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n",
+            "---\n# M\n\n## Public API\n\n",
+            "| Name | Description |\n|------|-------------|\n",
+            "<<<<",
+            "<<< HEAD\n| `a` | MAIN description. |\n",
+            "===",
+            "====\n| `b` | SIDE description. |\n",
+            ">>>>",
+            ">>> side\n",
+        );
+        let (resolved, result, should_write) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Resolved);
+        assert!(should_write);
+        assert!(resolved.contains("MAIN description."), "{resolved}");
+        assert!(resolved.contains("SIDE description."), "{resolved}");
+        let detail = &result.details[0];
+        assert!(detail.contains("HEAD"), "{detail}");
+        assert!(detail.contains("side"), "{detail}");
+        assert!(detail.contains("union of both sides"), "{detail}");
+        assert!(!detail.contains("wins"), "{detail}");
+    }
+
+    #[test]
+    fn frontmatter_version_takes_max_not_incoming() {
+        // #427: version 3 on HEAD regressing to 2 from the incoming side.
+        let ours = "module: auth\nversion: 3\n";
+        let theirs = "module: auth\nversion: 2\n";
+        match resolve_frontmatter_conflict(ours, theirs) {
+            Resolution::Auto(merged, _) => {
+                assert!(merged.contains("version: 3"), "{merged}");
+                assert!(!merged.contains("version: 2"));
+            }
+            Resolution::Manual(reason) => panic!("expected auto resolution: {reason}"),
+        }
+    }
+
+    #[test]
+    fn nonnumeric_version_requires_manual_resolution() {
+        let ours = "module: auth\nversion: next\n";
+        let theirs = "module: auth\nversion: 3\n";
+        match resolve_frontmatter_conflict(ours, theirs) {
+            Resolution::Manual(reason) => {
+                assert!(reason.contains("unsigned integers"), "{reason}");
+            }
+            Resolution::Auto(merged, _) => panic!("must not choose a version: {merged}"),
+        }
+    }
+
+    #[test]
+    fn numeric_versions_accept_supported_yaml_scalar_syntax_and_preserve_the_max_side() {
+        let ours = "module: auth\nversion: '3' # current\nstatus: stable\n";
+        let theirs = "module: auth\nversion: \"2\" # incoming\nstatus: stable\n";
+        match resolve_frontmatter_conflict(ours, theirs) {
+            Resolution::Auto(merged, _) => {
+                assert!(merged.contains("version: '3' # current"), "{merged}");
+                assert!(!merged.contains("\"2\""), "{merged}");
+            }
+            Resolution::Manual(reason) => panic!("expected auto resolution: {reason}"),
+        }
+
+        assert_eq!(parse_numeric_version_scalar("0"), Ok(0));
+        assert_eq!(
+            parse_numeric_version_scalar(&u64::MAX.to_string()),
+            Ok(u64::MAX)
+        );
+        assert!(parse_numeric_version_scalar("-1").is_err());
+        assert!(parse_numeric_version_scalar("1.2.3").is_err());
+        assert!(parse_numeric_version_scalar("18446744073709551616").is_err());
+    }
+
+    #[test]
+    fn equal_versions_with_different_scalar_syntax_require_manual_resolution() {
+        let ours = "module: auth\nversion: 3\n";
+        let theirs = "module: auth\nversion: '3'\n";
+        assert!(matches!(
+            resolve_frontmatter_conflict(ours, theirs),
+            Resolution::Manual("equal version values use different scalar syntax")
+        ));
+    }
+
+    #[test]
+    fn divergent_frontmatter_scalar_requires_manual_resolution() {
+        let ours = "module: auth\nversion: 3\nstatus: stable\n";
+        let theirs = "module: auth\nversion: 3\nstatus: deprecated\n";
+        match resolve_frontmatter_conflict(ours, theirs) {
+            Resolution::Manual(reason) => {
+                assert!(reason.contains("scalar values differ"), "{reason}");
+            }
+            Resolution::Auto(merged, _) => panic!("must not choose a scalar: {merged}"),
+        }
+    }
+
+    #[test]
+    fn one_sided_scalar_fields_require_manual_resolution() {
+        for (ours, theirs) in [
+            (
+                "module: auth\nversion: 3\nstatus: stable\n",
+                "module: auth\nversion: 3\n",
+            ),
+            (
+                "module: auth\nversion: 3\n",
+                "module: auth\nversion: 3\nstatus: stable\n",
+            ),
+            (
+                "module: auth\nversion: 3\nstatus: stable\n",
+                "module: auth\nstatus: stable\n",
+            ),
+            (
+                "module: auth\nversion: 3\nowner: team\n",
+                "module: auth\nversion: 3\n",
+            ),
+        ] {
+            assert!(matches!(
+                resolve_frontmatter_conflict(ours, theirs),
+                Resolution::Manual("frontmatter field exists on only one side")
+            ));
+        }
+    }
+
+    #[test]
+    fn supported_frontmatter_lists_union_and_sort_every_key() {
+        let ours = "\
+module: auth
+version: 3
+status: stable
+files:
+  - src/z.rs
+db_tables:
+  - z_table
+depends_on:
+  - specs/z/z.spec.md
+";
+        let theirs = "\
+module: auth
+version: 3
+status: stable
+files:
+  - src/a.rs
+db_tables:
+  - a_table
+depends_on:
+  - specs/a/a.spec.md
+";
+        match resolve_frontmatter_conflict(ours, theirs) {
+            Resolution::Auto(merged, _) => {
+                assert!(
+                    merged.contains("files:\n  - src/a.rs\n  - src/z.rs"),
+                    "{merged}"
+                );
+                assert!(
+                    merged.contains("db_tables:\n  - a_table\n  - z_table"),
+                    "{merged}"
+                );
+                assert!(
+                    merged.contains("depends_on:\n  - specs/a/a.spec.md\n  - specs/z/z.spec.md"),
+                    "{merged}"
+                );
+            }
+            Resolution::Manual(reason) => panic!("expected auto resolution: {reason}"),
+        }
+    }
+
+    #[test]
+    fn diff3_base_markers_do_not_leak_into_output() {
+        // #427: with merge.conflictStyle diff3, `|||||||` base content must not
+        // survive in an auto-resolved file.
+        let content = format!(
+            "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n\
+             ---\n# M\n\n## Public API\n\n\
+             | Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | MAIN description. |\n\
+             {BASE_MARKER}| `base` | BASE description. |\n\
+             {SEPARATOR}| `b` | SIDE description. |\n{CLOSE_SIDE}"
+        );
+        let (resolved, result, _) = resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Resolved);
+        assert!(!resolved.contains("|||||||"), "{resolved}");
+        assert!(!resolved.contains("BASE description"), "{resolved}");
+        assert!(resolved.contains("MAIN description"), "{resolved}");
+        assert!(resolved.contains("SIDE description"), "{resolved}");
+    }
+
+    #[test]
+    fn manual_hunk_preserves_diff3_block_verbatim() {
+        let content = format!(
+            "## Purpose\n\n{OPEN_HEAD}Our purpose.\n{BASE_MARKER}Base purpose.\n\
+             {SEPARATOR}Their purpose.\n{CLOSE_SIDE}"
+        );
+        let (resolved, result, should_write) = resolve_spec_conflicts(&content, "test.spec.md");
+        assert_eq!(result.status, MergeStatus::Manual);
+        assert!(!should_write, "nothing auto-resolved — do not write");
+        assert!(resolved.contains("||||||| base"), "{resolved}");
+        assert!(resolved.contains("Base purpose."), "{resolved}");
+    }
+
+    #[test]
+    fn malformed_conflict_block_is_never_auto_resolved() {
+        let content = concat!(
+            "---\nmodule: m\nversion: 1\n---\n# M\n\n## Public API\n\n",
+            "<<<<",
+            "<<< HEAD\n| `a` | MAIN description. |\n",
+            "===",
+            "====\n| `b` | SIDE description. |\n",
+        );
+        let (resolved, result, should_write) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Manual);
+        assert!(!should_write);
+        assert!(resolved.contains("<<<<<<< HEAD"), "{resolved}");
+        assert!(
+            result
+                .details
+                .iter()
+                .any(|detail| detail.contains("malformed or incomplete")),
+            "{:?}",
+            result.details
+        );
+    }
+
+    #[test]
+    fn diff3_marker_requires_exact_seven_pipes_and_label_separator() {
+        let malformed_base = concat!("||||", "|||| base\n");
+        let content = format!(
+            "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n---\n\
+             # M\n\n## Public API\n\n| Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | ours |\n{malformed_base}| discarded | must survive |\n\
+             {SEPARATOR}| `b` | incoming |\n{CLOSE_SIDE}"
+        );
+        let (resolved, result, should_write) =
+            resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Manual);
+        assert!(!should_write);
+        assert_eq!(resolved, content);
+    }
+
+    #[test]
+    fn orphan_marker_families_after_a_valid_hunk_block_every_write() {
+        for orphan in [
+            SEPARATOR,
+            BASE_MARKER,
+            CLOSE_SIDE,
+            concat!("||||", "|||| base\n"),
+        ] {
+            let content = format!(
+                "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n---\n\
+                 # M\n\n## Public API\n\n| Name | Description |\n|------|-------------|\n\
+                 {OPEN_HEAD}| `a` | ours |\n\
+                 {SEPARATOR}| `b` | incoming |\n{CLOSE_SIDE}{orphan}"
+            );
+            let (resolved, result, should_write) =
+                resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+            assert_eq!(result.status, MergeStatus::Manual, "orphan {orphan:?}");
+            assert!(!should_write, "orphan {orphan:?}");
+            assert!(resolved.contains(orphan.trim_end()), "orphan {orphan:?}");
+
+            let tmp = tempfile::tempdir().unwrap();
+            let specs = tmp.path().join("specs");
+            fs::create_dir_all(&specs).unwrap();
+            let spec = specs.join("m.spec.md");
+            fs::write(&spec, &content).unwrap();
+            let results = merge_specs(tmp.path(), &specs, false, true);
+            assert_eq!(results[0].status, MergeStatus::Manual);
+            assert_eq!(fs::read_to_string(&spec).unwrap(), content);
+        }
+    }
+
+    #[test]
+    fn nested_marker_diagnostics_keep_the_outer_side_labels() {
+        let content = format!(
+            "## Purpose\n\n{OPEN_OUTER}ours\n{OPEN_INNER}inner ours\n\
+             {SEPARATOR}inner incoming\n{CLOSE_INNER}outer ours tail\n\
+             {SEPARATOR}outer incoming\n{CLOSE_OUTER}"
+        );
+        let (_resolved, result, should_write) = resolve_spec_conflicts(&content, "test.spec.md");
+        assert_eq!(result.status, MergeStatus::Manual);
+        assert!(!should_write);
+        let detail = &result.details[0];
+        assert!(detail.contains("outer-ours ↔ outer-incoming"), "{detail}");
+        assert!(!detail.contains("inner-incoming"), "{detail}");
+    }
+
+    #[test]
+    fn table_hunks_containing_headers_or_separators_remain_manual() {
+        for section in ["Public API", "Change Log"] {
+            let content = format!(
+                "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n---\n\
+                 # M\n\n## {section}\n\n{OPEN_HEAD}| Name | Description |\n\
+                 |------|-------------|\n| `a` | ours |\n\
+                 {SEPARATOR}| Name | Description |\n|------|-------------|\n\
+                 | `b` | incoming |\n{CLOSE_SIDE}"
+            );
+            let (resolved, result, should_write) =
+                resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+            assert_eq!(result.status, MergeStatus::Manual, "{section}");
+            assert!(!should_write, "{section}");
+            assert_eq!(resolved, content, "{section}");
+            assert!(
+                result
+                    .details
+                    .iter()
+                    .any(|detail| detail.contains("table header separator")),
+                "{:?}",
+                result.details
+            );
+        }
+    }
+
+    #[test]
+    fn table_header_only_hunks_remain_manual_and_byte_identical() {
+        for section in ["Public API", "Change Log"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let specs = tmp.path().join("specs/m");
+            fs::create_dir_all(&specs).unwrap();
+            let spec = specs.join("m.spec.md");
+            let content = format!(
+                "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n---\n\
+                 # M\n\n## {section}\n\n\
+                 {OPEN_HEAD}| Name | Description |\n\
+                 {SEPARATOR}| Symbol | Summary |\n\
+                 {CLOSE_SIDE}|------|-------------|\n| `a` | body row |\n"
+            );
+            fs::write(&spec, &content).unwrap();
+
+            let results = merge_specs(tmp.path(), &tmp.path().join("specs"), false, true);
+            assert_eq!(results.len(), 1, "{section}");
+            assert_eq!(results[0].status, MergeStatus::Manual, "{section}");
+            assert!(
+                results[0]
+                    .details
+                    .iter()
+                    .any(|detail| detail.contains("table header")),
+                "{:?}",
+                results[0].details
+            );
+            assert_eq!(fs::read_to_string(&spec).unwrap(), content, "{section}");
+        }
+    }
+
+    #[test]
+    fn unknown_empty_scalar_and_empty_list_are_not_equivalent() {
+        for (ours, theirs) in [("metadata:", "metadata: []"), ("metadata: []", "metadata:")] {
+            let tmp = tempfile::tempdir().unwrap();
+            let specs = tmp.path().join("specs/m");
+            fs::create_dir_all(&specs).unwrap();
+            let spec = specs.join("m.spec.md");
+            let content = format!(
+                "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n\
+                 {OPEN_HEAD}{ours}\n\
+                 {SEPARATOR}{theirs}\n\
+                 {CLOSE_SIDE}---\n# M\n"
+            );
+            fs::write(&spec, &content).unwrap();
+
+            let results = merge_specs(tmp.path(), &tmp.path().join("specs"), false, true);
+            assert_eq!(results.len(), 1, "{ours:?} vs {theirs:?}");
+            assert_eq!(
+                results[0].status,
+                MergeStatus::Manual,
+                "{ours:?} vs {theirs:?}"
+            );
+            assert_eq!(
+                fs::read_to_string(&spec).unwrap(),
+                content,
+                "{ours:?} vs {theirs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_frontmatter_prevents_resolvable_body_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs/m");
+        fs::create_dir_all(&specs).unwrap();
+        let spec = specs.join("m.spec.md");
+        let content = format!(
+            "# M\n\n## Public API\n\n| Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | ours |\n\
+             {SEPARATOR}| `b` | incoming |\n{CLOSE_SIDE}"
+        );
+        fs::write(&spec, &content).unwrap();
+
+        let results = merge_specs(tmp.path(), &tmp.path().join("specs"), false, true);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, MergeStatus::Manual);
+        assert!(
+            results[0]
+                .details
+                .iter()
+                .any(|detail| detail.contains("invalid or empty frontmatter")),
+            "{:?}",
+            results[0].details
+        );
+        assert_eq!(fs::read_to_string(&spec).unwrap(), content);
+    }
+
+    #[test]
+    fn nested_frontmatter_mapping_is_not_flattened() {
+        let content = format!(
+            "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n\
+             {OPEN_HEAD}metadata:\n  owner: team-a\n\
+             {SEPARATOR}metadata:\n  owner: team-b\n{CLOSE_SIDE}---\n# M\n"
+        );
+        let (resolved, result, should_write) =
+            resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Manual);
+        assert!(!should_write);
+        assert_eq!(resolved, content);
+    }
+
+    #[test]
+    fn duplicate_or_invalid_frontmatter_suppresses_otherwise_resolvable_writes() {
+        for frontmatter in [
+            "module: m\nmodule: duplicate\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n",
+            "module: m\nstatus: stable\nfiles:\n  - src/m.rs\n",
+            "module: m\nversion: 1\nfiles:\n  - src/m.rs\n",
+            "module: m\nversion: 1\nstatus: impossible\nfiles:\n  - src/m.rs\n",
+            "module: m\nversion: 1\nstatus: stable\nfiles: []\n",
+        ] {
+            let content = format!(
+                "---\n{frontmatter}---\n# M\n\n## Public API\n\n\
+                 | Name | Description |\n|------|-------------|\n\
+                 {OPEN_HEAD}| `a` | ours |\n\
+                 {SEPARATOR}| `b` | incoming |\n{CLOSE_SIDE}"
+            );
+            let (_resolved, result, should_write) =
+                resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+            assert_eq!(result.status, MergeStatus::Manual, "{frontmatter}");
+            assert!(!should_write, "{frontmatter}");
+            assert!(
+                result
+                    .details
+                    .iter()
+                    .any(|detail| detail.contains("invalid or empty frontmatter")),
+                "{:?}",
+                result.details
+            );
+        }
+    }
+
+    #[test]
+    fn resolved_diff3_file_preserves_crlf_line_endings() {
+        let content = concat!(
+            "---\r\nmodule: m\r\nversion: 1\r\nstatus: stable\r\n",
+            "files:\r\n  - src/m.rs\r\n---\r\n# M\r\n\r\n",
+            "## Public API\r\n\r\n| Name | Description |\r\n|------|-------------|\r\n",
+            "<<<<",
+            "<<< HEAD\r\n| `a` | MAIN description. |\r\n",
+            "||||",
+            "||| base\r\n| `base` | BASE description. |\r\n",
+            "===",
+            "====\r\n| `b` | SIDE description. |\r\n",
+            ">>>>",
+            ">>> side\r\n",
+        );
+        let (resolved, result, should_write) = resolve_spec_conflicts(content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Resolved);
+        assert!(should_write);
+        assert!(!resolved.replace("\r\n", "").contains('\n'), "{resolved:?}");
+        assert!(resolved.ends_with("\r\n"));
+    }
+
+    #[test]
+    fn fully_resolved_file_preserves_missing_final_newline() {
+        let content = format!(
+            "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n---\n\
+             # M\n\n## Public API\n\n| Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | ours |\n\
+             {SEPARATOR}| `b` | incoming |\n{}",
+            CLOSE_SIDE.trim_end()
+        );
+        let (resolved, result, should_write) =
+            resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Resolved);
+        assert!(should_write);
+        assert!(!resolved.ends_with('\n'));
+    }
+
+    #[test]
+    fn fully_resolvable_dry_run_leaves_disk_bytes_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let specs = root.join("specs");
+        fs::create_dir_all(&specs).unwrap();
+        let spec = specs.join("m.spec.md");
+        let content = format!(
+            "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n---\n\
+             # M\n\n## Public API\n\n| Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | ours |\n\
+             {SEPARATOR}| `b` | incoming |\n{CLOSE_SIDE}"
+        );
+        fs::write(&spec, &content).unwrap();
+
+        let results = merge_specs(root, &specs, true, true);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, MergeStatus::Resolved);
+        assert_eq!(fs::read_to_string(&spec).unwrap(), content);
+    }
+
+    #[test]
+    fn git_discovery_failure_is_a_safe_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let specs = tmp.path().join("specs");
+        fs::create_dir_all(&specs).unwrap();
+        assert!(detect_conflicted_specs(tmp.path(), &specs).is_empty());
+    }
+
+    #[test]
+    fn partial_resolution_preview_keeps_all_or_nothing_write_boundary() {
+        let content = format!(
+            "---\nmodule: m\nversion: 1\n---\n# M\n\n## Public API\n\n\
+             | Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | MAIN description. |\n\
+             {SEPARATOR}| `b` | SIDE description. |\n{CLOSE_SIDE}\n\
+             ## Purpose\n\n{OPEN_HEAD}Our purpose.\n\
+             {SEPARATOR}Their purpose.\n{CLOSE_SIDE}"
+        );
+        let (resolved, result, should_write) =
+            resolve_spec_conflicts(&content, "specs/m/m.spec.md");
+        assert_eq!(result.status, MergeStatus::Manual);
+        assert!(!should_write, "ambiguous files must remain untouched");
+        assert!(resolved.contains("MAIN description"), "{resolved}");
+        assert!(resolved.contains("SIDE description"), "{resolved}");
+        assert!(has_conflict_markers(&resolved), "manual hunk keeps markers");
+        assert!(resolved.contains("Our purpose."), "{resolved}");
+        assert!(
+            result
+                .details
+                .iter()
+                .any(|d| d.contains("left unchanged (all-or-nothing)")),
+            "{:?}",
+            result.details
+        );
+        assert!(
+            result
+                .details
+                .iter()
+                .all(|detail| !detail.contains("Auto-resolved")),
+            "{:?}",
+            result.details
+        );
+    }
+
+    #[test]
+    fn merge_specs_leaves_partially_resolvable_file_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let specs = root.join("specs");
+        fs::create_dir_all(&specs).unwrap();
+        let spec = specs.join("m.spec.md");
+        let content = format!(
+            "---\nmodule: m\nversion: 1\n---\n# M\n\n## Public API\n\n\
+             | Name | Description |\n|------|-------------|\n\
+             {OPEN_HEAD}| `a` | MAIN description. |\n\
+             {SEPARATOR}| `b` | SIDE description. |\n{CLOSE_SIDE}\n\
+             ## Purpose\n\n{OPEN_HEAD}Our purpose.\n\
+             {SEPARATOR}Their purpose.\n{CLOSE_SIDE}"
+        );
+        fs::write(&spec, &content).unwrap();
+        let results = merge_specs(root, &specs, false, true);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, MergeStatus::Manual);
+        let on_disk = fs::read_to_string(&spec).unwrap();
+        assert_eq!(on_disk, content);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn all_files_reports_unreadable_specs_as_manual() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let specs = root.join("specs");
+        fs::create_dir_all(&specs).unwrap();
+        let spec = specs.join("m.spec.md");
+        fs::write(
+            &spec,
+            format!(
+                "---\nmodule: m\nversion: 1\nstatus: stable\nfiles:\n  - src/m.rs\n---\n\
+                 # M\n\n## Public API\n\n{OPEN_HEAD}| `a` | ours |\n\
+                 {SEPARATOR}| `b` | incoming |\n{CLOSE_SIDE}"
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&spec, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let results = merge_specs(root, &specs, false, true);
+
+        fs::set_permissions(&spec, fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status, MergeStatus::Manual);
+        assert!(
+            results[0]
+                .details
+                .iter()
+                .any(|detail| detail.contains("Cannot read file")),
+            "{:?}",
+            results[0].details
+        );
     }
 }

--- a/tests/integration/commands.rs
+++ b/tests/integration/commands.rs
@@ -3885,7 +3885,9 @@ Minimal module.
         .current_dir(root)
         .args(["merge", "--all"])
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains("Auto-resolved"))
+        .stdout(predicate::str::contains("Auto-resolvable").not());
 
     let resolved = fs::read_to_string(&spec_path).unwrap();
     assert!(
@@ -3902,6 +3904,102 @@ Minimal module.
         .arg("check")
         .assert()
         .stdout(predicate::str::contains("Frontmatter invalid").not());
+}
+
+#[test]
+fn merge_issue_427_diff3_max_version_and_dry_run_are_lossless() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/minimal.ts"),
+        "export function doThing() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/minimal")).unwrap();
+
+    let conflicted = concat!(
+        "---\nmodule: minimal\n",
+        "<<<<",
+        "<<< HEAD\nversion: 3\n",
+        "||||",
+        "||| base\nversion: 1\n",
+        "===",
+        "====\nversion: 2\n",
+        ">>>>",
+        ">>> branch\n",
+        "status: active\nfiles:\n  - src/minimal.ts\ndb_tables: []\ndepends_on: []\n",
+        "---\n# Minimal\n\n## Purpose\n\nMinimal module.\n",
+    );
+    let spec_path = root.join("specs/minimal/minimal.spec.md");
+    fs::write(&spec_path, conflicted).unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["merge", "--all", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("would resolve"))
+        .stdout(predicate::str::contains("Auto-resolvable"));
+    assert_eq!(fs::read_to_string(&spec_path).unwrap(), conflicted);
+
+    specsync()
+        .current_dir(root)
+        .args(["merge", "--all"])
+        .assert()
+        .success();
+    let resolved = fs::read_to_string(&spec_path).unwrap();
+    assert!(resolved.contains("version: 3"), "{resolved}");
+    assert!(!resolved.contains("version: 2"), "{resolved}");
+    assert!(!resolved.contains("|||||||"), "{resolved}");
+    assert!(!resolved.contains("<<<<<<<"), "{resolved}");
+}
+
+#[test]
+fn merge_issue_427_mixed_manual_file_remains_byte_identical() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/minimal.ts"),
+        "export function doThing() {}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/minimal")).unwrap();
+
+    let conflicted = concat!(
+        "---\nmodule: minimal\n",
+        "<<<<",
+        "<<< HEAD\nversion: 3\n",
+        "===",
+        "====\nversion: 2\n",
+        ">>>>",
+        ">>> branch\n",
+        "status: active\nfiles:\n  - src/minimal.ts\ndb_tables: []\ndepends_on: []\n",
+        "---\n# Minimal\n\n## Public API\n\n| Name | Description |\n|------|-------------|\n",
+        "<<<<",
+        "<<< HEAD\n| `doThing` | Main description. |\n",
+        "===",
+        "====\n| `doThing` | Incoming description. |\n",
+        ">>>>",
+        ">>> branch\n",
+    );
+    let spec_path = root.join("specs/minimal/minimal.spec.md");
+    fs::write(&spec_path, conflicted).unwrap();
+
+    specsync()
+        .current_dir(root)
+        .args(["merge", "--all"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Auto-resolvable"))
+        .stdout(predicate::str::contains("HEAD"))
+        .stdout(predicate::str::contains("branch"))
+        .stdout(predicate::str::contains("left unchanged (all-or-nothing)"));
+
+    assert_eq!(fs::read_to_string(&spec_path).unwrap(), conflicted);
 }
 
 // ─── specsync hooks ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- parse diff3 conflict bases without ever selecting base content
- report both ours and incoming labels truthfully
- resolve versions using the maximum numeric value and union supported list fields
- leave divergent scalars, same-key API rows, unsafe YAML shapes, and malformed markers unresolved
- preserve line endings and final-newline form
- keep each conflicted file all-or-nothing: any manual region prevents every write
- add CHG-0066 lifecycle evidence and synchronize the merge spec and companions

## Root cause

The previous merge resolver treated conflict structure too loosely, could mislabel the selected side, and mixed auto-resolvable and manual regions in ways that made partial writes possible or diagnostics misleading.

## Verification

- 46 focused merge unit tests passed
- 2 issue #427 integration tests passed
- 2,031 repository unit tests passed
- 331 repository integration tests passed
- `fledge lanes run verify` passed
- `fledge trust verify` passed
- 62/62 specs passed with 100% file and LOC coverage
- independent acceptance and adversarial reviews found no high- or medium-severity issues
- private `CorvidLabs/spec-sync-sandbox` reproduction confirmed dry-run, successful persistence, and byte-identical all-or-nothing failure behavior
- CHG-0066 was approved, freshly verified, and accepted

Fixes #427
