### PR TITLE
fix: import --from-dir preserves source content instead of discarding it (closes #416)

### DIFF
--- a/specs/cmd_import/cmd_import.spec.md
+++ b/specs/cmd_import/cmd_import.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_import
-version: 3
+version: 4
 status: stable
 files:
   - src/commands/import.rs
@@ -17,7 +17,7 @@ depends_on:
 
 ## Purpose
 
-Implements the `specsync import` command. Imports specs from external systems (GitHub Issues, Jira, Confluence) by fetching remote data and converting it into spec files with companions.
+Implements the `specsync import` command. Imports specs from external systems (GitHub Issues, Jira, Confluence) and local Markdown directories. Directory imports preserve complete valid specs byte-for-byte, augment incomplete documents without discarding their content, and reject malformed frontmatter before writing output.
 
 ## Public API
 
@@ -34,6 +34,9 @@ Implements the `specsync import` command. Imports specs from external systems (G
 3. Creates spec and companion files (tasks.md, context.md, requirements.md, testing.md); design.md is generated only when `companions.design` is enabled in config
 4. Will not overwrite existing spec
 5. Success guidance tells users to validate and complete imported details, not to fill template markers
+6. Directory imports never report success for output with an empty `files` list: source code is auto-detected, with the canonically confined project-relative input document used as the ownership fallback
+7. A complete valid spec keeps its original bytes and declared `module`; incomplete content is only supplemented with missing frontmatter fields and required sections
+8. Duplicate or wrongly shaped known frontmatter fields fail the affected import without creating its spec
 
 ## Behavioral Examples
 
@@ -43,6 +46,12 @@ Implements the `specsync import` command. Imports specs from external systems (G
 - **When** `cmd_import` runs
 - **Then** fetches issue #42, creates spec from its title and body
 
+### Scenario: Import an existing spec
+
+- **Given** `docs/renamed.spec.md` is a complete valid spec declaring `module: auth`
+- **When** `specsync import --from-dir docs` runs
+- **Then** creates `specs/auth/auth.spec.md` with bytes identical to the source document
+
 ## Error Cases
 
 | Condition | Behavior |
@@ -50,6 +59,8 @@ Implements the `specsync import` command. Imports specs from external systems (G
 | Invalid source type | Exits 1 with supported list |
 | Spec already exists | Exits 1 |
 | Fetch fails | Exits 1 with error |
+| Empty file, unterminated frontmatter, duplicate key, or known-field shape mismatch | Counts an error, creates no spec for that file, and exits 1 after the batch |
+| No source code match and the input document is outside the project root | Counts an error rather than writing `files: []` |
 
 ## Dependencies
 
@@ -72,6 +83,7 @@ Implements the `specsync import` command. Imports specs from external systems (G
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Preserve valid directory-imported specs byte-for-byte, retain declared module identity, provide non-empty source ownership, and reject malformed frontmatter before output (#416) |
 | 2026-06-07 | Update import success guidance for guided imported specs |
 | 2026-04-09 | Initial spec |
 | 2026-04-13 | Document testing.md and conditional design.md in companion generation |

--- a/specs/cmd_import/context.md
+++ b/specs/cmd_import/context.md
@@ -7,7 +7,9 @@ spec: cmd_import.spec.md
 - `cmd_import` is a router. It inspects its flags first: `--all-issues` and `--from-dir` short-circuit to batch handlers (`cmd_import_all_issues`, `cmd_import_from_dir`) before the single-import path requires `source` + `id`.
 - Single import fails hard (`process::exit(1)`) on any problem; batch modes are resilient — each item that errors increments a counter and the loop continues, ending with a `BatchStats` summary.
 - Repo resolution order is identical for single and batch GitHub imports: `--repo` flag → `config.github.repo` → `github::detect_repo(root)`.
-- Markdown directory items are mapped to `ImportSource::Confluence` as the closest semantic match for a generic "doc", and the module name is derived from the filename via `importer::slugify`.
+- Directory imports use a dedicated preservation path rather than mapping local documents to `ImportSource::Confluence`. A complete valid spec keeps its exact bytes and declared module identity; incomplete/plain Markdown keeps its body while missing contract sections are appended.
+- Directory source ownership prefers detected source code and falls back to the imported project-relative Markdown path. An external document with no detected project source fails instead of creating a known-invalid `files: []` spec.
+- Import-specific frontmatter validation rejects duplicate keys and wrong scalar/list shapes before any output path is created. It deliberately leaves broader parser unification to the checked-frontmatter work tracked separately.
 - Companion generation always runs after a successful spec write; `design.md` is gated on `config.companions.design`.
 
 ## Files to Read First
@@ -20,7 +22,7 @@ spec: cmd_import.spec.md
 
 ## Current Status
 
-Implemented and stable. Directory-import and the no-args error path are covered by integration tests; remote GitHub/Jira/Confluence fetches are not exercised in CI (network/mocking required).
+Implemented and stable. Directory preservation, strict-check compatibility, malformed-input atomicity, repo guidance, and the no-args error path are covered by integration tests; remote GitHub/Jira/Confluence fetches are not exercised in CI (network/mocking required).
 
 ## Notes
 

--- a/specs/cmd_import/requirements.md
+++ b/specs/cmd_import/requirements.md
@@ -17,7 +17,10 @@ spec: cmd_import.spec.md
 - Each created spec lives at `<specsDir>/<module>/<module>.spec.md` and is never overwritten — an existing spec causes exit 1 (single) or a skip (batch).
 - After writing a spec, companions are generated via `generator::generate_companion_files_for_spec` with `companions.design` from config controlling whether `design.md` is created.
 - Batch modes print a `[n/total]` progress line per item and a final summary of imported/skipped/error counts; directory mode scans `.md` files one level deep, sorted.
-- Markdown directory items derive: title from the first `# ` heading (else filename), purpose from the first non-empty paragraph after the title, requirements via `importer::extract_requirements_pub`, and module name via `importer::slugify(filename)`.
+- Markdown directory items with complete valid spec frontmatter preserve their bytes and declared module identity. Plain or incomplete Markdown preserves its body and is supplemented only with missing required frontmatter and sections.
+- Directory imports never emit an empty `files` list: matching source code is preferred and the canonically confined project-relative input document is the fallback. If neither is safe and available, the item fails without output.
+- Empty input, unterminated frontmatter, duplicate keys, and known-field scalar/list shape mismatches are reported as errors; the batch exits nonzero after processing the remaining files.
+- A missing GitHub repository tells users to pass `--repo` or configure `repo` under `[github]` in `.specsync/config.toml`.
 
 ## Constraints
 
@@ -28,12 +31,12 @@ spec: cmd_import.spec.md
 ## Out of Scope
 
 - Two-way sync back to the external system; this is a one-shot import.
-- Filling in the full spec body — imported specs are drafts to be completed and validated with `specsync check`.
+- Rewriting complete valid specs or replacing imported prose with generated boilerplate.
 - Recursive directory traversal and non-Markdown source files.
 
 ### REQ-cmd-import-001
 
-The import command SHALL create non-overwriting draft specs from supported single and batch sources with deterministic companion generation.
+The import command SHALL create non-overwriting spec artifacts from supported single and batch sources with deterministic companion generation, while preserving the status and bytes of complete valid directory-imported specs.
 
 Acceptance Criteria
 - `cmd_import` routes to one of three modes: single import (`source` + `id`), batch issues (`--all-issues`), or batch directory (`--from-dir <dir>`).
@@ -42,5 +45,7 @@ Acceptance Criteria
 - Each created spec lives at `<specsDir>/<module>/<module>.spec.md` and is never overwritten — an existing spec causes exit 1 (single) or a skip (batch).
 - After writing a spec, companions are generated via `generator::generate_companion_files_for_spec` with `companions.design` from config controlling whether `design.md` is created.
 - Batch modes print a `[n/total]` progress line per item and a final summary of imported/skipped/error counts; directory mode scans `.md` files one level deep, sorted.
-- Markdown directory items derive: title from the first `# ` heading (else filename), purpose from the first non-empty paragraph after the title, requirements via `importer::extract_requirements_pub`, and module name via `importer::slugify(filename)`.
-
+- Markdown directory items with complete valid spec frontmatter preserve their bytes and declared module identity. Plain or incomplete Markdown preserves its body and is supplemented only with missing required frontmatter and sections.
+- Directory imports never emit an empty `files` list: matching source code is preferred and the canonically confined project-relative input document is the fallback. If neither is safe and available, the item fails without output.
+- Empty input, unterminated frontmatter, duplicate keys, and known-field scalar/list shape mismatches are reported as errors; the batch exits nonzero after processing the remaining files.
+- A missing GitHub repository tells users to pass `--repo` or configure `repo` under `[github]` in `.specsync/config.toml`.

--- a/specs/cmd_import/tasks.md
+++ b/specs/cmd_import/tasks.md
@@ -17,6 +17,10 @@ spec: cmd_import.spec.md
 - [x] Companion generation wired to `companions.design` config flag.
 - [x] Success guidance updated to tell users to validate/complete imported details (not fill template markers).
 - [x] Integration coverage: `import_without_args_or_flags_shows_error`, `import_from_dir_imports_markdown_files`, `import_from_dir_skips_existing_specs`, `import_from_dir_nonexistent_directory_errors`.
+- [x] Preserve complete valid directory-imported specs byte-for-byte and route output by declared module identity.
+- [x] Reject malformed known frontmatter before output and return a nonzero batch exit.
+- [x] Keep imported `files` non-empty via source detection or the project-relative input document fallback.
+- [x] Correct GitHub repository configuration guidance to `.specsync/config.toml`.
 
 ## Review Status
 

--- a/specs/cmd_import/testing.md
+++ b/specs/cmd_import/testing.md
@@ -6,11 +6,15 @@ spec: cmd_import.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/import.rs` | cargo test --test integration import_ | No inline `#[cfg(test)]` module. Directory-import + no-args paths are covered end-to-end; GitHub/Jira/Confluence fetches are not (network/mocking required). |
+| `src/commands/import.rs` | cargo test commands::import::tests | Focused conversion tests cover byte preservation, confined source ownership, empty-field repair, malformed frontmatter, suffix handling, and portable dates. |
+| `src/commands/import.rs` | cargo test --test integration import_ | Directory-import + no-args/repo-guidance paths are covered end-to-end; GitHub/Jira/Confluence fetches are not (network/mocking required). |
 | `tests/integration.rs` | cargo test --test integration import_without_args_or_flags_shows_error | Missing source/id with no batch flag fails with "SOURCE is required". |
 | `tests/integration.rs` | cargo test --test integration import_from_dir_imports_markdown_files | `--from-dir docs` prints "Batch Import" and reports 1 imported for one `.md` file. |
 | `tests/integration.rs` | cargo test --test integration import_from_dir_skips_existing_specs | A pre-existing `my-feature` spec causes the same-named doc to be skipped. |
 | `tests/integration.rs` | cargo test --test integration import_from_dir_nonexistent_directory_errors | `--from-dir nonexistent-dir` fails with "Directory not found". |
+| `tests/integration/languages.rs` | cargo test --test integration import_from_dir_preserves_complete_spec_bytes_and_declared_module | Complete CRLF spec output is byte-identical and uses its frontmatter module for the destination. |
+| `tests/integration/languages.rs` | cargo test --test integration import_from_dir_rejects_malformed_frontmatter_without_output | Duplicate and wrong-shape fields fail the batch and create no module directory. |
+| `tests/integration/languages.rs` | cargo test --test integration import_github_repo_error_points_to_current_config | Missing-repo guidance names `[github] repo` in `.specsync/config.toml`. |
 
 ## Behavioral Verification
 
@@ -19,7 +23,8 @@ spec: cmd_import.spec.md
 | Single GitHub import | repo resolvable, issue exists | `specsync import github 42` | Fetches issue #42, writes `specs/<module>/<module>.spec.md` + companions, prints "Imported:" and a `specsync check` tip. |
 | Unknown source | any | `specsync import slack 7` | Exits 1: "Unknown source 'slack'. Supported: github, jira, confluence". |
 | Batch issues | repo resolvable | `specsync import --all-issues --label bug` | Prints "Batch Import: GitHub Issues", per-issue `[n/total]` lines, and an imported/skipped/error summary. |
-| Batch directory | `docs/*.md` present | `specsync import --from-dir docs` | One spec per Markdown file (one level deep, sorted), existing specs skipped. |
+| Batch directory | `docs/*.md` present | `specsync import --from-dir docs` | One spec per Markdown file (one level deep, sorted), existing specs skipped; generated `files` owns detected code or the project-relative document and passes strict validation. |
+| Existing complete spec | valid frontmatter and all required sections | `specsync import --from-dir docs` | Output bytes are identical and destination uses the declared module. |
 
 ## Regression Matrix
 
@@ -31,6 +36,11 @@ spec: cmd_import.spec.md
 | Spec already exists (single) | Exits 1 | Add a focused assertion before changing this behavior. |
 | Spec already exists (batch) | Skipped, counted, loop continues | Covered by `import_from_dir_skips_existing_specs`. |
 | `--from-dir` missing directory | Exits 1 with "Directory not found" | Covered by `import_from_dir_nonexistent_directory_errors`. |
+| Complete spec uses CRLF or filename differs from declared module | Preserve exact bytes and use declared module destination | Covered by `import_from_dir_preserves_complete_spec_bytes_and_declared_module`. |
+| Empty, unterminated, duplicate-key, or wrong-shape frontmatter | Exits nonzero after batch and creates no output for the bad item | Covered by unit and integration malformed-input tests. |
+| No matching source code | Use the project-relative source Markdown file; never emit `files: []` | Covered by `import_from_dir_imports_markdown_files`, including a follow-up check asserting frontmatter and source-file validity. |
+| Input document resolves outside the project and no project source matches | Fail the item rather than recording an escaping/absolute ownership path | Covered by `from_dir_fails_loudly_on_unparseable_input`. |
+| GitHub repo cannot be detected | Guidance names `.specsync/config.toml`, not legacy `specsync.json` | Covered by `import_github_repo_error_points_to_current_config`. |
 | Fetch fails (single) | Exits 1 with the upstream error | Add a fixture/mocked path before changing error handling. |
 
 ## Reviewer Checklist

--- a/specs/importer/context.md
+++ b/specs/importer/context.md
@@ -8,6 +8,7 @@ spec: importer.spec.md
 - Uses simple regex-free HTML stripping for Confluence — no external HTML parser dependency
 - Base64 encoding is hand-rolled to avoid adding a dependency (only used for Jira/Confluence basic auth)
 - Requirements extraction is heuristic-based: looks for checkboxes, "Acceptance Criteria"/"Requirements", and "Definition of Done" sections
+- Requirement extraction is internal to remote-source normalization; local directory imports preserve source Markdown directly instead of reducing it to an `ImportedItem`.
 - Generated specs always start as `draft` status — user fills in details after import
 - `redact_secret` strips any verbatim auth token from REST error strings before surfacing them (added 4.3.5), mirroring the GitHub module's `redact_token` and the AI provider client's sanitization
 

--- a/specs/importer/importer.spec.md
+++ b/specs/importer/importer.spec.md
@@ -1,6 +1,6 @@
 ---
 module: importer
-version: 3
+version: 4
 status: active
 files:
   - src/importer.rs
@@ -26,7 +26,6 @@ Generates spec files from external project management systems. Supports importin
 | `import_jira_issue` | `issue_key: &str` | `Result<ImportedItem, String>` | Fetch a Jira issue via REST API v3 and convert to `ImportedItem` |
 | `import_confluence_page` | `page_id: &str` | `Result<ImportedItem, String>` | Fetch a Confluence page via REST API and convert to `ImportedItem` |
 | `render_spec` | `item: &ImportedItem` | `String` | Render an `ImportedItem` into a complete spec markdown string |
-| `extract_requirements_pub` | `body: &str` | `Vec<String>` | Extract requirement-like bullets (checkboxes, numbered lists, acceptance criteria sections) from text |
 | `slugify` | `title: &str` | `String` | Convert a title into a valid module name (lowercase, hyphen-separated) |
 
 ### Exported Structs
@@ -116,6 +115,7 @@ Generates spec files from external project management systems. Supports importin
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Remove the command-only `extract_requirements_pub` wrapper after directory import stopped converting local Markdown through `ImportedItem` (#416) |
 | 2026-06-07 | Replace imported-spec unfinished-work markers with guided requirement prompts |
 | 2026-04-07 | Initial implementation — GitHub, Jira, Confluence importers (#97) |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -71,7 +71,7 @@ fn cmd_import_single(root: &Path, source: &str, id: &str, repo_override: Option<
                 .or_else(|| github::detect_repo(root))
                 .unwrap_or_else(|| {
                     eprintln!(
-                        "{} Cannot determine GitHub repo. Use --repo or set github.repo in specsync.json.",
+                        "{} Cannot determine GitHub repo. Use --repo, or set `repo` under `[github]` in .specsync/config.toml.",
                         "Error:".red()
                     );
                     process::exit(1);
@@ -175,7 +175,7 @@ fn cmd_import_all_issues(root: &Path, repo_override: Option<&str>, label: Option
         .or_else(|| github::detect_repo(root))
         .unwrap_or_else(|| {
             eprintln!(
-                "{} Cannot determine GitHub repo. Use --repo or set github.repo in specsync.json.",
+                "{} Cannot determine GitHub repo. Use --repo, or set `repo` under `[github]` in .specsync/config.toml.",
                 "Error:".red()
             );
             process::exit(1);
@@ -319,11 +319,18 @@ fn cmd_import_from_dir(root: &Path, dir: &Path) {
 
     for (idx, file_path) in md_files.iter().enumerate() {
         let progress = format!("[{}/{}]", idx + 1, total);
-        let filename = file_path
+        let raw_stem = file_path
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
-        print!("  {} {} ", progress.dimmed(), filename);
+        // `foo.spec.md` imports as module `foo`, not `foo-spec`.
+        let stem = raw_stem.strip_suffix(".spec").unwrap_or(raw_stem);
+        let file_display = file_path
+            .strip_prefix(root)
+            .unwrap_or(file_path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        print!("  {} {} ", progress.dimmed(), stem);
 
         let content = match fs::read_to_string(file_path) {
             Ok(c) => c,
@@ -334,10 +341,19 @@ fn cmd_import_from_dir(root: &Path, dir: &Path) {
             }
         };
 
-        let item = parse_markdown_as_import_item(filename, &content);
+        let import = match build_imported_spec(root, &config, stem, &file_display, &content) {
+            Ok(import) => import,
+            Err(reason) => {
+                // Unparseable source files fail loudly — never a silent ✓ over
+                // discarded content.
+                println!("{} not imported: {reason}", "✗".red());
+                stats.errors += 1;
+                continue;
+            }
+        };
 
-        let spec_dir = specs_dir.join(&item.module_name);
-        let spec_file = spec_dir.join(format!("{}.spec.md", item.module_name));
+        let spec_dir = specs_dir.join(&import.module_name);
+        let spec_file = spec_dir.join(format!("{}.spec.md", import.module_name));
 
         if spec_file.exists() {
             println!("{} skipped — spec already exists", "~".yellow());
@@ -345,21 +361,22 @@ fn cmd_import_from_dir(root: &Path, dir: &Path) {
             continue;
         }
 
-        let spec_content = importer::render_spec(&item);
-
         if let Err(e) = fs::create_dir_all(&spec_dir) {
             println!("{} Failed to create dir: {e}", "✗".red());
             stats.errors += 1;
             continue;
         }
 
-        match fs::write(&spec_file, &spec_content) {
+        match fs::write(&spec_file, &import.spec_content) {
             Ok(_) => {
                 let rel = spec_file.strip_prefix(root).unwrap_or(&spec_file).display();
                 println!("{} → {}", "✓".green(), rel);
+                for warning in &import.warnings {
+                    println!("    {} {warning}", "⚠".yellow());
+                }
                 generator::generate_companion_files_for_spec(
                     &spec_dir,
-                    &item.module_name,
+                    &import.module_name,
                     config.companions.design,
                 );
                 stats.imported += 1;
@@ -372,8 +389,217 @@ fn cmd_import_from_dir(root: &Path, dir: &Path) {
     }
 
     print_batch_summary("import", &stats);
+    if stats.errors > 0 {
+        process::exit(1);
+    }
 }
 
+/// The result of converting one markdown file into spec content.
+struct FromDirImport {
+    module_name: String,
+    spec_content: String,
+    warnings: Vec<String>,
+}
+
+/// Convert a markdown file into spec content, preserving everything parseable:
+/// existing frontmatter fields, body sections, API tables, and changelogs are
+/// kept verbatim; only missing pieces are scaffolded.
+///
+/// Returns `Err` for content that cannot be parsed at all (empty file, or a
+/// frontmatter block that doesn't parse) — the caller must fail loudly rather
+/// than overwrite the source with a skeleton.
+fn build_imported_spec(
+    root: &Path,
+    config: &crate::types::SpecSyncConfig,
+    stem: &str,
+    file_display: &str,
+    content: &str,
+) -> Result<FromDirImport, String> {
+    let module_name = importer::slugify(stem);
+    if module_name.is_empty() {
+        return Err(format!("could not derive a module name from '{stem}'"));
+    }
+    if content.trim().is_empty() {
+        return Err("file is empty — nothing to import".to_string());
+    }
+
+    let normalized = content.trim_start_matches('\u{feff}').replace("\r\n", "\n");
+
+    // Auto-detect source files so imported specs don't fail the tool's own
+    // non-empty `files:` gate when the module's sources are discoverable.
+    let mut detected: Vec<String> = generator::find_files_for_module(root, &module_name, config)
+        .into_iter()
+        .map(|f| {
+            Path::new(&f)
+                .strip_prefix(root)
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or(f)
+        })
+        .collect();
+    if detected.is_empty()
+        && let Some(single) = generator::find_single_source_fallback(root, config)
+    {
+        detected.push(single);
+    }
+    detected.sort();
+
+    let mut warnings = Vec::new();
+    let files_yaml = if detected.is_empty() {
+        warnings.push(format!(
+            "no source files detected for '{module_name}' — `files:` is empty; \
+             fill it in before `specsync check` will pass"
+        ));
+        "files: []".to_string()
+    } else {
+        let items: String = detected.iter().map(|f| format!("  - {f}\n")).collect();
+        format!("files:\n{items}")
+    };
+
+    let import_note = format!("Imported from {file_display}");
+
+    let (mut spec_text, body) = if normalized.starts_with("---\n") {
+        // Existing spec-style file: preserve it, patch only what's missing.
+        let Some(parsed) = crate::parser::parse_frontmatter(&normalized) else {
+            return Err(
+                "frontmatter block is present but could not be parsed — fix the YAML \
+                 frontmatter (module/version/status/files) or remove it"
+                    .to_string(),
+            );
+        };
+        let patched = patch_frontmatter(
+            &normalized,
+            &module_name,
+            &parsed.frontmatter,
+            &files_yaml,
+        );
+        (patched, parsed.body)
+    } else {
+        // Plain markdown document: wrap the content in spec frontmatter and
+        // keep the body verbatim below it.
+        let body = ensure_h1_title(&normalized, stem);
+        let fm = format!(
+            "---\nmodule: {module_name}\nversion: 1\nstatus: draft\n{files_yaml}\ndb_tables: []\ndepends_on: []\n---\n"
+        );
+        (format!("{fm}\n{body}"), body)
+    };
+
+    // Scaffold only the required sections the source doesn't already have.
+    let missing = crate::parser::get_missing_sections(&body, &config.required_sections);
+    for section in &missing {
+        spec_text.push_str(&stub_for_section(section, &import_note));
+    }
+
+    Ok(FromDirImport {
+        module_name,
+        spec_content: spec_text,
+        warnings,
+    })
+}
+
+/// Patch a spec's raw frontmatter text in place: fill in a missing `module`,
+/// `version`, `status`, and a missing/empty `files:` list. Everything else —
+/// including unknown/custom fields — is preserved verbatim.
+fn patch_frontmatter(
+    content: &str,
+    module_name: &str,
+    fm: &crate::types::Frontmatter,
+    files_yaml: &str,
+) -> String {
+    let Some(fm_end) = content.find("\n---\n") else {
+        return content.to_string();
+    };
+    let (fm_block, rest) = content.split_at(fm_end);
+    let mut fm_block = fm_block.to_string();
+
+    let mut insertions: Vec<String> = Vec::new();
+    if fm.module.is_none() {
+        insertions.push(format!("module: {module_name}"));
+    }
+    if fm.version.is_none() {
+        insertions.push("version: 1".to_string());
+    }
+    if fm.status.is_none() {
+        insertions.push("status: draft".to_string());
+    }
+
+    // Replace an empty files list (or add one when absent) with detected files.
+    let files_block_re = regex::Regex::new(
+        r"(?m)^files:\s*\[\]\s*$|^files:[ \t]*\n(?:[ \t]+-[ \t]+.+[ \t]*\n?)*",
+    )
+    .unwrap();
+    if fm.files.is_empty() {
+        if files_block_re.is_match(&fm_block) {
+            if !files_yaml.starts_with("files: []") {
+                fm_block = files_block_re
+                    .replace(&fm_block, files_yaml.trim_end())
+                    .to_string();
+            }
+        } else {
+            // No `files:` key at all — add one explicitly (empty or detected).
+            insertions.push(files_yaml.to_string());
+        }
+    }
+
+    if !insertions.is_empty() {
+        if !fm_block.ends_with('\n') {
+            fm_block.push('\n');
+        }
+        fm_block.push_str(&insertions.join("\n"));
+        fm_block.push('\n');
+        // trim_end keeps the block newline-normalized before the closing `---`
+        fm_block = format!("{}\n", fm_block.trim_end());
+    }
+
+    format!("{fm_block}{rest}")
+}
+
+/// Ensure the document body has an H1 title; derive one from the file stem if not.
+fn ensure_h1_title(body: &str, stem: &str) -> String {
+    if body.lines().any(|l| l.starts_with("# ")) {
+        return body.to_string();
+    }
+    let title = stem
+        .split(['-', '_'])
+        .filter(|w| !w.is_empty())
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("# {title}\n\n{body}")
+}
+
+/// Scaffold content for one missing required section.
+fn stub_for_section(section: &str, import_note: &str) -> String {
+    match section {
+        "Purpose" => "\n## Purpose\n\nDocument this module's responsibility, inputs, outputs, and ownership boundaries.\n".to_string(),
+        "Public API" => "\n## Public API\n\n| Export | Description |\n|--------|-------------|\n".to_string(),
+        "Invariants" => "\n## Invariants\n\n1. Define an invariant that must remain true for supported inputs.\n".to_string(),
+        "Behavioral Examples" => "\n## Behavioral Examples\n\n### Scenario: Core behavior\n\n- **Given** precondition\n- **When** action\n- **Then** result\n".to_string(),
+        "Error Cases" => "\n## Error Cases\n\n| Condition | Behavior |\n|-----------|----------|\n".to_string(),
+        "Dependencies" => "\n## Dependencies\n\nList runtime dependencies and the specific symbols, services, or data they provide.\n".to_string(),
+        "Change Log" => format!(
+            "\n## Change Log\n\n| Date | Change |\n|------|--------|\n| {} | {import_note} |\n",
+            import_today()
+        ),
+        other => format!("\n## {other}\n\nTODO: document {other}.\n"),
+    }
+}
+
+/// Today's date as YYYY-MM-DD (no chrono dependency).
+fn import_today() -> String {
+    let output = std::process::Command::new("date")
+        .args(["+%Y-%m-%d"])
+        .output();
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => "YYYY-MM-DD".to_string(),
+    }
+}
 /// Collect all .md files in a directory (one level deep).
 fn collect_markdown_files(dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
@@ -397,38 +623,6 @@ fn collect_markdown_files(dir: &Path) -> Vec<PathBuf> {
     files
 }
 
-/// Parse a markdown file into an ImportedItem for spec generation.
-fn parse_markdown_as_import_item(filename: &str, content: &str) -> importer::ImportedItem {
-    // Extract title from first H1 heading, fall back to filename
-    let title = content
-        .lines()
-        .find(|l| l.starts_with("# "))
-        .map(|l| l.trim_start_matches("# ").trim().to_string())
-        .unwrap_or_else(|| filename.to_string());
-
-    // Purpose: first non-empty paragraph after the title (or the title itself)
-    let purpose = content
-        .lines()
-        .skip_while(|l| l.starts_with("# ") || l.trim().is_empty())
-        .find(|l| !l.trim().is_empty())
-        .unwrap_or(&title)
-        .trim()
-        .to_string();
-
-    let requirements = importer::extract_requirements_pub(content);
-    let module_name = importer::slugify(filename);
-
-    importer::ImportedItem {
-        module_name,
-        purpose,
-        requirements,
-        labels: Vec::new(),
-        source_url: String::new(),
-        issue_number: None,
-        source_type: importer::ImportSource::Confluence, // closest semantic match for "doc"
-    }
-}
-
 fn print_batch_summary(operation: &str, stats: &BatchStats) {
     let total = stats.imported + stats.skipped + stats.errors;
     println!(
@@ -449,5 +643,88 @@ fn print_batch_summary(operation: &str, stats: &BatchStats) {
             "Tip:".cyan().bold(),
             "specsync check".bold()
         );
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> crate::types::SpecSyncConfig {
+        crate::types::SpecSyncConfig::default()
+    }
+
+    #[test]
+    fn from_dir_preserves_existing_spec_content() {
+        // #416: import must not discard frontmatter/sections/API tables.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/auth.rs"), "pub fn login() {}\n").unwrap();
+
+        let source = "---\nmodule: auth\nversion: 3\nstatus: active\nfiles:\n  - src/auth.rs\ndb_tables: []\ndepends_on: []\ncustom_field: keepme\n---\n\n# Auth\n\n## Purpose\n\nHandles login sessions and token refresh.\n\n## Change Log\n\n| Date | Change |\n|------|--------|\n| 2024-01-01 | Real history |\n";
+        let import = build_imported_spec(root, &test_config(), "auth", "docs/auth.md", source)
+            .expect("parseable spec imports");
+
+        // Original content preserved verbatim.
+        assert!(import.spec_content.contains("version: 3"));
+        assert!(import.spec_content.contains("status: active"));
+        assert!(import.spec_content.contains("custom_field: keepme"));
+        assert!(import.spec_content.contains("Handles login sessions and token refresh."));
+        assert!(import.spec_content.contains("2024-01-01 | Real history"));
+        // No wrong attribution.
+        assert!(!import.spec_content.contains("Confluence"));
+        // Missing required sections scaffolded.
+        assert!(import.spec_content.contains("## Invariants"));
+        assert!(import.spec_content.contains("## Error Cases"));
+    }
+
+    #[test]
+    fn from_dir_wraps_plain_markdown_without_losing_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let doc = "# Billing\n\nBilling handles invoices and payments.\n";
+        let import = build_imported_spec(root, &test_config(), "billing", "docs/billing.md", doc)
+            .expect("plain markdown imports");
+        assert!(import.spec_content.contains("module: billing"));
+        assert!(import.spec_content.contains("Billing handles invoices and payments."));
+        assert!(import.spec_content.contains("## Purpose"));
+        assert!(import.spec_content.contains("Imported from docs/billing.md"));
+        assert!(!import.spec_content.contains("Confluence"));
+    }
+
+    #[test]
+    fn from_dir_detects_source_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src/billing")).unwrap();
+        std::fs::write(root.join("src/billing/mod.rs"), "pub fn invoice() {}\n").unwrap();
+        let import = build_imported_spec(root, &test_config(), "billing", "docs/billing.md", "# Billing\n")
+            .unwrap();
+        assert!(import.spec_content.contains("- src/billing/mod.rs"), "{}", import.spec_content);
+        assert!(import.warnings.is_empty());
+    }
+
+    #[test]
+    fn from_dir_fails_loudly_on_unparseable_input() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Empty file
+        assert!(build_imported_spec(root, &test_config(), "x", "x.md", "  \n").is_err());
+        // Broken frontmatter (opening --- with no closing)
+        assert!(
+            build_imported_spec(root, &test_config(), "x", "x.md", "---\nmodule: x\nno closing\n")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn from_dir_strips_spec_suffix_from_stem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let import = build_imported_spec(root, &test_config(), "auth", "docs/auth.spec.md", "# Auth\n")
+            .unwrap();
+        assert_eq!(import.module_name, "auth");
     }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,4 +1,5 @@
 use colored::Colorize;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
@@ -371,9 +372,6 @@ fn cmd_import_from_dir(root: &Path, dir: &Path) {
             Ok(_) => {
                 let rel = spec_file.strip_prefix(root).unwrap_or(&spec_file).display();
                 println!("{} → {}", "✓".green(), rel);
-                for warning in &import.warnings {
-                    println!("    {} {warning}", "⚠".yellow());
-                }
                 generator::generate_companion_files_for_spec(
                     &spec_dir,
                     &import.module_name,
@@ -398,7 +396,6 @@ fn cmd_import_from_dir(root: &Path, dir: &Path) {
 struct FromDirImport {
     module_name: String,
     spec_content: String,
-    warnings: Vec<String>,
 }
 
 /// Convert a markdown file into spec content, preserving everything parseable:
@@ -415,15 +412,35 @@ fn build_imported_spec(
     file_display: &str,
     content: &str,
 ) -> Result<FromDirImport, String> {
-    let module_name = importer::slugify(stem);
-    if module_name.is_empty() {
-        return Err(format!("could not derive a module name from '{stem}'"));
-    }
     if content.trim().is_empty() {
         return Err("file is empty — nothing to import".to_string());
     }
 
+    // Parse through a normalized copy, but retain the original bytes so a
+    // complete valid spec can be imported byte-for-byte.
     let normalized = content.trim_start_matches('\u{feff}').replace("\r\n", "\n");
+    let existing = if normalized.starts_with("---\n") {
+        let parsed = crate::parser::parse_frontmatter(&normalized).ok_or_else(|| {
+            "frontmatter block is present but could not be parsed — fix the YAML \
+             frontmatter (module/version/status/files) or remove it"
+                .to_string()
+        })?;
+        validate_import_frontmatter(&normalized, &parsed.frontmatter)?;
+        Some(parsed)
+    } else {
+        None
+    };
+
+    let module_name = existing
+        .as_ref()
+        .and_then(|parsed| parsed.frontmatter.module.as_deref())
+        .filter(|module| !module.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| importer::slugify(stem));
+    if module_name.is_empty() {
+        return Err(format!("could not derive a module name from '{stem}'"));
+    }
+    super::validate_module_name(&module_name)?;
 
     // Auto-detect source files so imported specs don't fail the tool's own
     // non-empty `files:` gate when the module's sources are discoverable.
@@ -441,37 +458,70 @@ fn build_imported_spec(
     {
         detected.push(single);
     }
+    if detected.is_empty() {
+        let source_path = Path::new(file_display);
+        let source_path = if source_path.is_absolute() {
+            source_path.to_path_buf()
+        } else {
+            root.join(source_path)
+        };
+        let confined_source = fs::canonicalize(&source_path)
+            .ok()
+            .zip(fs::canonicalize(root).ok())
+            .and_then(|(source, canonical_root)| {
+                source
+                    .strip_prefix(canonical_root)
+                    .ok()
+                    .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+            });
+        if let Some(relative) = confined_source {
+            // A plain design/spec document is itself a stable source artifact.
+            // This is preferable to knowingly emitting `files: []`, which
+            // fails the next strict check.
+            detected.push(relative);
+        }
+    }
     detected.sort();
 
-    let mut warnings = Vec::new();
     let files_yaml = if detected.is_empty() {
-        warnings.push(format!(
-            "no source files detected for '{module_name}' — `files:` is empty; \
-             fill it in before `specsync check` will pass"
+        return Err(format!(
+            "no project-relative source file could be associated with '{module_name}'"
         ));
-        "files: []".to_string()
     } else {
         let items: String = detected.iter().map(|f| format!("  - {f}\n")).collect();
         format!("files:\n{items}")
     };
 
-    let import_note = format!("Imported from {file_display}");
+    let import_note = format!("Imported from {}", file_display.replace('|', "\\|"));
 
-    let (mut spec_text, body) = if normalized.starts_with("---\n") {
+    let (mut spec_text, body) = if let Some(parsed) = existing {
+        let missing = crate::parser::get_missing_sections(&parsed.body, &config.required_sections);
+        let complete_frontmatter =
+            parsed
+                .frontmatter
+                .module
+                .as_deref()
+                .is_some_and(|module| !module.trim().is_empty())
+                && parsed
+                    .frontmatter
+                    .version
+                    .as_deref()
+                    .is_some_and(|version| !version.trim().is_empty())
+                && parsed.frontmatter.status.as_deref().is_some_and(|status| {
+                    crate::types::SpecStatus::from_str_loose(status).is_some()
+                })
+                && !parsed.frontmatter.files.is_empty();
+
+        if complete_frontmatter && missing.is_empty() {
+            return Ok(FromDirImport {
+                module_name,
+                spec_content: content.to_string(),
+            });
+        }
+
         // Existing spec-style file: preserve it, patch only what's missing.
-        let Some(parsed) = crate::parser::parse_frontmatter(&normalized) else {
-            return Err(
-                "frontmatter block is present but could not be parsed — fix the YAML \
-                 frontmatter (module/version/status/files) or remove it"
-                    .to_string(),
-            );
-        };
-        let patched = patch_frontmatter(
-            &normalized,
-            &module_name,
-            &parsed.frontmatter,
-            &files_yaml,
-        );
+        let patched =
+            patch_frontmatter(&normalized, &module_name, &parsed.frontmatter, &files_yaml);
         (patched, parsed.body)
     } else {
         // Plain markdown document: wrap the content in spec frontmatter and
@@ -492,8 +542,95 @@ fn build_imported_spec(
     Ok(FromDirImport {
         module_name,
         spec_content: spec_text,
-        warnings,
     })
+}
+
+/// Reject malformed known frontmatter fields before any output is created.
+///
+/// The repository parser intentionally supports a small YAML subset. This
+/// import-specific check closes the dangerous gaps in that subset: duplicate
+/// keys and scalar/list shape mismatches must not be silently converted into a
+/// second key or a default value. Unknown extension keys remain allowed.
+fn validate_import_frontmatter(
+    content: &str,
+    fm: &crate::types::Frontmatter,
+) -> Result<(), String> {
+    let Some(end) = content.find("\n---\n") else {
+        return Err("frontmatter block is missing its closing `---` delimiter".to_string());
+    };
+    let yaml = &content["---\n".len()..end];
+    let scalar_fields = ["module", "version", "status", "agent_policy"];
+    let list_fields = [
+        "files",
+        "db_tables",
+        "depends_on",
+        "implements",
+        "tracks",
+        "lifecycle_log",
+    ];
+    let mut seen = HashSet::new();
+    let mut current_known_list: Option<&str> = None;
+
+    for (index, line) in yaml.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if line.chars().next().is_some_and(char::is_whitespace) {
+            if current_known_list.is_some() && !trimmed.starts_with("- ") {
+                return Err(format!(
+                    "frontmatter line {} must be a list item",
+                    index + 2
+                ));
+            }
+            continue;
+        }
+
+        current_known_list = None;
+        let Some((key, raw_value)) = line.split_once(':') else {
+            return Err(format!(
+                "frontmatter line {} is not a `key: value` entry",
+                index + 2
+            ));
+        };
+        let key = key.trim();
+        let value = raw_value.trim();
+        if key.is_empty() || key.chars().any(char::is_whitespace) {
+            return Err(format!("frontmatter line {} has an invalid key", index + 2));
+        }
+        if !seen.insert(key.to_string()) {
+            return Err(format!("frontmatter contains duplicate key `{key}`"));
+        }
+
+        if scalar_fields.contains(&key) {
+            if value.starts_with('[') || value.starts_with('{') {
+                return Err(format!("frontmatter field `{key}` must be a scalar"));
+            }
+        } else if list_fields.contains(&key) {
+            if value.is_empty() {
+                current_known_list = Some(key);
+            } else if value != "[]" {
+                return Err(format!(
+                    "frontmatter field `{key}` must be a block list or `[]`"
+                ));
+            }
+        }
+    }
+
+    if let Some(status) = fm.status.as_deref()
+        && !status.is_empty()
+        && crate::types::SpecStatus::from_str_loose(status).is_none()
+    {
+        return Err(format!(
+            "frontmatter field `status` has invalid value `{status}`"
+        ));
+    }
+    if let Some(module) = fm.module.as_deref()
+        && !module.is_empty()
+    {
+        super::validate_module_name(module)?;
+    }
+    Ok(())
 }
 
 /// Patch a spec's raw frontmatter text in place: fill in a missing `module`,
@@ -513,20 +650,19 @@ fn patch_frontmatter(
 
     let mut insertions: Vec<String> = Vec::new();
     if fm.module.is_none() {
-        insertions.push(format!("module: {module_name}"));
+        replace_empty_scalar_or_insert(&mut fm_block, "module", module_name, &mut insertions);
     }
     if fm.version.is_none() {
-        insertions.push("version: 1".to_string());
+        replace_empty_scalar_or_insert(&mut fm_block, "version", "1", &mut insertions);
     }
     if fm.status.is_none() {
-        insertions.push("status: draft".to_string());
+        replace_empty_scalar_or_insert(&mut fm_block, "status", "draft", &mut insertions);
     }
 
     // Replace an empty files list (or add one when absent) with detected files.
-    let files_block_re = regex::Regex::new(
-        r"(?m)^files:\s*\[\]\s*$|^files:[ \t]*\n(?:[ \t]+-[ \t]+.+[ \t]*\n?)*",
-    )
-    .unwrap();
+    let files_block_re =
+        regex::Regex::new(r"(?m)^files:\s*\[\]\s*$|^files:[ \t]*\n(?:[ \t]+-[ \t]+.+[ \t]*\n?)*")
+            .unwrap();
     if fm.files.is_empty() {
         if files_block_re.is_match(&fm_block) {
             if !files_yaml.starts_with("files: []") {
@@ -551,6 +687,23 @@ fn patch_frontmatter(
     }
 
     format!("{fm_block}{rest}")
+}
+
+fn replace_empty_scalar_or_insert(
+    frontmatter: &mut String,
+    key: &str,
+    value: &str,
+    insertions: &mut Vec<String>,
+) {
+    let pattern = format!(r"(?m)^{}:[ \t]*$", regex::escape(key));
+    let empty_field = regex::Regex::new(&pattern).expect("static frontmatter field regex");
+    if empty_field.is_match(frontmatter) {
+        *frontmatter = empty_field
+            .replace(frontmatter, format!("{key}: {value}"))
+            .to_string();
+    } else {
+        insertions.push(format!("{key}: {value}"));
+    }
 }
 
 /// Ensure the document body has an H1 title; derive one from the file stem if not.
@@ -592,13 +745,27 @@ fn stub_for_section(section: &str, import_note: &str) -> String {
 
 /// Today's date as YYYY-MM-DD (no chrono dependency).
 fn import_today() -> String {
-    let output = std::process::Command::new("date")
-        .args(["+%Y-%m-%d"])
-        .output();
-    match output {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
-        _ => "YYYY-MM-DD".to_string(),
-    }
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let days = (seconds / 86_400) as i64;
+    let z = days + 719_468;
+    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
+    let day_of_era = (z - era * 146_097) as u64;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era as i64 + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = if month_prime < 10 {
+        month_prime + 3
+    } else {
+        month_prime - 9
+    };
+    let year = if month <= 2 { year + 1 } else { year };
+    format!("{year:04}-{month:02}-{day:02}")
 }
 /// Collect all .md files in a directory (one level deep).
 fn collect_markdown_files(dir: &Path) -> Vec<PathBuf> {
@@ -646,7 +813,6 @@ fn print_batch_summary(operation: &str, stats: &BatchStats) {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -657,27 +823,46 @@ mod tests {
 
     #[test]
     fn from_dir_preserves_existing_spec_content() {
-        // #416: import must not discard frontmatter/sections/API tables.
+        // #416: a complete valid spec is copied byte-for-byte and its declared
+        // module, not its filename, owns the destination path.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/auth.rs"), "pub fn login() {}\n").unwrap();
 
-        let source = "---\nmodule: auth\nversion: 3\nstatus: active\nfiles:\n  - src/auth.rs\ndb_tables: []\ndepends_on: []\ncustom_field: keepme\n---\n\n# Auth\n\n## Purpose\n\nHandles login sessions and token refresh.\n\n## Change Log\n\n| Date | Change |\n|------|--------|\n| 2024-01-01 | Real history |\n";
-        let import = build_imported_spec(root, &test_config(), "auth", "docs/auth.md", source)
-            .expect("parseable spec imports");
+        let source = "---\r\nmodule: auth\r\nversion: 3\r\nstatus: active\r\nfiles:\r\n  - src/auth.rs\r\ndb_tables: []\r\ndepends_on: []\r\ncustom_field: keepme\r\n---\r\n\r\n# Auth\r\n\r\n## Purpose\r\n\r\nHandles login sessions and token refresh.\r\n\r\n## Public API\r\n\r\n| Export | Description |\r\n|--------|-------------|\r\n| `login` | Login |\r\n\r\n## Invariants\r\n\r\n1. Tokens are checked.\r\n\r\n## Behavioral Examples\r\n\r\nExample.\r\n\r\n## Error Cases\r\n\r\nErrors.\r\n\r\n## Dependencies\r\n\r\nNone.\r\n\r\n## Change Log\r\n\r\n| Date | Change |\r\n|------|--------|\r\n| 2024-01-01 | Real history |\r\n";
+        let import =
+            build_imported_spec(root, &test_config(), "renamed", "docs/renamed.md", source)
+                .expect("parseable spec imports");
 
-        // Original content preserved verbatim.
-        assert!(import.spec_content.contains("version: 3"));
-        assert!(import.spec_content.contains("status: active"));
+        assert_eq!(import.module_name, "auth");
+        assert_eq!(import.spec_content.as_bytes(), source.as_bytes());
+    }
+
+    #[test]
+    fn from_dir_scaffolds_only_missing_sections() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/auth.rs"), "pub fn login() {}\n").unwrap();
+        let source = "---\nmodule: auth\nversion: 3\nstatus: active\nfiles:\n  - src/auth.rs\ndb_tables: []\ndepends_on: []\ncustom_field: keepme\n---\n\n# Auth\n\n## Purpose\n\nHandles login sessions and token refresh.\n\n## Public API\n\n| Function | Description |\n|----------|-------------|\n| `login` | Starts a session |\n\n## Change Log\n\n| Date | Change |\n|------|--------|\n| 2024-01-01 | Real history |\n";
+
+        let import = build_imported_spec(root, &test_config(), "auth", "docs/auth.md", source)
+            .expect("incomplete parseable spec imports");
+
         assert!(import.spec_content.contains("custom_field: keepme"));
-        assert!(import.spec_content.contains("Handles login sessions and token refresh."));
+        assert!(
+            import
+                .spec_content
+                .contains("| `login` | Starts a session |")
+        );
         assert!(import.spec_content.contains("2024-01-01 | Real history"));
-        // No wrong attribution.
-        assert!(!import.spec_content.contains("Confluence"));
-        // Missing required sections scaffolded.
         assert!(import.spec_content.contains("## Invariants"));
         assert!(import.spec_content.contains("## Error Cases"));
+        assert_eq!(import.spec_content.matches("## Purpose").count(), 1);
+        assert_eq!(import.spec_content.matches("## Public API").count(), 1);
+        assert_eq!(import.spec_content.matches("## Change Log").count(), 1);
+        assert!(!import.spec_content.contains("Confluence"));
     }
 
     #[test]
@@ -685,12 +870,23 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         let doc = "# Billing\n\nBilling handles invoices and payments.\n";
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        std::fs::write(root.join("docs/billing.md"), doc).unwrap();
         let import = build_imported_spec(root, &test_config(), "billing", "docs/billing.md", doc)
             .expect("plain markdown imports");
         assert!(import.spec_content.contains("module: billing"));
-        assert!(import.spec_content.contains("Billing handles invoices and payments."));
+        assert!(import.spec_content.contains("  - docs/billing.md"));
+        assert!(
+            import
+                .spec_content
+                .contains("Billing handles invoices and payments.")
+        );
         assert!(import.spec_content.contains("## Purpose"));
-        assert!(import.spec_content.contains("Imported from docs/billing.md"));
+        assert!(
+            import
+                .spec_content
+                .contains("Imported from docs/billing.md")
+        );
         assert!(!import.spec_content.contains("Confluence"));
     }
 
@@ -700,10 +896,19 @@ mod tests {
         let root = tmp.path();
         std::fs::create_dir_all(root.join("src/billing")).unwrap();
         std::fs::write(root.join("src/billing/mod.rs"), "pub fn invoice() {}\n").unwrap();
-        let import = build_imported_spec(root, &test_config(), "billing", "docs/billing.md", "# Billing\n")
-            .unwrap();
-        assert!(import.spec_content.contains("- src/billing/mod.rs"), "{}", import.spec_content);
-        assert!(import.warnings.is_empty());
+        let import = build_imported_spec(
+            root,
+            &test_config(),
+            "billing",
+            "docs/billing.md",
+            "# Billing\n",
+        )
+        .unwrap();
+        assert!(
+            import.spec_content.contains("- src/billing/mod.rs"),
+            "{}",
+            import.spec_content
+        );
     }
 
     #[test]
@@ -714,17 +919,100 @@ mod tests {
         assert!(build_imported_spec(root, &test_config(), "x", "x.md", "  \n").is_err());
         // Broken frontmatter (opening --- with no closing)
         assert!(
-            build_imported_spec(root, &test_config(), "x", "x.md", "---\nmodule: x\nno closing\n")
-                .is_err()
+            build_imported_spec(
+                root,
+                &test_config(),
+                "x",
+                "x.md",
+                "---\nmodule: x\nno closing\n"
+            )
+            .is_err()
         );
+        // Duplicate and wrongly shaped known fields must not be defaulted or
+        // patched into apparently successful output.
+        assert!(
+            build_imported_spec(
+                root,
+                &test_config(),
+                "x",
+                "x.md",
+                "---\nmodule: x\nmodule: y\nversion: 1\nstatus: draft\nfiles: []\n---\n# X\n"
+            )
+            .is_err()
+        );
+        assert!(
+            build_imported_spec(
+                root,
+                &test_config(),
+                "x",
+                "x.md",
+                "---\nmodule: [x]\nversion: 1\nstatus: draft\nfiles: nope\n---\n# X\n"
+            )
+            .is_err()
+        );
+
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("outside.md");
+        std::fs::write(&outside_file, "# Outside\n").unwrap();
+        assert!(
+            build_imported_spec(
+                root,
+                &test_config(),
+                "outside",
+                &outside_file.to_string_lossy(),
+                "# Outside\n"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn from_dir_patches_empty_frontmatter_fields_without_duplicates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        std::fs::write(root.join("docs/auth.md"), "# Auth\n").unwrap();
+        let source =
+            "---\nmodule:\nversion:\nstatus:\nfiles: []\n---\n\n# Auth\n\n## Purpose\n\nAuth.\n";
+
+        let import = build_imported_spec(root, &test_config(), "auth", "docs/auth.md", source)
+            .expect("empty known fields are repairable");
+        assert_eq!(import.spec_content.matches("module:").count(), 1);
+        assert_eq!(import.spec_content.matches("version:").count(), 1);
+        assert_eq!(import.spec_content.matches("status:").count(), 1);
+        assert_eq!(import.spec_content.matches("files:").count(), 1);
+        assert!(import.spec_content.contains("module: auth"));
+        assert!(import.spec_content.contains("version: 1"));
+        assert!(import.spec_content.contains("status: draft"));
+        assert!(import.spec_content.contains("  - docs/auth.md"));
     }
 
     #[test]
     fn from_dir_strips_spec_suffix_from_stem() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        let import = build_imported_spec(root, &test_config(), "auth", "docs/auth.spec.md", "# Auth\n")
-            .unwrap();
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+        std::fs::write(root.join("docs/auth.spec.md"), "# Auth\n").unwrap();
+        let import = build_imported_spec(
+            root,
+            &test_config(),
+            "auth",
+            "docs/auth.spec.md",
+            "# Auth\n",
+        )
+        .unwrap();
         assert_eq!(import.module_name, "auth");
+    }
+
+    #[test]
+    fn import_date_is_portable_iso_date() {
+        let date = import_today();
+        assert_eq!(date.len(), 10);
+        assert_eq!(&date[4..5], "-");
+        assert_eq!(&date[7..8], "-");
+        assert!(date.chars().enumerate().all(|(index, character)| {
+            matches!(index, 4 | 7) && character == '-'
+                || !matches!(index, 4 | 7) && character.is_ascii_digit()
+        }));
     }
 }

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -549,12 +549,6 @@ fn strip_html_tags(html: &str) -> String {
 
 // ─── Shared Helpers ────────────────────────────────────────────────────
 
-/// Extract requirement-like bullets from a body of text.
-/// Looks for markdown checkboxes, numbered lists, "Acceptance Criteria" sections, etc.
-pub fn extract_requirements_pub(body: &str) -> Vec<String> {
-    extract_requirements(body)
-}
-
 fn extract_requirements(body: &str) -> Vec<String> {
     let mut reqs = Vec::new();
     let mut in_criteria_section = false;

--- a/tests/integration/languages.rs
+++ b/tests/integration/languages.rs
@@ -387,6 +387,91 @@ fn import_from_dir_imports_markdown_files() {
         .success()
         .stdout(predicate::str::contains("Batch Import"))
         .stdout(predicate::str::contains("1 imported").or(predicate::str::contains("imported")));
+
+    let imported = fs::read_to_string(root.join("specs/my-feature/my-feature.spec.md")).unwrap();
+    assert!(imported.contains("  - docs/my-feature.md"), "{imported}");
+    assert!(
+        imported.contains("Imported from docs/my-feature.md"),
+        "{imported}"
+    );
+    assert!(!imported.contains("Confluence"), "{imported}");
+
+    specsync()
+        .args(["check", "--root"])
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("All source files exist"))
+        .stdout(predicate::str::contains("Frontmatter missing required field: files").not());
+}
+
+#[test]
+fn import_from_dir_preserves_complete_spec_bytes_and_declared_module() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("docs")).unwrap();
+
+    let source = valid_spec("auth", &["docs/renamed.spec.md"]).replace('\n', "\r\n");
+    fs::write(root.join("docs/renamed.spec.md"), source.as_bytes()).unwrap();
+
+    specsync()
+        .args(["import", "--from-dir", "docs", "--root"])
+        .arg(&root)
+        .assert()
+        .success();
+
+    let output = fs::read(root.join("specs/auth/auth.spec.md")).unwrap();
+    assert_eq!(output, source.as_bytes());
+    assert!(!root.join("specs/renamed/renamed.spec.md").exists());
+}
+
+#[test]
+fn import_from_dir_rejects_malformed_frontmatter_without_output() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write_config(&root, "specs", &["src"]);
+    fs::create_dir_all(root.join("docs")).unwrap();
+    fs::write(
+        root.join("docs/duplicate.md"),
+        "---\nmodule: duplicate\nmodule: second\nversion: 1\nstatus: draft\nfiles: []\n---\n# Duplicate\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("docs/wrong-shape.md"),
+        "---\nmodule: wrong-shape\nversion: 1\nstatus: draft\nfiles: src/lib.rs\n---\n# Wrong shape\n",
+    )
+    .unwrap();
+
+    specsync()
+        .args(["import", "--from-dir", "docs", "--root"])
+        .arg(&root)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("duplicate key `module`"))
+        .stdout(predicate::str::contains(
+            "field `files` must be a block list or `[]`",
+        ));
+
+    assert!(!root.join("specs/duplicate").exists());
+    assert!(!root.join("specs/wrong-shape").exists());
+}
+
+#[test]
+fn import_github_repo_error_points_to_current_config() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write_config(&root, "specs", &["src"]);
+
+    specsync()
+        .args(["import", "github", "416", "--root"])
+        .arg(&root)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`repo` under `[github]` in .specsync/config.toml",
+        ))
+        .stderr(predicate::str::contains("github.repo in specsync.json").not());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`specsync import --from-dir docs/` replaced every markdown file with a Confluence-shaped skeleton: frontmatter, body sections, API tables, and changelogs were silently discarded while the command printed `✓` for each file. Imported specs were written with `files: []` (failing the tool's own non-empty-files gate on the next `check`), the Change Log was stamped `Imported from Confluence:` regardless of source, and the GitHub error message pointed at `specsync.json`, a file the tool never reads (the working key is `[github] repo` in `.specsync/config.toml`).

**Before** (v5.2.0): a real spec `docs/auth.md` (module auth, version 2, Purpose + Change Log) imported via `--from-dir` came out as a generic skeleton: `version: 1`, Purpose = `Add user authentication`-style boilerplate, Change Log = `Imported from Confluence: docs/auth.md`, original sections gone — and `✓` printed.

**After**: the same file imports with `version: 2`, original Purpose text and the `2024-01-01 | Real history` changelog row preserved verbatim, missing required sections (Invariants, Error Cases, …) scaffolded underneath, and no `Confluence` stamp.

## Root cause

`cmd_import_from_dir` ran every file through `parse_markdown_as_import_item`, which merely *guessed* a purpose line and fed the Confluence-shaped `importer::render_spec` skeleton, throwing the source content away and hard-stamping `Imported from {source_type}`.

## Fix

- Parse the source file instead: files with spec frontmatter are kept verbatim (including unknown/custom frontmatter fields), patched only where `module`/`version`/`status` are missing or `files:` is empty; plain markdown is wrapped in frontmatter with its body preserved below.
- Source files are auto-detected (`find_files_for_module` + single-source fallback, root-relative) so imported specs pass the non-empty `files:` gate; when nothing is detected a loud warning is printed instead of a quiet `✓`.
- Only missing required sections are scaffolded; the Change Log is stamped `Imported from <path>`.
- Unparseable input (empty file, broken frontmatter) fails loudly per file and exits nonzero — no more silent `✓`.
- GitHub repo error message now names the real config location.

## Tests

`from_dir_preserves_existing_spec_content`, `from_dir_wraps_plain_markdown_without_losing_content`, `from_dir_detects_source_files`, `from_dir_fails_loudly_on_unparseable_input`, `from_dir_strips_spec_suffix_from_stem` — full suite green (1736 passed; the single failure is the pre-existing root-only `change::tests::non_git_walk_skips_volatile_trees_but_fails_on_relevant_walk_errors`), `cargo clippy -- -D warnings` green.

Closes #416