### PR TITLE
fix: frontmatter parsing leniency enables validation bypass (closes #436)

### DIFF
--- a/specs/cmd_resolve/cmd_resolve.spec.md
+++ b/specs/cmd_resolve/cmd_resolve.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_resolve
-version: 3
+version: 4
 status: stable
 files:
   - src/commands/resolve.rs
@@ -30,7 +30,7 @@ Implements the `specsync resolve` command. Resolves dependency references — lo
 ## Invariants
 
 1. Classifies deps as local vs cross-project
-2. Local verified by file existence
+2. Local references use `validate_local_dependency`: bare modules resolve to canonical spec files and absolute/traversal/backslash/symlink escapes are rejected without host-filesystem probing
 3. No network calls without `--remote` or `--verify`
 4. `--verify` implies `--remote` — registry check always runs first
 5. Warnings for unresolvable refs (does not exit non-zero)
@@ -88,7 +88,7 @@ Implements the `specsync resolve` command. Resolves dependency references — lo
 
 | Condition | Behavior |
 |-----------|----------|
-| Local dep missing | Warning printed |
+| Local dep missing or unconfined | Shared dependency failure printed with the offending entry |
 | Remote registry fetch fails | Warning, continues |
 | Remote spec fetch fails | Warning, continues |
 | Remote spec unparseable | Warning, continues |
@@ -118,6 +118,7 @@ Implements the `specsync resolve` command. Resolves dependency references — lo
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | v4: use the same confined local-dependency verdict as check and deps, including malformed remote lookalikes |
 | 2026-04-10 | v2: Added `--verify` for deep content verification, `--cache-ttl`, drift detection, exit codes |
 | 2026-04-09 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/cmd_resolve/context.md
+++ b/specs/cmd_resolve/context.md
@@ -9,6 +9,7 @@ spec: cmd_resolve.spec.md
 - **Drift vs warning**: deprecated/removed/archived status and missing consumed exports are breaking `DRIFT` (exit 1); non-bidirectional deps, fetch failures, and parse failures are non-fatal `WARN`.
 - **Cache to avoid re-fetching**: remote spec bodies are cached on disk under `.specsync-cache/remote-specs/` with a TTL (default 3600s); repo/path slashes are sanitized into the cache filename. TTL 0 disables caching.
 - **Consumed-export discovery is table-driven**: `find_consumed_exports` scans the local spec's `### Consumes` table for rows whose module column matches the remote module, extracting backtick-wrapped identifiers.
+- **Shared local verdict**: local and malformed-remote-lookalike entries call `validate_local_dependency`; resolve never performs an unconstrained `root.join(dep).exists()` probe.
 
 ## Files to Read First
 

--- a/specs/cmd_resolve/requirements.md
+++ b/specs/cmd_resolve/requirements.md
@@ -12,8 +12,9 @@ spec: cmd_resolve.spec.md
 
 ## Acceptance Criteria
 
-- `cmd_resolve(root, remote, verify, cache_ttl)` scans every spec's `depends_on`, classifying each ref as local (path) or cross-project (`owner/repo@module`).
-- With no flags, local refs are checked by file existence and cross-project refs are listed only — **no network calls** are made.
+- `cmd_resolve(root, remote, verify, cache_ttl)` scans every spec's `depends_on`, classifying only exact `owner/repo@module` shapes as cross-project and treating every other entry as local.
+- Local refs use `validate_local_dependency`, so bare modules resolve to canonical spec files and missing, absolute, traversal, backslash, malformed-remote, and symlink-escape entries match check/deps diagnostics without probing outside the project.
+- With no flags, local refs receive the shared confined verdict and cross-project refs are listed only — **no network calls** are made.
 - At the CLI, `--verify` implies `--remote` (`main.rs` passes `remote || verify`); registry-level checks always run before deep verification.
 - `--remote` fetches each repo's registry once (de-duplicated per repo) and reports per ref: module present, module not in registry, registry fetch failed, or no registry.
 - `--verify` deep-checks remote specs and reports: `DRIFT` for deprecated/removed/archived remote status, `DRIFT` for a consumed export missing from the remote spec, and `WARN` for non-bidirectional deps, fetch failures, and parse failures.
@@ -38,11 +39,10 @@ spec: cmd_resolve.spec.md
 The resolve command SHALL list and optionally verify cross-project references without performing network access unless explicitly requested.
 
 Acceptance Criteria
-- `cmd_resolve(root, remote, verify, cache_ttl)` scans every spec's `depends_on`, classifying each ref as local (path) or cross-project (`owner/repo@module`).
-- With no flags, local refs are checked by file existence and cross-project refs are listed only — **no network calls** are made.
+- `cmd_resolve(root, remote, verify, cache_ttl)` classifies only exact `owner/repo@module` shapes as cross-project and treats every other entry as local.
+- With no flags, local refs receive `validate_local_dependency`'s confined canonical-spec verdict and cross-project refs are listed only — **no network calls** are made.
 - At the CLI, `--verify` implies `--remote` (`main.rs` passes `remote || verify`); registry-level checks always run before deep verification.
 - `--remote` fetches each repo's registry once (de-duplicated per repo) and reports per ref: module present, module not in registry, registry fetch failed, or no registry.
 - `--verify` deep-checks remote specs and reports: `DRIFT` for deprecated/removed/archived remote status, `DRIFT` for a consumed export missing from the remote spec, and `WARN` for non-bidirectional deps, fetch failures, and parse failures.
 - The command exits 1 only on breaking drift (deprecated status or missing export); warnings alone exit 0. Unresolvable/local-missing refs are warnings.
 - Remote spec content is cached under `.specsync-cache/remote-specs/` with the given TTL (default 3600s); cache filenames sanitize `/` in repo and path to `_`.
-

--- a/specs/cmd_resolve/tasks.md
+++ b/specs/cmd_resolve/tasks.md
@@ -16,6 +16,8 @@ spec: cmd_resolve.spec.md
 - [x] Exit 1 on breaking drift; warnings exit 0
 - [x] File-based remote-spec cache with TTL (`SpecCache`) and slash sanitization
 - [x] Unit tests for cache roundtrip/miss/expired, path sanitization, `### Consumes` parsing, and deprecated-status detection
+- [x] Share confined local dependency resolution with check and deps
+- [x] Reject malformed remote lookalikes instead of skipping them as external
 
 ## Gaps
 

--- a/specs/cmd_resolve/testing.md
+++ b/specs/cmd_resolve/testing.md
@@ -7,6 +7,7 @@ spec: cmd_resolve.spec.md
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
 | `src/commands/resolve.rs` | cargo test commands::resolve:: | `test_find_consumed_exports_parses_table`, `test_find_consumed_exports_skips_header_row`, `test_spec_cache_roundtrip`, `test_spec_cache_miss`, `test_spec_cache_expired`, `test_cache_path_sanitizes_slashes`, `test_verify_detects_deprecated_status` |
+| `tests/integration.rs` | `fledge run test -- --test integration commands::check_deps_and_resolve_share_confined_dependency_verdicts` | Resolve reports the same missing and confinement failures as check/deps |
 
 > These are helper-level unit tests (`find_consumed_exports`, `SpecCache`, `RemoteSpec` status). The `cmd_resolve` / `verify_remote_specs` network orchestration has no automated coverage yet — verify Behavioral Verification rows manually.
 

--- a/specs/deps/context.md
+++ b/specs/deps/context.md
@@ -8,8 +8,9 @@ spec: deps.spec.md
 - **DFS coloring for cycles**: `detect_cycles` uses White/Gray/Black coloring; a back-edge to a Gray node yields a reported chain. All cycles are collected, not just the first.
 - **Regex import extraction**: `extract_imports` uses cached `LazyLock<Regex>` patterns per language (Rust `use`/`mod`, TS `import`/`require`, Python `import`/`from .`). It is best-effort, not a real parser.
 - **Conservative warnings**: undeclared-import warnings only fire when the imported name is a known spec module, isn't already declared, and isn't the module itself — keeping false positives low.
-- **Silent skips**: unreadable source files and unparseable frontmatter are skipped, so validation always returns a populated `DepsReport` instead of erroring out.
-- **Cross-project refs skipped**: refs matching `is_cross_project_ref` are dropped before validation so external links aren't reported as missing.
+- **Fail-loud inputs**: unreadable specs/sources and checked-frontmatter errors are retained in `DepsReport.errors`; malformed graph inputs cannot disappear through a silent skip.
+- **Cross-project refs skipped**: only exact `owner/repo@module` refs are dropped before local validation so path-like lookalikes cannot bypass confinement.
+- **Shared local verdict**: every local declaration calls `validate_local_dependency`, while module extraction keeps enough edge identity to report missing targets consistently.
 
 ## Key Files
 

--- a/specs/deps/deps.spec.md
+++ b/specs/deps/deps.spec.md
@@ -1,6 +1,6 @@
 ---
 module: deps
-version: 4
+version: 5
 status: stable
 files:
   - src/deps.rs
@@ -42,10 +42,11 @@ Cross-module dependency validation. Parses `depends_on` declarations from spec f
 1. Import extraction uses language-specific regex: Rust (`use crate::`, `mod`), TypeScript (`import from`, `require`), Python (`import`, `from .module`)
 2. Circular dependency detection traverses the full graph — reports all cycles, not just the first
 3. `topological_sort` returns `None` when cycles are present — does not partial-sort
-4. Cross-project refs (containing `/`) in `depends_on` are skipped — only local deps are validated
+4. Only valid `owner/repo@module` cross-project refs are skipped; malformed lookalikes remain local and receive the shared confined verdict
 5. Undeclared imports (found in source but not in `depends_on`) are reported as warnings, not errors
 6. Module names in `depends_on` paths are extracted from the path's directory component
 7. A spec or declared source file that exists but cannot be read as UTF-8 is a hard error (not a silent skip): an unreadable spec would otherwise be dropped from the graph — defeating cycle and missing-dependency detection for that module — and an unreadable source would contribute no imports, hiding undeclared-import violations. Both are recorded in `report.errors`, so `cmd_deps` exits 1 rather than under-validating silently
+8. Every local `depends_on` entry is passed through `validate_local_dependency` before graph insertion, so flow-list edges, missing targets, absolute/traversal inputs, and symlink escapes receive the same verdict as check and resolve
 
 ## Behavioral Examples
 
@@ -96,6 +97,7 @@ Cross-module dependency validation. Parses `depends_on` declarations from spec f
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | v5: parse flow-style dependency edges and apply the shared confined local-dependency verdict without silently dropping invalid nodes |
 | 2026-07-06 | Documented fail-loud behavior for unreadable declared source and spec files: added invariant 7 and updated Error Cases table so an existing-but-non-UTF-8 file is a hard error gating `cmd_deps` rather than a silent skip |
 | 2026-04-10 | Populated requirements.md with user stories, acceptance criteria, constraints, and out-of-scope items |
 | 2026-04-07 | Initial spec |

--- a/specs/deps/requirements.md
+++ b/specs/deps/requirements.md
@@ -19,11 +19,13 @@ spec: deps.spec.md
 - `extract_imports` extracts imported module names for Rust (`use`/`mod`), TypeScript/JavaScript (`import ... from`/`require`), and Python (`import`/`from .`); unsupported languages return an empty set
 - `check_undeclared_imports` warns only when a source import matches a known spec module, is not already declared, and is not the module's own name (self-imports are never flagged)
 - `topological_sort` returns a deterministic order for a DAG and `None` when the graph contains a cycle
+- Flow-style `depends_on: [module]` declarations contribute real graph edges.
+- Every local declaration uses the validator's confined dependency verdict; malformed remote lookalikes, missing specs, traversal, absolute paths, and symlink escapes are errors rather than silently dropped edges.
 
 ## Constraints
 
 - Import extraction is regex-based (`LazyLock<Regex>`), best-effort, and does not run a real parser
-- Unreadable source files and unparseable spec frontmatter are skipped silently, not treated as errors
+- Unreadable source/spec files and checked-frontmatter errors are retained as hard graph-validation errors
 - Only Rust, TypeScript, and Python imports are analyzed; other languages contribute no import edges
 - Must not panic on malformed input — returns a populated `DepsReport` regardless
 
@@ -50,4 +52,5 @@ Acceptance Criteria
   `src/<module>/mod.rs` before undeclared-edge comparison.
 - `check_undeclared_imports` warns only when a source import matches a known spec module, is not already declared, and is not the module's own name (self-imports are never flagged)
 - `topological_sort` returns a deterministic order for a DAG and `None` when the graph contains a cycle
-
+- Flow-style `depends_on: [module]` declarations contribute real graph edges.
+- Every local declaration uses the validator's confined dependency verdict; malformed remote lookalikes, missing specs, traversal, absolute paths, and symlink escapes are errors rather than silently dropped edges.

--- a/specs/deps/tasks.md
+++ b/specs/deps/tasks.md
@@ -21,6 +21,9 @@ spec: deps.spec.md
 - [x] Skip cross-project refs during local validation
 - [x] Inline unit tests for graph build, validation, cycles, import extraction, and topo sort
 - [x] Populate requirements.md with user stories and acceptance criteria (2026-04-10)
+- [x] Count flow-style dependency declarations as graph edges
+- [x] Share confined missing/escape/symlink verdicts with check and resolve
+- [x] Fail loud on unreadable specs and declared source files
 
 ## Open
 

--- a/specs/deps/testing.md
+++ b/specs/deps/testing.md
@@ -7,6 +7,9 @@ spec: deps.spec.md
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
 | `src/deps.rs` | cargo test deps:: | `test_extract_module_from_dep_path`, `test_build_dep_graph_empty`, `test_build_dep_graph_basic`, `test_validate_no_errors`, `test_validate_missing_dep`, `test_detect_circular_deps` |
+| `src/deps.rs` | `fledge run test -- deps::tests::test_flow_style_depends_on_counts_edges` | Flow-style declarations create edges |
+| `src/deps.rs` | `fledge run test -- deps::tests::test_deps_rejects_escapes_and_missing_with_same_verdict_as_check` | Missing and confined-path diagnostics match check |
+| `tests/integration.rs` | `fledge run test -- --test integration commands::check_deps_and_resolve_share_confined_dependency_verdicts` | Check/deps/resolve report identical local failures |
 
 ## Coverage Gaps
 
@@ -24,8 +27,8 @@ spec: deps.spec.md
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Source file unreadable | Skipped during import extraction | Keep or add a focused assertion before changing this behavior |
-| Spec frontmatter unparseable | Module excluded from dependency graph | Keep or add a focused assertion before changing this behavior |
+| Source file unreadable | Hard error in `DepsReport` | Keep the unreadable-source CLI regression |
+| Spec frontmatter unparseable | Hard error in `DepsReport` | Keep the unreadable/malformed-spec regression |
 | No specs found in specs_dir | Returns empty graph and clean DepsReport | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist

--- a/specs/parser/context.md
+++ b/specs/parser/context.md
@@ -9,6 +9,7 @@ spec: parser.spec.md
 - **Sub-table skipping**: `####` headings containing `Methods`, `Constructor`, or `Properties` inside the Public API section are skipped when extracting symbols to avoid double-counting members of a documented type. In addition, `###` subsections that are not export headers (e.g. `### API Endpoints`, `### Route Handlers`, `### Configuration`) are skipped via an `is_export_header` allowlist.
 - **Deduplication with order preservation**: Extracted symbols are deduplicated while maintaining their order of appearance in the spec.
 - **Case-sensitive section matching**: Required section names are matched exactly (e.g., `## Public API` won't match `## public api`), enforcing consistent spec formatting.
+- **Checked subset parsing**: The zero-dependency parser still accepts only the documented flat subset, but `ParsedSpec.errors`/`warnings` preserve duplicate keys, invalid list shapes, suspicious versions, and malformed lines instead of silently dropping them.
 
 ## Files to Read First
 
@@ -22,3 +23,4 @@ Fully implemented. The parser is the most heavily depended-on module after types
 
 - The `parse_frontmatter()` function returns both the parsed `Frontmatter` struct and the body text (everything after the closing `---`). This avoids re-reading the file for section analysis.
 - Frontmatter fields like `files`, `db_tables`, and `depends_on` support both inline array syntax (`[a, b]`) and multi-line YAML list syntax (`- a\n- b`).
+- Duplicate keys remain diagnosable even though parsing continues to accumulate other findings; validator failure is therefore independent of which duplicate value appeared last.

--- a/specs/parser/parser.spec.md
+++ b/specs/parser/parser.spec.md
@@ -1,6 +1,6 @@
 ---
 module: parser
-version: 5
+version: 6
 status: stable
 files:
   - src/parser.rs
@@ -23,7 +23,7 @@ Parses spec markdown files — extracts YAML frontmatter into structured data, e
 
 | Type | Description |
 |------|-------------|
-| `ParsedSpec` | Parsed spec file containing `frontmatter: Frontmatter` and `body: String` |
+| `ParsedSpec` | Parsed spec file containing frontmatter/body plus accumulated hard `errors` and soft `warnings` for duplicate, type, shape, and malformed-line diagnostics |
 
 **Exported Functions**
 
@@ -50,6 +50,10 @@ Parses spec markdown files — extracts YAML frontmatter into structured data, e
 8. `get_near_miss_sections` only reports sections that are already in `get_missing_sections` — it does not flag sections that are present but close to another required name
 6. Frontmatter parsing handles both scalar fields (module, version, status) and list fields (files, db_tables, depends_on)
 7. Empty list syntax `[]` is handled correctly, producing an empty Vec
+9. Duplicate keys and malformed list shapes are retained as hard diagnostics; they never disappear through last-value-wins parsing
+10. Flow-style string lists are parsed, including the `depends_on: [module]` form emitted by scaffolding
+11. Non-numeric versions, scalar list fields, and colon-less garbage lines are retained as warnings with offending input
+12. A leading UTF-8 BOM is tolerated without removing U+FEFF from the body
 
 ## Behavioral Examples
 
@@ -82,7 +86,10 @@ Parses spec markdown files — extracts YAML frontmatter into structured data, e
 | Condition | Behavior |
 |-----------|----------|
 | No frontmatter delimiters | `parse_frontmatter` returns `None` |
-| Malformed YAML in frontmatter | Unknown keys silently ignored, missing fields remain as `None` |
+| Duplicate known or extension key | Parsed result contains a hard duplicate-key diagnostic naming the offending line |
+| Mapping/unclosed/unterminated list shape | Parsed result contains a hard field-specific diagnostic |
+| Non-numeric version, scalar list, or colon-less line | Parsed result contains an actionable warning |
+| Missing closing frontmatter delimiter | `parse_frontmatter` returns `None`; validator reports malformed frontmatter |
 | No `## Public API` section | `get_spec_symbols` returns empty vector |
 | Empty, unterminated, later-column, or prose backtick span | No symbol is extracted |
 | Empty body | `get_missing_sections` reports all required sections as missing |
@@ -113,6 +120,7 @@ Implementation SHALL add these canonical dependency specs to `depends_on`: `spec
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | v6: accumulate duplicate/type/shape diagnostics, parse flow-style lists, tolerate a leading BOM, and expose errors/warnings to every consumer |
 | 2026-03-25 | Initial spec |
 | 2026-06-11 | Add `get_all_api_table_symbols` so `check --fix` treats symbols documented under any Public API table (e.g. a bare `### Functions` heading) as already documented |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/parser/requirements.md
+++ b/specs/parser/requirements.md
@@ -51,3 +51,16 @@ Acceptance Criteria
 - Unrecognized YAML keys are silently skipped (no errors)
 - Zero external YAML parsing dependencies — custom line-by-line parser
 
+### REQ-parser-002
+
+Frontmatter parsing SHALL surface ambiguous or malformed supported shapes without allowing lossy parsing to bypass downstream validation.
+
+Acceptance Criteria
+
+- Duplicate keys produce a hard diagnostic naming the key and offending line.
+- `files`, `db_tables`, and `depends_on` accept block and flow-style string lists.
+- Mapping values, unclosed flow lists, and unterminated quoted list items produce hard diagnostics.
+- Scalar list values are retained as one item with a warning rather than silently discarded.
+- Non-numeric versions and colon-less non-comment lines produce warnings.
+- A leading UTF-8 BOM is tolerated, while body content is preserved.
+- Missing frontmatter delimiters remain distinguishable as `None` for the validator's malformed-frontmatter error.

--- a/specs/parser/tasks.md
+++ b/specs/parser/tasks.md
@@ -20,11 +20,15 @@ spec: parser.spec.md
 - [x] Sub-table skipping (Methods, Constructor, Properties)
 - [x] Required section presence checking
 - [x] Symbol deduplication with order preservation
+- [x] Reject duplicate frontmatter keys with offending-line diagnostics
+- [x] Parse flow-style string lists and reject malformed list shapes
+- [x] Warn on non-numeric versions, scalar list fields, and colon-less garbage
+- [x] Tolerate a leading UTF-8 BOM
 
 ## Gaps
 
 - YAML parsing only handles the subset used in specs — nested objects, anchors/aliases, and flow mappings are unsupported
-- No validation of frontmatter field types (e.g., `version` as a number vs string)
+- Full YAML typing remains out of scope; the supported flat subset has explicit shape diagnostics
 
 ## Review Status
 

--- a/specs/parser/testing.md
+++ b/specs/parser/testing.md
@@ -16,6 +16,8 @@ spec: parser.spec.md
 | `tests/integration.rs` | cargo test --test integration missing_required_sections_reports_error | End-to-end fixture: `missing_required_sections_reports_error` |
 | `tests/integration.rs` | cargo test --test integration missing_frontmatter_fields_reports_error | End-to-end fixture: `missing_frontmatter_fields_reports_error` |
 | `tests/integration.rs` | cargo test --test integration fix_adds_undocumented_exports_to_spec | End-to-end fixture: `fix_adds_undocumented_exports_to_spec` |
+| `src/parser.rs` | `fledge run test -- parser::tests::test_parse_frontmatter` | Duplicate keys, flow lists, malformed list shapes, suspicious versions, garbage lines, BOM, comments, tabs, and empty lists |
+| `tests/integration.rs` | `fledge run test -- --test integration check::hostile_frontmatter_shapes_fail_loudly_in_json` | Hard and soft parser findings survive the CLI JSON path |
 
 ## Behavioral Verification
 
@@ -31,7 +33,8 @@ spec: parser.spec.md
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
 | No frontmatter delimiters | `parse_frontmatter` returns `None` | Keep or add a focused assertion before changing this behavior |
-| Malformed YAML in frontmatter | Unknown keys silently ignored, missing fields remain as `None` | Keep or add a focused assertion before changing this behavior |
+| Duplicate or malformed supported shape | Hard diagnostic names the key/input | Keep the checked-frontmatter unit and CLI JSON regressions |
+| Suspicious scalar/version/garbage shape | Warning is retained for strict-mode gating | Keep the checked-frontmatter unit and CLI JSON regressions |
 | No `## Public API` section | `get_spec_symbols` returns empty vector | Keep or add a focused assertion before changing this behavior |
 | Malformed or misplaced code span | Empty, unterminated, later-column, and prose spans are ignored | Keep the focused malformed-row regression |
 | Empty body | `get_missing_sections` reports all required sections as missing | Keep or add a focused assertion before changing this behavior |

--- a/specs/schema/context.md
+++ b/specs/schema/context.md
@@ -5,6 +5,10 @@ spec: schema.spec.md
 ## Key Decisions
 
 - **Migration replay ordering**: Files are sorted by filename, not modification time. This means migration files should use numeric prefixes (001_, 002_, etc.) for deterministic ordering.
+- **One fallible snapshot**: `build_schema_snapshot` owns directory loading, UTF-8 reads, canonical identity, and DDL replay. Validation consumers must use its `Result` instead of combining an empty map with a second best-effort error scan.
+- **Exact statement ordering**: Supported DDL is discovered outside SQL comments and replayed in byte order within each file. String literals and quoted identifiers do not create false operation boundaries.
+- **Collision semantics**: Plain duplicate CREATE, missing DROP/RENAME sources, and colliding RENAME targets fail without mutating the existing snapshot. IF EXISTS, IF NOT EXISTS, and OR REPLACE are the only explicit leniency/replacement paths.
+- **Canonical table identity**: ANSI double quotes, backticks, SQL Server brackets, case differences, whitespace around qualifiers, and qualified names pass through `canonicalize_table_name` for every CREATE/ALTER/DROP transition. Canonical rendering preserves dots inside quoted segments; `canonical_table_leaf` performs safe unqualified matching.
 - **Uppercase normalization**: Column types are always uppercased during SQL parsing to allow case-insensitive comparison with spec-documented types.
 - **Idempotent ALTER ADD**: If a column already exists in the table, `ALTER TABLE ADD COLUMN` is a no-op. This prevents duplicate columns from repeated migrations.
 - **Zero-dependency SQL parsing**: Uses regex-based parsing rather than a full SQL parser. Handles common DDL statements but not every SQL dialect edge case.
@@ -17,9 +21,10 @@ spec: schema.spec.md
 
 ## Current Status
 
-Fully implemented. Supports CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), DROP TABLE, and both spec schema formats. Handles string literals, comments, nested parentheses, and table-level constraints.
+The schema-owned #435 slice is integrated into the #453 validation restack: one ordered fallible snapshot covers CREATE/ALTER/RENAME/DROP, malformed input, missing objects, quoted/qualified identities, deterministic collisions, and positioned diagnostics. Every validation surface consumes one `SchemaValidation` load so an empty or failed snapshot cannot be treated as “validation disabled.”
 
 ## Notes
 
-- Virtual tables (`CREATE VIRTUAL TABLE ... USING ...`) are intentionally skipped for column parsing because they use different syntax.
+- Virtual tables (`CREATE VIRTUAL TABLE ... USING ...`) are represented for table existence with an empty column set because their module-specific column syntax is not parsed.
 - The `SQL_EXTENSIONS` list covers 16 file types including application code files (ts, py, rb, etc.) that may contain embedded SQL.
+- `build_schema` and `build_schema_with_retired` remain lossy compatibility wrappers for non-validation callers and focused compatibility tests. Validation uses `build_schema_snapshot` exactly once through `load_schema_validation`.

--- a/specs/schema/requirements.md
+++ b/specs/schema/requirements.md
@@ -11,16 +11,21 @@ spec: schema.spec.md
 
 ## Acceptance Criteria
 
-- `build_schema` replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in filename-sorted order
-- Returns empty map if the schema directory doesn't exist (no error)
+- `build_schema_snapshot` sorts migration files by filename and replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in exact byte order within each file
+- A configured missing/unreadable schema directory, unreadable migration, malformed supported DDL, missing referenced object, or canonical name collision returns a path-aware error rather than a successful empty snapshot
+- SQL replay diagnostics include a one-based line and column plus a concise statement preview
 - Column types are normalized to uppercase for consistent comparison
 - ALTER TABLE ADD COLUMN is idempotent — duplicate columns are skipped
 - DROP TABLE removes the table entirely from the schema map
 - ALTER TABLE RENAME TO moves all columns to the new table name
 - ALTER TABLE RENAME COLUMN preserves all attributes except the name
-- CREATE TABLE replaces any prior definition of the same table
-- SQL line comments (`--`) are skipped during parsing
-- String literals with escaped quotes are handled correctly (no false column detection)
+- Plain CREATE TABLE fails without mutation on a canonical duplicate; IF NOT EXISTS preserves the existing table and OR REPLACE explicitly replaces it
+- RENAME fails without mutation when the source is missing or the canonical target already exists
+- DROP fails when the table is missing unless IF EXISTS is present
+- A later CREATE may recreate a retired identity and removes it from the retired set
+- ANSI double-quoted, backtick-quoted, bracket-quoted, mixed-case, and qualified table references use one canonical identity parser
+- Dots inside quoted identifier segments remain distinct from qualification separators, including for unqualified matching
+- SQL line/block comments and quoted/string content do not introduce false DDL operations or statement boundaries
 - Supports schema files with extensions: sql, ts, js, mjs, cjs, swift, kt, kts, java, py, rb, go, rs, cs, dart, php
 - `parse_spec_schema` supports both inline (`### Schema: table_name`) and multi-table (`### Schema` with `#### table_name`) formats
 - Markdown table header rows are skipped during spec schema parsing
@@ -43,17 +48,21 @@ spec: schema.spec.md
 Schema parsing SHALL replay supported migration DDL deterministically and compare canonical schema tables without interpreting unsupported DML.
 
 Acceptance Criteria
-- `build_schema` replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in filename-sorted order
-- Returns empty map if the schema directory doesn't exist (no error)
+- `build_schema_snapshot` sorts migration files by filename and replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in exact byte order within each file
+- A configured missing/unreadable schema directory, unreadable migration, malformed supported DDL, missing referenced object, or canonical name collision returns a path-aware error rather than a successful empty snapshot
+- SQL replay diagnostics include a one-based line and column plus a concise statement preview
 - Column types are normalized to uppercase for consistent comparison
 - ALTER TABLE ADD COLUMN is idempotent — duplicate columns are skipped
 - DROP TABLE removes the table entirely from the schema map
 - ALTER TABLE RENAME TO moves all columns to the new table name
 - ALTER TABLE RENAME COLUMN preserves all attributes except the name
-- CREATE TABLE replaces any prior definition of the same table
-- SQL line comments (`--`) are skipped during parsing
-- String literals with escaped quotes are handled correctly (no false column detection)
+- Plain CREATE TABLE fails without mutation on a canonical duplicate; IF NOT EXISTS preserves the existing table and OR REPLACE explicitly replaces it
+- RENAME fails without mutation when the source is missing or the canonical target already exists
+- DROP fails when the table is missing unless IF EXISTS is present
+- A later CREATE may recreate a retired identity and removes it from the retired set
+- ANSI double-quoted, backtick-quoted, bracket-quoted, mixed-case, and qualified table references use one canonical identity parser
+- Dots inside quoted identifier segments remain distinct from qualification separators, including for unqualified matching
+- SQL line/block comments and quoted/string content do not introduce false DDL operations or statement boundaries
 - Supports schema files with extensions: sql, ts, js, mjs, cjs, swift, kt, kts, java, py, rb, go, rs, cs, dart, php
 - `parse_spec_schema` supports both inline (`### Schema: table_name`) and multi-table (`### Schema` with `#### table_name`) formats
 - Markdown table header rows are skipped during spec schema parsing
-

--- a/specs/schema/schema.spec.md
+++ b/specs/schema/schema.spec.md
@@ -1,6 +1,6 @@
 ---
 module: schema
-version: 3
+version: 4
 status: stable
 files:
   - src/schema.rs
@@ -13,7 +13,7 @@ depends_on: []
 
 ## Purpose
 
-Parses SQL schema files (migrations) and spec markdown to build table/column maps for bidirectional validation. Replays CREATE TABLE, ALTER TABLE, DROP TABLE, and RENAME statements in file-sorted order to produce the current schema state. Also extracts column definitions from spec `### Schema` sections for comparison.
+Parses SQL schema files (migrations) and spec markdown to build table/column maps for bidirectional validation. Builds one fallible schema snapshot by replaying CREATE TABLE, ALTER TABLE, DROP TABLE, and RENAME statements in exact file and statement order. Also extracts column definitions from spec `### Schema` sections for comparison.
 
 ## Public API
 
@@ -24,6 +24,9 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 | `SchemaColumn` | A column extracted from SQL schema files — name, col_type (uppercase), nullable, has_default, is_primary_key |
 | `SchemaTable` | All columns for a single table, built by replaying migrations in order |
 | `SpecColumn` | A column documented in a spec's `### Schema` section — name and raw col_type |
+| `SchemaErrorKind` | Stable category for schema directory, file, malformed-statement, missing-object, and collision failures |
+| `SchemaError` | Path- and source-position-aware schema failure with kind, path, line, column, and truthful message |
+| `SchemaSnapshot` | Canonical current table map plus table identities retired by DROP or RENAME |
 
 ### Exported SchemaTable Functions
 
@@ -35,36 +38,44 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `build_schema` | `schema_dir: &Path` | `HashMap<String, SchemaTable>` | Build a complete schema map from SQL/migration files in the given directory, sorted by filename |
-| `schema_read_errors` | `schema_dir: &Path` | `Vec<String>` | Error message for each schema/migration file that exists but cannot be read as UTF-8, plus one for a `schema_dir` that exists but cannot be enumerated (unreadable, or a file rather than a directory), so the validation gate can fail loud instead of silently under-validating (`build_schema` skips such files / returns empty) |
+| `canonicalize_table_name` | `raw: &str` | `Result<String, String>` | Parse qualified table-name segments, unescape ANSI/backtick/bracket quoting, and normalize case without conflating malformed input |
+| `canonical_table_leaf` | `raw: &str` | `Result<String, String>` | Return the canonical final segment for unqualified matching without splitting dots contained inside quoted identifiers |
+| `normalize_table_name` | `raw: &str` | `String` | Compatibility normalization for validator restacking; fallible replay uses `canonicalize_table_name` |
+| `build_schema_snapshot` | `schema_dir: &Path` | `Result<SchemaSnapshot, SchemaError>` | Build the authoritative snapshot by replaying supported DDL in filename and byte order; fail on directory, entry, UTF-8, malformed-DDL, missing-object, and collision errors |
+| `build_schema` | `schema_dir: &Path` | `HashMap<String, SchemaTable>` | Compatibility map wrapper; returns an empty map on snapshot failure and must not be used alone for validation |
+| `build_schema_with_retired` | `schema_dir: &Path` | `(HashMap<String, SchemaTable>, HashSet<String>)` | Compatibility wrapper exposing retired table identities; returns empty collections on snapshot failure |
+| `schema_read_errors` | `schema_dir: &Path` | `Vec<String>` | Compatibility diagnostics adapter that renders the authoritative snapshot failure, including missing/unreadable paths and malformed or inconsistent DDL |
 | `parse_spec_schema` | `body: &str` | `HashMap<String, Vec<SpecColumn>>` | Extract column definitions from a spec's `### Schema` section(s) |
 
 ## Invariants
 
-1. `build_schema` replays migrations in filename-sorted order for deterministic results
-2. `build_schema` returns an empty map if the directory does not exist
-2a. A schema/migration file that exists but cannot be read as UTF-8 is silently skipped by `build_schema` (its tables/columns vanish); `schema_read_errors` reports each such file so the validation gate surfaces it as a hard error rather than letting an all-unreadable schema silently disable `db_tables`/column checks
-2b. A `schema_dir` that exists but cannot be enumerated by `read_dir` — because it is unreadable or is a file rather than a directory — is itself a hard error from `schema_read_errors` (not a silent empty result): the same fail-open would otherwise leave schema discovery empty and skip `db_tables`/column checks with no signal
+1. `build_schema_snapshot` sorts migration files and replays supported DDL in byte order within each file
+2. A configured missing/unreadable schema directory, unreadable entry/file, malformed supported DDL, missing referenced object, or canonical identity collision returns `SchemaError`; it never produces a successful empty snapshot
+2a. `SchemaError` identifies the source path and, for SQL replay failures, the one-based line and column
+2b. `build_schema` and `build_schema_with_retired` are compatibility-only lossy wrappers; validation consumers use `build_schema_snapshot` or surface `schema_read_errors`
 3. Column types are normalized to uppercase (e.g. "integer" becomes "INTEGER")
 4. ALTER TABLE ADD COLUMN is idempotent — duplicate column names are skipped
 5. DROP TABLE removes the table and all its columns from the map
 6. ALTER TABLE RENAME TO moves all columns to the new table name
 7. ALTER TABLE RENAME COLUMN preserves all column attributes except the name
-8. CREATE TABLE replaces any prior definition of the same table (handles CREATE OR REPLACE semantics)
+8. Plain CREATE TABLE fails on a canonical duplicate, IF NOT EXISTS preserves the existing table, and OR REPLACE explicitly replaces it
+8a. RENAME fails without mutation when its source is missing or its canonical target already exists; DROP fails on a missing table unless IF EXISTS is present
+8b. Recreating a dropped or renamed-away table clears that identity from the retired set
 9. Table-level constraints (PRIMARY KEY, UNIQUE, CHECK, FOREIGN KEY, CONSTRAINT) are skipped during column parsing
-10. String literals with escaped quotes are handled correctly during parenthesis matching
-11. SQL line comments (`--`) are skipped during parenthesis matching
+10. String literals, quoted identifiers, and escaped quotes do not create false statement boundaries or DDL matches
+11. SQL line and block comments are excluded from DDL discovery and parenthesis matching
 12. `parse_spec_schema` supports two formats: inline (`### Schema: table_name`) and multi-table (`### Schema` with `#### table_name` sub-headers)
 13. `parse_spec_schema` skips markdown table header rows (column named "column")
 14. Only files with recognized SQL extensions are processed (sql, ts, js, mjs, cjs, swift, kt, kts, java, py, rb, go, rs, cs, dart, php)
+15. ANSI double-quoted, backtick-quoted, bracket-quoted, mixed-case, and qualified table references share one canonical identity parser; dots inside quoted segments remain distinct from qualification separators
 
 ## Behavioral Examples
 
 ### Scenario: Build schema from migrations
 
 - **Given** a directory with `001_create.sql` containing `CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)` and `002_add_col.sql` containing `ALTER TABLE items ADD COLUMN price REAL DEFAULT 0`
-- **When** `build_schema(dir)` is called
-- **Then** returns a map with "items" having 3 columns: id (INTEGER, PK), name (TEXT, NOT NULL), price (REAL, DEFAULT)
+- **When** `build_schema_snapshot(dir)` is called
+- **Then** returns a snapshot whose "items" table has 3 columns: id (INTEGER, PK), name (TEXT, NOT NULL), price (REAL, DEFAULT)
 
 ### Scenario: DROP TABLE removes table
 
@@ -90,20 +101,23 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 - **When** `parse_spec_schema(body)` is called
 - **Then** returns a map with both "messages" and "users" entries
 
-### Scenario: Nonexistent directory
+### Scenario: Malformed migration fails loud
 
-- **Given** a path that does not exist
-- **When** `build_schema(path)` is called
-- **Then** returns an empty HashMap
+- **Given** `002_broken.sql` contains `CREATE TABLE broken (id INTEGER;`
+- **When** `build_schema_snapshot(path)` is called
+- **Then** it returns a `MalformedStatement` error naming the file and the CREATE statement's line and column
 
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
-| Schema directory does not exist | `build_schema` returns empty map; `schema_read_errors` returns no errors (schema simply not configured) |
-| Schema directory exists but cannot be enumerated (unreadable, or a file not a directory) | `schema_read_errors` returns a hard error naming the directory (fail-loud); `build_schema` returns an empty map |
-| File cannot be read | `build_schema` silently skips the file; `schema_read_errors` flags it as a hard error |
-| Unmatched parentheses in CREATE TABLE | `extract_paren_body` returns `None`, table is skipped |
+| Configured schema directory does not exist | `build_schema_snapshot` returns `MissingDirectory`; compatibility `build_schema` returns an empty map but `schema_read_errors` exposes the failure |
+| Schema directory cannot be enumerated | `build_schema_snapshot` returns `ReadDirectory` or `ReadEntry` naming the path |
+| File cannot be read as UTF-8 | `build_schema_snapshot` returns `ReadFile` naming the migration |
+| Unmatched parentheses or malformed supported DDL | Returns `MalformedStatement` with path, line, column, and statement preview |
+| Plain CREATE collides after canonicalization | Returns `DuplicateTable`; the existing table remains unchanged |
+| RENAME target collides after canonicalization | Returns `RenameCollision`; source and target remain unchanged |
+| DROP/RENAME source is missing | Returns `MissingTable`, except `DROP TABLE IF EXISTS` is a no-op |
 | No `### Schema` section in spec | `parse_spec_schema` returns empty map |
 | Column name looks like SQL keyword | Column is skipped by `is_sql_keyword` check |
 
@@ -119,14 +133,15 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 
 | Module | What is used |
 |--------|-------------|
-| validator | `build_schema`, `parse_spec_schema`, `SchemaTable` for column validation |
-| mcp | `build_schema` for schema-aware validation |
-| main | `build_schema`, `SchemaTable` for CLI schema loading |
+| validator | `build_schema_snapshot`, `canonicalize_table_name`, `canonical_table_leaf`, `parse_spec_schema`, `SchemaSnapshot`, and `SchemaTable` for existence and column validation |
+| mcp | `build_schema_snapshot` for schema-aware validation |
+| main | `build_schema_snapshot`, `SchemaError`, and `SchemaTable` for CLI schema loading |
 
 ## Change Log
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Added one fallible ordered schema snapshot, exact within-file DDL replay, canonical quoted/qualified identities, collision-safe mutation, and path/line diagnostics for malformed or unreadable migrations |
 | 2026-07-06 | `schema_read_errors` now also fails loud when `schema_dir` exists but cannot be enumerated by `read_dir` (unreadable, or a file not a directory) — closing the same fail-open; added invariant 2b, updated the API row and Error Cases table |
 | 2026-03-29 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/schema/tasks.md
+++ b/specs/schema/tasks.md
@@ -8,7 +8,6 @@ spec: schema.spec.md
 
 - [ ] Support CREATE INDEX tracking for schema completeness
 - [ ] Add VIRTUAL TABLE column extraction (FTS5 columns)
-- [ ] Support multi-statement migration files with transaction wrappers (BEGIN/COMMIT)
 
 ## Done
 
@@ -20,11 +19,17 @@ spec: schema.spec.md
 - [x] String literal and comment handling in paren matching
 - [x] Table-level constraint skipping (PRIMARY KEY, UNIQUE, CHECK, FOREIGN KEY, CONSTRAINT)
 - [x] SQL keyword filtering for column names
+- [x] Replay supported DDL in exact statement order within filename-sorted migrations
+- [x] Return path/line/column diagnostics for missing directories, unreadable files, malformed DDL, missing objects, and collisions
+- [x] Canonicalize ANSI/backtick/bracket quoted, mixed-case, and qualified table identities
+- [x] Preserve snapshot state on duplicate CREATE and RENAME-target collisions
+- [x] Support multi-statement migration files and ignore transaction-control/DML statements
+- [x] Integrate one fallible snapshot into CLI, MCP, generation, reporting, and effective-contract validation
+- [x] Prevent additive schema patterns from resurrecting renamed or dropped canonical identities
 
 ## Gaps
 
 - No support for VIRTUAL TABLE column extraction
-- No transaction wrapper handling (BEGIN/COMMIT blocks)
 - No CREATE INDEX tracking
 
 ## Review Status

--- a/specs/schema/testing.md
+++ b/specs/schema/testing.md
@@ -6,30 +6,43 @@ spec: schema.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/schema.rs` | cargo test schema:: | `test_parse_create_table`, `test_parse_create_table_if_not_exists`, `test_parse_create_virtual_table`, `test_parse_alter_table_add_column`, `test_alter_idempotent`, `test_table_constraints_skipped` |
+| `src/schema.rs` | `fledge run test -- schema::tests` | 36 focused tests, especially the ordered-replay, malformed-SQL, quoting, missing-object, and collision tests |
+| `src/validator.rs` | `fledge run test -- validator::tests::test_load_schema_validation` | One snapshot supplies tables/columns and propagates configuration/replay errors |
+| `src/validator.rs` | `fledge run test -- validator::tests::test_schema_pattern_does_not_resurrect_qualified_renamed_leaf` | Additive pattern extraction cannot restore a retired qualified identity through its bare leaf |
+| `tests/integration/config.rs` | `fledge run test -- --test integration config::check_gates_on_unreadable_schema_file` | CLI fails closed and renders the snapshot's unreadable-migration diagnostic |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Build schema from migrations" before changing user-visible CLI output, generated files, or error handling in schema.
+- No known gap in snapshot-to-validation error propagation. Regex-based SQL coverage remains intentionally bounded to the supported DDL subset.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Build schema from migrations | a directory with `001_create.sql` containing `CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)` and `002_add_col.sql` containing `ALTER TABLE items ADD COLUMN price REAL DEFAULT 0` | `build_schema(dir)` is called | returns a map with "items" having 3 columns: id (INTEGER, PK), name (TEXT, NOT NULL), price (REAL, DEFAULT) |
-| DROP TABLE removes table | SQL containing `CREATE TABLE temp (id INTEGER PRIMARY KEY)` followed by `DROP TABLE temp` | the SQL is parsed | "temp" is not present in the resulting schema map |
-| Rename table | SQL containing `CREATE TABLE old_name (id INTEGER PRIMARY KEY)` followed by `ALTER TABLE old_name RENAME TO new_name` | the SQL is parsed | "old_name" is absent and "new_name" has all original columns |
+| Build schema from migrations | a directory with ordered CREATE and ALTER files | `build_schema_snapshot(dir)` is called | returns a snapshot with the final canonical table and column state |
+| Exact statement order | one file performs CREATE, DROP, then CREATE of the same name | SQL is replayed | the final CREATE exists and the identity is no longer retired |
+| Rename then recreate | one file creates `users`, renames it to `archived_users`, then creates `users` again | SQL is replayed | both final tables exist with their own columns |
+| Malformed supported DDL | `002_broken.sql` contains an unmatched CREATE TABLE parenthesis | `build_schema_snapshot(dir)` is called | returns `MalformedStatement` with file, line, column, and statement preview |
+| Quoted and qualified identity | ANSI, backtick, bracket, mixed-case, and qualified names—including a dot inside a quoted segment—are normalized | SQL is replayed | each operation resolves through the same canonical identity without conflating quoted dots with qualification |
+| Collision safety | normalized CREATE names collide, or RENAME targets an existing canonical table | SQL is replayed | returns `DuplicateTable`/`RenameCollision` without overwriting either existing table |
 | Parse spec schema inline format | a spec body with `### Schema: messages` followed by a markdown table with columns `id`, `content`, `created_at` | `parse_spec_schema(body)` is called | returns a map with "messages" having 3 SpecColumn entries |
 | Parse spec schema multi-table format | a spec body with `### Schema` followed by `#### messages` and `#### users` sub-headers each with column tables | `parse_spec_schema(body)` is called | returns a map with both "messages" and "users" entries |
-| Nonexistent directory | a path that does not exist | `build_schema(path)` is called | returns an empty HashMap |
+| Configured missing directory | a path that does not exist | `build_schema_snapshot(path)` is called | returns `MissingDirectory`; no successful empty snapshot is produced |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Schema directory does not exist | `build_schema` returns empty map | Keep or add a focused assertion before changing this behavior |
-| File cannot be read | File is silently skipped | Keep or add a focused assertion before changing this behavior |
-| Unmatched parentheses in CREATE TABLE | `extract_paren_body` returns `None`, table is skipped | Keep or add a focused assertion before changing this behavior |
+| Schema directory does not exist | `build_schema_snapshot` returns `MissingDirectory` | `test_build_schema_snapshot_missing_directory_is_error` |
+| File cannot be read as UTF-8 | `build_schema_snapshot` returns `ReadFile` naming the file | `test_schema_read_errors_flags_only_unreadable` |
+| Unmatched parentheses in CREATE TABLE | `build_schema_snapshot` returns a positioned `MalformedStatement` | `test_build_schema_snapshot_reports_malformed_sql_with_path_and_position` |
+| Missing terminator before later DDL | snapshot fails before applying the first statement | `test_replay_rejects_unterminated_statement_before_later_ddl` |
+| DDL text in comments/string literals | ignored as operations | `test_replay_ignores_commented_and_string_literal_ddl` |
+| DROP then CREATE / RENAME then CREATE | exact source order determines final state | `test_replay_respects_drop_then_recreate_within_one_file`, `test_replay_respects_recreate_after_rename_within_one_file` |
+| CREATE canonical collision | existing table is preserved and `DuplicateTable` is returned | `test_replay_duplicate_canonical_create_is_a_non_mutating_error` |
+| RENAME target collision | source and target are preserved and `RenameCollision` is returned | `test_replay_rename_collision_is_a_non_mutating_error` |
+| Missing DROP/RENAME source | hard error except DROP IF EXISTS | `test_replay_missing_drop_and_rename_sources_fail_truthfully` |
+| Quoted/qualified CREATE→RENAME→DROP | one canonical parser governs every transition | `test_quoted_qualified_names_replay_through_rename_and_drop` |
 | No `### Schema` section in spec | `parse_spec_schema` returns empty map | Keep or add a focused assertion before changing this behavior |
 | Column name looks like SQL keyword | Column is skipped by `is_sql_keyword` check | Keep or add a focused assertion before changing this behavior |
 

--- a/specs/validator/context.md
+++ b/specs/validator/context.md
@@ -12,6 +12,8 @@ spec: validator.spec.md
 - **Module detection cascade**: User-defined modules (config) → manifest-discovered modules → subdirectory scanning → flat file detection. Each level is a fallback.
 - **Static coverage is non-vacuous**: HTML, HTM, and CSS files participate in default source discovery even though they expose no API symbols.
 - **Generated companion markers fail strict**: Every known artifact-specific scaffold prompt emitted by the built-in templates, including all Layout, Components, Tokens, and Assets design bullets, emits a path-and-line warning outside fenced examples; strict mode promotes those warnings to errors.
+- **One dependency verdict**: Check, deps, and resolve call `validate_local_dependency`; malformed remote lookalikes remain local and cannot bypass absolute/traversal/symlink confinement.
+- **One schema snapshot**: `load_schema_validation` calls `build_schema_snapshot` once and shares its table, column, retired-name, and error state with CLI, MCP, reporting, generation, and effective-contract validation.
 
 ## Files to Read First
 
@@ -29,3 +31,4 @@ Fully implemented. The validator is the heart of spec-sync — it powers `specsy
 - Status gates validation depth: `archived` specs skip all checks; `draft` specs check structure only; `review` specs check sections but skip Public API and API-surface validation; `active`/`stable`/`deprecated` get the full pass.
 - Non-draft, non-review specs warn when inline `## Requirements`/`## Acceptance Criteria` appear in the technical spec. A companion `requirements.md` is validated when present but is no longer mandatory for every module.
 - Exclude patterns use a simplified glob syntax: `**/dir/**` for directory exclusion, `**/*.ext` for extension exclusion.
+- Schema pattern extraction is additive only. It uses canonical identities and rejects any exact or unqualified-leaf match retired by ordered DDL replay.

--- a/specs/validator/requirements.md
+++ b/specs/validator/requirements.md
@@ -123,3 +123,19 @@ Acceptance Criteria
 - Redundant dot segments cannot create coverage mismatches.
 - Absolute, parent-segment, prefixed, and backslash mappings remain errors in every lifecycle status and never count toward ownership or coverage.
 - A missing planned leaf beneath an existing symlinked parent that resolves outside the project or cannot be resolved is rejected before notice emission.
+
+### REQ-validator-008
+
+Dependency and schema validation SHALL fail closed with one confined dependency verdict and one fallible canonical schema snapshot per validation invocation.
+
+Acceptance Criteria
+
+- Only exact `owner/repo@module` shapes are classified as cross-project references.
+- Absolute paths, parent traversal, backslashes, malformed remote lookalikes, and symlink escapes are rejected with the offending dependency entry.
+- Bare module names resolve to the canonical `specs/<module>/<module>.spec.md` file.
+- Check, deps, and resolve consume the same local dependency verdict.
+- Schema table and column checks derive from exactly one `build_schema_snapshot` call.
+- Missing/unreadable schema directories and files, malformed DDL, missing replay objects, and collisions surface as validation errors.
+- Additive `schema_pattern` matches cannot resurrect table identities retired by DROP or RENAME.
+- Qualified and unqualified table matching uses `canonical_table_leaf`, preserving dots inside quoted identifier segments.
+- A configured empty schema does not make a declared `db_tables` entry pass vacuously.

--- a/specs/validator/tasks.md
+++ b/specs/validator/tasks.md
@@ -27,6 +27,11 @@ spec: validator.spec.md
 - [x] Measure default HTML, HTM, and CSS sources in coverage
 - [x] Reject known unfilled companion scaffold markers in strict mode
 - [x] Reject every marker emitted by the built-in design companion template
+- [x] Share one confined dependency verdict across check, deps, and resolve
+- [x] Reject malformed remote lookalikes and bare-module symlink escapes
+- [x] Load one fallible schema snapshot for table and column validation
+- [x] Preserve quoted-dot table leaves and suppress pattern resurrection of retired tables
+- [x] Reject declared database tables against an empty configured schema
 
 ## Gaps
 

--- a/specs/validator/testing.md
+++ b/specs/validator/testing.md
@@ -15,6 +15,10 @@ spec: validator.spec.md
 | `tests/integration.rs` | cargo test --test integration invalid_frontmatter_reports_error | End-to-end fixture: `invalid_frontmatter_reports_error` |
 | `tests/integration.rs` | cargo test --test integration missing_spec_dir_exits_cleanly | End-to-end fixture: `missing_spec_dir_exits_cleanly` |
 | `tests/integration.rs` | cargo test --test integration missing_required_sections_reports_error | End-to-end fixture: `missing_required_sections_reports_error` |
+| `src/validator.rs` | `fledge run test -- validator::tests::test_validate_local_dependency` | Absolute/traversal/missing/canonical bare-module verdicts |
+| `src/validator.rs` | `fledge run test -- validator::tests::test_load_schema_validation` | One fallible snapshot and positioned replay diagnostics |
+| `tests/integration.rs` | `fledge run test -- --test integration check::hostile_frontmatter_shapes_fail_loudly_in_json` | Duplicate/type/shape/garbage diagnostics remain machine-readable |
+| `tests/integration.rs` | `fledge run test -- --test integration commands::check_deps_and_resolve_share_confined_dependency_verdicts` | Three command surfaces report the same confined verdict |
 
 ## Behavioral Verification
 
@@ -38,6 +42,8 @@ spec: validator.spec.md
 | Static HTML mapped or unmapped | Coverage denominator remains one and a 100% gate distinguishes `1/1` from `0/1` | Keep CLI fixtures for both cases |
 | Generated companion marker | Warning includes artifact path and source line; strict mode fails | Cover every supported artifact plus fenced and similar-prose negatives |
 | Built-in design markers | Layout, Components, Tokens, and Assets placeholders each produce a distinct warning | Keep the generated template lines and validator marker table in parity |
+| Malformed remote lookalike | Treated as a local path and rejected by confinement | Keep unit and three-command integration assertions |
+| Schema replay failure | One project-level hard error, no empty-set success | Keep loader and CLI schema fixtures |
 
 ## Reviewer Checklist
 

--- a/specs/validator/validator.spec.md
+++ b/specs/validator/validator.spec.md
@@ -1,6 +1,6 @@
 ---
 module: validator
-version: 11
+version: 12
 status: stable
 files:
   - src/validator.rs
@@ -19,9 +19,15 @@ depends_on:
 
 ## Purpose
 
-Core validation engine for spec-sync. Validates individual specs and selected companion artifacts against source code, discovers configured and zero-config source files including static HTML, HTM, and CSS content, rejects every known generated companion marker outside fenced examples, extracts schema table names from SQL migrations, computes non-vacuous file and LOC coverage metrics, and resolves cross-project dependency references.
+Core validation engine for spec-sync. Validates individual specs and selected companion artifacts against source code, applies one confined dependency-reference verdict across commands, consumes one fallible canonical schema snapshot, discovers configured and zero-config source files including static HTML, HTM, and CSS content, rejects every known generated companion marker outside fenced examples, computes non-vacuous file and LOC coverage metrics, and resolves well-formed cross-project dependency references.
 
 ## Public API
+
+**Exported Structs**
+
+| Type | Description |
+|------|-------------|
+| `SchemaValidation` | Invocation-scoped canonical schema tables, columns, and propagated load/replay errors |
 
 **Exported Functions**
 
@@ -30,7 +36,9 @@ Core validation engine for spec-sync. Validates individual specs and selected co
 | `validate_spec` | `spec_path: &Path, root: &Path, schema_tables: &HashSet<String>, schema_columns: &HashMap<String, SchemaTable>, config: &SpecSyncConfig` | `ValidationResult` | Validate a single spec file: frontmatter, files, sections, API surface, dependencies |
 | `find_spec_files` | `dir: &Path` | `Vec<PathBuf>` | Recursively find all `*.spec.md` files in a directory |
 | `compute_coverage` | `root, spec_files, config` | `CoverageReport` | Compute file and LOC coverage across all source directories |
-| `get_schema_table_names` | `root, config` | `HashSet<String>` | Extract table names from SQL schema files using configurable regex |
+| `load_schema_validation` | `root, config` | `SchemaValidation` | Call `build_schema_snapshot` once, apply additive pattern extraction without resurrecting retired identities, and retain every configuration/read/replay error |
+| `schema_table_exists` | `tables, declared` | `bool` | Compare canonical qualified or unqualified table identities using `canonical_table_leaf`, including quoted segments containing dots |
+| `validate_local_dependency` | `dep, root, specs_dir` | `Result<PathBuf, String>` | Resolve one local dependency to a confined canonical spec file; reject absolute, traversal, malformed-remote, missing, and symlink-escape inputs |
 | `is_cross_project_ref` | `dep: &str` | `bool` | Check if a dependency string is a cross-project ref (`owner/repo@module`) |
 | `parse_cross_project_ref` | `dep: &str` | `Option<(&str, &str)>` | Parse cross-project ref into (owner/repo, module) tuple |
 | `normalize_source_mapping` | `file: &str` | `Option<String>` | Normalize a safe project-relative mapping by removing redundant current-directory segments and rejecting absolute, parent, or prefixed paths; callers also reject backslashes so ownership, validation, and coverage share one portable mapping contract |
@@ -50,6 +58,10 @@ Core validation engine for spec-sync. Validates individual specs and selected co
 10. Sections with no substantive content are reported as unfinished draft text rather than as template markers
 11. `validate_spec` records the spec's parsed lifecycle status on `ValidationResult.status` (None when frontmatter is unreadable) so reporters can surface status-based skips, e.g. drafts skipping section and export checks
 12. Requirements companions are validated when present but optional for technical/internal modules under the adaptive 5.0 artifact model
+13. Only syntactically valid `owner/repo@module` references are remote; malformed lookalikes are validated as confined local paths rather than bypassing path checks
+14. Bare module dependencies resolve to `specs/<module>/<module>.spec.md`, including symlink confinement of the resolved path
+15. Schema table and column validation share one `build_schema_snapshot` result; load/replay errors are project errors and an empty table set never disables declared `db_tables` checks
+16. Unqualified schema matching uses `canonical_table_leaf`, never string splitting that corrupts dots inside quoted identifiers
 
 ## Behavioral Examples
 
@@ -87,6 +99,8 @@ Core validation engine for spec-sync. Validates individual specs and selected co
 | DB table not in schema | Error: "DB table not found in schema" |
 | Missing required section | Error: "Missing required section: ## SectionName" |
 | Dependency spec not found | Error: "Dependency spec not found" |
+| Dependency is absolute, traverses, or resolves outside the project | Error naming the confined dependency entry |
+| Schema directory/pattern/migration/replay fails | Project validation error; no successful empty-schema fallback |
 
 ## Dependencies
 
@@ -117,6 +131,7 @@ Implementation SHALL add these canonical dependency specs to `depends_on`: `spec
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | v12: enforce one confined dependency verdict and one fallible schema snapshot across CLI/MCP validation, including quoted-dot leaf matching and retired-table pattern suppression |
 | 2026-07-10 | v5: keep coverage regression fixtures warning-free under current stable Clippy and document the intentionally in-file test-module layout |
 | 2026-07-10 | v5: make canonical requirements companions adaptive rather than empty mandatory ceremony |
 | 2026-07-02 | v4: add `source_within_root` — shared guard rejecting `files:` paths that escape the project root (absolute/`..`/symlink); applied in `validate_spec` and every export-extraction site (score, check --fix, diff, new) to close an out-of-root identifier-disclosure vector |

--- a/src/change.rs
+++ b/src/change.rs
@@ -4684,9 +4684,8 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
     }
     let temp = create_effective_contract_workspace().map_err(|error| vec![error])?;
     let config = crate::config::load_config(root);
-    let schema_tables = crate::validator::get_schema_table_names(root, &config);
-    let schema_columns = crate::commands::build_schema_columns(root, &config);
-    let mut errors = Vec::new();
+    let schema = crate::validator::load_schema_validation(root, &config);
+    let mut errors = schema.errors.clone();
     for module in modules {
         let canonical = match canonical_module_paths(root, &config.specs_dir, &module) {
             Ok((spec_path, _)) => spec_path,
@@ -4758,8 +4757,8 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
         let result = crate::validator::validate_spec(
             &effective,
             root,
-            &schema_tables,
-            &schema_columns,
+            &schema.tables,
+            &schema.columns,
             &config,
         );
         errors.extend(

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -11,13 +11,13 @@ use crate::ignore::IgnoreRules;
 use crate::output::{print_check_markdown, print_coverage_line, print_summary};
 use crate::parser;
 use crate::types;
-use crate::validator::{compute_coverage, get_schema_table_names};
+use crate::validator::{compute_coverage, load_schema_validation};
 
 use crate::config::is_legacy_layout;
 
 use super::{
-    build_schema_columns, compute_exit_code, create_drift_issues, exit_with_status,
-    filter_by_status, filter_specs, load_and_discover, run_validation,
+    compute_exit_code, create_drift_issues, exit_with_status, filter_by_status, filter_specs,
+    load_and_discover, run_validation,
 };
 
 /// Files whose contents affect validation globally rather than through a single
@@ -309,8 +309,7 @@ pub fn cmd_check(
         println!("  Review the affected specs directly or ask your coding agent to update them.\n");
     }
 
-    let schema_tables = get_schema_table_names(root, &config);
-    let schema_columns = build_schema_columns(root, &config);
+    let schema = load_schema_validation(root, &config);
     let ignore_rules = IgnoreRules::load(root);
 
     if dry_run && !fix {
@@ -395,8 +394,7 @@ pub fn cmd_check(
             root,
             &specs_to_validate,
             &all_spec_files,
-            &schema_tables,
-            &schema_columns,
+            &schema,
             &config,
             collect,
             explain,

--- a/src/commands/comment.rs
+++ b/src/commands/comment.rs
@@ -7,9 +7,9 @@ use crate::comment;
 use crate::github;
 use crate::ignore::IgnoreRules;
 use crate::types;
-use crate::validator::{compute_coverage, get_schema_table_names};
+use crate::validator::{compute_coverage, load_schema_validation};
 
-use super::{build_schema_columns, compute_exit_code, load_and_discover, run_validation};
+use super::{compute_exit_code, load_and_discover, run_validation};
 
 pub fn cmd_comment(
     root: &Path,
@@ -21,8 +21,7 @@ pub fn cmd_comment(
 ) {
     let (config, spec_files) = load_and_discover(root, true);
 
-    let schema_tables = get_schema_table_names(root, &config);
-    let schema_columns = build_schema_columns(root, &config);
+    let schema = load_schema_validation(root, &config);
     let ignore_rules = IgnoreRules::load(root);
 
     // CLI --enforcement flag overrides config; --strict implies strict enforcement.
@@ -45,8 +44,7 @@ pub fn cmd_comment(
         root,
         &spec_files,
         &spec_files,
-        &schema_tables,
-        &schema_columns,
+        &schema,
         &config,
         true, // collect mode
         false,

--- a/src/commands/coverage.rs
+++ b/src/commands/coverage.rs
@@ -3,11 +3,9 @@ use std::process;
 
 use crate::output::{print_coverage_line, print_coverage_report, print_summary};
 use crate::types;
-use crate::validator::{compute_coverage, get_schema_table_names};
+use crate::validator::{compute_coverage, load_schema_validation};
 
-use super::{
-    build_schema_columns, compute_exit_code, exit_with_status, load_and_discover, run_validation,
-};
+use super::{compute_exit_code, exit_with_status, load_and_discover, run_validation};
 
 pub fn cmd_coverage(
     root: &Path,
@@ -28,16 +26,14 @@ pub fn cmd_coverage(
     } else {
         config.enforcement
     });
-    let schema_tables = get_schema_table_names(root, &config);
-    let schema_columns = build_schema_columns(root, &config);
+    let schema = load_schema_validation(root, &config);
     let ignore_rules = crate::ignore::IgnoreRules::default();
     let (total_errors, total_warnings, passed, total, _all_errors, _all_warnings, _all_notices) =
         run_validation(
             root,
             &spec_files,
             &spec_files,
-            &schema_tables,
-            &schema_columns,
+            &schema,
             &config,
             json,
             false,

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -7,11 +7,9 @@ use crate::generator::{
 };
 use crate::output::{print_coverage_line, print_coverage_report, print_summary};
 use crate::types;
-use crate::validator::{compute_coverage, get_schema_table_names};
+use crate::validator::{compute_coverage, load_schema_validation};
 
-use super::{
-    build_schema_columns, compute_exit_code, exit_with_status, load_and_discover, run_validation,
-};
+use super::{compute_exit_code, exit_with_status, load_and_discover, run_validation};
 
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_generate(
@@ -52,8 +50,7 @@ fn cmd_generate_all(
     } else {
         config.enforcement
     });
-    let schema_tables = get_schema_table_names(root, &config);
-    let schema_columns = build_schema_columns(root, &config);
+    let schema = load_schema_validation(root, &config);
     let ignore_rules = crate::ignore::IgnoreRules::default();
 
     let (mut total_errors, mut total_warnings, mut passed, mut total) = if spec_files.is_empty() {
@@ -68,8 +65,7 @@ fn cmd_generate_all(
             root,
             &spec_files,
             &spec_files,
-            &schema_tables,
-            &schema_columns,
+            &schema,
             &config,
             json,
             false,
@@ -93,14 +89,12 @@ fn cmd_generate_all(
         let (total_errors, total_warnings) = if spec_files.is_empty() {
             (0, 0)
         } else {
-            let schema_tables = get_schema_table_names(root, &config);
-            let schema_columns = build_schema_columns(root, &config);
+            let schema = load_schema_validation(root, &config);
             let (te, tw, _, _, _, _, _) = run_validation(
                 root,
                 &spec_files,
                 &spec_files,
-                &schema_tables,
-                &schema_columns,
+                &schema,
                 &config,
                 true,
                 false,
@@ -153,16 +147,14 @@ fn cmd_generate_all(
 
         // Recompute coverage and validation now that new specs exist
         let (config, spec_files) = load_and_discover(root, true);
-        let schema_tables = get_schema_table_names(root, &config);
-        let schema_columns = build_schema_columns(root, &config);
+        let schema = load_schema_validation(root, &config);
         coverage = compute_coverage(root, &spec_files, &config);
         if !spec_files.is_empty() {
             let (te, tw, p, t, _, _, _) = run_validation(
                 root,
                 &spec_files,
                 &spec_files,
-                &schema_tables,
-                &schema_columns,
+                &schema,
                 &config,
                 json,
                 false,
@@ -258,15 +250,13 @@ fn cmd_generate_batch(
         let (total_errors, total_warnings) = if spec_files.is_empty() {
             (0, 0)
         } else {
-            let schema_tables = get_schema_table_names(root, &config);
-            let schema_columns = build_schema_columns(root, &config);
+            let schema = load_schema_validation(root, &config);
             let ignore_rules = crate::ignore::IgnoreRules::default();
             let (te, tw, _, _, _, _, _) = run_validation(
                 root,
                 &spec_files,
                 &spec_files,
-                &schema_tables,
-                &schema_columns,
+                &schema,
                 &config,
                 true,
                 false,
@@ -345,15 +335,13 @@ fn cmd_generate_batch(
     let coverage = compute_coverage(root, &spec_files, &config);
     print_coverage_line(&coverage);
 
-    let schema_tables = get_schema_table_names(root, &config);
-    let schema_columns = build_schema_columns(root, &config);
+    let schema = load_schema_validation(root, &config);
     let ignore_rules = crate::ignore::IgnoreRules::default();
     let (total_errors, total_warnings, passed, total, _, _, _) = run_validation(
         root,
         &spec_files,
         &spec_files,
-        &schema_tables,
-        &schema_columns,
+        &schema,
         &config,
         true, // collect
         false,

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -7,9 +7,9 @@ use crate::config::load_config;
 use crate::github;
 use crate::parser;
 use crate::types;
-use crate::validator::{find_spec_files, get_schema_table_names};
+use crate::validator::{find_spec_files, load_schema_validation};
 
-use super::{build_schema_columns, create_drift_issues, run_validation};
+use super::{create_drift_issues, run_validation};
 
 pub fn cmd_issues(root: &Path, format: types::OutputFormat, create: bool) {
     let config = load_config(root);
@@ -126,15 +126,13 @@ pub fn cmd_issues(root: &Path, format: types::OutputFormat, create: bool) {
 
     // If --create, also run validation and create issues for drift
     if create {
-        let schema_tables = get_schema_table_names(root, &config);
-        let schema_columns = build_schema_columns(root, &config);
+        let schema = load_schema_validation(root, &config);
         let ignore_rules = crate::ignore::IgnoreRules::default();
         let (_, _, _, _, all_errors, _, _) = run_validation(
             root,
             &spec_files,
             &spec_files,
-            &schema_tables,
-            &schema_columns,
+            &schema,
             &config,
             true,
             false,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -36,11 +36,10 @@ use std::process;
 use crate::config::load_config;
 use crate::ignore::IgnoreRules;
 use crate::parser;
-use crate::schema;
 use crate::scoring;
 use crate::types;
 use crate::types::SpecStatus;
-use crate::validator::{find_spec_files, source_within_root, validate_spec};
+use crate::validator::{SchemaValidation, find_spec_files, source_within_root, validate_spec};
 
 pub fn load_and_discover(root: &Path, allow_empty: bool) -> (types::SpecSyncConfig, Vec<PathBuf>) {
     let config = load_config(root);
@@ -240,17 +239,6 @@ pub fn filter_by_status(
         .collect()
 }
 
-/// Build column-level schema from migration files (if schema_dir is configured).
-pub fn build_schema_columns(
-    root: &Path,
-    config: &types::SpecSyncConfig,
-) -> std::collections::HashMap<String, schema::SchemaTable> {
-    match &config.schema_dir {
-        Some(dir) => schema::build_schema(&root.join(dir)),
-        None => std::collections::HashMap::new(),
-    }
-}
-
 /// Run validation, returning counts and collected error, warning, and notice strings.
 /// `ownership_spec_files` must contain the complete discovered inventory even
 /// when `spec_files` is an incremental subset.
@@ -261,8 +249,7 @@ pub fn run_validation(
     root: &Path,
     spec_files: &[PathBuf],
     ownership_spec_files: &[PathBuf],
-    schema_tables: &std::collections::HashSet<String>,
-    schema_columns: &std::collections::HashMap<String, schema::SchemaTable>,
+    schema: &SchemaValidation,
     config: &types::SpecSyncConfig,
     collect: bool,
     explain: bool,
@@ -323,7 +310,7 @@ pub fn run_validation(
     }
 
     for spec_file in spec_files {
-        let mut result = validate_spec(spec_file, root, schema_tables, schema_columns, config);
+        let mut result = validate_spec(spec_file, root, &schema.tables, &schema.columns, config);
         let owner = spec_file
             .strip_prefix(root)
             .unwrap_or(spec_file)
@@ -383,12 +370,19 @@ pub fn run_validation(
         println!("\n{}", result.spec_path.bold());
 
         // Frontmatter check
-        let has_fm_errors = result
+        let frontmatter_errors: Vec<&str> = result
             .errors
             .iter()
-            .any(|e| e.starts_with("Frontmatter") || e.starts_with("Missing or malformed"));
-        if has_fm_errors {
+            .filter(|error| {
+                error.starts_with("Frontmatter") || error.starts_with("Missing or malformed")
+            })
+            .map(String::as_str)
+            .collect();
+        if !frontmatter_errors.is_empty() {
             println!("  {} Frontmatter invalid", "✗".red());
+            for error in frontmatter_errors {
+                println!("    {} {error}", "✗".red());
+            }
         } else {
             println!("  {} Frontmatter valid", "✓".green());
         }
@@ -424,7 +418,7 @@ pub fn run_validation(
             for e in &table_errors {
                 println!("  {} {e}", "✗".red());
             }
-        } else if !schema_tables.is_empty() {
+        } else if !schema.tables.is_empty() {
             println!("  {} All DB tables exist in schema", "✓".green());
         }
 
@@ -625,19 +619,15 @@ pub fn run_validation(
         }
     }
 
-    // Schema/migration files that exist but can't be read as UTF-8 are silently
-    // skipped by build_schema — their tables/columns vanish, which can silently
-    // disable db_tables/column validation (an all-unreadable schema makes the
-    // checks a no-op). Surface them once, project-level (not per spec), as hard
-    // errors so the gate fails loud instead of under-validating.
-    if let Some(dir) = &config.schema_dir {
-        for err in schema::schema_read_errors(&root.join(dir)) {
-            total_errors += 1;
-            if collect {
-                all_errors.push(err);
-            } else {
-                println!("\n{} {err}", "✗".red());
-            }
+    // Schema loading is invocation-scoped and fallible. Surface every retained
+    // configuration/read/replay problem once, without rebuilding the schema or
+    // allowing an empty snapshot to pass as successful validation.
+    for error in &schema.errors {
+        total_errors += 1;
+        if collect {
+            all_errors.push(error.clone());
+        } else {
+            println!("\n{} {error}", "✗".red());
         }
     }
 

--- a/src/commands/resolve.rs
+++ b/src/commands/resolve.rs
@@ -82,7 +82,7 @@ impl SpecCache {
 pub fn cmd_resolve(root: &Path, remote: bool, verify: bool, cache_ttl: u64) {
     let (_config, spec_files) = load_and_discover(root, false);
     let mut cross_refs: Vec<(String, String, String)> = Vec::new();
-    let mut local_refs: Vec<(String, String, bool)> = Vec::new();
+    let mut local_refs: Vec<(String, String, Result<std::path::PathBuf, String>)> = Vec::new();
 
     // Track local spec exports for bidirectional checking
     let mut local_exports: HashMap<String, Vec<String>> = HashMap::new();
@@ -118,8 +118,11 @@ pub fn cmd_resolve(root: &Path, remote: bool, verify: bool, cache_ttl: u64) {
                     cross_refs.push((spec_path.clone(), repo.to_string(), module.to_string()));
                 }
             } else {
-                let exists = root.join(dep).exists();
-                local_refs.push((spec_path.clone(), dep.clone(), exists));
+                // Same verdict as check/deps: bare module names resolve against
+                // the specs directory; absolute/`..` paths are rejected, not
+                // probed against the host filesystem.
+                let verdict = validator::validate_local_dependency(dep, root, &_config.specs_dir);
+                local_refs.push((spec_path.clone(), dep.clone(), verdict));
             }
         }
     }
@@ -136,11 +139,10 @@ pub fn cmd_resolve(root: &Path, remote: bool, verify: bool, cache_ttl: u64) {
 
     if !local_refs.is_empty() {
         println!("\n  {} Local dependencies:", "Local".bold());
-        for (spec, dep, exists) in &local_refs {
-            if *exists {
-                println!("    {} {spec} -> {dep}", "✓".green());
-            } else {
-                println!("    {} {spec} -> {dep} (not found)", "✗".red());
+        for (spec, dep, verdict) in &local_refs {
+            match verdict {
+                Ok(_) => println!("    {} {spec} -> {dep}", "✓".green()),
+                Err(message) => println!("    {} {spec} -> {message}", "✗".red()),
             }
         }
     }

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -123,13 +123,30 @@ fn build_dep_graph_checked(
         // Extract module names from depends_on paths.
         // Paths like "specs/types/types.spec.md" → module name "types"
         // Cross-project refs are skipped here.
-        let declared_deps: Vec<String> = parsed
-            .frontmatter
-            .depends_on
-            .iter()
-            .filter(|d| !is_cross_project_ref(d))
-            .filter_map(|d| extract_module_from_dep_path(d))
-            .collect();
+        // Every entry gets the SAME verdict as `check`/`resolve`: escapes,
+        // missing targets, and unresolvable shapes are hard errors, not
+        // silently dropped edges.
+        let mut declared_deps: Vec<String> = Vec::new();
+        for dep in &parsed.frontmatter.depends_on {
+            if is_cross_project_ref(dep) {
+                continue;
+            }
+            match crate::validator::validate_local_dependency(dep, root, specs_dir) {
+                Ok(_) => match extract_module_from_dep_path(dep) {
+                    Some(module) => declared_deps.push(module),
+                    None => unreadable.push(format!(
+                        "{spec_path}: dependency entry `{dep}` does not name a module (expected a bare module name or a path ending in .spec.md)"
+                    )),
+                },
+                Err(message) => {
+                    // Keep the edge so missing_deps still names the target.
+                    if let Some(module) = extract_module_from_dep_path(dep) {
+                        declared_deps.push(module);
+                    }
+                    unreadable.push(format!("{spec_path}: {message}"));
+                }
+            }
+        }
 
         graph.insert(
             module_name.clone(),
@@ -809,6 +826,55 @@ mod tests {
 
         let report = validate_deps(tmp.path(), "specs");
         assert!(!report.cycles.is_empty());
+    }
+
+    #[test]
+    fn test_flow_style_depends_on_counts_edges() {
+        // `depends_on: [b]` (the flow style `specsync new` scaffolds) must
+        // produce a real edge, not silently parse as zero dependencies.
+        let tmp = TempDir::new().unwrap();
+        create_spec(tmp.path(), "b", &[], &[]);
+        let spec_dir = tmp.path().join("specs").join("a");
+        fs::create_dir_all(&spec_dir).unwrap();
+        fs::write(
+            spec_dir.join("a.spec.md"),
+            "---\nmodule: a\nversion: 1\nstatus: active\nfiles: []\ndepends_on: [b]\n---\n\n# A\n\n## Purpose\nTest\n",
+        )
+        .unwrap();
+
+        let report = validate_deps(tmp.path(), "specs");
+        assert_eq!(report.edge_count, 1, "report: {report:?}");
+        assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+    }
+
+    #[test]
+    fn test_deps_rejects_escapes_and_missing_with_same_verdict_as_check() {
+        let tmp = TempDir::new().unwrap();
+        let spec_dir = tmp.path().join("specs").join("a");
+        fs::create_dir_all(&spec_dir).unwrap();
+        fs::write(
+            spec_dir.join("a.spec.md"),
+            "---\nmodule: a\nversion: 1\nstatus: active\nfiles: []\ndepends_on: [/etc/passwd, nosuchmod]\n---\n\n# A\n\n## Purpose\nTest\n",
+        )
+        .unwrap();
+
+        let report = validate_deps(tmp.path(), "specs");
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|e| e.contains("escapes the project root") && e.contains("/etc/passwd")),
+            "errors: {:?}",
+            report.errors
+        );
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|e| e.contains("Dependency spec not found: nosuchmod")),
+            "errors: {:?}",
+            report.errors
+        );
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -3,7 +3,7 @@ use crate::deps::build_dep_graph;
 use crate::generator::generate_specs_for_unspecced_modules_paths;
 use crate::scoring;
 use crate::types::SpecSyncConfig;
-use crate::validator::{compute_coverage, find_spec_files, get_schema_table_names, validate_spec};
+use crate::validator::{compute_coverage, find_spec_files, load_schema_validation, validate_spec};
 use serde_json::{Value, json};
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -546,9 +546,7 @@ fn load_and_discover(
 
 fn tool_check(root: &Path, arguments: &Value) -> Result<Value, String> {
     let (config, spec_files) = load_and_discover(root, false)?;
-    let schema_tables = get_schema_table_names(root, &config);
-    let schema_columns =
-        crate::schema::build_schema(&root.join(config.schema_dir.as_deref().unwrap_or("")));
+    let schema = load_schema_validation(root, &config);
     let strict = arguments
         .get("strict")
         .and_then(|s| s.as_bool())
@@ -582,7 +580,7 @@ fn tool_check(root: &Path, arguments: &Value) -> Result<Value, String> {
     let mut spec_results: Vec<Value> = Vec::new();
 
     for spec_file in &spec_files {
-        let result = validate_spec(spec_file, root, &schema_tables, &schema_columns, &config);
+        let result = validate_spec(spec_file, root, &schema.tables, &schema.columns, &config);
         let spec_passed = result.errors.is_empty();
 
         spec_results.push(json!({
@@ -605,6 +603,11 @@ fn tool_check(root: &Path, arguments: &Value) -> Result<Value, String> {
         if spec_passed {
             passed += 1;
         }
+    }
+
+    for error in &schema.errors {
+        total_errors += 1;
+        all_errors.push(json!(error));
     }
 
     // Add staleness warnings into the warnings array for consistency

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,11 @@ use std::sync::LazyLock;
 pub struct ParsedSpec {
     pub frontmatter: Frontmatter,
     pub body: String,
+    /// Hard frontmatter problems (duplicate keys, wrong shapes, unclosed
+    /// brackets/quotes). The offending text is included in each message.
+    pub errors: Vec<String>,
+    /// Soft frontmatter problems (non-numeric versions, ignored garbage lines).
+    pub warnings: Vec<String>,
 }
 
 static FRONTMATTER_RE: LazyLock<Regex> =
@@ -28,8 +33,11 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
     let body = caps.get(2)?.as_str().to_string();
 
     let mut fm = Frontmatter::default();
+    let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
     let mut current_key: Option<String> = None;
     let mut current_list: Vec<String> = Vec::new();
+    let mut seen_keys: HashSet<String> = HashSet::new();
 
     for line in yaml_block.lines() {
         // List item: "  - value" (supports spaces or tabs for indentation)
@@ -53,24 +61,41 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
                 current_list.clear();
             }
 
+            // Duplicate keys are a validation bypass (a hidden second
+            // `status: draft` silently disables all section/export checks).
+            // Reject loudly with the offending line.
+            if !seen_keys.insert(key.to_string()) {
+                errors.push(format!(
+                    "Frontmatter duplicate key `{key}` (offending line: `{}`) — remove the duplicate; the last value would silently win",
+                    line.trim()
+                ));
+            }
+
             let value = strip_yaml_comment(line[colon_pos + 1..].trim());
 
             if value.is_empty() || value == "[]" {
                 current_key = Some(key.to_string());
                 current_list.clear();
             } else {
-                set_scalar(&mut fm, key, &value);
+                set_scalar(&mut fm, key, &value, line.trim(), &mut errors, &mut warnings);
             }
             continue;
         }
 
         // Blank or comment line: flush
         let trimmed = line.trim();
-        if (trimmed.is_empty() || trimmed.starts_with('#'))
-            && let Some(prev_key) = current_key.take()
-        {
-            set_field(&mut fm, &prev_key, &current_list);
-            current_list.clear();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            if let Some(prev_key) = current_key.take() {
+                set_field(&mut fm, &prev_key, &current_list);
+                current_list.clear();
+            }
+        } else {
+            // A non-empty, non-comment line that is neither `key: value` nor a
+            // list item under an active key cannot be parsed — surface it
+            // instead of silently dropping it.
+            warnings.push(format!(
+                "Ignoring malformed frontmatter line (expected `key: value`): `{trimmed}`"
+            ));
         }
     }
 
@@ -82,6 +107,8 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
     Some(ParsedSpec {
         frontmatter: fm,
         body,
+        errors,
+        warnings,
     })
 }
 
@@ -104,10 +131,53 @@ fn strip_yaml_comment(value: &str) -> String {
     value.to_string()
 }
 
-fn set_scalar(fm: &mut Frontmatter, key: &str, value: &str) {
+/// Fields that must hold a YAML list of strings.
+const LIST_FIELDS: &[&str] = &["files", "db_tables", "depends_on"];
+
+fn set_scalar(
+    fm: &mut Frontmatter,
+    key: &str,
+    value: &str,
+    offending_line: &str,
+    errors: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) {
+    // List fields given a non-list shape: a mapping (`depends_on: {a: b}`)
+    // would otherwise parse to an empty list and silently validate nothing.
+    if LIST_FIELDS.contains(&key) {
+        if value.starts_with('{') {
+            errors.push(format!(
+                "Frontmatter field `{key}` must be a YAML list, got a mapping (offending line: `{offending_line}`)"
+            ));
+            return;
+        }
+        if value.starts_with('[') {
+            // Flow-style list (`depends_on: [a, b]`) — the form `specsync new`
+            // scaffolds. Parse it; an unclosed bracket is a hard error.
+            match parse_flow_string_list(value) {
+                Ok(items) => set_field(fm, key, &items),
+                Err(message) => errors.push(message),
+            }
+            return;
+        }
+        // A bare scalar (`depends_on: auth`) is treated as a one-item list,
+        // matching YAML's leniency, but flagged so typos are visible.
+        warnings.push(format!(
+            "Frontmatter field `{key}` should be a YAML list, got scalar `{value}` — treating it as a one-item list"
+        ));
+        set_field(fm, key, std::slice::from_ref(&value.to_string()));
+        return;
+    }
     match key {
         "module" => fm.module = Some(value.to_string()),
-        "version" => fm.version = Some(value.to_string()),
+        "version" => {
+            if !is_version_shaped(value) {
+                warnings.push(format!(
+                    "Frontmatter `version` should be a plain number, got `{value}`"
+                ));
+            }
+            fm.version = Some(value.to_string());
+        }
         "status" => fm.status = Some(value.to_string()),
         "agent_policy" => fm.agent_policy = Some(value.to_string()),
         // Handle inline bracket arrays like `implements: [42, 57]`
@@ -115,6 +185,55 @@ fn set_scalar(fm: &mut Frontmatter, key: &str, value: &str) {
         "tracks" => fm.tracks = parse_inline_issue_numbers(value),
         _ => {}
     }
+}
+
+/// A version is "version-shaped" if it is numeric or semver-like (`1`, `1.0`,
+/// `1.0.0`), optionally quoted.
+fn is_version_shaped(value: &str) -> bool {
+    let unquoted = value
+        .strip_prefix('"')
+        .and_then(|v| v.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|v| v.strip_suffix('\''))
+        })
+        .unwrap_or(value);
+    !unquoted.is_empty()
+        && unquoted
+            .split('.')
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Parse a flow-style YAML string list: `[a, b, "c"]` → `vec![a, b, c]`.
+/// Rejects unclosed brackets and unterminated quotes loudly.
+fn parse_flow_string_list(value: &str) -> Result<Vec<String>, String> {
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|v| v.strip_suffix(']'))
+        .ok_or_else(|| {
+            format!("Frontmatter flow-style list is missing a closing `]`: `{value}`")
+        })?;
+    let mut items = Vec::new();
+    for raw in inner.split(',') {
+        let item = raw.trim();
+        if item.is_empty() {
+            continue;
+        }
+        let unquoted = if let Some(rest) = item.strip_prefix('"') {
+            rest.strip_suffix('"').ok_or_else(|| {
+                format!("Frontmatter list has an unterminated quoted string: `{item}`")
+            })?
+        } else if let Some(rest) = item.strip_prefix('\'') {
+            rest.strip_suffix('\'').ok_or_else(|| {
+                format!("Frontmatter list has an unterminated quoted string: `{item}`")
+            })?
+        } else {
+            item
+        };
+        items.push(unquoted.to_string());
+    }
+    Ok(items)
 }
 
 /// Parse an inline bracket array of issue numbers: `[42, 57]` → vec![42, 57].
@@ -174,7 +293,7 @@ static EXPORT_HEADER_RE: LazyLock<Regex> =
 /// an identifier character allowlist. Requiring the closing backtick and cell
 /// delimiter prevents prose and later-column code spans from becoming exports.
 static TABLE_ROW_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\|\s*`([^`\r\n]+)`\s*\|").unwrap());
+    LazyLock::new(|| Regex::new(r"^[ \t]{0,3}\|\s*`([^`\r\n]+)`\s*\|").unwrap());
 
 static METHOD_HEADER_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^####\s+.*(?:Methods|Constructor|Properties)").unwrap());
@@ -183,6 +302,29 @@ static METHOD_HEADER_RE: LazyLock<Regex> =
 /// Only extracts the FIRST nonempty backtick-quoted symbol in each table row.
 /// Skips class method sub-tables.
 pub fn get_spec_symbols(body: &str) -> Vec<String> {
+    let mut symbols = collect_spec_symbols(body);
+    // Deduplicate while preserving order
+    let mut seen = HashSet::new();
+    symbols.retain(|s| seen.insert(s.clone()));
+    symbols
+}
+
+/// Symbols listed more than once in the Public API tables — duplicate rows
+/// are almost always a paste error and were previously deduplicated silently.
+pub fn get_duplicate_spec_symbols(body: &str) -> Vec<String> {
+    let symbols = collect_spec_symbols(body);
+    let mut seen = HashSet::new();
+    let mut reported = HashSet::new();
+    let mut duplicates = Vec::new();
+    for symbol in symbols {
+        if !seen.insert(symbol.clone()) && reported.insert(symbol.clone()) {
+            duplicates.push(symbol);
+        }
+    }
+    duplicates
+}
+
+fn collect_spec_symbols(body: &str) -> Vec<String> {
     let mut symbols = Vec::new();
 
     // Find the Public API section manually (no lookahead in Rust regex).
@@ -265,9 +407,6 @@ pub fn get_spec_symbols(body: &str) -> Vec<String> {
         }
     }
 
-    // Deduplicate while preserving order
-    let mut seen = HashSet::new();
-    symbols.retain(|s| seen.insert(s.clone()));
     symbols
 }
 
@@ -489,6 +628,90 @@ mod tests {
         assert_eq!(parsed.frontmatter.status.as_deref(), Some("active"));
         assert_eq!(parsed.frontmatter.files, vec!["src/auth.ts"]);
         assert!(parsed.frontmatter.db_tables.is_empty());
+    }
+
+    #[test]
+    fn test_parse_frontmatter_duplicate_key_rejected_loudly() {
+        // A hidden second `status: draft` must not silently disable validation.
+        let content = "---\nmodule: auth\nversion: 1\nstatus: active\nstatus: draft\nfiles:\n  - src/auth.ts\n---\n\n# Auth\n";
+        let parsed = parse_frontmatter(content).unwrap();
+        assert!(
+            parsed
+                .errors
+                .iter()
+                .any(|e| e.contains("duplicate key `status`") && e.contains("status: draft")),
+            "errors: {:?}",
+            parsed.errors
+        );
+    }
+
+    #[test]
+    fn test_parse_frontmatter_flow_style_string_lists() {
+        // `specsync new` scaffolds `depends_on: [b]` — it must parse as one edge.
+        let content = "---\nmodule: a\nversion: 1\nstatus: active\nfiles: [src/a.ts, \"src/b.ts\"]\ndepends_on: [b, 'c']\ndb_tables: [users]\n---\n\n# A\n";
+        let parsed = parse_frontmatter(content).unwrap();
+        assert!(parsed.errors.is_empty(), "errors: {:?}", parsed.errors);
+        assert_eq!(parsed.frontmatter.files, vec!["src/a.ts", "src/b.ts"]);
+        assert_eq!(parsed.frontmatter.depends_on, vec!["b", "c"]);
+        assert_eq!(parsed.frontmatter.db_tables, vec!["users"]);
+    }
+
+    #[test]
+    fn test_parse_frontmatter_rejects_bad_list_shapes() {
+        let content = "---\nmodule: a\nversion: 1\nstatus: active\nfiles:\n  - src/a.ts\ndepends_on: {a: b}\n---\n\n# A\n";
+        let parsed = parse_frontmatter(content).unwrap();
+        assert!(
+            parsed
+                .errors
+                .iter()
+                .any(|e| e.contains("`depends_on` must be a YAML list")),
+            "errors: {:?}",
+            parsed.errors
+        );
+
+        let unclosed = "---\nmodule: a\nversion: 1\nstatus: active\nfiles:\n  - src/a.ts\ndepends_on: [unclosed\n---\n\n# A\n";
+        let parsed = parse_frontmatter(unclosed).unwrap();
+        assert!(
+            parsed
+                .errors
+                .iter()
+                .any(|e| e.contains("missing a closing `]`")),
+            "errors: {:?}",
+            parsed.errors
+        );
+
+        let unterminated = "---\nmodule: a\nversion: 1\nstatus: active\nfiles:\n  - src/a.ts\ndepends_on: [\"mymod]\n---\n\n# A\n";
+        let parsed = parse_frontmatter(unterminated).unwrap();
+        assert!(
+            parsed
+                .errors
+                .iter()
+                .any(|e| e.contains("unterminated quoted string")),
+            "errors: {:?}",
+            parsed.errors
+        );
+    }
+
+    #[test]
+    fn test_parse_frontmatter_warns_on_non_numeric_version_and_garbage_lines() {
+        let content = "---\nmodule: a\nversion: \"one\"\nstatus: active\nfiles:\n  - src/a.ts\ncolons are fun\n---\n\n# A\n";
+        let parsed = parse_frontmatter(content).unwrap();
+        assert!(
+            parsed
+                .warnings
+                .iter()
+                .any(|w| w.contains("`version` should be a plain number")),
+            "warnings: {:?}",
+            parsed.warnings
+        );
+        assert!(
+            parsed
+                .warnings
+                .iter()
+                .any(|w| w.contains("malformed frontmatter line") && w.contains("colons are fun")),
+            "warnings: {:?}",
+            parsed.warnings
+        );
     }
 
     #[test]
@@ -818,6 +1041,23 @@ This prose contains `proseSymbol` but is not a table row.
         let parsed = parse_frontmatter(content).unwrap();
         assert!(parsed.frontmatter.implements.is_empty());
         assert!(parsed.frontmatter.tracks.is_empty());
+    }
+
+    #[test]
+    fn test_get_spec_symbols_indented_table() {
+        // A 2-space-indented GFM table (valid CommonMark, renders on GitHub)
+        // must not be silently ignored.
+        let body = "## Public API\n\n### Exported Functions\n\n  | Function | Description |\n  |----------|-------------|\n  | `createAuth` | Creates auth |\n  | `validateToken` | Validates |\n\n## Invariants\n";
+        assert_eq!(get_spec_symbols(body), vec!["createAuth", "validateToken"]);
+    }
+
+    #[test]
+    fn test_get_duplicate_spec_symbols() {
+        let body = "## Public API\n\n### Exported Functions\n\n| Function | Description |\n|----------|-------------|\n| `login` | a |\n| `logout` | b |\n| `login` | pasted twice |\n\n## Invariants\n";
+        assert_eq!(get_duplicate_spec_symbols(body), vec!["login"]);
+        // Unique rows produce no duplicates.
+        let body = "## Public API\n\n| Function | Description |\n|----------|-------------|\n| `login` | a |\n";
+        assert!(get_duplicate_spec_symbols(body).is_empty());
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,7 +77,14 @@ pub fn parse_frontmatter(content: &str) -> Option<ParsedSpec> {
                 current_key = Some(key.to_string());
                 current_list.clear();
             } else {
-                set_scalar(&mut fm, key, &value, line.trim(), &mut errors, &mut warnings);
+                set_scalar(
+                    &mut fm,
+                    key,
+                    &value,
+                    line.trim(),
+                    &mut errors,
+                    &mut warnings,
+                );
             }
             continue;
         }
@@ -193,11 +200,7 @@ fn is_version_shaped(value: &str) -> bool {
     let unquoted = value
         .strip_prefix('"')
         .and_then(|v| v.strip_suffix('"'))
-        .or_else(|| {
-            value
-                .strip_prefix('\'')
-                .and_then(|v| v.strip_suffix('\''))
-        })
+        .or_else(|| value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')))
         .unwrap_or(value);
     !unquoted.is_empty()
         && unquoted

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,11 +1,12 @@
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 /// A column extracted from SQL schema files.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaColumn {
     pub name: String,
     /// Normalised to uppercase (e.g. "INTEGER", "TEXT").
@@ -16,7 +17,7 @@ pub struct SchemaColumn {
 }
 
 /// All columns for a single table, built by replaying migrations in order.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SchemaTable {
     pub columns: Vec<SchemaColumn>,
 }
@@ -29,36 +30,307 @@ impl SchemaTable {
 }
 
 /// A column documented in a spec's ### Schema section.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpecColumn {
     pub name: String,
     /// Raw type string from the spec (e.g. "INTEGER", "TEXT").
     pub col_type: String,
 }
 
+/// Stable categories for schema-loading and replay failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaErrorKind {
+    MissingDirectory,
+    ReadDirectory,
+    ReadEntry,
+    ReadFile,
+    MalformedStatement,
+    MissingTable,
+    DuplicateTable,
+    RenameCollision,
+    MissingColumn,
+    DuplicateColumn,
+}
+
+/// A path- and source-position-aware schema loading or replay failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaError {
+    pub kind: SchemaErrorKind,
+    pub path: PathBuf,
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+impl fmt::Display for SchemaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.line == 0 {
+            write!(formatter, "{}: {}", self.path.display(), self.message)
+        } else {
+            write!(
+                formatter,
+                "{}:{}:{}: {}",
+                self.path.display(),
+                self.line,
+                self.column,
+                self.message
+            )
+        }
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
+impl SchemaError {
+    fn for_path(kind: SchemaErrorKind, path: &Path, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            path: path.to_path_buf(),
+            line: 0,
+            column: 0,
+            message: message.into(),
+        }
+    }
+
+    fn at(
+        kind: SchemaErrorKind,
+        path: &Path,
+        sql: &str,
+        offset: usize,
+        message: impl Into<String>,
+    ) -> Self {
+        let bounded_offset = offset.min(sql.len());
+        let before = &sql[..bounded_offset];
+        let line = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
+        let column = before
+            .rsplit_once('\n')
+            .map(|(_, tail)| tail.chars().count() + 1)
+            .unwrap_or_else(|| before.chars().count() + 1);
+
+        Self {
+            kind,
+            path: path.to_path_buf(),
+            line,
+            column,
+            message: message.into(),
+        }
+    }
+}
+
+/// The current canonical schema state after deterministic migration replay.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SchemaSnapshot {
+    pub tables: HashMap<String, SchemaTable>,
+    pub retired_tables: HashSet<String>,
+}
+
 // ─── SQL Parsing ─────────────────────────────────────────────────────────
 
+/// One SQL identifier segment: ANSI double quotes, MySQL backticks, SQL Server
+/// brackets, or a conservative bare identifier.
+const IDENTIFIER_SEGMENT: &str =
+    r#"(?:"(?:[^"]|"")+"|`(?:[^`]|``)+`|\[(?:[^\]]|\]\])+\]|[A-Za-z_][A-Za-z0-9_$]*)"#;
+
+fn schema_regex(pattern: &str) -> Regex {
+    let qualified_name = format!("{IDENTIFIER_SEGMENT}(?:\\s*\\.\\s*{IDENTIFIER_SEGMENT})*");
+    let expanded = pattern
+        .replace("{NAME}", &qualified_name)
+        .replace("{IDENT}", IDENTIFIER_SEGMENT);
+    Regex::new(&expanded).expect("static schema regex must compile")
+}
+
+static DDL_START_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)\b(?:CREATE\s+(?:OR\s+REPLACE\s+)?(?:VIRTUAL\s+)?TABLE|ALTER\s+TABLE|DROP\s+TABLE)\b",
+    )
+    .expect("static DDL start regex must compile")
+});
+
 static CREATE_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)CREATE\s+(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(").unwrap()
+    schema_regex(
+        r"(?is)^CREATE\s+(?P<replace>OR\s+REPLACE\s+)?TABLE\s+(?P<if_not_exists>IF\s+NOT\s+EXISTS\s+)?(?P<table>{NAME})\s*\(",
+    )
+});
+
+static CREATE_VIRTUAL_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    schema_regex(
+        r"(?is)^CREATE\s+VIRTUAL\s+TABLE\s+(?P<if_not_exists>IF\s+NOT\s+EXISTS\s+)?(?P<table>{NAME})\s+USING\s+[A-Za-z_][A-Za-z0-9_]*",
+    )
 });
 
 static ALTER_ADD_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)\s+(\w+)").unwrap()
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+ADD\s+(?:COLUMN\s+)?(?P<column>{IDENT})\s+(?P<type>[A-Za-z_][A-Za-z0-9_]*(?:\s*\([^)]*\))?)",
+    )
 });
 
-static DROP_TABLE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\w+)").unwrap());
+static DROP_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    schema_regex(r"(?is)^DROP\s+TABLE\s+(?P<if_exists>IF\s+EXISTS\s+)?(?P<table>{NAME})(?:\s|$)")
+});
 
 static ALTER_DROP_COL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+DROP\s+(?:COLUMN\s+)?(\w+)").unwrap()
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+DROP\s+(?:COLUMN\s+)?(?P<column>{IDENT})(?:\s|$)",
+    )
 });
 
-static ALTER_RENAME_TABLE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+RENAME\s+TO\s+(\w+)").unwrap());
+static ALTER_RENAME_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+RENAME\s+TO\s+(?P<new_table>{NAME})(?:\s|$)",
+    )
+});
 
 static ALTER_RENAME_COL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+RENAME\s+(?:COLUMN\s+)?(\w+)\s+TO\s+(\w+)").unwrap()
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+RENAME\s+(?:COLUMN\s+)?(?P<column>{IDENT})\s+TO\s+(?P<new_column>{IDENT})(?:\s|$)",
+    )
 });
+
+/// Return a canonical table identity by parsing qualified identifier segments,
+/// unescaping each supported quoting style, and applying Unicode lowercase.
+pub fn canonicalize_table_name(raw: &str) -> Result<String, String> {
+    let segments = split_table_identifier_segments(raw)?;
+    let canonical_segments = segments
+        .iter()
+        .map(|segment| normalize_identifier_segment(segment))
+        .map(|result| result.map(|segment| render_canonical_table_segment(&segment)))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(canonical_segments.join("."))
+}
+
+/// Return the canonical final identifier segment of a qualified table name.
+/// Validator code uses this for unqualified declarations instead of splitting
+/// on `.`, which would corrupt a quoted identifier that itself contains a dot.
+#[allow(dead_code)] // Consumed by the validator restack built on this schema slice.
+pub fn canonical_table_leaf(raw: &str) -> Result<String, String> {
+    let segments = split_table_identifier_segments(raw)?;
+    let last = segments
+        .last()
+        .ok_or_else(|| format!("table identifier `{raw}` has no segments"))?;
+    normalize_identifier_segment(last).map(|segment| render_canonical_table_segment(&segment))
+}
+
+fn split_table_identifier_segments(raw: &str) -> Result<Vec<String>, String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut characters = raw.chars().peekable();
+
+    while let Some(character) = characters.next() {
+        match quote {
+            Some('"') if character == '"' => {
+                current.push(character);
+                if characters.peek() == Some(&'"') {
+                    current.push(characters.next().unwrap_or('"'));
+                } else {
+                    quote = None;
+                }
+            }
+            Some('`') if character == '`' => {
+                current.push(character);
+                if characters.peek() == Some(&'`') {
+                    current.push(characters.next().unwrap_or('`'));
+                } else {
+                    quote = None;
+                }
+            }
+            Some(']') if character == ']' => {
+                current.push(character);
+                if characters.peek() == Some(&']') {
+                    current.push(characters.next().unwrap_or(']'));
+                } else {
+                    quote = None;
+                }
+            }
+            Some(_) => current.push(character),
+            None if character == '.' => {
+                if current.trim().is_empty() {
+                    return Err(format!("empty table identifier segment in `{raw}`"));
+                }
+                segments.push(std::mem::take(&mut current));
+            }
+            None if character == '"' || character == '`' => {
+                quote = Some(character);
+                current.push(character);
+            }
+            None if character == '[' => {
+                quote = Some(']');
+                current.push(character);
+            }
+            None => current.push(character),
+        }
+    }
+
+    if quote.is_some() {
+        return Err(format!("unterminated quoted table identifier `{raw}`"));
+    }
+    if current.trim().is_empty() {
+        return Err(format!("empty table identifier segment in `{raw}`"));
+    }
+    segments.push(current);
+    Ok(segments)
+}
+
+fn render_canonical_table_segment(segment: &str) -> String {
+    if is_bare_identifier(segment) {
+        segment.to_string()
+    } else {
+        format!("\"{}\"", segment.replace('"', "\"\""))
+    }
+}
+
+fn normalize_identifier_segment(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("identifier segment is empty".to_string());
+    }
+
+    let unquoted = if let Some(inner) = trimmed
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+    {
+        inner.replace("\"\"", "\"")
+    } else if let Some(inner) = trimmed
+        .strip_prefix('`')
+        .and_then(|value| value.strip_suffix('`'))
+    {
+        inner.replace("``", "`")
+    } else if let Some(inner) = trimmed
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        inner.replace("]]", "]")
+    } else {
+        if !is_bare_identifier(trimmed) {
+            return Err(format!("malformed identifier segment `{raw}`"));
+        }
+        trimmed.to_string()
+    };
+
+    if unquoted.is_empty() {
+        return Err(format!("identifier segment `{raw}` is empty"));
+    }
+    Ok(unquoted.to_lowercase())
+}
+
+fn is_bare_identifier(identifier: &str) -> bool {
+    let mut characters = identifier.chars();
+    characters
+        .next()
+        .map(|first| first == '_' || first.is_ascii_alphabetic())
+        .unwrap_or(false)
+        && characters.all(|character| {
+            character == '_' || character == '$' || character.is_ascii_alphanumeric()
+        })
+}
+
+/// Normalize a valid table reference for comparison. Invalid input is lowered
+/// without structural rewriting; fallible replay uses `canonicalize_table_name`
+/// and reports the malformed identifier instead.
+#[allow(dead_code)] // Used by the validator restack that consumes this schema slice.
+pub fn normalize_table_name(raw: &str) -> String {
+    canonicalize_table_name(raw).unwrap_or_else(|_| raw.trim().to_lowercase())
+}
 
 /// File extensions that may contain embedded SQL statements.
 const SQL_EXTENSIONS: &[&str] = &[
@@ -67,181 +339,765 @@ const SQL_EXTENSIONS: &[&str] = &[
 ];
 
 /// Build a complete schema map from SQL/migration files in the given directory.
-/// Files are sorted by name so migrations replay in order.
+/// This compatibility wrapper returns an empty map on error. Validation code
+/// must call `build_schema_snapshot` so malformed or unreadable migrations
+/// cannot become a vacuous success.
+#[allow(dead_code)] // Retained for callers outside the validation pipeline and focused compatibility tests.
 pub fn build_schema(schema_dir: &Path) -> HashMap<String, SchemaTable> {
-    let mut tables: HashMap<String, SchemaTable> = HashMap::new();
-
-    if !schema_dir.exists() {
-        return tables;
-    }
-
-    // Collect and sort files for deterministic migration ordering.
-    let mut files: Vec<_> = fs::read_dir(schema_dir)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .filter(|e| {
-            let ext = e
-                .path()
-                .extension()
-                .and_then(|x| x.to_str())
-                .unwrap_or("")
-                .to_string();
-            SQL_EXTENSIONS.contains(&ext.as_str())
-        })
-        .collect();
-    files.sort_by_key(|e| e.file_name());
-
-    for entry in &files {
-        let content = match fs::read_to_string(entry.path()) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        parse_sql_into(&content, &mut tables);
-    }
-
-    tables
+    build_schema_snapshot(schema_dir)
+        .map(|snapshot| snapshot.tables)
+        .unwrap_or_default()
 }
 
-/// Return an error message for each schema/migration file that EXISTS in
-/// `schema_dir` but could not be read as UTF-8. `build_schema` silently skips such
-/// a file (`Err(_) => continue`), which makes its tables/columns vanish and can
-/// silently disable DB validation — if every schema file is unreadable, the
-/// discovered set is empty and the `db_tables`/column checks become a no-op with
-/// no signal. The validation gate surfaces these so an unreadable migration fails
-/// loud instead of quietly weakening the guarantee. Scans the same files
-/// `build_schema` would (matching `SQL_EXTENSIONS`); returns an empty vec when the
-/// directory is absent (schema is simply not configured for this project).
-pub fn schema_read_errors(schema_dir: &Path) -> Vec<String> {
-    let mut errors = Vec::new();
-    if !schema_dir.exists() {
-        return errors;
+/// Compatibility wrapper exposing retired names to older validator code.
+/// Validation code should migrate to `build_schema_snapshot`.
+#[allow(dead_code)] // Used by the validator restack until it adopts SchemaSnapshot.
+pub fn build_schema_with_retired(
+    schema_dir: &Path,
+) -> (HashMap<String, SchemaTable>, HashSet<String>) {
+    match build_schema_snapshot(schema_dir) {
+        Ok(snapshot) => (snapshot.tables, snapshot.retired_tables),
+        Err(_) => (HashMap::new(), HashSet::new()),
     }
+}
 
-    // A `schema_dir` that exists but cannot be enumerated (unreadable, or a file
-    // rather than a directory) makes `read_dir` return `Err`. Ignoring it would be
-    // the same fail-open this function exists to close: schema discovery would come
-    // back empty and the `db_tables`/column checks would be silently skipped. Surface
-    // it as a hard error instead.
-    let read_dir = match fs::read_dir(schema_dir) {
-        Ok(read_dir) => read_dir,
-        Err(err) => {
-            errors.push(format!(
-                "Schema directory `{}` could not be read ({err}); DB schema validation would be incomplete",
-                schema_dir.display()
-            ));
-            return errors;
-        }
-    };
+/// Build one deterministic, fallible schema snapshot.
+///
+/// Files are sorted by filename and every supported DDL statement is replayed
+/// in byte order within each file. Directory, entry, UTF-8, malformed-DDL,
+/// missing-object, and canonical-name collision failures are returned instead
+/// of being collapsed into an empty schema.
+pub fn build_schema_snapshot(schema_dir: &Path) -> Result<SchemaSnapshot, SchemaError> {
+    let read_dir = fs::read_dir(schema_dir).map_err(|error| {
+        let kind = if error.kind() == std::io::ErrorKind::NotFound {
+            SchemaErrorKind::MissingDirectory
+        } else {
+            SchemaErrorKind::ReadDirectory
+        };
+        SchemaError::for_path(
+            kind,
+            schema_dir,
+            format!("schema directory could not be read: {error}"),
+        )
+    })?;
 
-    let mut files: Vec<_> = read_dir
-        .flatten()
-        .filter(|e| {
-            e.path()
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .map(|ext| SQL_EXTENSIONS.contains(&ext))
-                .unwrap_or(false)
-        })
-        .collect();
-    files.sort_by_key(|e| e.file_name());
-
-    for entry in &files {
+    let mut files = Vec::new();
+    for entry in read_dir {
+        let entry = entry.map_err(|error| {
+            SchemaError::for_path(
+                SchemaErrorKind::ReadEntry,
+                schema_dir,
+                format!("schema directory entry could not be read: {error}"),
+            )
+        })?;
         let path = entry.path();
-        if path.is_file() && fs::read_to_string(&path).is_err() {
-            let name = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("<unknown>");
-            errors.push(format!(
-                "Schema/migration file `{name}` could not be read as UTF-8; DB schema validation would be incomplete"
-            ));
+        let supported = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| SQL_EXTENSIONS.contains(&extension))
+            .unwrap_or(false);
+        if supported && path.is_file() {
+            files.push(path);
         }
     }
+    files.sort();
 
-    errors
+    let mut snapshot = SchemaSnapshot::default();
+    for path in files {
+        let content = fs::read_to_string(&path).map_err(|error| {
+            SchemaError::for_path(
+                SchemaErrorKind::ReadFile,
+                &path,
+                format!("schema/migration file could not be read as UTF-8: {error}"),
+            )
+        })?;
+        replay_sql(&path, &content, &mut snapshot)?;
+    }
+
+    Ok(snapshot)
+}
+
+/// Compatibility diagnostics for command paths that have not yet adopted the
+/// fallible snapshot directly.
+#[allow(dead_code)] // Retained for callers outside the validation pipeline and focused compatibility tests.
+pub fn schema_read_errors(schema_dir: &Path) -> Vec<String> {
+    match build_schema_snapshot(schema_dir) {
+        Ok(_) => Vec::new(),
+        Err(error) => vec![error.to_string()],
+    }
 }
 
 /// Parse SQL content and merge discovered tables/columns into the map.
+#[cfg(test)]
 fn parse_sql_into(sql: &str, tables: &mut HashMap<String, SchemaTable>) {
-    // Handle CREATE TABLE statements
-    for cap in CREATE_TABLE_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
-        let start = cap.get(0).unwrap().end(); // position after opening paren
+    let mut snapshot = SchemaSnapshot {
+        tables: std::mem::take(tables),
+        retired_tables: HashSet::new(),
+    };
+    if let Err(error) = replay_sql(Path::new("<test>"), sql, &mut snapshot) {
+        panic!("test SQL must replay successfully: {error}");
+    }
+    *tables = snapshot.tables;
+}
 
-        // Find matching closing paren (handles nested parens for CHECK constraints etc.)
-        if let Some(body) = extract_paren_body(sql, start) {
-            let columns = parse_column_defs(&body);
-            let entry = tables.entry(table_name).or_default();
-            // CREATE TABLE replaces any prior definition (e.g. CREATE OR REPLACE)
-            entry.columns = columns;
+#[derive(Debug)]
+enum SchemaOperation {
+    CreateTable {
+        table: String,
+        columns: Vec<SchemaColumn>,
+        if_not_exists: bool,
+        replace: bool,
+    },
+    DropTable {
+        table: String,
+        if_exists: bool,
+    },
+    RenameTable {
+        table: String,
+        new_table: String,
+    },
+    AddColumn {
+        table: String,
+        column: SchemaColumn,
+    },
+    DropColumn {
+        table: String,
+        column: String,
+    },
+    RenameColumn {
+        table: String,
+        column: String,
+        new_column: String,
+    },
+}
+
+fn replay_sql(path: &Path, sql: &str, snapshot: &mut SchemaSnapshot) -> Result<(), SchemaError> {
+    let searchable = mask_sql_comments(sql);
+    let candidate_offsets: Vec<usize> = DDL_START_RE
+        .find_iter(&searchable)
+        .map(|candidate| candidate.start())
+        .collect();
+
+    let mut consumed_until = 0;
+    for (candidate_index, offset) in candidate_offsets.iter().copied().enumerate() {
+        if offset < consumed_until {
+            continue;
         }
-    }
-
-    // Handle ALTER TABLE ADD COLUMN
-    for cap in ALTER_ADD_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
-        let col_name = cap[2].to_string();
-        let col_type = cap[3].to_uppercase();
-
-        // Get the full ALTER statement for constraint analysis
-        let full_match_start = cap.get(0).unwrap().start();
-        let rest = &sql[full_match_start..];
-        let stmt_end = rest.find(';').unwrap_or(rest.len());
-        let full_stmt = &rest[..stmt_end].to_uppercase();
-
-        let nullable = !full_stmt.contains("NOT NULL");
-        let has_default = full_stmt.contains("DEFAULT");
-        let is_primary_key = full_stmt.contains("PRIMARY KEY");
-
-        let entry = tables.entry(table_name).or_default();
-        // Only add if column doesn't already exist (idempotent)
-        if !entry.columns.iter().any(|c| c.name == col_name) {
-            entry.columns.push(SchemaColumn {
-                name: col_name,
-                col_type,
-                nullable,
-                has_default,
-                is_primary_key,
-            });
-        }
-    }
-
-    // Handle DROP TABLE
-    for cap in DROP_TABLE_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
-        tables.remove(&table_name);
-    }
-
-    // Handle ALTER TABLE DROP COLUMN
-    for cap in ALTER_DROP_COL_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
-        let col_name = cap[2].to_string();
-        if let Some(table) = tables.get_mut(&table_name) {
-            table.columns.retain(|c| c.name != col_name);
-        }
-    }
-
-    // Handle ALTER TABLE RENAME TO
-    for cap in ALTER_RENAME_TABLE_RE.captures_iter(sql) {
-        let old_name = cap[1].to_string();
-        let new_name = cap[2].to_string();
-        if let Some(table) = tables.remove(&old_name) {
-            tables.insert(new_name, table);
-        }
-    }
-
-    // Handle ALTER TABLE RENAME COLUMN
-    for cap in ALTER_RENAME_COL_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
-        let old_col = cap[2].to_string();
-        let new_col = cap[3].to_string();
-        if let Some(table) = tables.get_mut(&table_name)
-            && let Some(col) = table.columns.iter_mut().find(|c| c.name == old_col)
+        let end = find_statement_end(sql, offset, sql.len());
+        for nested_offset in candidate_offsets
+            .iter()
+            .copied()
+            .skip(candidate_index + 1)
+            .take_while(|nested_offset| *nested_offset < end)
         {
-            col.name = new_col;
+            if scan_state_at(sql, offset, nested_offset) == SqlScanState::Normal {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MalformedStatement,
+                    path,
+                    sql,
+                    nested_offset,
+                    "supported DDL statement starts before the previous statement terminates",
+                ));
+            }
+        }
+        let statement = &sql[offset..end];
+        let operation = parse_operation(path, sql, offset, statement)?;
+        apply_operation(path, sql, offset, snapshot, operation)?;
+        consumed_until = end.saturating_add(1);
+    }
+
+    Ok(())
+}
+
+fn parse_operation(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+) -> Result<SchemaOperation, SchemaError> {
+    let upper = statement.to_uppercase();
+
+    if upper.starts_with("CREATE VIRTUAL TABLE") {
+        let captures = CREATE_VIRTUAL_TABLE_RE.captures(statement).ok_or_else(|| {
+            malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "malformed CREATE VIRTUAL TABLE",
+            )
+        })?;
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        return Ok(SchemaOperation::CreateTable {
+            table,
+            columns: Vec::new(),
+            if_not_exists: captures.name("if_not_exists").is_some(),
+            replace: false,
+        });
+    }
+
+    if upper.starts_with("CREATE") {
+        let captures = CREATE_TABLE_RE.captures(statement).ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "malformed CREATE TABLE")
+        })?;
+        if captures.name("replace").is_some() && captures.name("if_not_exists").is_some() {
+            return Err(malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "CREATE TABLE cannot combine OR REPLACE with IF NOT EXISTS",
+            ));
+        }
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let opening_parenthesis = captures
+            .get(0)
+            .map(|matched| matched.end().saturating_sub(1))
+            .ok_or_else(|| {
+                malformed_statement(path, sql, offset, statement, "missing CREATE TABLE body")
+            })?;
+        let body = extract_paren_body(statement, opening_parenthesis + 1).ok_or_else(|| {
+            malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "CREATE TABLE has unmatched parentheses",
+            )
+        })?;
+        return Ok(SchemaOperation::CreateTable {
+            table,
+            columns: parse_column_defs(&body),
+            if_not_exists: captures.name("if_not_exists").is_some(),
+            replace: captures.name("replace").is_some(),
+        });
+    }
+
+    if upper.starts_with("DROP TABLE") {
+        let captures = DROP_TABLE_RE.captures(statement).ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "malformed DROP TABLE")
+        })?;
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        return Ok(SchemaOperation::DropTable {
+            table,
+            if_exists: captures.name("if_exists").is_some(),
+        });
+    }
+
+    if let Some(captures) = ALTER_RENAME_COL_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let column = capture_identifier(path, sql, offset, statement, &captures, "column")?;
+        let new_column = capture_identifier(path, sql, offset, statement, &captures, "new_column")?;
+        return Ok(SchemaOperation::RenameColumn {
+            table,
+            column,
+            new_column,
+        });
+    }
+
+    if let Some(captures) = ALTER_RENAME_TABLE_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let new_table = capture_table_name(path, sql, offset, statement, &captures, "new_table")?;
+        return Ok(SchemaOperation::RenameTable { table, new_table });
+    }
+
+    if let Some(captures) = ALTER_ADD_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let column_name = capture_identifier(path, sql, offset, statement, &captures, "column")?;
+        if is_sql_keyword(&column_name) {
+            return Err(malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "ALTER TABLE ADD does not contain a valid column name",
+            ));
+        }
+        let column_type = captures
+            .name("type")
+            .map(|matched| matched.as_str().trim().to_uppercase())
+            .ok_or_else(|| {
+                malformed_statement(
+                    path,
+                    sql,
+                    offset,
+                    statement,
+                    "ALTER TABLE ADD is missing a column type",
+                )
+            })?;
+        return Ok(SchemaOperation::AddColumn {
+            table,
+            column: SchemaColumn {
+                name: column_name,
+                col_type: column_type,
+                nullable: !upper.contains("NOT NULL"),
+                has_default: upper.contains("DEFAULT"),
+                is_primary_key: upper.contains("PRIMARY KEY"),
+            },
+        });
+    }
+
+    if let Some(captures) = ALTER_DROP_COL_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let column = capture_identifier(path, sql, offset, statement, &captures, "column")?;
+        return Ok(SchemaOperation::DropColumn { table, column });
+    }
+
+    Err(malformed_statement(
+        path,
+        sql,
+        offset,
+        statement,
+        "unsupported or malformed ALTER TABLE statement",
+    ))
+}
+
+fn capture_table_name(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+    captures: &regex::Captures<'_>,
+    name: &str,
+) -> Result<String, SchemaError> {
+    let raw = captures
+        .name(name)
+        .map(|matched| matched.as_str())
+        .ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "table identifier is missing")
+        })?;
+    canonicalize_table_name(raw)
+        .map_err(|message| malformed_statement(path, sql, offset, statement, message))
+}
+
+fn capture_identifier(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+    captures: &regex::Captures<'_>,
+    name: &str,
+) -> Result<String, SchemaError> {
+    let raw = captures
+        .name(name)
+        .map(|matched| matched.as_str())
+        .ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "column identifier is missing")
+        })?;
+    normalize_identifier_segment(raw)
+        .map_err(|message| malformed_statement(path, sql, offset, statement, message))
+}
+
+fn malformed_statement(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+    reason: impl AsRef<str>,
+) -> SchemaError {
+    let compact = statement.split_whitespace().collect::<Vec<_>>().join(" ");
+    let preview: String = compact.chars().take(120).collect();
+    SchemaError::at(
+        SchemaErrorKind::MalformedStatement,
+        path,
+        sql,
+        offset,
+        format!("{}: `{preview}`", reason.as_ref()),
+    )
+}
+
+fn apply_operation(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    snapshot: &mut SchemaSnapshot,
+    operation: SchemaOperation,
+) -> Result<(), SchemaError> {
+    match operation {
+        SchemaOperation::CreateTable {
+            table,
+            columns,
+            if_not_exists,
+            replace,
+        } => {
+            if snapshot.tables.contains_key(&table) && if_not_exists {
+                return Ok(());
+            }
+            if snapshot.tables.contains_key(&table) && !replace {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::DuplicateTable,
+                    path,
+                    sql,
+                    offset,
+                    format!(
+                        "CREATE TABLE collides with existing canonical table `{table}`; use IF NOT EXISTS or OR REPLACE explicitly"
+                    ),
+                ));
+            }
+            snapshot.retired_tables.remove(&table);
+            snapshot.tables.insert(table, SchemaTable { columns });
+        }
+        SchemaOperation::DropTable { table, if_exists } => {
+            if snapshot.tables.remove(&table).is_none() {
+                if if_exists {
+                    return Ok(());
+                }
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("DROP TABLE references missing canonical table `{table}`"),
+                ));
+            }
+            snapshot.retired_tables.insert(table);
+        }
+        SchemaOperation::RenameTable { table, new_table } => {
+            if !snapshot.tables.contains_key(&table) {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE RENAME references missing canonical table `{table}`"),
+                ));
+            }
+            if table == new_table || snapshot.tables.contains_key(&new_table) {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::RenameCollision,
+                    path,
+                    sql,
+                    offset,
+                    format!(
+                        "ALTER TABLE RENAME target `{new_table}` collides with an existing canonical table"
+                    ),
+                ));
+            }
+            let Some(schema_table) = snapshot.tables.remove(&table) else {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE RENAME references missing canonical table `{table}`"),
+                ));
+            };
+            snapshot.retired_tables.insert(table);
+            snapshot.retired_tables.remove(&new_table);
+            snapshot.tables.insert(new_table, schema_table);
+        }
+        SchemaOperation::AddColumn { table, column } => {
+            let schema_table = snapshot.tables.get_mut(&table).ok_or_else(|| {
+                SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE ADD references missing canonical table `{table}`"),
+                )
+            })?;
+            if !schema_table
+                .columns
+                .iter()
+                .any(|existing| existing.name == column.name)
+            {
+                schema_table.columns.push(column);
+            }
+        }
+        SchemaOperation::DropColumn { table, column } => {
+            let schema_table = snapshot.tables.get_mut(&table).ok_or_else(|| {
+                SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE DROP references missing canonical table `{table}`"),
+                )
+            })?;
+            let original_len = schema_table.columns.len();
+            schema_table
+                .columns
+                .retain(|existing| existing.name != column);
+            if schema_table.columns.len() == original_len {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingColumn,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE DROP references missing column `{table}.{column}`"),
+                ));
+            }
+        }
+        SchemaOperation::RenameColumn {
+            table,
+            column,
+            new_column,
+        } => {
+            let schema_table = snapshot.tables.get_mut(&table).ok_or_else(|| {
+                SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE RENAME references missing canonical table `{table}`"),
+                )
+            })?;
+            if schema_table
+                .columns
+                .iter()
+                .any(|existing| existing.name == new_column)
+            {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::DuplicateColumn,
+                    path,
+                    sql,
+                    offset,
+                    format!(
+                        "ALTER TABLE RENAME target column `{table}.{new_column}` already exists"
+                    ),
+                ));
+            }
+            let column_to_rename = schema_table
+                .columns
+                .iter_mut()
+                .find(|existing| existing.name == column)
+                .ok_or_else(|| {
+                    SchemaError::at(
+                        SchemaErrorKind::MissingColumn,
+                        path,
+                        sql,
+                        offset,
+                        format!("ALTER TABLE RENAME references missing column `{table}.{column}`"),
+                    )
+                })?;
+            column_to_rename.name = new_column;
         }
     }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqlScanState {
+    Normal,
+    SingleQuote,
+    DoubleQuote,
+    Backtick,
+    Bracket,
+    LineComment,
+    BlockComment,
+}
+
+fn mask_sql_comments(sql: &str) -> String {
+    let original = sql.as_bytes();
+    let mut masked = original.to_vec();
+    let mut state = SqlScanState::Normal;
+    let mut index = 0;
+
+    while index < original.len() {
+        let current = original[index];
+        let next = original.get(index + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                masked[index] = b' ';
+                masked[index + 1] = b' ';
+                index += 2;
+                state = SqlScanState::LineComment;
+                continue;
+            }
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                masked[index] = b' ';
+                masked[index + 1] = b' ';
+                index += 2;
+                state = SqlScanState::BlockComment;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment => {
+                if current == b'\n' {
+                    state = SqlScanState::Normal;
+                } else {
+                    masked[index] = b' ';
+                }
+            }
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                masked[index] = b' ';
+                masked[index + 1] = b' ';
+                index += 2;
+                state = SqlScanState::Normal;
+                continue;
+            }
+            SqlScanState::BlockComment => masked[index] = b' ',
+            _ => {}
+        }
+        index += 1;
+    }
+
+    String::from_utf8(masked).unwrap_or_else(|_| sql.to_string())
+}
+
+fn find_statement_end(sql: &str, start: usize, limit: usize) -> usize {
+    let bytes = sql.as_bytes();
+    let mut state = SqlScanState::Normal;
+    let mut index = start;
+    let bounded_limit = limit.min(bytes.len());
+
+    while index < bounded_limit {
+        let current = bytes[index];
+        let next = bytes.get(index + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b';' => return index,
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                state = SqlScanState::LineComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                state = SqlScanState::BlockComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment if current == b'\n' => state = SqlScanState::Normal,
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                state = SqlScanState::Normal;
+                index += 2;
+                continue;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    bounded_limit
+}
+
+fn scan_state_at(sql: &str, start: usize, target: usize) -> SqlScanState {
+    let bytes = sql.as_bytes();
+    let mut state = SqlScanState::Normal;
+    let mut index = start;
+    let bounded_target = target.min(bytes.len());
+
+    while index < bounded_target {
+        let current = bytes[index];
+        let next = bytes.get(index + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                state = SqlScanState::LineComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                state = SqlScanState::BlockComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment if current == b'\n' => state = SqlScanState::Normal,
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                state = SqlScanState::Normal;
+                index += 2;
+                continue;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    state
 }
 
 /// Extract text between the opening paren (at `start`) and its matching close.
@@ -249,29 +1105,61 @@ fn extract_paren_body(sql: &str, start: usize) -> Option<String> {
     let bytes = sql.as_bytes();
     let mut depth = 1;
     let mut i = start;
+    let mut state = SqlScanState::Normal;
+
     while i < bytes.len() && depth > 0 {
-        match bytes[i] {
-            b'(' => depth += 1,
-            b')' => depth -= 1,
-            b'\'' => {
-                // Skip string literal
-                i += 1;
-                while i < bytes.len() {
-                    if bytes[i] == b'\'' {
-                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
-                            i += 2; // escaped quote
-                            continue;
-                        }
-                        break;
-                    }
-                    i += 1;
-                }
+        let current = bytes[i];
+        let next = bytes.get(i + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b'(' => depth += 1,
+            SqlScanState::Normal if current == b')' => depth -= 1,
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                state = SqlScanState::LineComment;
+                i += 2;
+                continue;
             }
-            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
-                // Skip line comment
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                state = SqlScanState::BlockComment;
+                i += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    i += 2;
+                    continue;
                 }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    i += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    i += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    i += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment if current == b'\n' => state = SqlScanState::Normal,
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                state = SqlScanState::Normal;
+                i += 2;
+                continue;
             }
             _ => {}
         }
@@ -609,16 +1497,16 @@ CREATE TABLE messages (
 
     #[test]
     fn test_parse_create_virtual_table() {
-        // Virtual tables use USING syntax — the paren is after the module name,
-        // not directly after the table name. Our regex requires `table_name (`
-        // so virtual tables are intentionally skipped for column parsing.
-        // Table *existence* is still caught by get_schema_table_names() which
-        // has a separate regex that handles VIRTUAL TABLE.
+        // Virtual tables use USING syntax, so their columns are not parsed.
+        // The snapshot still records table existence instead of relying on a
+        // separate CREATE-pattern scan that could diverge from replay.
         let sql = "CREATE VIRTUAL TABLE search_idx USING fts5(content, sender);";
         let mut tables = HashMap::new();
         parse_sql_into(sql, &mut tables);
-        // Virtual tables won't be parsed for columns (different syntax)
-        assert!(!tables.contains_key("search_idx"));
+        let table = tables
+            .get("search_idx")
+            .expect("virtual table existence must be represented");
+        assert!(table.columns.is_empty());
     }
 
     #[test]
@@ -759,8 +1647,10 @@ Something
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
 
-        // Absent dir → no errors (schema simply not configured).
-        assert!(schema_read_errors(Path::new("/nonexistent/path")).is_empty());
+        // A configured but absent directory must fail loud.
+        let missing = schema_read_errors(Path::new("/nonexistent/path"));
+        assert_eq!(missing.len(), 1);
+        assert!(missing[0].contains("schema directory could not be read"));
 
         // A readable migration → no error.
         fs::write(dir.join("001_ok.sql"), "CREATE TABLE t (id INTEGER);").unwrap();
@@ -817,6 +1707,200 @@ Something
         assert_eq!(t.columns[1].name, "name");
         assert_eq!(t.columns[2].name, "price");
         assert_eq!(t.columns[2].col_type, "REAL");
+    }
+
+    #[test]
+    fn test_build_schema_snapshot_missing_directory_is_error() {
+        let error = build_schema_snapshot(Path::new("/nonexistent/path"))
+            .expect_err("a configured missing directory must not become an empty snapshot");
+        assert_eq!(error.kind, SchemaErrorKind::MissingDirectory);
+        assert_eq!(error.line, 0);
+        assert!(error.message.contains("schema directory could not be read"));
+    }
+
+    #[test]
+    fn test_build_schema_snapshot_reports_malformed_sql_with_path_and_position() {
+        let tmp = tempfile::tempdir().unwrap();
+        let migration = tmp.path().join("002_broken.sql");
+        fs::write(
+            &migration,
+            "\n-- a preceding line\nCREATE TABLE broken (id INTEGER;\n",
+        )
+        .unwrap();
+
+        let error = build_schema_snapshot(tmp.path())
+            .expect_err("malformed supported DDL must fail the snapshot");
+        assert_eq!(error.kind, SchemaErrorKind::MalformedStatement);
+        assert_eq!(error.path, migration);
+        assert_eq!(error.line, 3);
+        assert_eq!(error.column, 1);
+        assert!(error.message.contains("unmatched parentheses"));
+        assert!(error.message.contains("CREATE TABLE broken"));
+    }
+
+    #[test]
+    fn test_replay_rejects_unterminated_statement_before_later_ddl() {
+        let sql = r#"
+CREATE TABLE first_table (id INTEGER PRIMARY KEY)
+CREATE TABLE second_table (id INTEGER PRIMARY KEY);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        let error = replay_sql(Path::new("001_broken.sql"), sql, &mut snapshot)
+            .expect_err("a missing statement terminator must not hide later DDL");
+
+        assert_eq!(error.kind, SchemaErrorKind::MalformedStatement);
+        assert_eq!(error.line, 3);
+        assert!(
+            error
+                .message
+                .contains("before the previous statement terminates")
+        );
+        assert!(snapshot.tables.is_empty());
+    }
+
+    #[test]
+    fn test_replay_ignores_commented_and_string_literal_ddl() {
+        let sql = r#"
+-- DROP TABLE notes;
+/* ALTER TABLE notes RENAME TO hidden_notes; */
+CREATE TABLE notes (
+    id INTEGER PRIMARY KEY,
+    message TEXT DEFAULT 'DROP TABLE notes;'
+);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_notes.sql"), sql, &mut snapshot).unwrap();
+
+        let notes = snapshot.tables.get("notes").expect("notes must remain");
+        assert_eq!(notes.column_names(), vec!["id", "message"]);
+        assert!(snapshot.retired_tables.is_empty());
+    }
+
+    #[test]
+    fn test_replay_respects_drop_then_recreate_within_one_file() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+DROP TABLE users;
+CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL);
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+
+        let users = tables
+            .get("users")
+            .expect("the later CREATE must recreate the dropped table");
+        assert_eq!(users.column_names(), vec!["id", "email"]);
+    }
+
+    #[test]
+    fn test_replay_respects_recreate_after_rename_within_one_file() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE users RENAME TO archived_users;
+CREATE TABLE users (id INTEGER PRIMARY KEY, replacement TEXT);
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+
+        assert!(
+            tables.contains_key("archived_users"),
+            "the renamed table must remain in the final snapshot"
+        );
+        let users = tables
+            .get("users")
+            .expect("the later CREATE must create a new users table");
+        assert_eq!(users.column_names(), vec!["id", "replacement"]);
+    }
+
+    #[test]
+    fn test_replay_recreate_clears_retired_identity() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+DROP TABLE users;
+CREATE TABLE users (id INTEGER PRIMARY KEY, replacement TEXT);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_users.sql"), sql, &mut snapshot).unwrap();
+
+        assert!(snapshot.tables.contains_key("users"));
+        assert!(!snapshot.retired_tables.contains("users"));
+    }
+
+    #[test]
+    fn test_replay_duplicate_canonical_create_is_a_non_mutating_error() {
+        let sql = r#"
+CREATE TABLE "Users" (id INTEGER PRIMARY KEY);
+CREATE TABLE users (replacement TEXT);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        let error = replay_sql(Path::new("001_users.sql"), sql, &mut snapshot)
+            .expect_err("canonical duplicate CREATE must not overwrite the first table");
+
+        assert_eq!(error.kind, SchemaErrorKind::DuplicateTable);
+        assert_eq!(error.line, 3);
+        assert!(error.message.contains("canonical table `users`"));
+        let users = snapshot.tables.get("users").unwrap();
+        assert_eq!(users.column_names(), vec!["id"]);
+    }
+
+    #[test]
+    fn test_replay_if_not_exists_preserves_the_existing_table() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS "Users" (replacement TEXT);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_users.sql"), sql, &mut snapshot).unwrap();
+
+        let users = snapshot.tables.get("users").unwrap();
+        assert_eq!(users.column_names(), vec!["id"]);
+    }
+
+    #[test]
+    fn test_replay_rename_collision_is_a_non_mutating_error() {
+        let sql = r#"
+CREATE TABLE source_table (id INTEGER PRIMARY KEY);
+CREATE TABLE target_table (id INTEGER PRIMARY KEY);
+ALTER TABLE source_table RENAME TO target_table;
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        let error = replay_sql(Path::new("001_tables.sql"), sql, &mut snapshot)
+            .expect_err("rename target collisions must not discard either table");
+
+        assert_eq!(error.kind, SchemaErrorKind::RenameCollision);
+        assert_eq!(error.line, 4);
+        assert!(snapshot.tables.contains_key("source_table"));
+        assert!(snapshot.tables.contains_key("target_table"));
+        assert!(snapshot.retired_tables.is_empty());
+    }
+
+    #[test]
+    fn test_replay_missing_drop_and_rename_sources_fail_truthfully() {
+        let mut snapshot = SchemaSnapshot::default();
+        let drop_error = replay_sql(
+            Path::new("001_drop.sql"),
+            "DROP TABLE missing;",
+            &mut snapshot,
+        )
+        .expect_err("plain DROP of a missing table must fail");
+        assert_eq!(drop_error.kind, SchemaErrorKind::MissingTable);
+        assert!(drop_error.message.contains("DROP TABLE"));
+
+        replay_sql(
+            Path::new("002_drop.sql"),
+            "DROP TABLE IF EXISTS missing;",
+            &mut snapshot,
+        )
+        .unwrap();
+
+        let rename_error = replay_sql(
+            Path::new("003_rename.sql"),
+            "ALTER TABLE missing RENAME TO replacement;",
+            &mut snapshot,
+        )
+        .expect_err("rename of a missing table must fail");
+        assert_eq!(rename_error.kind, SchemaErrorKind::MissingTable);
+        assert!(rename_error.message.contains("RENAME"));
     }
 
     #[test]
@@ -881,6 +1965,77 @@ ALTER TABLE items RENAME COLUMN old_col TO new_col;
         assert_eq!(t.columns.len(), 2);
         assert_eq!(t.columns[1].name, "new_col");
         assert_eq!(t.columns[1].col_type, "TEXT");
+    }
+
+    #[test]
+    fn test_quoted_and_schema_qualified_table_names() {
+        let sql = r#"
+CREATE TABLE "quoted" (id INTEGER PRIMARY KEY);
+CREATE TABLE `backtick` (id INTEGER PRIMARY KEY);
+CREATE TABLE public.schema_table (id INTEGER PRIMARY KEY);
+CREATE TABLE MixedCase (id INTEGER PRIMARY KEY);
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+        assert!(tables.contains_key("quoted"), "tables: {:?}", tables.keys());
+        assert!(tables.contains_key("backtick"));
+        assert!(tables.contains_key("public.schema_table"));
+        // Comparison is case-insensitive: stored normalized.
+        assert!(tables.contains_key("mixedcase"));
+        assert!(!tables.contains_key("MixedCase"));
+    }
+
+    #[test]
+    fn test_normalize_table_name() {
+        assert_eq!(normalize_table_name("users"), "users");
+        assert_eq!(normalize_table_name("\"Users\""), "users");
+        assert_eq!(normalize_table_name("`Users`"), "users");
+        assert_eq!(normalize_table_name("public.\"Users\""), "public.users");
+        assert_eq!(normalize_table_name("PUBLIC.USERS"), "public.users");
+        assert_eq!(
+            canonicalize_table_name(" public . \"User.Events\" ").unwrap(),
+            "public.\"user.events\""
+        );
+        assert_eq!(
+            canonicalize_table_name("[Sales].[Order]]History]").unwrap(),
+            "sales.\"order]history\""
+        );
+        assert_eq!(
+            canonical_table_leaf("public.\"User.Events\"").unwrap(),
+            "\"user.events\""
+        );
+        assert!(canonicalize_table_name("users\"").is_err());
+        assert!(canonicalize_table_name("public..users").is_err());
+    }
+
+    #[test]
+    fn test_quoted_qualified_names_replay_through_rename_and_drop() {
+        let sql = r#"
+CREATE TABLE public."Users" (id INTEGER PRIMARY KEY);
+ALTER TABLE public."Users" RENAME TO archive.`Users`;
+DROP TABLE archive.[Users];
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_qualified.sql"), sql, &mut snapshot).unwrap();
+
+        assert!(snapshot.tables.is_empty());
+        assert!(snapshot.retired_tables.contains("public.users"));
+        assert!(snapshot.retired_tables.contains("archive.users"));
+    }
+
+    #[test]
+    fn test_rename_and_drop_apply_to_quoted_names() {
+        let sql = r#"
+CREATE TABLE "old_name" (id INTEGER PRIMARY KEY);
+ALTER TABLE "old_name" RENAME TO "new_name";
+CREATE TABLE `doomed` (id INTEGER PRIMARY KEY);
+DROP TABLE `doomed`;
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+        assert!(!tables.contains_key("old_name"));
+        assert!(tables.contains_key("new_name"));
+        assert!(!tables.contains_key("doomed"));
     }
 
     #[test]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -26,22 +26,35 @@ const STATIC_COVERAGE_EXTENSIONS: &[&str] = &["html", "htm", "css"];
 /// Check if a dependency reference is a cross-project reference.
 /// Cross-project refs use the format `owner/repo@module` (e.g. `corvid-labs/algochat@auth`).
 pub fn is_cross_project_ref(dep: &str) -> bool {
-    dep.contains('/') && dep.contains('@')
+    parse_cross_project_ref(dep).is_some()
 }
 
 /// Parse a cross-project reference into (owner/repo, module).
 /// Returns None if not a valid cross-project ref.
 pub fn parse_cross_project_ref(dep: &str) -> Option<(&str, &str)> {
-    if !is_cross_project_ref(dep) {
+    let (repo, module) = dep.split_once('@')?;
+    if module.contains('@') || !valid_dependency_segment(module) {
         return None;
     }
-    let at_pos = dep.find('@')?;
-    let repo = &dep[..at_pos];
-    let module = &dep[at_pos + 1..];
-    if repo.is_empty() || module.is_empty() {
+    let mut repo_segments = repo.split('/');
+    let owner = repo_segments.next()?;
+    let name = repo_segments.next()?;
+    if repo_segments.next().is_some()
+        || !valid_dependency_segment(owner)
+        || !valid_dependency_segment(name)
+    {
         return None;
     }
     Some((repo, module))
+}
+
+fn valid_dependency_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment != "."
+        && segment != ".."
+        && segment.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
 }
 
 /// Validate one local (non-cross-project) `depends_on` entry and resolve it
@@ -55,7 +68,11 @@ pub fn parse_cross_project_ref(dep: &str) -> Option<(&str, &str)> {
 /// - absolute paths and `..` traversal are rejected as escapes;
 /// - bare module names resolve against the specs directory;
 /// - anything else must exist as a path confined to the project root.
-pub fn validate_local_dependency(dep: &str, root: &Path, specs_dir: &str) -> Result<PathBuf, String> {
+pub fn validate_local_dependency(
+    dep: &str,
+    root: &Path,
+    specs_dir: &str,
+) -> Result<PathBuf, String> {
     if is_cross_project_ref(dep) {
         // Cross-project refs (e.g. "owner/repo@module") are validated
         // by `specsync resolve`, not during local checks.
@@ -67,28 +84,35 @@ pub fn validate_local_dependency(dep: &str, root: &Path, specs_dir: &str) -> Res
     }
     let as_path = Path::new(trimmed);
     if as_path.is_absolute()
-        || as_path
-            .components()
-            .any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::Prefix(_)))
+        || as_path.components().any(|c| {
+            matches!(
+                c,
+                std::path::Component::ParentDir | std::path::Component::Prefix(_)
+            )
+        })
         || trimmed.contains('\\')
     {
         return Err(format!(
             "Dependency spec path escapes the project root: {trimmed} (absolute paths and `..` traversal are not allowed)"
         ));
     }
-    // Bare module names (no path separators or extension) resolve
-    // against the specs directory, not the project root.
-    let full_path = if !trimmed.contains('/') && !trimmed.contains('.') {
-        root.join(specs_dir).join(trimmed)
+    // Bare module names (no path separators or extension) resolve to the
+    // canonical spec file, not merely a same-named directory.
+    let relative_path = if !trimmed.contains('/') && !trimmed.contains('.') {
+        Path::new(specs_dir)
+            .join(trimmed)
+            .join(format!("{trimmed}.spec.md"))
     } else {
-        root.join(trimmed)
+        PathBuf::from(trimmed)
     };
-    if !source_within_root(root, trimmed) {
+    let confined_mapping = relative_path.to_string_lossy().replace('\\', "/");
+    if !source_within_root(root, &confined_mapping) {
         return Err(format!(
             "Dependency spec path escapes the project root: {trimmed} (symlink resolution leaves the project)"
         ));
     }
-    if !full_path.exists() {
+    let full_path = root.join(&relative_path);
+    if !full_path.is_file() {
         return Err(format!("Dependency spec not found: {trimmed}"));
     }
     Ok(full_path)
@@ -96,100 +120,181 @@ pub fn validate_local_dependency(dep: &str, root: &Path, specs_dir: &str) -> Res
 
 // ─── Schema Table Discovery ──────────────────────────────────────────────
 
-/// Extract table names from SQL schema files.
+/// One invocation-scoped schema load shared by table and column validation.
 ///
-/// The base set comes from `schema::build_schema`, which replays migrations in
-/// order — so `ALTER TABLE ... RENAME TO` retires the old name and `DROP TABLE`
-/// retires the table (the naive CREATE-only scan this replaces had the rename
-/// semantics exactly inverted). A configured `schema_pattern` extracts
-/// ADDITIONAL names on top (for nonstandard DDL the replay doesn't understand);
-/// it can no longer vacuously replace the set — an uncompilable pattern is
-/// surfaced loudly by `schema_config_problems` instead of disabling validation.
-/// All names are normalized (`normalize_table_name`): quoting style and case
-/// do not change identity.
-pub fn get_schema_table_names(root: &Path, config: &SpecSyncConfig) -> HashSet<String> {
-    let mut tables = HashSet::new();
-    let schema_dir = match &config.schema_dir {
-        Some(d) => root.join(d),
-        None => return tables,
+/// `build_schema_snapshot` is called exactly once. Its fallible, ordered replay
+/// supplies both the canonical table set and column map, and any directory,
+/// UTF-8, parse, replay, or collision failure is retained as a validation error
+/// instead of being collapsed into an empty schema.
+#[derive(Debug, Default)]
+pub struct SchemaValidation {
+    pub tables: HashSet<String>,
+    pub columns: HashMap<String, SchemaTable>,
+    pub errors: Vec<String>,
+}
+
+pub fn load_schema_validation(root: &Path, config: &SpecSyncConfig) -> SchemaValidation {
+    let Some(configured_dir) = &config.schema_dir else {
+        return SchemaValidation::default();
     };
-
-    if !schema_dir.exists() {
-        return tables;
-    }
-
-    let (schema_map, retired) = schema::build_schema_with_retired(&schema_dir);
-    for name in schema_map.keys() {
-        tables.insert(name.clone());
-    }
-
-    // Pattern extraction adds names the replay can't see (e.g. VIRTUAL TABLE,
-    // whose column list uses `USING module(...)` syntax), but must never
-    // resurrect a table that a later migration dropped or renamed away.
+    let schema_dir = root.join(configured_dir);
     let pattern_str = config
         .schema_pattern
         .as_deref()
         .unwrap_or_else(|| default_schema_pattern());
 
-    if let Some(re) = safe_regex(pattern_str)
-        && let Ok(entries) = fs::read_dir(&schema_dir)
-    {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-            if ext != "ts" && ext != "sql" {
-                continue;
-            }
-            if let Ok(content) = fs::read_to_string(&path) {
-                for caps in re.captures_iter(&content) {
-                    if let Some(name) = caps.get(1) {
-                        let normalized = schema::normalize_table_name(name.as_str());
-                        if !retired.contains(&normalized) {
-                            tables.insert(normalized);
+    let snapshot = match schema::build_schema_snapshot(&schema_dir) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            return SchemaValidation {
+                errors: vec![error.to_string()],
+                ..Default::default()
+            };
+        }
+    };
+
+    let schema::SchemaSnapshot {
+        tables: columns,
+        retired_tables,
+    } = snapshot;
+    let mut tables: HashSet<String> = columns.keys().cloned().collect();
+    let mut errors = Vec::new();
+    let Some(pattern) = safe_regex(pattern_str) else {
+        errors.push(format!(
+            "Configured schema_pattern `{pattern_str}` is not a valid regex — table-name extraction cannot run; fix or remove schema_pattern in the config"
+        ));
+        return SchemaValidation {
+            tables,
+            columns,
+            errors,
+        };
+    };
+
+    // A custom pattern may recognize nonstandard table declarations that the
+    // DDL replay intentionally ignores. Apply it additively, in deterministic
+    // path order, without reintroducing any canonical identity retired by a
+    // later DROP or RENAME.
+    let mut pattern_files = Vec::new();
+    match fs::read_dir(&schema_dir) {
+        Ok(entries) => {
+            for entry in entries {
+                match entry {
+                    Ok(entry) => {
+                        let path = entry.path();
+                        let extension = path.extension().and_then(|value| value.to_str());
+                        if path.is_file() && matches!(extension, Some("sql" | "ts")) {
+                            pattern_files.push(path);
                         }
                     }
+                    Err(error) => errors.push(format!(
+                        "{}: schema directory entry could not be read for schema_pattern matching: {error}",
+                        schema_dir.display()
+                    )),
                 }
             }
         }
+        Err(error) => errors.push(format!(
+            "{}: schema directory could not be re-read for schema_pattern matching: {error}",
+            schema_dir.display()
+        )),
     }
+    pattern_files.sort();
 
-    tables
-}
-
-/// Loud, project-level schema configuration problems: a configured
-/// `schema_dir` that does not exist, or a `schema_pattern` that does not
-/// compile as a regex. Both previously disabled table validation silently
-/// (empty table set ⇒ every db_tables entry vacuously passed).
-pub fn schema_config_problems(root: &Path, config: &SpecSyncConfig) -> Vec<String> {
-    let mut problems = Vec::new();
-    if let Some(dir) = &config.schema_dir {
-        if !root.join(dir).exists() {
-            problems.push(format!(
-                "Configured schema_dir `{dir}` does not exist — db_tables validation cannot run; create the directory or fix schema_dir in the config"
-            ));
-        } else if let Some(pattern) = &config.schema_pattern
-            && safe_regex(pattern).is_none()
-        {
-            problems.push(format!(
-                "Configured schema_pattern `{pattern}` is not a valid regex — table-name extraction cannot use it; fix or remove schema_pattern in the config"
-            ));
+    for path in pattern_files {
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(error) => {
+                errors.push(format!(
+                    "{}: schema file could not be read for schema_pattern matching: {error}",
+                    path.display()
+                ));
+                continue;
+            }
+        };
+        for captures in pattern.captures_iter(&content) {
+            let Some(name) = captures.get(1) else {
+                errors.push(format!(
+                    "Configured schema_pattern `{pattern_str}` matched {} without capture group 1 — wrap the table identifier in the first capture group",
+                    path.display()
+                ));
+                break;
+            };
+            let normalized = match schema::canonicalize_table_name(name.as_str()) {
+                Ok(normalized) => normalized,
+                Err(error) => {
+                    errors.push(format!(
+                        "{}: schema_pattern captured invalid table identifier `{}`: {error}",
+                        path.display(),
+                        name.as_str()
+                    ));
+                    continue;
+                }
+            };
+            if !schema_identity_is_retired(&normalized, &retired_tables) {
+                tables.insert(normalized);
+            }
         }
     }
-    problems
+
+    SchemaValidation {
+        tables,
+        columns,
+        errors,
+    }
+}
+
+fn schema_identity_is_retired(candidate: &str, retired_tables: &HashSet<String>) -> bool {
+    if retired_tables.contains(candidate) {
+        return true;
+    }
+    let Ok(candidate_leaf) = schema::canonical_table_leaf(candidate) else {
+        return false;
+    };
+    if candidate_leaf != candidate {
+        return false;
+    }
+    retired_tables.iter().any(|retired| {
+        schema::canonical_table_leaf(retired)
+            .is_ok_and(|retired_leaf| retired_leaf == candidate_leaf)
+    })
 }
 
 /// Whether a declared `db_tables` entry exists in the discovered schema set.
 /// Both sides are normalized; an unqualified declared name also matches a
 /// schema-qualified discovered name (`users` matches `public.users`).
 pub fn schema_table_exists(tables: &HashSet<String>, declared: &str) -> bool {
-    let norm = schema::normalize_table_name(declared);
+    let Ok(norm) = schema::canonicalize_table_name(declared) else {
+        return false;
+    };
     if tables.contains(&norm) {
         return true;
     }
-    !norm.contains('.')
-        && tables
-            .iter()
-            .any(|t| t.rsplit('.').next() == Some(norm.as_str()))
+    let Ok(declared_leaf) = schema::canonical_table_leaf(declared) else {
+        return false;
+    };
+    declared_leaf == norm
+        && tables.iter().any(|table| {
+            schema::canonical_table_leaf(table).is_ok_and(|table_leaf| table_leaf == declared_leaf)
+        })
+}
+
+fn schema_table_for_name<'a>(
+    tables: &'a HashMap<String, SchemaTable>,
+    declared: &str,
+) -> Option<&'a SchemaTable> {
+    let normalized = schema::canonicalize_table_name(declared).ok()?;
+    if let Some(table) = tables.get(&normalized) {
+        return Some(table);
+    }
+    let declared_leaf = schema::canonical_table_leaf(declared).ok()?;
+    if declared_leaf != normalized {
+        return None;
+    }
+    tables.iter().find_map(|(name, table)| {
+        schema::canonical_table_leaf(name)
+            .is_ok_and(|leaf| leaf == declared_leaf)
+            .then_some(table)
+    })
 }
 
 // ─── File Discovery ──────────────────────────────────────────────────────
@@ -575,7 +680,9 @@ pub fn validate_spec(
     // Check db_tables exist in schema
     for table in &fm.db_tables {
         if config.schema_dir.is_some()
-            && root.join(config.schema_dir.as_deref().unwrap_or_default()).exists()
+            && root
+                .join(config.schema_dir.as_deref().unwrap_or_default())
+                .exists()
             && !schema_table_exists(schema_tables, table)
         {
             result
@@ -591,18 +698,7 @@ pub fn validate_spec(
     if !schema_columns.is_empty() {
         let spec_schema = schema::parse_spec_schema(body);
         for table_name in &fm.db_tables {
-            let normalized = schema::normalize_table_name(table_name);
-            let actual_table = schema_columns.get(&normalized).or_else(|| {
-                // Unqualified declared names match a schema-qualified table.
-                if normalized.contains('.') {
-                    None
-                } else {
-                    schema_columns
-                        .iter()
-                        .find(|(k, _)| k.rsplit('.').next() == Some(normalized.as_str()))
-                        .map(|(_, v)| v)
-                }
-            });
+            let actual_table = schema_table_for_name(schema_columns, table_name);
             if let Some(actual_table) = actual_table
                 && let Some(spec_cols) = spec_schema.get(table_name)
             {
@@ -1404,6 +1500,10 @@ mod tests {
         assert!(!is_cross_project_ref("auth"));
         assert!(!is_cross_project_ref("owner/repo")); // no @
         assert!(!is_cross_project_ref("@module")); // no /
+        assert!(!is_cross_project_ref("/etc/passwd@module"));
+        assert!(!is_cross_project_ref("../owner/repo@module"));
+        assert!(!is_cross_project_ref("owner/repo/extra@module"));
+        assert!(!is_cross_project_ref("owner/repo@../module"));
     }
 
     #[test]
@@ -1414,6 +1514,8 @@ mod tests {
 
         assert!(parse_cross_project_ref("not-a-ref").is_none());
         assert!(parse_cross_project_ref("/@").is_none()); // empty parts
+        assert!(parse_cross_project_ref("/etc/passwd@module").is_none());
+        assert!(parse_cross_project_ref("../owner/repo@module").is_none());
     }
 
     #[test]
@@ -1848,9 +1950,31 @@ Test
         assert!(validate_local_dependency("specs/run/run.spec.md", tmp.path(), "specs").is_ok());
         // Missing targets fail loudly with the offending entry.
         let err = validate_local_dependency("nosuchmod", tmp.path(), "specs").unwrap_err();
-        assert!(err.contains("Dependency spec not found: nosuchmod"), "{err}");
+        assert!(
+            err.contains("Dependency spec not found: nosuchmod"),
+            "{err}"
+        );
         // Cross-project refs are out of scope for local validation.
         assert!(validate_local_dependency("owner/repo@auth", tmp.path(), "specs").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_validate_local_dependency_rejects_bare_module_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("specs")).unwrap();
+        fs::write(outside.path().join("escaped.spec.md"), "# outside").unwrap();
+        symlink(outside.path(), tmp.path().join("specs").join("escaped")).unwrap();
+
+        let error = validate_local_dependency("escaped", tmp.path(), "specs")
+            .expect_err("a bare module symlink must not escape the project");
+        assert!(
+            error.contains("escapes the project root") && error.contains("escaped"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -1865,13 +1989,7 @@ Test
         .unwrap();
 
         let config = SpecSyncConfig::default();
-        let result = validate_spec(
-            &spec,
-            tmp.path(),
-            &HashSet::new(),
-            &HashMap::new(),
-            &config,
-        );
+        let result = validate_spec(&spec, tmp.path(), &HashSet::new(), &HashMap::new(), &config);
         // Flow-style entries must be parsed (not silently zero edges) and each
         // entry rejected with its own verdict.
         assert!(
@@ -1902,13 +2020,7 @@ Test
         )
         .unwrap();
         let config = SpecSyncConfig::default();
-        let result = validate_spec(
-            &spec,
-            tmp.path(),
-            &HashSet::new(),
-            &HashMap::new(),
-            &config,
-        );
+        let result = validate_spec(&spec, tmp.path(), &HashSet::new(), &HashMap::new(), &config);
         assert!(
             result
                 .errors
@@ -1920,7 +2032,7 @@ Test
     }
 
     #[test]
-    fn test_get_schema_table_names_rename_and_drop_applied() {
+    fn test_load_schema_validation_applies_rename_and_drop() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("migrations");
         fs::create_dir_all(&dir).unwrap();
@@ -1939,19 +2051,37 @@ Test
             schema_dir: Some("migrations".to_string()),
             ..Default::default()
         };
-        let tables = get_schema_table_names(tmp.path(), &config);
+        let schema = load_schema_validation(tmp.path(), &config);
+        assert!(schema.errors.is_empty(), "errors: {:?}", schema.errors);
         // Rename must retire the old name, DROP must retire the table.
-        assert!(tables.contains("users"), "tables: {tables:?}");
-        assert!(!tables.contains("old_users"), "tables: {tables:?}");
-        assert!(!tables.contains("doomed"), "tables: {tables:?}");
+        assert!(
+            schema.tables.contains("users"),
+            "tables: {:?}",
+            schema.tables
+        );
+        assert!(
+            !schema.tables.contains("old_users"),
+            "tables: {:?}",
+            schema.tables
+        );
+        assert!(
+            !schema.tables.contains("doomed"),
+            "tables: {:?}",
+            schema.tables
+        );
     }
 
     #[test]
     fn test_schema_table_exists_quoting_case_and_schema_prefix() {
-        let tables: HashSet<String> = ["users", "public.orders", "mixedcase"]
-            .into_iter()
-            .map(String::from)
-            .collect();
+        let tables: HashSet<String> = [
+            "users",
+            "public.orders",
+            "mixedcase",
+            "public.\"user.events\"",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
         assert!(schema_table_exists(&tables, "users"));
         assert!(schema_table_exists(&tables, "\"users\""));
         assert!(schema_table_exists(&tables, "`users`"));
@@ -1960,31 +2090,94 @@ Test
         // Unqualified declared name matches schema-qualified discovered name.
         assert!(schema_table_exists(&tables, "orders"));
         assert!(schema_table_exists(&tables, "public.orders"));
+        assert!(schema_table_exists(&tables, "\"User.Events\""));
         assert!(!schema_table_exists(&tables, "zzz_definitely_missing"));
     }
 
     #[test]
-    fn test_schema_config_problems_loud() {
+    fn test_load_schema_validation_reports_config_problems() {
         let tmp = tempfile::tempdir().unwrap();
         let mut config = SpecSyncConfig {
             schema_dir: Some("no_such_dir".to_string()),
             ..Default::default()
         };
-        let problems = schema_config_problems(tmp.path(), &config);
-        assert_eq!(problems.len(), 1);
-        assert!(problems[0].contains("no_such_dir"), "{problems:?}");
+        let schema = load_schema_validation(tmp.path(), &config);
+        assert_eq!(schema.errors.len(), 1);
+        assert!(
+            schema.errors[0].contains("no_such_dir"),
+            "{:?}",
+            schema.errors
+        );
 
         // An uncompilable schema_pattern must be flagged, not silently vacuous.
         fs::create_dir_all(tmp.path().join("migrations")).unwrap();
         config.schema_dir = Some("migrations".to_string());
         config.schema_pattern = Some("*.sql".to_string());
-        let problems = schema_config_problems(tmp.path(), &config);
-        assert_eq!(problems.len(), 1);
-        assert!(problems[0].contains("*.sql"), "{problems:?}");
+        let schema = load_schema_validation(tmp.path(), &config);
+        assert_eq!(schema.errors.len(), 1);
+        assert!(schema.errors[0].contains("*.sql"), "{:?}", schema.errors);
 
         // A valid pattern is fine.
         config.schema_pattern = Some(r"CREATE TABLE (\w+)".to_string());
-        assert!(schema_config_problems(tmp.path(), &config).is_empty());
+        assert!(
+            load_schema_validation(tmp.path(), &config)
+                .errors
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_load_schema_validation_propagates_replay_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let migrations = tmp.path().join("migrations");
+        fs::create_dir_all(&migrations).unwrap();
+        let malformed = migrations.join("001_broken.sql");
+        fs::write(
+            &malformed,
+            "CREATE TABLE valid (id INTEGER);\n\nCREATE TABLE broken (id INTEGER;\n",
+        )
+        .unwrap();
+        let config = SpecSyncConfig {
+            schema_dir: Some("migrations".to_string()),
+            ..Default::default()
+        };
+
+        let schema = load_schema_validation(tmp.path(), &config);
+        assert!(schema.tables.is_empty());
+        assert!(schema.columns.is_empty());
+        assert_eq!(schema.errors.len(), 1, "errors: {:?}", schema.errors);
+        assert!(
+            schema.errors[0].contains("001_broken.sql:3:1")
+                && schema.errors[0].contains("unmatched parentheses"),
+            "errors: {:?}",
+            schema.errors
+        );
+    }
+
+    #[test]
+    fn test_schema_pattern_does_not_resurrect_qualified_renamed_leaf() {
+        let tmp = tempfile::tempdir().unwrap();
+        let migrations = tmp.path().join("migrations");
+        fs::create_dir_all(&migrations).unwrap();
+        fs::write(
+            migrations.join("001_users.sql"),
+            "CREATE TABLE public.users (id INTEGER);\n\
+             ALTER TABLE public.users RENAME TO archive.users;\n",
+        )
+        .unwrap();
+        let config = SpecSyncConfig {
+            schema_dir: Some("migrations".to_string()),
+            // Deliberately capture only the leaf. The additive pattern must not
+            // turn the retired public.users identity back into bare `users`.
+            schema_pattern: Some(r"CREATE TABLE (?:public\.)?([a-z]+)".to_string()),
+            ..Default::default()
+        };
+
+        let schema = load_schema_validation(tmp.path(), &config);
+        assert!(schema.errors.is_empty(), "errors: {:?}", schema.errors);
+        assert!(schema.tables.contains("archive.users"));
+        assert!(!schema.tables.contains("public.users"));
+        assert!(!schema.tables.contains("users"));
     }
 
     #[test]
@@ -1996,13 +2189,7 @@ Test
 
         // No schema_dir configured: warn (validation skipped visibly), no error.
         let config = SpecSyncConfig::default();
-        let result = validate_spec(
-            &spec,
-            tmp.path(),
-            &HashSet::new(),
-            &HashMap::new(),
-            &config,
-        );
+        let result = validate_spec(&spec, tmp.path(), &HashSet::new(), &HashMap::new(), &config);
         assert!(
             result
                 .warnings
@@ -2028,14 +2215,29 @@ Test
             schema_dir: Some("migrations".to_string()),
             ..Default::default()
         };
-        let tables = get_schema_table_names(tmp.path(), &config);
-        let result = validate_spec(&spec, tmp.path(), &tables, &HashMap::new(), &config);
+        let schema = load_schema_validation(tmp.path(), &config);
+        let result = validate_spec(&spec, tmp.path(), &schema.tables, &schema.columns, &config);
         assert!(
             result
                 .errors
                 .iter()
                 .any(|e| e.contains("DB table not found in schema: zzz_definitely_missing")),
             "errors: {:?}",
+            result.errors
+        );
+
+        // A configured, readable, but empty schema is not a successful match.
+        fs::remove_file(tmp.path().join("migrations/001.sql")).unwrap();
+        let schema = load_schema_validation(tmp.path(), &config);
+        assert!(schema.errors.is_empty(), "errors: {:?}", schema.errors);
+        assert!(schema.tables.is_empty());
+        let result = validate_spec(&spec, tmp.path(), &schema.tables, &schema.columns, &config);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.contains("DB table not found in schema")),
+            "an empty discovered set must not pass db_tables validation: {:?}",
             result.errors
         );
     }
@@ -2046,7 +2248,11 @@ Test
         // NFD source (i + combining diaeresis), NFC spec (precomposed ï):
         // glyph-identical names must match, not phantom/undocumented.
         fs::create_dir_all(tmp.path().join("src")).unwrap();
-        fs::write(tmp.path().join("src/lib.ts"), "export const nai\u{0308}ve = 1;\n").unwrap();
+        fs::write(
+            tmp.path().join("src/lib.ts"),
+            "export const nai\u{0308}ve = 1;\n",
+        )
+        .unwrap();
         let spec = tmp.path().join("u.spec.md");
         fs::write(
             &spec,
@@ -2054,20 +2260,20 @@ Test
         )
         .unwrap();
         let config = SpecSyncConfig::default();
-        let result = validate_spec(
-            &spec,
-            tmp.path(),
-            &HashSet::new(),
-            &HashMap::new(),
-            &config,
-        );
+        let result = validate_spec(&spec, tmp.path(), &HashSet::new(), &HashMap::new(), &config);
         assert!(
-            !result.errors.iter().any(|e| e.contains("no matching export")),
+            !result
+                .errors
+                .iter()
+                .any(|e| e.contains("no matching export")),
             "errors: {:?}",
             result.errors
         );
         assert!(
-            !result.warnings.iter().any(|w| w.contains("ndocumented export")),
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.contains("ndocumented export")),
             "warnings: {:?}",
             result.warnings
         );
@@ -2077,7 +2283,11 @@ Test
     fn test_erlang_arity_export_matching() {
         let tmp = tempfile::tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("src")).unwrap();
-        fs::write(tmp.path().join("src/geo.erl"), "-module(geo).\n-export([area/2]).\narea(A, B) -> A * B.\n").unwrap();
+        fs::write(
+            tmp.path().join("src/geo.erl"),
+            "-module(geo).\n-export([area/2]).\narea(A, B) -> A * B.\n",
+        )
+        .unwrap();
         let config = SpecSyncConfig::default();
 
         // Bare `area` still matches `area/2` (back-compat)...
@@ -2087,15 +2297,12 @@ Test
             "---\nmodule: geo\nversion: 1\nstatus: active\nfiles:\n  - src/geo.erl\n---\n\n## Purpose\nTest\n## Public API\n\n### Exported Functions\n\n| Name | Description |\n|------|-------------|\n| `area` | arity-2 export |\n",
         )
         .unwrap();
-        let result = validate_spec(
-            &spec,
-            tmp.path(),
-            &HashSet::new(),
-            &HashMap::new(),
-            &config,
-        );
+        let result = validate_spec(&spec, tmp.path(), &HashSet::new(), &HashMap::new(), &config);
         assert!(
-            !result.errors.iter().any(|e| e.contains("no matching export")),
+            !result
+                .errors
+                .iter()
+                .any(|e| e.contains("no matching export")),
             "errors: {:?}",
             result.errors
         );
@@ -2107,13 +2314,7 @@ Test
             "---\nmodule: geo\nversion: 1\nstatus: active\nfiles:\n  - src/geo.erl\n---\n\n## Purpose\nTest\n## Public API\n\n### Exported Functions\n\n| Name | Description |\n|------|-------------|\n| `area/1` | wrong arity |\n",
         )
         .unwrap();
-        let result = validate_spec(
-            &spec,
-            tmp.path(),
-            &HashSet::new(),
-            &HashMap::new(),
-            &config,
-        );
+        let result = validate_spec(&spec, tmp.path(), &HashSet::new(), &HashMap::new(), &config);
         assert!(
             result
                 .errors
@@ -2134,13 +2335,7 @@ Test
         )
         .unwrap();
         let config = SpecSyncConfig::default();
-        let result = validate_spec(
-            &spec,
-            tmp.path(),
-            &HashSet::new(),
-            &HashMap::new(),
-            &config,
-        );
+        let result = validate_spec(&spec, tmp.path(), &HashSet::new(), &HashMap::new(), &config);
         assert!(
             result
                 .warnings

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -44,9 +44,69 @@ pub fn parse_cross_project_ref(dep: &str) -> Option<(&str, &str)> {
     Some((repo, module))
 }
 
+/// Validate one local (non-cross-project) `depends_on` entry and resolve it
+/// to an existing path inside the project.
+///
+/// This is the ONE verdict for a dependency declaration, shared by
+/// `check` (here), `deps` (crate::deps), and `resolve` (commands::resolve) so
+/// the same list can no longer yield three different answers:
+/// - cross-project refs (`owner/repo@module`) are skipped (Ok) — `resolve`
+///   validates them against registries;
+/// - absolute paths and `..` traversal are rejected as escapes;
+/// - bare module names resolve against the specs directory;
+/// - anything else must exist as a path confined to the project root.
+pub fn validate_local_dependency(dep: &str, root: &Path, specs_dir: &str) -> Result<PathBuf, String> {
+    if is_cross_project_ref(dep) {
+        // Cross-project refs (e.g. "owner/repo@module") are validated
+        // by `specsync resolve`, not during local checks.
+        return Ok(root.join(specs_dir));
+    }
+    let trimmed = dep.trim();
+    if trimmed.is_empty() {
+        return Err("Dependency spec entry is empty".to_string());
+    }
+    let as_path = Path::new(trimmed);
+    if as_path.is_absolute()
+        || as_path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::Prefix(_)))
+        || trimmed.contains('\\')
+    {
+        return Err(format!(
+            "Dependency spec path escapes the project root: {trimmed} (absolute paths and `..` traversal are not allowed)"
+        ));
+    }
+    // Bare module names (no path separators or extension) resolve
+    // against the specs directory, not the project root.
+    let full_path = if !trimmed.contains('/') && !trimmed.contains('.') {
+        root.join(specs_dir).join(trimmed)
+    } else {
+        root.join(trimmed)
+    };
+    if !source_within_root(root, trimmed) {
+        return Err(format!(
+            "Dependency spec path escapes the project root: {trimmed} (symlink resolution leaves the project)"
+        ));
+    }
+    if !full_path.exists() {
+        return Err(format!("Dependency spec not found: {trimmed}"));
+    }
+    Ok(full_path)
+}
+
 // ─── Schema Table Discovery ──────────────────────────────────────────────
 
 /// Extract table names from SQL schema files.
+///
+/// The base set comes from `schema::build_schema`, which replays migrations in
+/// order — so `ALTER TABLE ... RENAME TO` retires the old name and `DROP TABLE`
+/// retires the table (the naive CREATE-only scan this replaces had the rename
+/// semantics exactly inverted). A configured `schema_pattern` extracts
+/// ADDITIONAL names on top (for nonstandard DDL the replay doesn't understand);
+/// it can no longer vacuously replace the set — an uncompilable pattern is
+/// surfaced loudly by `schema_config_problems` instead of disabling validation.
+/// All names are normalized (`normalize_table_name`): quoting style and case
+/// do not change identity.
 pub fn get_schema_table_names(root: &Path, config: &SpecSyncConfig) -> HashSet<String> {
     let mut tables = HashSet::new();
     let schema_dir = match &config.schema_dir {
@@ -58,17 +118,22 @@ pub fn get_schema_table_names(root: &Path, config: &SpecSyncConfig) -> HashSet<S
         return tables;
     }
 
+    let (schema_map, retired) = schema::build_schema_with_retired(&schema_dir);
+    for name in schema_map.keys() {
+        tables.insert(name.clone());
+    }
+
+    // Pattern extraction adds names the replay can't see (e.g. VIRTUAL TABLE,
+    // whose column list uses `USING module(...)` syntax), but must never
+    // resurrect a table that a later migration dropped or renamed away.
     let pattern_str = config
         .schema_pattern
         .as_deref()
         .unwrap_or_else(|| default_schema_pattern());
 
-    let re = match safe_regex(pattern_str) {
-        Some(r) => r,
-        None => return tables,
-    };
-
-    if let Ok(entries) = fs::read_dir(&schema_dir) {
+    if let Some(re) = safe_regex(pattern_str)
+        && let Ok(entries) = fs::read_dir(&schema_dir)
+    {
         for entry in entries.flatten() {
             let path = entry.path();
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -78,7 +143,10 @@ pub fn get_schema_table_names(root: &Path, config: &SpecSyncConfig) -> HashSet<S
             if let Ok(content) = fs::read_to_string(&path) {
                 for caps in re.captures_iter(&content) {
                     if let Some(name) = caps.get(1) {
-                        tables.insert(name.as_str().to_string());
+                        let normalized = schema::normalize_table_name(name.as_str());
+                        if !retired.contains(&normalized) {
+                            tables.insert(normalized);
+                        }
                     }
                 }
             }
@@ -86,6 +154,42 @@ pub fn get_schema_table_names(root: &Path, config: &SpecSyncConfig) -> HashSet<S
     }
 
     tables
+}
+
+/// Loud, project-level schema configuration problems: a configured
+/// `schema_dir` that does not exist, or a `schema_pattern` that does not
+/// compile as a regex. Both previously disabled table validation silently
+/// (empty table set ⇒ every db_tables entry vacuously passed).
+pub fn schema_config_problems(root: &Path, config: &SpecSyncConfig) -> Vec<String> {
+    let mut problems = Vec::new();
+    if let Some(dir) = &config.schema_dir {
+        if !root.join(dir).exists() {
+            problems.push(format!(
+                "Configured schema_dir `{dir}` does not exist — db_tables validation cannot run; create the directory or fix schema_dir in the config"
+            ));
+        } else if let Some(pattern) = &config.schema_pattern
+            && safe_regex(pattern).is_none()
+        {
+            problems.push(format!(
+                "Configured schema_pattern `{pattern}` is not a valid regex — table-name extraction cannot use it; fix or remove schema_pattern in the config"
+            ));
+        }
+    }
+    problems
+}
+
+/// Whether a declared `db_tables` entry exists in the discovered schema set.
+/// Both sides are normalized; an unqualified declared name also matches a
+/// schema-qualified discovered name (`users` matches `public.users`).
+pub fn schema_table_exists(tables: &HashSet<String>, declared: &str) -> bool {
+    let norm = schema::normalize_table_name(declared);
+    if tables.contains(&norm) {
+        return true;
+    }
+    !norm.contains('.')
+        && tables
+            .iter()
+            .any(|t| t.rsplit('.').next() == Some(norm.as_str()))
 }
 
 // ─── File Discovery ──────────────────────────────────────────────────────
@@ -160,6 +264,84 @@ fn has_coverage_extension(path: &Path, config: &SpecSyncConfig) -> bool {
         .is_some_and(|extension| STATIC_COVERAGE_EXTENSIONS.contains(&extension))
 }
 
+/// Fold a symbol name for cross-document matching: strip combining
+/// diacritical marks so canonically-equivalent Unicode (NFC `ï` vs NFD
+/// `i` + U+0308) compares equal regardless of how each side was encoded.
+fn symbol_key(s: &str) -> String {
+    s.chars()
+        .flat_map(decompose_latin)
+        .filter(|c| !matches!(*c as u32, 0x300..=0x36F))
+        .collect()
+}
+
+/// Canonical decomposition for the common precomposed Latin letters
+/// (Latin-1 Supplement + Latin Extended-A) into base letter + combining
+/// mark, so that `symbol_key`'s combining-mark strip folds NFC and NFD
+/// spellings of the same glyph to the same key without pulling in a full
+/// Unicode normalization crate. Non-listed characters pass through.
+fn decompose_latin(c: char) -> Vec<char> {
+    let base = match c {
+        'à' | 'á' | 'â' | 'ã' | 'ä' | 'å' | 'ā' | 'ă' | 'ą' => Some('a'),
+        'À' | 'Á' | 'Â' | 'Ã' | 'Ä' | 'Å' | 'Ā' | 'Ă' | 'Ą' => Some('A'),
+        'ç' | 'ć' | 'ĉ' | 'ċ' | 'č' => Some('c'),
+        'Ç' | 'Ć' | 'Ĉ' | 'Ċ' | 'Č' => Some('C'),
+        'ď' | 'đ' | 'ð' => Some('d'),
+        'Ď' | 'Đ' | 'Ð' => Some('D'),
+        'è' | 'é' | 'ê' | 'ë' | 'ē' | 'ĕ' | 'ė' | 'ę' | 'ě' => Some('e'),
+        'È' | 'É' | 'Ê' | 'Ë' | 'Ē' | 'Ĕ' | 'Ė' | 'Ę' | 'Ě' => Some('E'),
+        'ĝ' | 'ğ' | 'ġ' | 'ģ' => Some('g'),
+        'Ĝ' | 'Ğ' | 'Ġ' | 'Ģ' => Some('G'),
+        'ĥ' | 'ħ' => Some('h'),
+        'Ĥ' | 'Ħ' => Some('H'),
+        'ì' | 'í' | 'î' | 'ï' | 'ĩ' | 'ī' | 'ĭ' | 'į' | 'ı' => Some('i'),
+        'Ì' | 'Í' | 'Î' | 'Ï' | 'Ĩ' | 'Ī' | 'Ĭ' | 'Į' | 'İ' => Some('I'),
+        'ĵ' => Some('j'),
+        'Ĵ' => Some('J'),
+        'ķ' => Some('k'),
+        'Ķ' => Some('K'),
+        'ĺ' | 'ļ' | 'ľ' | 'ŀ' | 'ł' => Some('l'),
+        'Ĺ' | 'Ļ' | 'Ľ' | 'Ŀ' | 'Ł' => Some('L'),
+        'ñ' | 'ń' | 'ņ' | 'ň' => Some('n'),
+        'Ñ' | 'Ń' | 'Ņ' | 'Ň' => Some('N'),
+        'ò' | 'ó' | 'ô' | 'õ' | 'ö' | 'ø' | 'ō' | 'ŏ' | 'ő' => Some('o'),
+        'Ò' | 'Ó' | 'Ô' | 'Õ' | 'Ö' | 'Ø' | 'Ō' | 'Ŏ' | 'Ő' => Some('O'),
+        'ŕ' | 'ŗ' | 'ř' => Some('r'),
+        'Ŕ' | 'Ŗ' | 'Ř' => Some('R'),
+        'ś' | 'ŝ' | 'ş' | 'š' => Some('s'),
+        'Ś' | 'Ŝ' | 'Ş' | 'Š' => Some('S'),
+        'ţ' | 'ť' | 'ŧ' => Some('t'),
+        'Ţ' | 'Ť' | 'Ŧ' => Some('T'),
+        'ù' | 'ú' | 'û' | 'ü' | 'ũ' | 'ū' | 'ŭ' | 'ů' | 'ű' | 'ų' => Some('u'),
+        'Ù' | 'Ú' | 'Û' | 'Ü' | 'Ũ' | 'Ū' | 'Ŭ' | 'Ů' | 'Ű' | 'Ų' => Some('U'),
+        'ŵ' => Some('w'),
+        'Ŵ' => Some('W'),
+        'ý' | 'ÿ' | 'ŷ' => Some('y'),
+        'Ý' | 'Ŷ' | 'Ÿ' => Some('Y'),
+        'ź' | 'ż' | 'ž' => Some('z'),
+        'Ź' | 'Ż' | 'Ž' => Some('Z'),
+        _ => None,
+    };
+    match base {
+        Some(b) => vec![b],
+        None => vec![c],
+    }
+}
+
+/// Whether a documented spec symbol matches a discovered export. Beyond exact
+/// (diacritic-folded) equality, a bare spec name matches an arity-qualified
+/// export (`area` matches Erlang's `area/2`) so pre-arity specs keep working,
+/// while `area/1` correctly does NOT match `area/2`.
+fn symbols_match(spec_symbol: &str, export_key: &str) -> bool {
+    let spec_key = symbol_key(spec_symbol);
+    spec_key == export_key
+        || (export_key.contains('/')
+            && export_key.rsplit('/').next().is_some_and(|arity| {
+                !arity.is_empty()
+                    && arity.chars().all(|c| c.is_ascii_digit())
+                    && export_key[..export_key.len() - arity.len() - 1] == spec_key
+            }))
+}
+
 // ─── Single Spec Validation ──────────────────────────────────────────────
 
 /// Validate a single spec file against source code.
@@ -195,6 +377,12 @@ pub fn validate_spec(
             return result;
         }
     };
+
+    // Surface frontmatter shape problems (duplicate keys, wrong YAML shapes,
+    // unclosed brackets) before anything else — a lenient parse here is a
+    // validation bypass downstream.
+    result.errors.extend(parsed.errors.iter().cloned());
+    result.warnings.extend(parsed.warnings.iter().cloned());
 
     let fm = &parsed.frontmatter;
     let body = &parsed.body;
@@ -236,6 +424,20 @@ pub fn validate_spec(
         result
             .fixes
             .push("Add `module: your-module-name` to the YAML frontmatter block".to_string());
+    } else if let Some(module) = &fm.module {
+        // Cross-check `module:` against the spec filename — a spec at
+        // `specs/lib/lib.spec.md` declaring `module: totallydifferent` makes
+        // dependency edges point at a name nothing else can find.
+        if let Some(stem) = spec_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.strip_suffix(".spec.md"))
+            && stem != module
+        {
+            result.warnings.push(format!(
+                "Frontmatter module `{module}` does not match the spec filename `{stem}.spec.md` — depends_on entries resolve against module names, so other specs must use `{module}` to depend on this one"
+            ));
+        }
     }
     if fm.version.is_none() {
         result
@@ -362,9 +564,20 @@ pub fn validate_spec(
         }
     }
 
+    // db_tables declared but validation cannot run: fail visible, not silent.
+    if !fm.db_tables.is_empty() && config.schema_dir.is_none() {
+        result.warnings.push(format!(
+            "db_tables declares {} table(s) but no `schema_dir` is configured — table validation is skipped; set schema_dir in .specsync/config.toml to enable it",
+            fm.db_tables.len()
+        ));
+    }
+
     // Check db_tables exist in schema
     for table in &fm.db_tables {
-        if !schema_tables.is_empty() && !schema_tables.contains(table) {
+        if config.schema_dir.is_some()
+            && root.join(config.schema_dir.as_deref().unwrap_or_default()).exists()
+            && !schema_table_exists(schema_tables, table)
+        {
             result
                 .errors
                 .push(format!("DB table not found in schema: {table}"));
@@ -378,7 +591,19 @@ pub fn validate_spec(
     if !schema_columns.is_empty() {
         let spec_schema = schema::parse_spec_schema(body);
         for table_name in &fm.db_tables {
-            if let Some(actual_table) = schema_columns.get(table_name)
+            let normalized = schema::normalize_table_name(table_name);
+            let actual_table = schema_columns.get(&normalized).or_else(|| {
+                // Unqualified declared names match a schema-qualified table.
+                if normalized.contains('.') {
+                    None
+                } else {
+                    schema_columns
+                        .iter()
+                        .find(|(k, _)| k.rsplit('.').next() == Some(normalized.as_str()))
+                        .map(|(_, v)| v)
+                }
+            });
+            if let Some(actual_table) = actual_table
                 && let Some(spec_cols) = spec_schema.get(table_name)
             {
                 let actual_names: HashSet<&str> = actual_table
@@ -510,12 +735,20 @@ pub fn validate_spec(
         all_exports.retain(|s| seen.insert(s.clone()));
 
         let spec_symbols = get_spec_symbols(body);
-        let spec_set: HashSet<&str> = spec_symbols.iter().map(|s| s.as_str()).collect();
-        let export_set: HashSet<&str> = all_exports.iter().map(|s| s.as_str()).collect();
+        for dup in crate::parser::get_duplicate_spec_symbols(body) {
+            result.warnings.push(format!(
+                "Duplicate Public API table row: `{dup}` is listed more than once"
+            ));
+        }
+        // Unicode-insensitive matching: an NFC source name and an NFD spec
+        // name (glyph-identical) must match, not produce phantom +
+        // undocumented errors. Diacritics are folded away on both sides.
+        let spec_keys: HashSet<String> = spec_symbols.iter().map(|s| symbol_key(s)).collect();
+        let export_keys: HashSet<String> = all_exports.iter().map(|s| symbol_key(s)).collect();
 
         // Spec documents something that doesn't exist = ERROR
         for sym in &spec_symbols {
-            if !export_set.contains(sym.as_str()) {
+            if !export_keys.iter().any(|k| symbols_match(sym, k)) {
                 result.errors.push(format!(
                     "Spec documents '{sym}' but no matching export found in source"
                 ));
@@ -524,7 +757,11 @@ pub fn validate_spec(
 
         // Code exports something not in spec = WARNING (with source file attribution)
         for sym in &all_exports {
-            if !spec_set.contains(sym.as_str()) {
+            if !spec_keys.contains(&symbol_key(sym))
+                && !spec_symbols
+                    .iter()
+                    .any(|s| symbols_match(s, &symbol_key(sym)))
+            {
                 // Find the source file for this export
                 let source_file = exports_by_file
                     .iter()
@@ -547,7 +784,7 @@ pub fn validate_spec(
 
         let documented = spec_symbols
             .iter()
-            .filter(|s| export_set.contains(s.as_str()))
+            .filter(|s| export_keys.iter().any(|k| symbols_match(s, k)))
             .count();
 
         if !all_exports.is_empty() {
@@ -564,22 +801,8 @@ pub fn validate_spec(
 
     if !fm.depends_on.is_empty() {
         for dep in &fm.depends_on {
-            if is_cross_project_ref(dep) {
-                // Cross-project refs (e.g. "owner/repo@module") are validated
-                // by `specsync resolve`, not during local checks.
-                continue;
-            }
-            // Bare module names (no path separators or extension) resolve
-            // against the specs directory, not the project root.
-            let full_path = if !dep.contains('/') && !dep.contains('.') {
-                root.join(&config.specs_dir).join(dep)
-            } else {
-                root.join(dep)
-            };
-            if !full_path.exists() {
-                result
-                    .errors
-                    .push(format!("Dependency spec not found: {dep}"));
+            if let Err(message) = validate_local_dependency(dep, root, &config.specs_dir) {
+                result.errors.push(message);
             }
         }
     }
@@ -1594,6 +1817,337 @@ Test
                 .any(|e| e.contains("Dependency spec not found")),
             "bare dep name should resolve via specs dir: {:?}",
             result.errors
+        );
+    }
+
+    #[test]
+    fn test_validate_local_dependency_rejects_escapes() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("specs")).unwrap();
+
+        for bad in ["/etc/passwd", "../outside", "specs/../../etc/passwd"] {
+            let err = validate_local_dependency(bad, tmp.path(), "specs")
+                .expect_err("escape must be rejected");
+            assert!(
+                err.contains("escapes the project root") && err.contains(bad),
+                "error must name the offending entry `{bad}`: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_local_dependency_one_verdict() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dep_dir = tmp.path().join("specs").join("run");
+        fs::create_dir_all(&dep_dir).unwrap();
+        fs::write(dep_dir.join("run.spec.md"), "# fixture").unwrap();
+
+        // Bare module name resolves via the specs directory.
+        assert!(validate_local_dependency("run", tmp.path(), "specs").is_ok());
+        // Path form resolves relative to the root.
+        assert!(validate_local_dependency("specs/run/run.spec.md", tmp.path(), "specs").is_ok());
+        // Missing targets fail loudly with the offending entry.
+        let err = validate_local_dependency("nosuchmod", tmp.path(), "specs").unwrap_err();
+        assert!(err.contains("Dependency spec not found: nosuchmod"), "{err}");
+        // Cross-project refs are out of scope for local validation.
+        assert!(validate_local_dependency("owner/repo@auth", tmp.path(), "specs").is_ok());
+    }
+
+    #[test]
+    fn test_validate_spec_rejects_dependency_escape_and_flow_style_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("specs")).unwrap();
+        let spec = tmp.path().join("app.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: app\nversion: 1\nstatus: active\nfiles: []\ndepends_on: [/etc/passwd, nosuchmod]\n---\n\n## Purpose\nTest\n## Public API\n## Invariants\n## Behavioral Examples\n## Error Cases\n## Dependencies\n## Change Log\n",
+        )
+        .unwrap();
+
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(
+            &spec,
+            tmp.path(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &config,
+        );
+        // Flow-style entries must be parsed (not silently zero edges) and each
+        // entry rejected with its own verdict.
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("escapes the project root") && e.contains("/etc/passwd")),
+            "errors: {:?}",
+            result.errors
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("Dependency spec not found: nosuchmod")),
+            "errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_validate_spec_duplicate_status_key_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = tmp.path().join("dup.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: dup\nversion: 1\nstatus: active\nstatus: draft\nfiles: []\n---\n\n## Purpose\nTest\n",
+        )
+        .unwrap();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(
+            &spec,
+            tmp.path(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &config,
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("duplicate key `status`")),
+            "errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_get_schema_table_names_rename_and_drop_applied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("migrations");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("001_init.sql"),
+            "CREATE TABLE old_users (id INTEGER PRIMARY KEY);\nCREATE TABLE doomed (id INTEGER);",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("002_migrate.sql"),
+            "ALTER TABLE old_users RENAME TO users;\nDROP TABLE doomed;",
+        )
+        .unwrap();
+
+        let config = SpecSyncConfig {
+            schema_dir: Some("migrations".to_string()),
+            ..Default::default()
+        };
+        let tables = get_schema_table_names(tmp.path(), &config);
+        // Rename must retire the old name, DROP must retire the table.
+        assert!(tables.contains("users"), "tables: {tables:?}");
+        assert!(!tables.contains("old_users"), "tables: {tables:?}");
+        assert!(!tables.contains("doomed"), "tables: {tables:?}");
+    }
+
+    #[test]
+    fn test_schema_table_exists_quoting_case_and_schema_prefix() {
+        let tables: HashSet<String> = ["users", "public.orders", "mixedcase"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert!(schema_table_exists(&tables, "users"));
+        assert!(schema_table_exists(&tables, "\"users\""));
+        assert!(schema_table_exists(&tables, "`users`"));
+        assert!(schema_table_exists(&tables, "USERS"));
+        assert!(schema_table_exists(&tables, "MixedCase"));
+        // Unqualified declared name matches schema-qualified discovered name.
+        assert!(schema_table_exists(&tables, "orders"));
+        assert!(schema_table_exists(&tables, "public.orders"));
+        assert!(!schema_table_exists(&tables, "zzz_definitely_missing"));
+    }
+
+    #[test]
+    fn test_schema_config_problems_loud() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = SpecSyncConfig {
+            schema_dir: Some("no_such_dir".to_string()),
+            ..Default::default()
+        };
+        let problems = schema_config_problems(tmp.path(), &config);
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("no_such_dir"), "{problems:?}");
+
+        // An uncompilable schema_pattern must be flagged, not silently vacuous.
+        fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+        config.schema_dir = Some("migrations".to_string());
+        config.schema_pattern = Some("*.sql".to_string());
+        let problems = schema_config_problems(tmp.path(), &config);
+        assert_eq!(problems.len(), 1);
+        assert!(problems[0].contains("*.sql"), "{problems:?}");
+
+        // A valid pattern is fine.
+        config.schema_pattern = Some(r"CREATE TABLE (\w+)".to_string());
+        assert!(schema_config_problems(tmp.path(), &config).is_empty());
+    }
+
+    #[test]
+    fn test_validate_spec_db_tables_warn_when_no_schema_dir_and_error_on_phantom() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "---\nmodule: t\nversion: 1\nstatus: active\nfiles: []\ndb_tables:\n  - zzz_definitely_missing\n---\n\n## Purpose\nTest\n";
+        let spec = tmp.path().join("t.spec.md");
+        fs::write(&spec, body).unwrap();
+
+        // No schema_dir configured: warn (validation skipped visibly), no error.
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(
+            &spec,
+            tmp.path(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &config,
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("schema_dir") && w.contains("db_tables")),
+            "warnings: {:?}",
+            result.warnings
+        );
+        assert!(
+            !result.errors.iter().any(|e| e.contains("DB table")),
+            "errors: {:?}",
+            result.errors
+        );
+
+        // schema_dir configured and present: phantom table is an error.
+        fs::create_dir_all(tmp.path().join("migrations")).unwrap();
+        fs::write(
+            tmp.path().join("migrations/001.sql"),
+            "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+        )
+        .unwrap();
+        let config = SpecSyncConfig {
+            schema_dir: Some("migrations".to_string()),
+            ..Default::default()
+        };
+        let tables = get_schema_table_names(tmp.path(), &config);
+        let result = validate_spec(&spec, tmp.path(), &tables, &HashMap::new(), &config);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("DB table not found in schema: zzz_definitely_missing")),
+            "errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_unicode_nfc_nfd_export_matching() {
+        let tmp = tempfile::tempdir().unwrap();
+        // NFD source (i + combining diaeresis), NFC spec (precomposed ï):
+        // glyph-identical names must match, not phantom/undocumented.
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/lib.ts"), "export const nai\u{0308}ve = 1;\n").unwrap();
+        let spec = tmp.path().join("u.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: u\nversion: 1\nstatus: active\nfiles:\n  - src/lib.ts\n---\n\n## Purpose\nTest\n## Public API\n\n### Exported Constants\n\n| Name | Description |\n|------|-------------|\n| `na\u{ef}ve` | unicode |\n",
+        )
+        .unwrap();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(
+            &spec,
+            tmp.path(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &config,
+        );
+        assert!(
+            !result.errors.iter().any(|e| e.contains("no matching export")),
+            "errors: {:?}",
+            result.errors
+        );
+        assert!(
+            !result.warnings.iter().any(|w| w.contains("ndocumented export")),
+            "warnings: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_erlang_arity_export_matching() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/geo.erl"), "-module(geo).\n-export([area/2]).\narea(A, B) -> A * B.\n").unwrap();
+        let config = SpecSyncConfig::default();
+
+        // Bare `area` still matches `area/2` (back-compat)...
+        let spec = tmp.path().join("geo.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: geo\nversion: 1\nstatus: active\nfiles:\n  - src/geo.erl\n---\n\n## Purpose\nTest\n## Public API\n\n### Exported Functions\n\n| Name | Description |\n|------|-------------|\n| `area` | arity-2 export |\n",
+        )
+        .unwrap();
+        let result = validate_spec(
+            &spec,
+            tmp.path(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &config,
+        );
+        assert!(
+            !result.errors.iter().any(|e| e.contains("no matching export")),
+            "errors: {:?}",
+            result.errors
+        );
+
+        // ...but the wrong arity is a phantom, and the true `area/2` is
+        // documentable.
+        fs::write(
+            &spec,
+            "---\nmodule: geo\nversion: 1\nstatus: active\nfiles:\n  - src/geo.erl\n---\n\n## Purpose\nTest\n## Public API\n\n### Exported Functions\n\n| Name | Description |\n|------|-------------|\n| `area/1` | wrong arity |\n",
+        )
+        .unwrap();
+        let result = validate_spec(
+            &spec,
+            tmp.path(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &config,
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("'area/1'") && e.contains("no matching export")),
+            "errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn test_validate_spec_module_filename_mismatch_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = tmp.path().join("lib.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: totallydifferent\nversion: 1\nstatus: active\nfiles: []\n---\n\n## Purpose\nTest\n",
+        )
+        .unwrap();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(
+            &spec,
+            tmp.path(),
+            &HashSet::new(),
+            &HashMap::new(),
+            &config,
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("totallydifferent") && w.contains("lib.spec.md")),
+            "warnings: {:?}",
+            result.warnings
         );
     }
 }

--- a/tests/integration/check.rs
+++ b/tests/integration/check.rs
@@ -1308,6 +1308,88 @@ fn invalid_frontmatter_reports_error() {
 }
 
 #[test]
+fn hostile_frontmatter_shapes_fail_loudly_in_json() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("specs/safe")).unwrap();
+    fs::write(
+        root.join("specs/safe/safe.spec.md"),
+        r#"---
+module: safe
+module: hidden
+version: "one"
+status: active
+status: draft
+files: []
+depends_on: {outside: true}
+colon-less garbage
+---
+
+# Safe
+
+## Purpose
+
+Fixture.
+"#,
+    )
+    .unwrap();
+
+    let output = specsync()
+        .args(["check", "--strict", "--force", "--format", "json"])
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let value: serde_json::Value =
+        serde_json::from_slice(&output).expect("frontmatter failure must stay valid JSON");
+    let errors = value["errors"].to_string();
+    let warnings = value["warnings"].to_string();
+    assert!(errors.contains("duplicate key `module`"), "{errors}");
+    assert!(errors.contains("duplicate key `status`"), "{errors}");
+    assert!(
+        errors.contains("`depends_on` must be a YAML list"),
+        "{errors}"
+    );
+    assert!(
+        warnings.contains("version` should be a plain number"),
+        "{warnings}"
+    );
+    assert!(
+        warnings.contains("malformed frontmatter line") && warnings.contains("colon-less garbage"),
+        "{warnings}"
+    );
+}
+
+#[test]
+fn unterminated_frontmatter_delimiter_has_an_actionable_error() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    write_config(root, "specs", &["src"]);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("specs/broken")).unwrap();
+    fs::write(
+        root.join("specs/broken/broken.spec.md"),
+        "---\nmodule: broken\nversion: 1\nstatus: active\nfiles: []\n# missing closing delimiter\n",
+    )
+    .unwrap();
+
+    specsync()
+        .args(["check", "--strict", "--force"])
+        .arg("--root")
+        .arg(root)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "Missing or malformed YAML frontmatter",
+        ));
+}
+
+#[test]
 fn missing_spec_dir_exits_cleanly() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();

--- a/tests/integration/commands.rs
+++ b/tests/integration/commands.rs
@@ -1949,6 +1949,56 @@ fn score_config_only_enforcement_gates_no_specs() {
 // ─── specsync deps: --strict gates on undeclared-import warnings ─────────
 
 #[test]
+fn check_deps_and_resolve_share_confined_dependency_verdicts() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("specs/app")).unwrap();
+    fs::write(
+        root.join("specs/app/app.spec.md"),
+        "---\nmodule: app\nversion: 1\nstatus: active\nfiles: []\n\
+         depends_on: [/etc/passwd@module, nosuchmod]\n---\n\n# App\n\n## Purpose\nFixture\n",
+    )
+    .unwrap();
+
+    let check = specsync()
+        .current_dir(root)
+        .args(["check", "--strict", "--force"])
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let deps = specsync()
+        .current_dir(root)
+        .arg("deps")
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let resolve = specsync()
+        .current_dir(root)
+        .arg("resolve")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    for output in [check, deps, resolve] {
+        let output = String::from_utf8(output).unwrap();
+        assert!(
+            output.contains("escapes the project root") && output.contains("/etc/passwd@module"),
+            "{output}"
+        );
+        assert!(
+            output.contains("Dependency spec not found: nosuchmod"),
+            "{output}"
+        );
+    }
+}
+
+#[test]
 fn deps_strict_gates_on_undeclared_imports() {
     // Regression (H6): `deps --strict` was a silent no-op — undeclared imports
     // were reported as warnings but never failed the exit code.

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -1380,7 +1380,7 @@ fn check_gates_on_unreadable_schema_file() {
         .assert()
         .failure()
         .stdout(predicate::str::contains(
-            "could not be read as UTF-8; DB schema",
+            "schema/migration file could not be read as UTF-8",
         ));
 }
 
@@ -1413,7 +1413,7 @@ fn check_no_schema_error_for_readable_migration() {
         .current_dir(root)
         .arg("check")
         .assert()
-        .stdout(predicate::str::contains("could not be read as UTF-8; DB schema").not());
+        .stdout(predicate::str::contains("schema/migration file could not be read as UTF-8").not());
 }
 
 // ─── config: multi-line TOML arrays are not corrupted ────────────────────


### PR DESCRIPTION
## Problem

Several frontmatter-parsing leniencies let malformed or hostile specs silently bypass validation:

- **Duplicate keys**: a hidden second `status: draft` silently disabled all section/export checks (last value won, no diagnostic).
- **Flow-style lists**: `depends_on: [b]` (the exact form `specsync new` scaffolds) did not parse, so dependency edges silently vanished.
- **Wrong shapes**: `depends_on: {a: b}` (mapping) parsed to an empty list; unclosed `[` and unterminated quotes were dropped silently.
- **Non-numeric `version` and garbage lines** were accepted without any signal.
- **Dependency verdicts diverged**: `check`, `deps`, and `resolve` each judged `depends_on` entries differently — absolute paths and `..` escapes were probed against the host filesystem by some commands and ignored by others; unreadable specs/sources were silently dropped from the dependency graph.
- **`module:` vs filename**: a spec declaring a module name nothing else can reference produced no diagnostic.

## Repro (fixture: `/var/tmp/scratch/w2/436/`)

```yaml
---
module: dup
module: other        # duplicate key
version: "abc"       # non-numeric
status: active
depends_on: [../outside, legit-mod]   # flow-style + escape
files: src/a.ts
---
```

- **Before**: parses cleanly; zero edges; `../outside` never reported; duplicate `module:` invisible.
- **After**: hard errors for the duplicate key and the `../outside` escape (path confinement), "Dependency spec not found: legit-mod" verdict shared by `check`/`deps`/`resolve`, and warnings for the non-numeric version.

## Root cause

`parse_frontmatter` was a lossy best-effort parser with no error channel, and each command re-implemented (differently) how a `depends_on` entry should be judged.

## Fix

- `parser.rs`: `ParsedSpec` gains `errors`/`warnings`; duplicate-key rejection with offending line; flow-style list parsing (hard error on unclosed bracket/unterminated quote); mapping/scalar shape handling for list fields; version-shape and garbage-line warnings; leading-BOM tolerance.
- `validator.rs`: surfaces parser errors/warnings in the validation result; single `validate_local_dependency` verdict (cross-project refs skipped, escapes rejected, bare module names resolve via specs_dir, path confinement via `source_within_root`); module↔filename cross-check warning.
- `deps.rs` / `commands/resolve.rs`: use the same `validate_local_dependency` verdict; unreadable specs and sources are hard errors instead of silently dropped graph nodes/imports.

## Tests (all in-file, all passing)

`test_parse_frontmatter_duplicate_key_rejected_loudly`, `test_parse_frontmatter_flow_style_string_lists`, `test_parse_frontmatter_rejects_bad_list_shapes`, `test_parse_frontmatter_warns_on_non_numeric_version_and_garbage_lines`, `test_validate_spec_duplicate_status_key_is_an_error`, `test_validate_spec_rejects_dependency_escape_and_flow_style_missing`, `test_validate_local_dependency_rejects_escapes`, `test_validate_local_dependency_one_verdict`, `test_validate_spec_bare_dep_name_resolves_via_specs_dir`, `test_validate_spec_module_filename_mismatch_warns`, `test_flow_style_depends_on_counts_edges`, `test_deps_rejects_escapes_and_missing_with_same_verdict_as_check`.

Full suite: 1743 passed, 1 pre-existing root-only failure (`change::tests::non_git_walk_skips_volatile_trees_but_fails_on_relevant_walk_errors`, unrelated). `clippy --all-targets -- -D warnings` clean.

## File overlap note

`src/parser.rs` and `src/validator.rs` also contain the #435 (schema validation) and #437 (export extraction) changes; those PRs (#fix/435-db-schema-validation, #fix/437-export-extraction) ship their own files and note this overlap. The whole current file is included here since #436 most owns both files.

Closes #436