### PR TITLE
fix: confine MCP tool roots to the server root (closes #414)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,7 +107,12 @@ pub enum Command {
     /// Watch spec and source files, re-running check on changes
     Watch,
     /// Run as an MCP (Model Context Protocol) server over stdio
-    Mcp,
+    Mcp {
+        /// Enable write-capable MCP tools (specsync_generate, specsync_init).
+        /// Off by default so a connected agent gets a read-only surface.
+        #[arg(long)]
+        allow_writes: bool,
+    },
     /// Scaffold a new spec with required companion files and optional design.md
     AddSpec {
         /// Module name for the new spec

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn run() {
             &cli.only_status,
         ),
         Command::Watch => watch::run_watch(&root, cli.strict, cli.require_coverage),
-        Command::Mcp => mcp::run_mcp_server(&root),
+        Command::Mcp { allow_writes } => mcp::run_mcp_server(&root, allow_writes),
         Command::AddSpec { name } => commands::scaffold::cmd_add_spec(&root, &name),
         Command::Scaffold {
             name,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -13,7 +13,12 @@ const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
 /// Run the MCP server on stdio.
-pub fn run_mcp_server(root: &Path) {
+///
+/// All tool `root` arguments are confined to the server `root` (see
+/// [`crate::util::confine_path_to_root`]); write-capable tools
+/// (`specsync_generate`, `specsync_init`) are rejected unless the server was
+/// started with `--allow-writes`.
+pub fn run_mcp_server(root: &Path, allow_writes: bool) {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
@@ -29,56 +34,66 @@ pub fn run_mcp_server(root: &Path) {
             continue;
         }
 
-        let request: Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(_) => {
-                let err = json!({
-                    "jsonrpc": "2.0",
-                    "id": null,
-                    "error": { "code": -32700, "message": "Parse error" }
-                });
-                let _ = writeln!(stdout, "{}", err);
-                let _ = stdout.flush();
-                continue;
-            }
-        };
-
-        let id = request.get("id").cloned();
-        let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
-
-        let response = match method {
-            "initialize" => Some(handle_initialize(id)),
-            "notifications/initialized" => None, // notification, no response
-            "tools/list" => Some(handle_tools_list(id)),
-            "tools/call" => {
-                let params = request.get("params").cloned().unwrap_or(json!({}));
-                Some(handle_tools_call(id, &params, root))
-            }
-            "resources/list" => Some(handle_resources_list(id)),
-            "resources/read" => {
-                let params = request.get("params").cloned().unwrap_or(json!({}));
-                Some(handle_resources_read(id, &params, root))
-            }
-            "ping" => Some(json!({ "jsonrpc": "2.0", "id": id, "result": {} })),
-            _ => {
-                // Notifications (no id) get no response
-                if id.is_some() {
-                    Some(json!({
-                        "jsonrpc": "2.0",
-                        "id": id,
-                        "error": { "code": -32601, "message": format!("Method not found: {method}") }
-                    }))
-                } else {
-                    None
-                }
-            }
-        };
-
-        if let Some(resp) = response {
+        if let Some(resp) = handle_request_line(&line, root, allow_writes) {
             let _ = writeln!(stdout, "{}", resp);
             let _ = stdout.flush();
         }
     }
+}
+
+/// Handle a single JSON-RPC request line. Returns the response to write, or
+/// `None` when the line is a notification (JSON-RPC forbids responding to
+/// notifications — including with an `"id": null` response).
+fn handle_request_line(line: &str, root: &Path, allow_writes: bool) -> Option<Value> {
+    let request: Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => {
+            return Some(json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": { "code": -32700, "message": "Parse error" }
+            }));
+        }
+    };
+
+    let id = request.get("id").cloned();
+    let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+    // JSON-RPC notifications (requests without an "id" member) MUST NOT be
+    // answered — not even with an "id": null response. An explicit
+    // `"id": null` is a (discouraged) request id, not a notification.
+    let is_notification = request.get("id").is_none();
+
+    let response = match method {
+        "initialize" => Some(handle_initialize(id)),
+        "notifications/initialized" => None, // notification, no response
+        "tools/list" => Some(handle_tools_list(id)),
+        "tools/call" => {
+            let params = request.get("params").cloned().unwrap_or(json!({}));
+            Some(handle_tools_call(id, &params, root, allow_writes))
+        }
+        "resources/list" => Some(handle_resources_list(id)),
+        "resources/read" => {
+            let params = request.get("params").cloned().unwrap_or(json!({}));
+            Some(handle_resources_read(id, &params, root))
+        }
+        "ping" => Some(json!({ "jsonrpc": "2.0", "id": id, "result": {} })),
+        _ => {
+            // Notifications (no id) get no response
+            if id.is_some() {
+                Some(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": { "code": -32601, "message": format!("Method not found: {method}") }
+                }))
+            } else {
+                None
+            }
+        }
+    };
+
+    // Suppress responses to notifications for known methods too.
+    if is_notification { None } else { response }
 }
 
 fn handle_initialize(id: Option<Value>) -> Value {
@@ -113,13 +128,14 @@ fn handle_tools_list(id: Option<Value>) -> Value {
                         "properties": {
                             "root": {
                                 "type": "string",
-                                "description": "Project root directory (default: server root)"
+                                "description": "Project root directory — must be the server root or a path inside it (default: server root)"
                             },
                             "strict": {
                                 "type": "boolean",
                                 "description": "Treat warnings as errors (default: false)"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 {
@@ -130,7 +146,7 @@ fn handle_tools_list(id: Option<Value>) -> Value {
                         "properties": {
                             "root": {
                                 "type": "string",
-                                "description": "Project root directory (default: server root)"
+                                "description": "Project root directory — must be the server root or a path inside it (default: server root)"
                             }
                         },
                         "additionalProperties": false
@@ -138,15 +154,16 @@ fn handle_tools_list(id: Option<Value>) -> Value {
                 },
                 {
                     "name": "specsync_generate",
-                    "description": "Deterministically scaffold spec files for uncovered source modules. Returns paths of generated specs.",
+                    "description": "Deterministically scaffold spec files for uncovered source modules. Returns paths of generated specs. Requires the server to be started with --allow-writes.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
                             "root": {
                                 "type": "string",
-                                "description": "Project root directory (default: server root)"
+                                "description": "Project root directory — must be the server root or a path inside it (default: server root)"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 {
@@ -157,22 +174,24 @@ fn handle_tools_list(id: Option<Value>) -> Value {
                         "properties": {
                             "root": {
                                 "type": "string",
-                                "description": "Project root directory (default: server root)"
+                                "description": "Project root directory — must be the server root or a path inside it (default: server root)"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 {
                     "name": "specsync_init",
-                    "description": "Initialize a specsync.json config file with auto-detected source directories.",
+                    "description": "Initialize a specsync.json config file with auto-detected source directories. Requires the server to be started with --allow-writes.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
                             "root": {
                                 "type": "string",
-                                "description": "Project root directory (default: server root)"
+                                "description": "Project root directory — must be the server root or a path inside it (default: server root)"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 {
@@ -183,9 +202,10 @@ fn handle_tools_list(id: Option<Value>) -> Value {
                         "properties": {
                             "root": {
                                 "type": "string",
-                                "description": "Project root directory (default: server root)"
+                                "description": "Project root directory — must be the server root or a path inside it (default: server root)"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 {
@@ -196,9 +216,10 @@ fn handle_tools_list(id: Option<Value>) -> Value {
                         "properties": {
                             "root": {
                                 "type": "string",
-                                "description": "Project root directory (default: server root)"
+                                "description": "Project root directory — must be the server root or a path inside it (default: server root)"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 }
             ]
@@ -206,16 +227,174 @@ fn handle_tools_list(id: Option<Value>) -> Value {
     })
 }
 
-fn handle_tools_call(id: Option<Value>, params: &Value, default_root: &Path) -> Value {
+/// Tools that mutate the filesystem. They run only when the server was
+/// started with `--allow-writes`.
+const WRITE_TOOLS: &[&str] = &["specsync_generate", "specsync_init"];
+
+/// Advertised argument types per tool, used to validate `tools/call`
+/// arguments against the schemas published by `tools/list`. Unknown argument
+/// names and wrong JSON types are rejected with -32602 (Invalid params).
+fn tool_arg_schema(tool_name: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    match tool_name {
+        "specsync_check" => Some(&[("root", "string"), ("strict", "boolean")]),
+        "specsync_coverage"
+        | "specsync_generate"
+        | "specsync_list_specs"
+        | "specsync_init"
+        | "specsync_score"
+        | "specsync_issues" => Some(&[("root", "string")]),
+        _ => None,
+    }
+}
+
+/// Validate `arguments` against the tool's advertised schema. Returns a
+/// -32602 message on the first violation.
+fn validate_tool_arguments(tool_name: &str, arguments: &Value) -> Result<(), String> {
+    let schema = match tool_arg_schema(tool_name) {
+        Some(s) => s,
+        None => return Ok(()), // unknown tools are reported as such elsewhere
+    };
+    let object = match arguments.as_object() {
+        Some(o) => o,
+        None => {
+            return Err(format!(
+                "Invalid params for tool `{tool_name}`: arguments must be a JSON object"
+            ));
+        }
+    };
+    for (name, value) in object {
+        let expected = schema.iter().find(|(n, _)| n == name);
+        match expected {
+            None => {
+                return Err(format!(
+                    "Invalid params for tool `{tool_name}`: unknown argument `{name}`"
+                ));
+            }
+            Some((_, "string")) if !value.is_string() => {
+                return Err(format!(
+                    "Invalid params for tool `{tool_name}`: argument `{name}` must be a string"
+                ));
+            }
+            Some((_, "boolean")) if !value.is_boolean() => {
+                return Err(format!(
+                    "Invalid params for tool `{tool_name}`: argument `{name}` must be a boolean"
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// MCP arguments that were removed in spec-sync 5.0. They are rejected with a
+/// dedicated migration message (before generic schema validation and the
+/// write gate) so the error stays stable for older clients.
+const RETIRED_GENERATE_ARGUMENTS: &[&str] = &[
+    "ai",
+    "provider",
+    "aiProvider",
+    "ai_provider",
+    "model",
+    "aiModel",
+    "ai_model",
+    "apiKey",
+    "api_key",
+    "aiApiKey",
+    "ai_api_key",
+    "credential",
+    "credentials",
+    "baseUrl",
+    "base_url",
+    "aiBaseUrl",
+    "ai_base_url",
+    "timeout",
+    "timeoutSecs",
+    "timeout_secs",
+    "aiTimeout",
+    "ai_timeout",
+    "command",
+    "aiCommand",
+    "ai_command",
+];
+
+/// JSON-RPC Invalid params (-32602) error response.
+fn invalid_params_error(id: Option<Value>, message: String) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": -32602, "message": message }
+    })
+}
+
+fn handle_tools_call(
+    id: Option<Value>,
+    params: &Value,
+    default_root: &Path,
+    allow_writes: bool,
+) -> Value {
     let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
     let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
 
-    let root = arguments
-        .get("root")
-        .and_then(|r| r.as_str())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| default_root.to_path_buf());
-    let root = root.canonicalize().unwrap_or(root);
+    // Retired generate arguments get a dedicated migration error, before any
+    // other validation, so older clients see a stable message.
+    if tool_name == "specsync_generate"
+        && let Some(name) = RETIRED_GENERATE_ARGUMENTS
+            .iter()
+            .find(|name| arguments.get(**name).is_some())
+    {
+        return json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "content": [{
+                    "type": "text",
+                    "text": format!(
+                        "MCP argument `{name}` was removed in spec-sync 5.0. `specsync_generate` is deterministic; use your coding agent to enrich the generated spec."
+                    )
+                }],
+                "isError": true
+            }
+        });
+    }
+
+    // Validate arguments against the advertised schema before touching the
+    // filesystem (rejects e.g. `strict: "yes please"` with -32602).
+    if let Err(message) = validate_tool_arguments(tool_name, &arguments) {
+        return invalid_params_error(id, message);
+    }
+
+    // Write-capable tools are opt-in via the server's --allow-writes flag.
+    if WRITE_TOOLS.contains(&tool_name) && !allow_writes {
+        return json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "content": [{
+                    "type": "text",
+                    "text": format!(
+                        "Tool `{tool_name}` modifies the filesystem and is disabled. Restart the MCP server with --allow-writes to enable it."
+                    )
+                }],
+                "isError": true
+            }
+        });
+    }
+
+    // Every tool defaults to the server's --root. A caller-supplied `root`
+    // must be the server root or a path inside it (canonicalized and
+    // symlink-resolved) — anything else is rejected with -32602.
+    let root = match arguments.get("root") {
+        None => default_root
+            .canonicalize()
+            .unwrap_or_else(|_| default_root.to_path_buf()),
+        Some(value) => {
+            let candidate = PathBuf::from(value.as_str().unwrap_or_default());
+            match crate::util::confine_path_to_root(default_root, &candidate) {
+                Ok(confined) => confined,
+                Err(message) => return invalid_params_error(id, message),
+            }
+        }
+    };
 
     let result = match tool_name {
         "specsync_check" => tool_check(&root, &arguments),
@@ -678,34 +857,7 @@ fn tool_coverage(root: &Path) -> Result<Value, String> {
 }
 
 fn tool_generate(root: &Path, arguments: &Value) -> Result<Value, String> {
-    const RETIRED_ARGUMENTS: &[&str] = &[
-        "ai",
-        "provider",
-        "aiProvider",
-        "ai_provider",
-        "model",
-        "aiModel",
-        "ai_model",
-        "apiKey",
-        "api_key",
-        "aiApiKey",
-        "ai_api_key",
-        "credential",
-        "credentials",
-        "baseUrl",
-        "base_url",
-        "aiBaseUrl",
-        "ai_base_url",
-        "timeout",
-        "timeoutSecs",
-        "timeout_secs",
-        "aiTimeout",
-        "ai_timeout",
-        "command",
-        "aiCommand",
-        "ai_command",
-    ];
-    if let Some(name) = RETIRED_ARGUMENTS
+    if let Some(name) = RETIRED_GENERATE_ARGUMENTS
         .iter()
         .find(|name| arguments.get(**name).is_some())
     {
@@ -1018,7 +1170,7 @@ mod tests {
     fn test_handle_tools_call_unknown_tool() {
         let tmp = setup_project();
         let params = json!({ "name": "nonexistent_tool", "arguments": {} });
-        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path());
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path(), true);
         assert_eq!(resp["result"]["isError"], true);
         let text = resp["result"]["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("Unknown tool"));
@@ -1032,7 +1184,7 @@ mod tests {
             "name": "specsync_coverage",
             "arguments": { "root": tmp.path().to_string_lossy() }
         });
-        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path());
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path(), true);
         assert!(!resp["result"]["isError"].as_bool().unwrap_or(false));
     }
 
@@ -1276,7 +1428,7 @@ mod tests {
     fn test_tools_call_success_response_structure() {
         let tmp = setup_project();
         let params = json!({ "name": "specsync_coverage", "arguments": {} });
-        let resp = handle_tools_call(Some(json!(42)), &params, tmp.path());
+        let resp = handle_tools_call(Some(json!(42)), &params, tmp.path(), true);
 
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 42);
@@ -1288,7 +1440,7 @@ mod tests {
     fn test_tools_call_error_response_structure() {
         let tmp = setup_project();
         let params = json!({ "name": "bogus", "arguments": {} });
-        let resp = handle_tools_call(Some(json!(99)), &params, tmp.path());
+        let resp = handle_tools_call(Some(json!(99)), &params, tmp.path(), true);
 
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 99);
@@ -1421,5 +1573,146 @@ mod tests {
                 .unwrap()
                 .contains("Unknown resource URI")
         );
+    }
+
+    // --- #414: path confinement, arg validation, write gating, notifications ---
+
+    #[test]
+    fn test_tools_call_rejects_root_outside_server_root() {
+        let server = setup_project();
+        let outside = TempDir::new().unwrap();
+        let params = json!({
+            "name": "specsync_generate",
+            "arguments": { "root": outside.path().to_string_lossy() }
+        });
+        let resp = handle_tools_call(Some(json!(1)), &params, server.path(), true);
+        assert_eq!(resp["error"]["code"], -32602);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("outside the server root")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_tools_call_rejects_symlink_root_escape() {
+        let server = setup_project();
+        let outside = TempDir::new().unwrap();
+        let link = server.path().join("link");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let params = json!({
+            "name": "specsync_coverage",
+            "arguments": { "root": link.to_string_lossy() }
+        });
+        let resp = handle_tools_call(Some(json!(1)), &params, server.path(), true);
+        assert_eq!(resp["error"]["code"], -32602);
+    }
+
+    #[test]
+    fn test_tools_call_accepts_child_of_server_root() {
+        let server = setup_project();
+        let child = server.path().join("sub");
+        std::fs::create_dir_all(child.join("specs")).unwrap();
+        std::fs::write(
+            child.join("specsync.json"),
+            r#"{"specsDir":"specs","sourceDirs":["src"]}"#,
+        )
+        .unwrap();
+        let params = json!({
+            "name": "specsync_coverage",
+            "arguments": { "root": child.to_string_lossy() }
+        });
+        let resp = handle_tools_call(Some(json!(1)), &params, server.path(), true);
+        assert!(resp["error"].is_null());
+        assert!(resp["result"]["isError"].is_null());
+    }
+
+    #[test]
+    fn test_tools_call_rejects_wrong_arg_type_with_32602() {
+        let tmp = setup_project();
+        let params = json!({
+            "name": "specsync_check",
+            "arguments": { "strict": "yes please" }
+        });
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path(), true);
+        assert_eq!(resp["error"]["code"], -32602);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("`strict` must be a boolean")
+        );
+    }
+
+    #[test]
+    fn test_tools_call_rejects_unknown_argument_with_32602() {
+        let tmp = setup_project();
+        let params = json!({
+            "name": "specsync_coverage",
+            "arguments": { "bogus": 1 }
+        });
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path(), true);
+        assert_eq!(resp["error"]["code"], -32602);
+        assert!(
+            resp["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("unknown argument `bogus`")
+        );
+    }
+
+    #[test]
+    fn test_tools_call_write_tools_require_allow_writes() {
+        let tmp = setup_project();
+        for tool in ["specsync_generate", "specsync_init"] {
+            let params = json!({ "name": tool, "arguments": {} });
+            let resp = handle_tools_call(Some(json!(1)), &params, tmp.path(), false);
+            assert_eq!(resp["result"]["isError"], true, "tool {tool}");
+            assert!(
+                resp["result"]["content"][0]["text"]
+                    .as_str()
+                    .unwrap()
+                    .contains("--allow-writes"),
+                "tool {tool}"
+            );
+        }
+        // Read-only tools still work without the flag.
+        let params = json!({ "name": "specsync_coverage", "arguments": {} });
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path(), false);
+        assert!(resp["result"]["isError"].is_null());
+    }
+
+    #[test]
+    fn test_tools_call_generate_allowed_with_allow_writes() {
+        let tmp = setup_project();
+        std::fs::write(tmp.path().join("src").join("auth.rs"), "pub fn login() {}").unwrap();
+        let params = json!({ "name": "specsync_generate", "arguments": {} });
+        let resp = handle_tools_call(Some(json!(1)), &params, tmp.path(), true);
+        assert!(resp["result"]["isError"].is_null());
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["count"], 1);
+    }
+
+    #[test]
+    fn test_known_method_notification_gets_no_response() {
+        let tmp = setup_project();
+        for method in ["tools/list", "initialize", "ping", "resources/list"] {
+            let line = format!(r#"{{"jsonrpc":"2.0","method":"{method}"}}"#);
+            assert!(
+                handle_request_line(&line, tmp.path(), false).is_none(),
+                "notification for {method} must not get a response"
+            );
+        }
+        // Requests still get responses, and explicit "id": null is a request id.
+        let line = r#"{"jsonrpc":"2.0","id":null,"method":"ping"}"#;
+        assert!(handle_request_line(line, tmp.path(), false).is_some());
+        // Unknown-method notifications get no response either.
+        let line = r#"{"jsonrpc":"2.0","method":"bogus/method"}"#;
+        assert!(handle_request_line(line, tmp.path(), false).is_none());
+        // Parse errors are still reported.
+        assert!(handle_request_line("not json", tmp.path(), false).is_some());
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -35,6 +35,42 @@ pub fn safe_regex(pattern: &str) -> Option<regex::Regex> {
         .ok()
 }
 
+/// Confine a caller-supplied path to a server/project root.
+///
+/// Canonicalizes (resolving symlinks, `.`/`..`, and platform prefixes) both
+/// `root` and `candidate`, then accepts `candidate` only when it equals the
+/// canonical root or is a descendant of it. Returns the canonical candidate on
+/// success.
+///
+/// Use this before honoring any caller-provided filesystem path (e.g. an MCP
+/// tool `root` argument) so a hostile or prompt-injected caller cannot make
+/// the process read or write outside its configured root. Both paths must
+/// exist — canonicalization of a non-existent path fails and is reported as an
+/// error rather than silently allowed.
+pub fn confine_path_to_root(
+    root: &std::path::Path,
+    candidate: &std::path::Path,
+) -> Result<std::path::PathBuf, String> {
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|e| format!("cannot resolve server root {}: {e}", root.display()))?;
+    let canonical_candidate = candidate.canonicalize().map_err(|e| {
+        format!(
+            "path {} cannot be resolved (must exist): {e}",
+            candidate.display()
+        )
+    })?;
+    if canonical_candidate == canonical_root || canonical_candidate.starts_with(&canonical_root) {
+        Ok(canonical_candidate)
+    } else {
+        Err(format!(
+            "path {} is outside the server root {}",
+            canonical_candidate.display(),
+            canonical_root.display()
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -57,5 +93,65 @@ mod tests {
     #[test]
     fn test_safe_regex_invalid() {
         assert!(safe_regex(r"[invalid").is_none());
+    }
+
+    #[test]
+    fn test_confine_path_to_root_accepts_root_itself() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let confined = confine_path_to_root(&root, &root).unwrap();
+        assert_eq!(confined, root);
+    }
+
+    #[test]
+    fn test_confine_path_to_root_accepts_child() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let child = root.join("sub");
+        std::fs::create_dir_all(&child).unwrap();
+        // Also accepts non-canonical spellings like `sub/../sub`.
+        let spelled = root.join("sub").join("..").join("sub");
+        let confined = confine_path_to_root(&root, &spelled).unwrap();
+        assert_eq!(confined, child.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_confine_path_to_root_rejects_sibling() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let err = confine_path_to_root(&root, &outside).unwrap_err();
+        assert!(err.contains("outside the server root"));
+    }
+
+    #[test]
+    fn test_confine_path_to_root_rejects_dotdot_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        let escape = root.join("..");
+        assert!(confine_path_to_root(&root, &escape).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_confine_path_to_root_rejects_symlink_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        assert!(confine_path_to_root(&root, &link).is_err());
+    }
+
+    #[test]
+    fn test_confine_path_to_root_rejects_nonexistent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        assert!(confine_path_to_root(&root, &root.join("missing")).is_err());
     }
 }

--- a/tests/integration/helpers.rs
+++ b/tests/integration/helpers.rs
@@ -142,6 +142,16 @@ pub fn mcp_request(
     root: &std::path::Path,
     requests: &[serde_json::Value],
 ) -> Vec<serde_json::Value> {
+    mcp_request_with_server_args(root, &[], requests)
+}
+
+/// Like [`mcp_request`], but passes extra arguments to the `mcp` subcommand
+/// (e.g. `--allow-writes`).
+pub fn mcp_request_with_server_args(
+    root: &std::path::Path,
+    server_args: &[&str],
+    requests: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
     let input: String = requests
         .iter()
         .map(|r| serde_json::to_string(r).unwrap())
@@ -151,6 +161,7 @@ pub fn mcp_request(
 
     let output = specsync()
         .arg("mcp")
+        .args(server_args)
         .arg("--root")
         .arg(root)
         .write_stdin(input)

--- a/tests/integration/mcp.rs
+++ b/tests/integration/mcp.rs
@@ -130,8 +130,10 @@ fn mcp_tool_init_creates_config() {
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
 
-    let responses = mcp_request(
+    // specsync_init is write-capable: it requires the server opt-in flag.
+    let responses = mcp_request_with_server_args(
         root,
+        &["--allow-writes"],
         &[serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -259,4 +261,126 @@ fn mcp_score_tool_returns_grades() {
         serde_json::from_str(score_result.as_str().unwrap()).unwrap();
     assert!(score_json["average_score"].is_number());
     assert!(score_json["grade"].is_string());
+}
+
+// ─── #414: path confinement, arg validation, write gating, notifications ───
+
+#[test]
+fn mcp_tools_call_rejects_root_outside_server_root() {
+    let server = TempDir::new().unwrap();
+    let victim = TempDir::new().unwrap();
+    fs::create_dir_all(victim.path().join("src")).unwrap();
+    fs::write(victim.path().join("src/evil.rs"), "pub fn evil() {}").unwrap();
+
+    let responses = mcp_request_with_server_args(
+        server.path(),
+        &["--allow-writes"],
+        &[serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "specsync_generate",
+                "arguments": { "root": victim.path().to_string_lossy() }
+            }
+        })],
+    );
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["error"]["code"], -32602);
+    assert!(
+        responses[0]["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("outside the server root")
+    );
+    // Nothing may have been written outside the server root.
+    assert!(!victim.path().join("specs").exists());
+}
+
+#[test]
+fn mcp_write_tools_require_allow_writes_flag() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/auth.rs"), "pub fn login() {}").unwrap();
+
+    let responses = mcp_request(
+        root,
+        &[
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": { "name": "specsync_generate", "arguments": {} }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": { "name": "specsync_init", "arguments": {} }
+            }),
+        ],
+    );
+
+    assert_eq!(responses.len(), 2);
+    for resp in &responses {
+        assert_eq!(resp["result"]["isError"].as_bool(), Some(true));
+        assert!(
+            resp["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("--allow-writes")
+        );
+    }
+    assert!(!root.join("specs").exists());
+    assert!(!root.join("specsync.json").exists());
+}
+
+#[test]
+fn mcp_tools_call_rejects_wrongly_typed_arguments() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_minimal_project(&tmp);
+
+    let responses = mcp_request(
+        &root,
+        &[serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "specsync_check",
+                "arguments": { "strict": "yes please" }
+            }
+        })],
+    );
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["error"]["code"], -32602);
+    assert!(
+        responses[0]["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("`strict` must be a boolean")
+    );
+}
+
+#[test]
+fn mcp_known_method_notification_gets_no_response() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // A notification (no "id") for a known method must NOT be answered —
+    // JSON-RPC forbids even an "id": null response. A following request with
+    // an id must still get exactly one response.
+    let responses = mcp_request(
+        root,
+        &[
+            serde_json::json!({ "jsonrpc": "2.0", "method": "tools/list" }),
+            serde_json::json!({ "jsonrpc": "2.0", "id": 7, "method": "ping" }),
+        ],
+    );
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], 7);
 }


### PR DESCRIPTION
## Summary

Every MCP tool accepted a caller-supplied `root` verbatim, allowing an arbitrary file write outside the server root. **Verified exploit:** `specsync_generate` with `{"root":"/tmp/victim"}` wrote `/tmp/victim/specs/evil/evil.spec.md` — a hostile or prompt-injected MCP client could make the server process write files anywhere it had permissions.

This was handled per SECURITY.md. Given the arbitrary-write primitive, we recommend maintainers consider publishing a security advisory for this issue.

## Fix

- **All tools default to the server `--root`.** A caller-supplied `root` is accepted only if it is the server root or a path inside it; anything else is rejected with `-32602` (Invalid params) via the new `util::confine_path_to_root`, which canonicalizes both paths (symlink- and `..`-resolved) before comparing.
- **Write tools gated:** `specsync_generate` and `specsync_init` now require the new `specsync mcp --allow-writes` flag, so a connected agent gets a read-only surface by default.
- **Schema validation:** `tools/call` arguments are validated against the schemas advertised by `tools/list`; unknown argument names and wrongly typed values are rejected with `-32602` before touching the filesystem.
- **JSON-RPC correctness:** notifications for known methods (no `id` member) no longer receive a forbidden `"id": null` response; parse errors and explicit `"id": null` requests still behave per spec.

## After

The same call — `specsync_generate {"root":"/tmp/victim"}` — now returns `-32602 path ... is outside the server root` and writes nothing.

## Tests

- New `util::confine_path_to_root` unit tests (child accepted, sibling/`..`/symlink escape rejected, nonexistent rejected) and `mcp.rs` unit tests covering rejection, write gating, arg-type validation, and notification handling.
- New integration tests: `mcp_tools_call_rejects_root_outside_server_root`, `mcp_write_tools_require_allow_writes_flag`, `mcp_tools_call_rejects_wrongly_typed_arguments`, `mcp_known_method_notification_gets_no_response`.
- Full suite passes: 1729 unit + 227 integration tests, clippy clean.

Closes #414