### PR TITLE
fix: hooks/agents managed-block uninstall, real git hooks dir resolution, install backups (closes #415, closes #438)

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -12,6 +12,14 @@ use std::path::{Path, PathBuf};
 
 const SKILL_BODY: &str = r#"## Companion files
 
+Each canonical spec may have policy-selected companion files. Read and update the ones present; do not create empty companions only for ceremony:
+
+- **`tasks.md`** — Work items for this module. Check off tasks (`- [x]`) as you complete them. Add new tasks if you discover work needed.
+- **`requirements.md`** — Acceptance criteria and user stories. These are permanent invariants, not tasks — do not check them off. Update if requirements change.
+- **`context.md`** — Architectural decisions, key files, and current status. Update when you make design decisions or change what's in progress.
+- **`testing.md`** — Test strategy: automated test locations, manual QA checklists, and edge cases/boundary conditions.
+- **`design.md`** *(opt-in)* — Layout, component hierarchy, design tokens, and asset references. Present when `companions.design` is enabled in config.
+
 ## Verified SDD change lifecycle (5.0)
 
 For every meaningful source, test, public documentation, schema, or configuration change:
@@ -29,14 +37,6 @@ For every meaningful source, test, public documentation, schema, or configuratio
 Never invent or self-grant either human approval. If an approved definition changes, its digest
 becomes stale and must be approved again. `specsync check` validates canonical specs plus approved
 active deltas, requirement-to-test evidence, change coverage, and CI gates.
-
-Each canonical spec may have policy-selected companion files. Read and update the ones present; do not create empty companions only for ceremony:
-
-- **`tasks.md`** — Work items for this module. Check off tasks (`- [x]`) as you complete them. Add new tasks if you discover work needed.
-- **`requirements.md`** — Acceptance criteria and user stories. These are permanent invariants, not tasks — do not check them off. Update if requirements change.
-- **`context.md`** — Architectural decisions, key files, and current status. Update when you make design decisions or change what's in progress.
-- **`testing.md`** — Test strategy: automated test locations, manual QA checklists, and edge cases/boundary conditions.
-- **`design.md`** *(opt-in)* — Layout, component hierarchy, design tokens, and asset references. Present when `companions.design` is enabled in config.
 
 ## Before modifying any module
 
@@ -291,60 +291,69 @@ pub fn is_installed(root: &Path, tool: AgentTool) -> bool {
     skill_ok && command_ok
 }
 
+/// Write `content` to `path`. If the file already exists with DIFFERENT
+/// content, the existing content is first copied to a `<name>.specsync-backup`
+/// sibling and a warning is printed — user customizations are never silently
+/// clobbered (#438). Returns Ok(true) if the file was written, Ok(false) when
+/// the content already matched (idempotent no-op, no backup churn).
+fn write_with_backup(path: &Path, content: &str) -> Result<bool, String> {
+    let existing = fs::read_to_string(path).ok();
+    if existing.as_deref() == Some(content) {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+    }
+    if let Some(old) = existing {
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("file");
+        let backup = path.with_file_name(format!("{file_name}.specsync-backup"));
+        fs::write(&backup, &old)
+            .map_err(|e| format!("Failed to write backup {}: {e}", backup.display()))?;
+        eprintln!(
+            "  {} {} existed with local modifications — backed up to {}",
+            "!".yellow(),
+            path.display(),
+            backup.display()
+        );
+    }
+    fs::write(path, content).map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+    Ok(true)
+}
+
 /// Install skill + command files for one tool. Returns Ok(true) if anything
 /// was written, Ok(false) if everything was already present and up to date.
 ///
 /// Re-running on an already-installed project upgrades stale content: if a
 /// newer spec-sync ships revised skill/command text, the existing file is
 /// overwritten to match rather than being silently left outdated because it
-/// already exists. Safe because these files are fully spec-sync-owned (see
-/// `uninstall_agent`'s doc comment) — there's no user content to preserve.
+/// already exists. Any differing pre-existing content is backed up to a
+/// `<name>.specsync-backup` sibling first (#438) so local customizations are
+/// never silently destroyed.
 pub fn install_agent(root: &Path, tool: AgentTool) -> Result<bool, String> {
     let mut changed = false;
 
     if let Some(dir) = tool.skill_dir(root) {
         let skill_path = dir.join("SKILL.md");
         let skill_content = skill_md_content(tool);
-        let needs_write = fs::read_to_string(&skill_path)
-            .map(|existing| existing != skill_content)
-            .unwrap_or(true);
-        if needs_write {
-            fs::create_dir_all(&dir)
-                .map_err(|e| format!("Failed to create {}: {e}", dir.display()))?;
-            fs::write(&skill_path, skill_content)
-                .map_err(|e| format!("Failed to write {}: {e}", skill_path.display()))?;
+        if write_with_backup(&skill_path, &skill_content)? {
             changed = true;
         }
     }
 
     if let Some(path) = tool.command_path(root) {
         let command_content = create_spec_command_content(tool);
-        let needs_write = fs::read_to_string(&path)
-            .map(|existing| existing != command_content)
-            .unwrap_or(true);
-        if needs_write {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)
-                    .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
-            }
-            fs::write(&path, command_content)
-                .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+        if write_with_backup(&path, &command_content)? {
             changed = true;
         }
     }
 
     if let Some(path) = tool.change_command_path(root) {
         let command_content = create_change_command_content(tool);
-        let needs_write = fs::read_to_string(&path)
-            .map(|existing| existing != command_content)
-            .unwrap_or(true);
-        if needs_write {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)
-                    .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
-            }
-            fs::write(&path, command_content)
-                .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+        if write_with_backup(&path, &command_content)? {
             changed = true;
         }
     }
@@ -922,6 +931,67 @@ mod tests {
         install_agent(tmp.path(), AgentTool::Claude).unwrap();
         // Second install: content is identical, so nothing should be rewritten.
         assert!(!install_agent(tmp.path(), AgentTool::Claude).unwrap());
+    }
+
+    #[test]
+    fn install_backs_up_user_customized_skill() {
+        // #438 regression: a user-customized skill file must be backed up and
+        // warned about — never silently clobbered while claiming success.
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Claude).unwrap();
+        let skill_path = tmp.path().join(".claude/skills/spec-sync/SKILL.md");
+        let customized = format!(
+            "{}\n\nMy custom additions I do not want to lose.\n",
+            fs::read_to_string(&skill_path).unwrap()
+        );
+        fs::write(&skill_path, &customized).unwrap();
+
+        assert!(install_agent(tmp.path(), AgentTool::Claude).unwrap());
+
+        let backup = tmp
+            .path()
+            .join(".claude/skills/spec-sync/SKILL.md.specsync-backup");
+        assert!(backup.exists(), "customized content must be backed up");
+        assert_eq!(fs::read_to_string(&backup).unwrap(), customized);
+        // The stock skill is restored, customization preserved in the backup.
+        assert!(!fs::read_to_string(&skill_path)
+            .unwrap()
+            .contains("custom additions"));
+    }
+
+    #[test]
+    fn install_backs_up_user_customized_command() {
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Cursor).unwrap();
+        let cmd_path = tmp
+            .path()
+            .join(".cursor/commands/specsync-create-spec.md");
+        fs::write(&cmd_path, "user's tweaked command").unwrap();
+
+        assert!(install_agent(tmp.path(), AgentTool::Cursor).unwrap());
+        let backup = tmp
+            .path()
+            .join(".cursor/commands/specsync-create-spec.md.specsync-backup");
+        assert_eq!(
+            fs::read_to_string(&backup).unwrap(),
+            "user's tweaked command"
+        );
+    }
+
+    #[test]
+    fn skill_md_companion_files_section_is_not_empty() {
+        // #438 regression: the installed SKILL.md's `## Companion files`
+        // section must actually contain the companion-files content.
+        let tmp = setup();
+        install_agent(tmp.path(), AgentTool::Claude).unwrap();
+        let skill =
+            fs::read_to_string(tmp.path().join(".claude/skills/spec-sync/SKILL.md")).unwrap();
+        let start = skill.find("## Companion files").unwrap();
+        let rest = &skill[start..];
+        let end = rest[3..].find("\n## ").map(|i| i + 3).unwrap_or(rest.len());
+        let section = &rest[..end];
+        assert!(section.contains("tasks.md"), "section body:\n{section}");
+        assert!(section.contains("requirements.md"), "section body:\n{section}");
     }
 
     // ── uninstall_agent ──────────────────────────────────────────────

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // ─── Agent instruction templates ─────────────────────────────────────────────
 
@@ -145,6 +145,79 @@ Run `specsync add-spec <module-name>` to scaffold the spec and companion files, 
 - `specsync resolve --remote` — verify cross-project dependencies
 "#;
 
+/// Shell-comment sentinels bracketing the spec-sync-managed block inside a
+/// `pre-commit` hook. They let `uninstall` remove EXACTLY our block and never
+/// touch user content — the same managed-block strategy the markdown
+/// companions use (`HOOK_BEGIN`/`HOOK_END` below).
+const PRE_COMMIT_BEGIN: &str =
+    "# >>> specsync:pre-commit (managed by `specsync hooks` — do not edit inside) >>>";
+const PRE_COMMIT_END: &str = "# <<< specsync:pre-commit <<<";
+
+/// Marker line used by spec-sync ≤5.2.0 when appending to an existing hook
+/// (no sentinels). Recognized on uninstall so legacy blocks are removed
+/// precisely too.
+const LEGACY_PRE_COMMIT_MARKER: &str = "# --- spec-sync pre-commit hook ---";
+
+/// Resolve the directory git ACTUALLY reads hooks from for the worktree at
+/// `root`, honoring nested project roots, linked worktrees/submodules (where
+/// `.git` is a file), and a configured `core.hooksPath`.
+///
+/// Strategy: ask git (`rev-parse --git-path hooks` already accounts for all
+/// of the above; its output is relative to `root` when relative). If git is
+/// unavailable or `root` is not inside a repository, fall back to an EXISTING
+/// `root/.git/hooks` directory only — we never fabricate a `.git/hooks` tree
+/// git would never read, and we never report success for a hook git can't
+/// run.
+fn git_hooks_dir(root: &Path) -> Result<PathBuf, String> {
+    let resolved = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--git-path", "hooks"])
+        .output();
+
+    if let Ok(output) = resolved
+        && output.status.success()
+    {
+        let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !text.is_empty() {
+            let path = PathBuf::from(&text);
+            let path = if path.is_absolute() {
+                path
+            } else {
+                root.join(path)
+            };
+            if path.is_dir() || fs::create_dir_all(&path).is_ok() {
+                return Ok(path);
+            }
+        }
+    }
+
+    // Fallback: an existing .git/hooks directory (git binary missing, or a
+    // bare .git dir laid out by hand). Never CREATE this tree — that is the
+    // #438 lie: a hook git never runs reported as installed.
+    let fallback = root.join(".git").join("hooks");
+    if fallback.is_dir() {
+        return Ok(fallback);
+    }
+
+    Err(format!(
+        "{} is not inside a git repository (or `git` is not installed). \
+         Run `git init` first, then re-run `specsync hooks install --precommit`.",
+        root.display()
+    ))
+}
+
+/// Resolve the hooks dir for read-only checks; `None` when unresolvable.
+fn git_hooks_dir_if_any(root: &Path) -> Option<PathBuf> {
+    git_hooks_dir(root).ok().filter(|p| p.is_dir())
+}
+
+/// The managed block (no shebang) wrapped in begin/end sentinels.
+fn pre_commit_block() -> String {
+    let body: Vec<&str> = PRE_COMMIT_HOOK.lines().skip(1).collect();
+    format!("{PRE_COMMIT_BEGIN}\n{}\n{PRE_COMMIT_END}", body.join("\n"))
+}
+
 const PRE_COMMIT_HOOK: &str = r#"#!/bin/sh
 # spec-sync pre-commit hook — validates specs before allowing commits.
 # Installed by: specsync hooks install --precommit
@@ -285,7 +358,10 @@ pub fn is_installed(root: &Path, target: HookTarget) -> bool {
                     .unwrap_or(false)
         }
         HookTarget::Precommit => {
-            let path = root.join(".git").join("hooks").join("pre-commit");
+            let Some(hooks_dir) = git_hooks_dir_if_any(root) else {
+                return false;
+            };
+            let path = hooks_dir.join("pre-commit");
             path.exists()
                 && fs::read_to_string(&path)
                     .map(|c| c.contains("spec-sync pre-commit hook"))
@@ -346,23 +422,10 @@ pub fn uninstall_hook(root: &Path, target: HookTarget) -> Result<bool, String> {
             remove_section_from_file(&path, "# Spec-Sync Integration", AGENTS_MD_SNIPPET)
         }
         HookTarget::Precommit => {
-            let path = root.join(".git").join("hooks").join("pre-commit");
-            if path.exists() {
-                let content = fs::read_to_string(&path)
-                    .map_err(|e| format!("Failed to read pre-commit hook: {e}"))?;
-                if content.contains("spec-sync pre-commit hook") {
-                    // If the entire file is our hook, remove it
-                    if content.trim().starts_with("#!/bin/sh")
-                        && content.contains("specsync check")
-                        && content.lines().count() < 35
-                    {
-                        fs::remove_file(&path)
-                            .map_err(|e| format!("Failed to remove pre-commit hook: {e}"))?;
-                        return Ok(true);
-                    }
-                }
-            }
-            Ok(false)
+            let Some(hooks_dir) = git_hooks_dir_if_any(root) else {
+                return Ok(false);
+            };
+            uninstall_precommit(&hooks_dir.join("pre-commit"))
         }
         HookTarget::ClaudeCodeHook => {
             // Don't auto-remove Claude Code settings — too risky
@@ -437,35 +500,56 @@ fn install_agents_md(root: &Path) -> Result<bool, String> {
 }
 
 fn install_precommit(root: &Path) -> Result<bool, String> {
-    let hooks_dir = root.join(".git").join("hooks");
-    if !hooks_dir.exists() {
-        fs::create_dir_all(&hooks_dir).map_err(|e| format!("Failed to create .git/hooks/: {e}"))?;
-    }
-
+    // Resolve the hooks dir git ACTUALLY reads (nested roots, worktrees,
+    // submodules, core.hooksPath). Errors instead of fabricating `.git/hooks`
+    // in a non-git directory and falsely reporting success (#438).
+    let hooks_dir = git_hooks_dir(root)?;
     let path = hooks_dir.join("pre-commit");
 
     if path.exists() {
         let existing = fs::read_to_string(&path)
             .map_err(|e| format!("Failed to read pre-commit hook: {e}"))?;
 
-        if existing.contains("specsync") {
+        if existing.contains(PRE_COMMIT_BEGIN)
+            || existing.contains(LEGACY_PRE_COMMIT_MARKER)
+            || existing.contains("spec-sync pre-commit hook")
+        {
             return Ok(false);
         }
 
-        // Append to existing pre-commit hook
-        let new_content = format!(
-            "{}\n\n# --- spec-sync pre-commit hook ---\n{}",
-            existing.trim_end(),
-            PRE_COMMIT_HOOK
-                .lines()
-                .skip(1) // Skip the shebang since the existing file has one
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
+        // Insert the sentinel-wrapped block BEFORE a trailing `exit 0` — a
+        // block appended after it would be dead code that never runs (#415).
+        let block = pre_commit_block();
+        let mut lines: Vec<&str> = existing.trim_end().lines().collect();
+        let insert_at = lines
+            .iter()
+            .rposition(|l| !l.trim().is_empty())
+            .filter(|&i| lines[i].trim() == "exit 0")
+            .map(|i| {
+                // Drop blank lines just above the `exit 0`; re-added below.
+                let mut start = i;
+                while start > 0 && lines[start - 1].trim().is_empty() {
+                    start -= 1;
+                }
+                start
+            })
+            .unwrap_or(lines.len());
+        let tail: Vec<&str> = lines.split_off(insert_at);
+        let mut new_content = lines.join("\n");
+        new_content.push_str("\n\n");
+        new_content.push_str(&block);
+        new_content.push('\n');
+        if !tail.is_empty() {
+            new_content.push('\n');
+            new_content.push_str(&tail.join("\n"));
+            new_content.push('\n');
+        }
         fs::write(&path, new_content)
             .map_err(|e| format!("Failed to write pre-commit hook: {e}"))?;
     } else {
-        fs::write(&path, PRE_COMMIT_HOOK)
+        // Fresh hook file: shebang, then the sentinel-wrapped managed block.
+        let content = format!("#!/bin/sh\n{}\n", pre_commit_block());
+        fs::write(&path, content)
             .map_err(|e| format!("Failed to create pre-commit hook: {e}"))?;
     }
 
@@ -478,6 +562,79 @@ fn install_precommit(root: &Path) -> Result<bool, String> {
             .map_err(|e| format!("Failed to set pre-commit hook permissions: {e}"))?;
     }
 
+    Ok(true)
+}
+
+/// Remove ONLY the spec-sync-managed block from a pre-commit hook (#415).
+///
+/// - Sentinel-wrapped block: remove exactly between the markers.
+/// - Legacy block (≤5.2.0, appended at end after a known marker): remove from
+///   the marker to end-of-file.
+/// - A file that is exactly our stock hook (nothing else): delete it.
+/// - Anything else: the file is user-owned — leave it untouched (Ok(false)).
+///
+/// The file itself is deleted only when nothing remains but our content; a
+/// hook file with any user content is never deleted.
+fn uninstall_precommit(path: &Path) -> Result<bool, String> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read pre-commit hook: {e}"))?;
+
+    let mut lines: Vec<&str> = content.lines().collect();
+    let removed = if lines.iter().any(|l| l.contains(PRE_COMMIT_BEGIN)) {
+        let begin = lines.iter().position(|l| l.contains(PRE_COMMIT_BEGIN));
+        let end = lines.iter().rposition(|l| l.contains(PRE_COMMIT_END));
+        match (begin, end) {
+            (Some(b), Some(e)) if e >= b => {
+                lines.drain(b..=e);
+                true
+            }
+            // Corrupted/partial markers: refuse to guess — never risk user data.
+            _ => {
+                return Err(format!(
+                    "{} contains a partial specsync block (begin without end). \
+                     Remove the block between the specsync markers manually.",
+                    path.display()
+                ));
+            }
+        }
+    } else if let Some(m) = lines
+        .iter()
+        .position(|l| l.contains(LEGACY_PRE_COMMIT_MARKER))
+    {
+        lines.truncate(m);
+        true
+    } else {
+        false
+    };
+
+    if !removed {
+        // Whole-file legacy install: stock hook and nothing else.
+        if content.trim() == PRE_COMMIT_HOOK.trim() {
+            fs::remove_file(path)
+                .map_err(|e| format!("Failed to remove pre-commit hook: {e}"))?;
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+
+    // Drop blank lines left where the block was, then reassemble.
+    while lines.last().is_some_and(|l| l.trim().is_empty()) {
+        lines.pop();
+    }
+    let remaining = lines.join("\n");
+    let remaining_trimmed = remaining.trim();
+
+    if remaining_trimmed.is_empty() || remaining_trimmed == "#!/bin/sh" {
+        // Nothing left but (optionally) a bare shebang — the file was ours.
+        fs::remove_file(path)
+            .map_err(|e| format!("Failed to remove pre-commit hook: {e}"))?;
+    } else {
+        fs::write(path, format!("{remaining}\n"))
+            .map_err(|e| format!("Failed to write pre-commit hook: {e}"))?;
+    }
     Ok(true)
 }
 
@@ -1068,17 +1225,178 @@ mod tests {
     }
 
     #[test]
-    fn install_precommit_creates_hooks_dir_if_missing() {
+    fn install_precommit_errors_in_non_git_dir() {
+        // #438: never fabricate a `.git/hooks` tree git would never read and
+        // report success — fail loudly with remediation instead.
         let tmp = setup();
-        // Don't create .git/hooks — let install do it
+        let result = install_hook(tmp.path(), HookTarget::Precommit);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("not inside a git repository"), "{err}");
+        assert!(err.contains("git init"), "{err}");
+        assert!(!tmp.path().join(".git").exists());
+    }
+
+    fn git_init(repo: &Path) -> bool {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["init", "-q", "."])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn install_precommit_resolves_nested_project_root_via_git() {
+        // #438 regression: running in repo/packages/app must install into the
+        // REAL hooks dir (repo/.git/hooks), never a fake nested .git tree.
+        let tmp = setup();
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        if !git_init(&repo) {
+            return; // git unavailable in this environment
+        }
+        let nested = repo.join("packages").join("app");
+        fs::create_dir_all(&nested).unwrap();
+
+        assert!(install_hook(&nested, HookTarget::Precommit).unwrap());
+        assert!(repo.join(".git/hooks/pre-commit").exists());
+        assert!(!nested.join(".git").exists());
+        // Uninstall from the nested root removes it again.
+        assert!(uninstall_hook(&nested, HookTarget::Precommit).unwrap());
+        assert!(!repo.join(".git/hooks/pre-commit").exists());
+    }
+
+    #[test]
+    fn install_precommit_honors_core_hooks_path() {
+        // #438: a configured core.hooksPath is where git looks — install there.
+        let tmp = setup();
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        if !git_init(&repo) {
+            return;
+        }
+        let ok = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(["config", "core.hooksPath", ".githooks"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            return;
+        }
+        assert!(install_hook(&repo, HookTarget::Precommit).unwrap());
+        assert!(repo.join(".githooks/pre-commit").exists());
+        assert!(!repo.join(".git/hooks/pre-commit").exists());
+    }
+
+    #[test]
+    fn install_precommit_wraps_block_in_sentinels() {
+        let tmp = setup();
+        fs::create_dir_all(tmp.path().join(".git").join("hooks")).unwrap();
         assert!(install_hook(tmp.path(), HookTarget::Precommit).unwrap());
+        let content =
+            fs::read_to_string(tmp.path().join(".git/hooks/pre-commit")).unwrap();
+        assert!(content.contains(PRE_COMMIT_BEGIN));
+        assert!(content.contains(PRE_COMMIT_END));
+    }
+
+    #[test]
+    fn install_precommit_inserts_before_trailing_exit_0() {
+        // #415: a block appended AFTER an existing `exit 0` is dead code.
+        let tmp = setup();
+        let hooks_dir = tmp.path().join(".git").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        fs::write(
+            hooks_dir.join("pre-commit"),
+            "#!/bin/sh\necho \"user hook content\"\nexit 0\n",
+        )
+        .unwrap();
+        assert!(install_hook(tmp.path(), HookTarget::Precommit).unwrap());
+        let content = fs::read_to_string(hooks_dir.join("pre-commit")).unwrap();
+        let block_pos = content.find(PRE_COMMIT_BEGIN).unwrap();
+        let exit_pos = content.rfind("exit 0").unwrap();
         assert!(
-            tmp.path()
-                .join(".git")
-                .join("hooks")
-                .join("pre-commit")
-                .exists()
+            block_pos < exit_pos,
+            "managed block must run before the user's exit 0:\n{content}"
         );
+        assert!(content.contains("user hook content"));
+    }
+
+    #[test]
+    fn uninstall_precommit_removes_only_managed_block() {
+        // #415 regression: user content must survive uninstall.
+        let tmp = setup();
+        let hooks_dir = tmp.path().join(".git").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        fs::write(
+            hooks_dir.join("pre-commit"),
+            "#!/bin/sh\necho \"user hook content\"\nexit 0\n",
+        )
+        .unwrap();
+        install_hook(tmp.path(), HookTarget::Precommit).unwrap();
+        assert!(uninstall_hook(tmp.path(), HookTarget::Precommit).unwrap());
+        let content = fs::read_to_string(hooks_dir.join("pre-commit")).unwrap();
+        assert!(content.contains("user hook content"));
+        assert!(content.contains("exit 0"));
+        assert!(!content.contains("specsync"));
+    }
+
+    #[test]
+    fn uninstall_precommit_deletes_file_that_is_purely_ours() {
+        let tmp = setup();
+        let hooks_dir = tmp.path().join(".git").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        install_hook(tmp.path(), HookTarget::Precommit).unwrap();
+        let path = hooks_dir.join("pre-commit");
+        assert!(path.exists());
+        assert!(uninstall_hook(tmp.path(), HookTarget::Precommit).unwrap());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn uninstall_precommit_leaves_user_hook_untouched() {
+        // #415: never delete a hook file the tool didn't create.
+        let tmp = setup();
+        let hooks_dir = tmp.path().join(".git").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let original = "#!/bin/sh\necho \"user hook content\"\nexit 0\n";
+        fs::write(hooks_dir.join("pre-commit"), original).unwrap();
+        assert!(!uninstall_hook(tmp.path(), HookTarget::Precommit).unwrap());
+        assert_eq!(
+            fs::read_to_string(hooks_dir.join("pre-commit")).unwrap(),
+            original
+        );
+    }
+
+    #[test]
+    fn uninstall_precommit_removes_legacy_appended_block() {
+        // Blocks installed by spec-sync ≤5.2.0 (marker, no sentinels) must
+        // still be removed precisely, preserving user content.
+        let tmp = setup();
+        let hooks_dir = tmp.path().join(".git").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let legacy = format!(
+            "#!/bin/sh\necho \"user hook content\"\n\n{LEGACY_PRE_COMMIT_MARKER}\n{}\n",
+            PRE_COMMIT_HOOK.lines().skip(1).collect::<Vec<_>>().join("\n")
+        );
+        fs::write(hooks_dir.join("pre-commit"), legacy).unwrap();
+        assert!(uninstall_hook(tmp.path(), HookTarget::Precommit).unwrap());
+        let content = fs::read_to_string(hooks_dir.join("pre-commit")).unwrap();
+        assert!(content.contains("user hook content"));
+        assert!(!content.contains("spec-sync pre-commit hook"));
+    }
+
+    #[test]
+    fn uninstall_precommit_removes_legacy_whole_file_hook() {
+        let tmp = setup();
+        let hooks_dir = tmp.path().join(".git").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        fs::write(hooks_dir.join("pre-commit"), PRE_COMMIT_HOOK).unwrap();
+        assert!(uninstall_hook(tmp.path(), HookTarget::Precommit).unwrap());
+        assert!(!hooks_dir.join("pre-commit").exists());
     }
 
     #[cfg(unix)]
@@ -1086,6 +1404,7 @@ mod tests {
     fn install_precommit_sets_executable_permission() {
         use std::os::unix::fs::PermissionsExt;
         let tmp = setup();
+        fs::create_dir_all(tmp.path().join(".git").join("hooks")).unwrap();
         install_hook(tmp.path(), HookTarget::Precommit).unwrap();
         let path = tmp.path().join(".git").join("hooks").join("pre-commit");
         let perms = fs::metadata(&path).unwrap().permissions();
@@ -1242,6 +1561,7 @@ mod tests {
     #[test]
     fn uninstall_precommit_removes_hook_file() {
         let tmp = setup();
+        fs::create_dir_all(tmp.path().join(".git").join("hooks")).unwrap();
         install_hook(tmp.path(), HookTarget::Precommit).unwrap();
         let result = uninstall_hook(tmp.path(), HookTarget::Precommit).unwrap();
         assert!(result);


### PR DESCRIPTION
## Problem

**#415 (data loss):** `specsync hooks uninstall --pre-commit` deleted the user's ENTIRE pre-existing `.git/hooks/pre-commit` (a 3-line user hook + appended specsync block = <35 lines starting with `#!/bin/sh` and containing "specsync check" → `fs::remove_file`). Also, the specsync block was appended AFTER an existing hook's `exit 0` — dead code that never ran.

**#438 (lies):** `hooks install` in a nested project root (`repo/packages/app`) created a fake `.git/hooks/pre-commit` (green ✓ but git never runs it); install in a non-git directory fabricated `.git/hooks` and reported success; `core.hooksPath` was ignored; `agents install` silently overwrote user-customized skill files with no warning or backup; the installed SKILL.md had an empty `## Companion files` section.

## Repro (v5.2.0)

```
$ printf '#!/bin/sh\necho "user hook content"\nexit 0\n' > .git/hooks/pre-commit
$ specsync hooks install --precommit   # ✓ block appended AFTER exit 0 (never runs)
$ specsync hooks uninstall --precommit # ✓ Removed
$ cat .git/hooks/pre-commit            # No such file — USER HOOK DELETED
```

After:
```
$ specsync hooks install --precommit   # sentinel block inserted BEFORE exit 0
$ specsync hooks uninstall --precommit # removes only the specsync block
$ cat .git/hooks/pre-commit            # user hook intact (shebang/echo/exit 0)

$ cd packages/app && specsync hooks install --precommit
# → installs into repo/.git/hooks (resolved via `git rev-parse --git-path hooks`)
$ mkdir /tmp/nogit && cd /tmp/nogit && specsync hooks install --precommit
# ✗ /tmp/nogit is not inside a git repository … Run `git init` first … (exit 1, nothing created)
```

## Root cause / fix

- Pre-commit installs are now wrapped in `# >>> specsync:pre-commit … >>>` / `# <<< specsync:pre-commit <<<` sentinels (same managed-block strategy as the markdown companions). Uninstall removes exactly the block — legacy ≤5.2.0 marker blocks and whole-file stock installs are also recognized and removed precisely — and the file is deleted only when nothing but our content remains. A hook with any user content is never deleted; a partial/corrupted marker set errors instead of guessing.
- Install inserts the block BEFORE a trailing `exit 0` instead of appending dead code after it.
- The hooks directory is resolved via `git rev-parse --git-path hooks`, which handles nested project roots, linked worktrees/submodules (`.git` as file), and `core.hooksPath`. Non-git directories now fail loudly with remediation instead of fabricating a `.git/hooks` tree git would never read.
- `agents install` backs up any differing pre-existing file to `<name>.specsync-backup` and prints a warning before overwriting; SKILL.md's `## Companion files` section now actually contains the companion-files guidance (it was an empty heading).

## Scope notes

- The issue's "also" item about `--format json` being ignored on `agents install/status` is a cross-command formatting concern, explicitly out of scope here.
- `agents uninstall` intentionally does NOT delete `.specsync-backup` files (user data).

## Tests

New regression tests — `src/hooks.rs`: `install_precommit_errors_in_non_git_dir`, `install_precommit_wraps_block_in_sentinels`, `install_precommit_inserts_before_trailing_exit_0`, `install_precommit_resolves_nested_project_root_via_git`, `install_precommit_honors_core_hooks_path`, `uninstall_precommit_removes_only_managed_block`, `uninstall_precommit_deletes_file_that_is_purely_ours`, `uninstall_precommit_leaves_user_hook_untouched`, `uninstall_precommit_removes_legacy_appended_block`, `uninstall_precommit_removes_legacy_whole_file_hook`. `src/agents.rs`: `install_backs_up_user_customized_skill`, `install_backs_up_user_customized_command`, `skill_md_companion_files_section_is_not_empty`.

Full suite green (plus the one known pre-existing root-only failure in `change::tests`); `cargo clippy -- -D warnings` clean; all repros re-verified end-to-end with the patched binary.

Closes #415
Closes #438