### PR TITLE
fix: db_tables validation silently passes dropped/renamed/misconfigured schemas (closes #435)

### DIFF
--- a/specs/schema/context.md
+++ b/specs/schema/context.md
@@ -5,6 +5,10 @@ spec: schema.spec.md
 ## Key Decisions
 
 - **Migration replay ordering**: Files are sorted by filename, not modification time. This means migration files should use numeric prefixes (001_, 002_, etc.) for deterministic ordering.
+- **One fallible snapshot**: `build_schema_snapshot` owns directory loading, UTF-8 reads, canonical identity, and DDL replay. Validation consumers must use its `Result` instead of combining an empty map with a second best-effort error scan.
+- **Exact statement ordering**: Supported DDL is discovered outside SQL comments and replayed in byte order within each file. String literals and quoted identifiers do not create false operation boundaries.
+- **Collision semantics**: Plain duplicate CREATE, missing DROP/RENAME sources, and colliding RENAME targets fail without mutating the existing snapshot. IF EXISTS, IF NOT EXISTS, and OR REPLACE are the only explicit leniency/replacement paths.
+- **Canonical table identity**: ANSI double quotes, backticks, SQL Server brackets, case differences, whitespace around qualifiers, and qualified names pass through `canonicalize_table_name` for every CREATE/ALTER/DROP transition. Canonical rendering preserves dots inside quoted segments; `canonical_table_leaf` performs safe unqualified matching.
 - **Uppercase normalization**: Column types are always uppercased during SQL parsing to allow case-insensitive comparison with spec-documented types.
 - **Idempotent ALTER ADD**: If a column already exists in the table, `ALTER TABLE ADD COLUMN` is a no-op. This prevents duplicate columns from repeated migrations.
 - **Zero-dependency SQL parsing**: Uses regex-based parsing rather than a full SQL parser. Handles common DDL statements but not every SQL dialect edge case.
@@ -17,9 +21,10 @@ spec: schema.spec.md
 
 ## Current Status
 
-Fully implemented. Supports CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), DROP TABLE, and both spec schema formats. Handles string literals, comments, nested parentheses, and table-level constraints.
+The schema-owned #435 slice is implemented: one ordered fallible snapshot covers CREATE/ALTER/RENAME/DROP, malformed input, missing objects, quoted/qualified identities, deterministic collisions, and positioned diagnostics. The validator/command integration remains a dependency of the #453 restack so empty snapshots are never treated as “validation disabled.”
 
 ## Notes
 
-- Virtual tables (`CREATE VIRTUAL TABLE ... USING ...`) are intentionally skipped for column parsing because they use different syntax.
+- Virtual tables (`CREATE VIRTUAL TABLE ... USING ...`) are represented for table existence with an empty column set because their module-specific column syntax is not parsed.
 - The `SQL_EXTENSIONS` list covers 16 file types including application code files (ts, py, rb, etc.) that may contain embedded SQL.
+- `build_schema` and `build_schema_with_retired` remain lossy compatibility wrappers only so this isolated schema commit compiles before #453 adopts `SchemaSnapshot`; validation must use `build_schema_snapshot` or surface `schema_read_errors`.

--- a/specs/schema/requirements.md
+++ b/specs/schema/requirements.md
@@ -11,16 +11,21 @@ spec: schema.spec.md
 
 ## Acceptance Criteria
 
-- `build_schema` replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in filename-sorted order
-- Returns empty map if the schema directory doesn't exist (no error)
+- `build_schema_snapshot` sorts migration files by filename and replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in exact byte order within each file
+- A configured missing/unreadable schema directory, unreadable migration, malformed supported DDL, missing referenced object, or canonical name collision returns a path-aware error rather than a successful empty snapshot
+- SQL replay diagnostics include a one-based line and column plus a concise statement preview
 - Column types are normalized to uppercase for consistent comparison
 - ALTER TABLE ADD COLUMN is idempotent — duplicate columns are skipped
 - DROP TABLE removes the table entirely from the schema map
 - ALTER TABLE RENAME TO moves all columns to the new table name
 - ALTER TABLE RENAME COLUMN preserves all attributes except the name
-- CREATE TABLE replaces any prior definition of the same table
-- SQL line comments (`--`) are skipped during parsing
-- String literals with escaped quotes are handled correctly (no false column detection)
+- Plain CREATE TABLE fails without mutation on a canonical duplicate; IF NOT EXISTS preserves the existing table and OR REPLACE explicitly replaces it
+- RENAME fails without mutation when the source is missing or the canonical target already exists
+- DROP fails when the table is missing unless IF EXISTS is present
+- A later CREATE may recreate a retired identity and removes it from the retired set
+- ANSI double-quoted, backtick-quoted, bracket-quoted, mixed-case, and qualified table references use one canonical identity parser
+- Dots inside quoted identifier segments remain distinct from qualification separators, including for unqualified matching
+- SQL line/block comments and quoted/string content do not introduce false DDL operations or statement boundaries
 - Supports schema files with extensions: sql, ts, js, mjs, cjs, swift, kt, kts, java, py, rb, go, rs, cs, dart, php
 - `parse_spec_schema` supports both inline (`### Schema: table_name`) and multi-table (`### Schema` with `#### table_name`) formats
 - Markdown table header rows are skipped during spec schema parsing
@@ -43,17 +48,21 @@ spec: schema.spec.md
 Schema parsing SHALL replay supported migration DDL deterministically and compare canonical schema tables without interpreting unsupported DML.
 
 Acceptance Criteria
-- `build_schema` replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in filename-sorted order
-- Returns empty map if the schema directory doesn't exist (no error)
+- `build_schema_snapshot` sorts migration files by filename and replays CREATE TABLE, ALTER TABLE (ADD/DROP/RENAME COLUMN, RENAME TO), and DROP TABLE in exact byte order within each file
+- A configured missing/unreadable schema directory, unreadable migration, malformed supported DDL, missing referenced object, or canonical name collision returns a path-aware error rather than a successful empty snapshot
+- SQL replay diagnostics include a one-based line and column plus a concise statement preview
 - Column types are normalized to uppercase for consistent comparison
 - ALTER TABLE ADD COLUMN is idempotent — duplicate columns are skipped
 - DROP TABLE removes the table entirely from the schema map
 - ALTER TABLE RENAME TO moves all columns to the new table name
 - ALTER TABLE RENAME COLUMN preserves all attributes except the name
-- CREATE TABLE replaces any prior definition of the same table
-- SQL line comments (`--`) are skipped during parsing
-- String literals with escaped quotes are handled correctly (no false column detection)
+- Plain CREATE TABLE fails without mutation on a canonical duplicate; IF NOT EXISTS preserves the existing table and OR REPLACE explicitly replaces it
+- RENAME fails without mutation when the source is missing or the canonical target already exists
+- DROP fails when the table is missing unless IF EXISTS is present
+- A later CREATE may recreate a retired identity and removes it from the retired set
+- ANSI double-quoted, backtick-quoted, bracket-quoted, mixed-case, and qualified table references use one canonical identity parser
+- Dots inside quoted identifier segments remain distinct from qualification separators, including for unqualified matching
+- SQL line/block comments and quoted/string content do not introduce false DDL operations or statement boundaries
 - Supports schema files with extensions: sql, ts, js, mjs, cjs, swift, kt, kts, java, py, rb, go, rs, cs, dart, php
 - `parse_spec_schema` supports both inline (`### Schema: table_name`) and multi-table (`### Schema` with `#### table_name`) formats
 - Markdown table header rows are skipped during spec schema parsing
-

--- a/specs/schema/schema.spec.md
+++ b/specs/schema/schema.spec.md
@@ -1,6 +1,6 @@
 ---
 module: schema
-version: 3
+version: 4
 status: stable
 files:
   - src/schema.rs
@@ -13,7 +13,7 @@ depends_on: []
 
 ## Purpose
 
-Parses SQL schema files (migrations) and spec markdown to build table/column maps for bidirectional validation. Replays CREATE TABLE, ALTER TABLE, DROP TABLE, and RENAME statements in file-sorted order to produce the current schema state. Also extracts column definitions from spec `### Schema` sections for comparison.
+Parses SQL schema files (migrations) and spec markdown to build table/column maps for bidirectional validation. Builds one fallible schema snapshot by replaying CREATE TABLE, ALTER TABLE, DROP TABLE, and RENAME statements in exact file and statement order. Also extracts column definitions from spec `### Schema` sections for comparison.
 
 ## Public API
 
@@ -24,6 +24,9 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 | `SchemaColumn` | A column extracted from SQL schema files — name, col_type (uppercase), nullable, has_default, is_primary_key |
 | `SchemaTable` | All columns for a single table, built by replaying migrations in order |
 | `SpecColumn` | A column documented in a spec's `### Schema` section — name and raw col_type |
+| `SchemaErrorKind` | Stable category for schema directory, file, malformed-statement, missing-object, and collision failures |
+| `SchemaError` | Path- and source-position-aware schema failure with kind, path, line, column, and truthful message |
+| `SchemaSnapshot` | Canonical current table map plus table identities retired by DROP or RENAME |
 
 ### Exported SchemaTable Functions
 
@@ -35,36 +38,44 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `build_schema` | `schema_dir: &Path` | `HashMap<String, SchemaTable>` | Build a complete schema map from SQL/migration files in the given directory, sorted by filename |
-| `schema_read_errors` | `schema_dir: &Path` | `Vec<String>` | Error message for each schema/migration file that exists but cannot be read as UTF-8, plus one for a `schema_dir` that exists but cannot be enumerated (unreadable, or a file rather than a directory), so the validation gate can fail loud instead of silently under-validating (`build_schema` skips such files / returns empty) |
+| `canonicalize_table_name` | `raw: &str` | `Result<String, String>` | Parse qualified table-name segments, unescape ANSI/backtick/bracket quoting, and normalize case without conflating malformed input |
+| `canonical_table_leaf` | `raw: &str` | `Result<String, String>` | Return the canonical final segment for unqualified matching without splitting dots contained inside quoted identifiers |
+| `normalize_table_name` | `raw: &str` | `String` | Compatibility normalization for validator restacking; fallible replay uses `canonicalize_table_name` |
+| `build_schema_snapshot` | `schema_dir: &Path` | `Result<SchemaSnapshot, SchemaError>` | Build the authoritative snapshot by replaying supported DDL in filename and byte order; fail on directory, entry, UTF-8, malformed-DDL, missing-object, and collision errors |
+| `build_schema` | `schema_dir: &Path` | `HashMap<String, SchemaTable>` | Compatibility map wrapper; returns an empty map on snapshot failure and must not be used alone for validation |
+| `build_schema_with_retired` | `schema_dir: &Path` | `(HashMap<String, SchemaTable>, HashSet<String>)` | Compatibility wrapper exposing retired table identities; returns empty collections on snapshot failure |
+| `schema_read_errors` | `schema_dir: &Path` | `Vec<String>` | Compatibility diagnostics adapter that renders the authoritative snapshot failure, including missing/unreadable paths and malformed or inconsistent DDL |
 | `parse_spec_schema` | `body: &str` | `HashMap<String, Vec<SpecColumn>>` | Extract column definitions from a spec's `### Schema` section(s) |
 
 ## Invariants
 
-1. `build_schema` replays migrations in filename-sorted order for deterministic results
-2. `build_schema` returns an empty map if the directory does not exist
-2a. A schema/migration file that exists but cannot be read as UTF-8 is silently skipped by `build_schema` (its tables/columns vanish); `schema_read_errors` reports each such file so the validation gate surfaces it as a hard error rather than letting an all-unreadable schema silently disable `db_tables`/column checks
-2b. A `schema_dir` that exists but cannot be enumerated by `read_dir` — because it is unreadable or is a file rather than a directory — is itself a hard error from `schema_read_errors` (not a silent empty result): the same fail-open would otherwise leave schema discovery empty and skip `db_tables`/column checks with no signal
+1. `build_schema_snapshot` sorts migration files and replays supported DDL in byte order within each file
+2. A configured missing/unreadable schema directory, unreadable entry/file, malformed supported DDL, missing referenced object, or canonical identity collision returns `SchemaError`; it never produces a successful empty snapshot
+2a. `SchemaError` identifies the source path and, for SQL replay failures, the one-based line and column
+2b. `build_schema` and `build_schema_with_retired` are compatibility-only lossy wrappers; validation consumers use `build_schema_snapshot` or surface `schema_read_errors`
 3. Column types are normalized to uppercase (e.g. "integer" becomes "INTEGER")
 4. ALTER TABLE ADD COLUMN is idempotent — duplicate column names are skipped
 5. DROP TABLE removes the table and all its columns from the map
 6. ALTER TABLE RENAME TO moves all columns to the new table name
 7. ALTER TABLE RENAME COLUMN preserves all column attributes except the name
-8. CREATE TABLE replaces any prior definition of the same table (handles CREATE OR REPLACE semantics)
+8. Plain CREATE TABLE fails on a canonical duplicate, IF NOT EXISTS preserves the existing table, and OR REPLACE explicitly replaces it
+8a. RENAME fails without mutation when its source is missing or its canonical target already exists; DROP fails on a missing table unless IF EXISTS is present
+8b. Recreating a dropped or renamed-away table clears that identity from the retired set
 9. Table-level constraints (PRIMARY KEY, UNIQUE, CHECK, FOREIGN KEY, CONSTRAINT) are skipped during column parsing
-10. String literals with escaped quotes are handled correctly during parenthesis matching
-11. SQL line comments (`--`) are skipped during parenthesis matching
+10. String literals, quoted identifiers, and escaped quotes do not create false statement boundaries or DDL matches
+11. SQL line and block comments are excluded from DDL discovery and parenthesis matching
 12. `parse_spec_schema` supports two formats: inline (`### Schema: table_name`) and multi-table (`### Schema` with `#### table_name` sub-headers)
 13. `parse_spec_schema` skips markdown table header rows (column named "column")
 14. Only files with recognized SQL extensions are processed (sql, ts, js, mjs, cjs, swift, kt, kts, java, py, rb, go, rs, cs, dart, php)
+15. ANSI double-quoted, backtick-quoted, bracket-quoted, mixed-case, and qualified table references share one canonical identity parser; dots inside quoted segments remain distinct from qualification separators
 
 ## Behavioral Examples
 
 ### Scenario: Build schema from migrations
 
 - **Given** a directory with `001_create.sql` containing `CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)` and `002_add_col.sql` containing `ALTER TABLE items ADD COLUMN price REAL DEFAULT 0`
-- **When** `build_schema(dir)` is called
-- **Then** returns a map with "items" having 3 columns: id (INTEGER, PK), name (TEXT, NOT NULL), price (REAL, DEFAULT)
+- **When** `build_schema_snapshot(dir)` is called
+- **Then** returns a snapshot whose "items" table has 3 columns: id (INTEGER, PK), name (TEXT, NOT NULL), price (REAL, DEFAULT)
 
 ### Scenario: DROP TABLE removes table
 
@@ -90,20 +101,23 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 - **When** `parse_spec_schema(body)` is called
 - **Then** returns a map with both "messages" and "users" entries
 
-### Scenario: Nonexistent directory
+### Scenario: Malformed migration fails loud
 
-- **Given** a path that does not exist
-- **When** `build_schema(path)` is called
-- **Then** returns an empty HashMap
+- **Given** `002_broken.sql` contains `CREATE TABLE broken (id INTEGER;`
+- **When** `build_schema_snapshot(path)` is called
+- **Then** it returns a `MalformedStatement` error naming the file and the CREATE statement's line and column
 
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
-| Schema directory does not exist | `build_schema` returns empty map; `schema_read_errors` returns no errors (schema simply not configured) |
-| Schema directory exists but cannot be enumerated (unreadable, or a file not a directory) | `schema_read_errors` returns a hard error naming the directory (fail-loud); `build_schema` returns an empty map |
-| File cannot be read | `build_schema` silently skips the file; `schema_read_errors` flags it as a hard error |
-| Unmatched parentheses in CREATE TABLE | `extract_paren_body` returns `None`, table is skipped |
+| Configured schema directory does not exist | `build_schema_snapshot` returns `MissingDirectory`; compatibility `build_schema` returns an empty map but `schema_read_errors` exposes the failure |
+| Schema directory cannot be enumerated | `build_schema_snapshot` returns `ReadDirectory` or `ReadEntry` naming the path |
+| File cannot be read as UTF-8 | `build_schema_snapshot` returns `ReadFile` naming the migration |
+| Unmatched parentheses or malformed supported DDL | Returns `MalformedStatement` with path, line, column, and statement preview |
+| Plain CREATE collides after canonicalization | Returns `DuplicateTable`; the existing table remains unchanged |
+| RENAME target collides after canonicalization | Returns `RenameCollision`; source and target remain unchanged |
+| DROP/RENAME source is missing | Returns `MissingTable`, except `DROP TABLE IF EXISTS` is a no-op |
 | No `### Schema` section in spec | `parse_spec_schema` returns empty map |
 | Column name looks like SQL keyword | Column is skipped by `is_sql_keyword` check |
 
@@ -119,14 +133,15 @@ Parses SQL schema files (migrations) and spec markdown to build table/column map
 
 | Module | What is used |
 |--------|-------------|
-| validator | `build_schema`, `parse_spec_schema`, `SchemaTable` for column validation |
-| mcp | `build_schema` for schema-aware validation |
-| main | `build_schema`, `SchemaTable` for CLI schema loading |
+| validator | `build_schema_snapshot`, `canonicalize_table_name`, `canonical_table_leaf`, `parse_spec_schema`, `SchemaSnapshot`, and `SchemaTable` for existence and column validation |
+| mcp | `build_schema_snapshot` for schema-aware validation |
+| main | `build_schema_snapshot`, `SchemaError`, and `SchemaTable` for CLI schema loading |
 
 ## Change Log
 
 | Date | Change |
 |------|--------|
+| 2026-07-26 | Added one fallible ordered schema snapshot, exact within-file DDL replay, canonical quoted/qualified identities, collision-safe mutation, and path/line diagnostics for malformed or unreadable migrations |
 | 2026-07-06 | `schema_read_errors` now also fails loud when `schema_dir` exists but cannot be enumerated by `read_dir` (unreadable, or a file not a directory) — closing the same fail-open; added invariant 2b, updated the API row and Error Cases table |
 | 2026-03-29 | Initial spec |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |

--- a/specs/schema/tasks.md
+++ b/specs/schema/tasks.md
@@ -8,7 +8,6 @@ spec: schema.spec.md
 
 - [ ] Support CREATE INDEX tracking for schema completeness
 - [ ] Add VIRTUAL TABLE column extraction (FTS5 columns)
-- [ ] Support multi-statement migration files with transaction wrappers (BEGIN/COMMIT)
 
 ## Done
 
@@ -20,12 +19,17 @@ spec: schema.spec.md
 - [x] String literal and comment handling in paren matching
 - [x] Table-level constraint skipping (PRIMARY KEY, UNIQUE, CHECK, FOREIGN KEY, CONSTRAINT)
 - [x] SQL keyword filtering for column names
+- [x] Replay supported DDL in exact statement order within filename-sorted migrations
+- [x] Return path/line/column diagnostics for missing directories, unreadable files, malformed DDL, missing objects, and collisions
+- [x] Canonicalize ANSI/backtick/bracket quoted, mixed-case, and qualified table identities
+- [x] Preserve snapshot state on duplicate CREATE and RENAME-target collisions
+- [x] Support multi-statement migration files and ignore transaction-control/DML statements
 
 ## Gaps
 
 - No support for VIRTUAL TABLE column extraction
-- No transaction wrapper handling (BEGIN/COMMIT blocks)
 - No CREATE INDEX tracking
+- Validator/CLI consumers must be restacked in #453 to use the fallible snapshot directly and remove the compatibility wrappers
 
 ## Review Status
 

--- a/specs/schema/testing.md
+++ b/specs/schema/testing.md
@@ -6,30 +6,41 @@ spec: schema.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/schema.rs` | cargo test schema:: | `test_parse_create_table`, `test_parse_create_table_if_not_exists`, `test_parse_create_virtual_table`, `test_parse_alter_table_add_column`, `test_alter_idempotent`, `test_table_constraints_skipped` |
+| `src/schema.rs` | `fledge run test -- schema::tests` | 36 focused tests, especially the ordered-replay, malformed-SQL, quoting, missing-object, and collision tests |
+| `tests/integration/config.rs` | `fledge run test -- --test integration config::check_gates_on_unreadable_schema_file` | CLI fails closed and renders the snapshot's unreadable-migration diagnostic |
 
 ## Coverage Gaps
 
-- Integration gap: add a fixture for "Build schema from migrations" before changing user-visible CLI output, generated files, or error handling in schema.
+- Validator/CLI consumption is intentionally deferred to the #453 restack: it must consume `build_schema_snapshot` directly and must not infer validity from an empty compatibility map.
 
 ## Behavioral Verification
 
 | Flow | Fixture / Setup | Action | Expected Result |
 |------|-----------------|--------|-----------------|
-| Build schema from migrations | a directory with `001_create.sql` containing `CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)` and `002_add_col.sql` containing `ALTER TABLE items ADD COLUMN price REAL DEFAULT 0` | `build_schema(dir)` is called | returns a map with "items" having 3 columns: id (INTEGER, PK), name (TEXT, NOT NULL), price (REAL, DEFAULT) |
-| DROP TABLE removes table | SQL containing `CREATE TABLE temp (id INTEGER PRIMARY KEY)` followed by `DROP TABLE temp` | the SQL is parsed | "temp" is not present in the resulting schema map |
-| Rename table | SQL containing `CREATE TABLE old_name (id INTEGER PRIMARY KEY)` followed by `ALTER TABLE old_name RENAME TO new_name` | the SQL is parsed | "old_name" is absent and "new_name" has all original columns |
+| Build schema from migrations | a directory with ordered CREATE and ALTER files | `build_schema_snapshot(dir)` is called | returns a snapshot with the final canonical table and column state |
+| Exact statement order | one file performs CREATE, DROP, then CREATE of the same name | SQL is replayed | the final CREATE exists and the identity is no longer retired |
+| Rename then recreate | one file creates `users`, renames it to `archived_users`, then creates `users` again | SQL is replayed | both final tables exist with their own columns |
+| Malformed supported DDL | `002_broken.sql` contains an unmatched CREATE TABLE parenthesis | `build_schema_snapshot(dir)` is called | returns `MalformedStatement` with file, line, column, and statement preview |
+| Quoted and qualified identity | ANSI, backtick, bracket, mixed-case, and qualified names—including a dot inside a quoted segment—are normalized | SQL is replayed | each operation resolves through the same canonical identity without conflating quoted dots with qualification |
+| Collision safety | normalized CREATE names collide, or RENAME targets an existing canonical table | SQL is replayed | returns `DuplicateTable`/`RenameCollision` without overwriting either existing table |
 | Parse spec schema inline format | a spec body with `### Schema: messages` followed by a markdown table with columns `id`, `content`, `created_at` | `parse_spec_schema(body)` is called | returns a map with "messages" having 3 SpecColumn entries |
 | Parse spec schema multi-table format | a spec body with `### Schema` followed by `#### messages` and `#### users` sub-headers each with column tables | `parse_spec_schema(body)` is called | returns a map with both "messages" and "users" entries |
-| Nonexistent directory | a path that does not exist | `build_schema(path)` is called | returns an empty HashMap |
+| Configured missing directory | a path that does not exist | `build_schema_snapshot(path)` is called | returns `MissingDirectory`; no successful empty snapshot is produced |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Schema directory does not exist | `build_schema` returns empty map | Keep or add a focused assertion before changing this behavior |
-| File cannot be read | File is silently skipped | Keep or add a focused assertion before changing this behavior |
-| Unmatched parentheses in CREATE TABLE | `extract_paren_body` returns `None`, table is skipped | Keep or add a focused assertion before changing this behavior |
+| Schema directory does not exist | `build_schema_snapshot` returns `MissingDirectory` | `test_build_schema_snapshot_missing_directory_is_error` |
+| File cannot be read as UTF-8 | `build_schema_snapshot` returns `ReadFile` naming the file | `test_schema_read_errors_flags_only_unreadable` |
+| Unmatched parentheses in CREATE TABLE | `build_schema_snapshot` returns a positioned `MalformedStatement` | `test_build_schema_snapshot_reports_malformed_sql_with_path_and_position` |
+| Missing terminator before later DDL | snapshot fails before applying the first statement | `test_replay_rejects_unterminated_statement_before_later_ddl` |
+| DDL text in comments/string literals | ignored as operations | `test_replay_ignores_commented_and_string_literal_ddl` |
+| DROP then CREATE / RENAME then CREATE | exact source order determines final state | `test_replay_respects_drop_then_recreate_within_one_file`, `test_replay_respects_recreate_after_rename_within_one_file` |
+| CREATE canonical collision | existing table is preserved and `DuplicateTable` is returned | `test_replay_duplicate_canonical_create_is_a_non_mutating_error` |
+| RENAME target collision | source and target are preserved and `RenameCollision` is returned | `test_replay_rename_collision_is_a_non_mutating_error` |
+| Missing DROP/RENAME source | hard error except DROP IF EXISTS | `test_replay_missing_drop_and_rename_sources_fail_truthfully` |
+| Quoted/qualified CREATE→RENAME→DROP | one canonical parser governs every transition | `test_quoted_qualified_names_replay_through_rename_and_drop` |
 | No `### Schema` section in spec | `parse_spec_schema` returns empty map | Keep or add a focused assertion before changing this behavior |
 | Column name looks like SQL keyword | Column is skipped by `is_sql_keyword` check | Keep or add a focused assertion before changing this behavior |
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -283,7 +283,6 @@ pub fn run_validation(
     let mut all_errors: Vec<String> = Vec::new();
     let mut all_warnings: Vec<String> = Vec::new();
     let mut all_notices: Vec<String> = Vec::new();
-    let mut suppressed_warnings = 0usize;
     let mut file_owners: HashMap<String, Vec<String>> = HashMap::new();
     let mut spec_files_by_path: HashMap<PathBuf, HashSet<String>> = HashMap::new();
     for spec_file in ownership_spec_files {
@@ -359,7 +358,6 @@ pub fn run_validation(
             .iter()
             .filter(|w| !ignore_rules.is_suppressed(w, &result.spec_path, &inline_ignores))
             .collect();
-        suppressed_warnings += result.warnings.len() - filtered_warnings.len();
 
         if collect {
             let prefix = &result.spec_path;
@@ -632,18 +630,6 @@ pub fn run_validation(
     // disable db_tables/column validation (an all-unreadable schema makes the
     // checks a no-op). Surface them once, project-level (not per spec), as hard
     // errors so the gate fails loud instead of under-validating.
-    // A configured schema_dir that doesn't exist, or a schema_pattern that
-    // doesn't compile, silently disabled db_tables validation (empty table set
-    // ⇒ every declared table vacuously passed). Fail loud, once, project-level.
-    for problem in crate::validator::schema_config_problems(root, config) {
-        total_errors += 1;
-        if collect {
-            all_errors.push(problem);
-        } else {
-            println!("\n{} {problem}", "✗".red());
-        }
-    }
-
     if let Some(dir) = &config.schema_dir {
         for err in schema::schema_read_errors(&root.join(dir)) {
             total_errors += 1;
@@ -652,28 +638,6 @@ pub fn run_validation(
             } else {
                 println!("\n{} {err}", "✗".red());
             }
-        }
-    }
-
-    // .specsyncignore problems (unmatchable patterns, invalid UTF-8 lines):
-    // dead rules must be visible, not silently inert.
-    for w in &ignore_rules.warnings {
-        total_warnings += 1;
-        if collect {
-            all_warnings.push(w.clone());
-        } else {
-            println!("\n{} {w}", "⚠".yellow());
-        }
-    }
-
-    // Suppression must be visible in every output format — otherwise a typo'd
-    // rule is indistinguishable from a working one.
-    if suppressed_warnings > 0 {
-        let note = format!("{suppressed_warnings} warning(s) suppressed by .specsyncignore");
-        if collect {
-            all_notices.push(note);
-        } else {
-            println!("\n{} {note}", "ℹ".cyan());
         }
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -283,6 +283,7 @@ pub fn run_validation(
     let mut all_errors: Vec<String> = Vec::new();
     let mut all_warnings: Vec<String> = Vec::new();
     let mut all_notices: Vec<String> = Vec::new();
+    let mut suppressed_warnings = 0usize;
     let mut file_owners: HashMap<String, Vec<String>> = HashMap::new();
     let mut spec_files_by_path: HashMap<PathBuf, HashSet<String>> = HashMap::new();
     for spec_file in ownership_spec_files {
@@ -358,6 +359,7 @@ pub fn run_validation(
             .iter()
             .filter(|w| !ignore_rules.is_suppressed(w, &result.spec_path, &inline_ignores))
             .collect();
+        suppressed_warnings += result.warnings.len() - filtered_warnings.len();
 
         if collect {
             let prefix = &result.spec_path;
@@ -630,6 +632,18 @@ pub fn run_validation(
     // disable db_tables/column validation (an all-unreadable schema makes the
     // checks a no-op). Surface them once, project-level (not per spec), as hard
     // errors so the gate fails loud instead of under-validating.
+    // A configured schema_dir that doesn't exist, or a schema_pattern that
+    // doesn't compile, silently disabled db_tables validation (empty table set
+    // ⇒ every declared table vacuously passed). Fail loud, once, project-level.
+    for problem in crate::validator::schema_config_problems(root, config) {
+        total_errors += 1;
+        if collect {
+            all_errors.push(problem);
+        } else {
+            println!("\n{} {problem}", "✗".red());
+        }
+    }
+
     if let Some(dir) = &config.schema_dir {
         for err in schema::schema_read_errors(&root.join(dir)) {
             total_errors += 1;
@@ -638,6 +652,28 @@ pub fn run_validation(
             } else {
                 println!("\n{} {err}", "✗".red());
             }
+        }
+    }
+
+    // .specsyncignore problems (unmatchable patterns, invalid UTF-8 lines):
+    // dead rules must be visible, not silently inert.
+    for w in &ignore_rules.warnings {
+        total_warnings += 1;
+        if collect {
+            all_warnings.push(w.clone());
+        } else {
+            println!("\n{} {w}", "⚠".yellow());
+        }
+    }
+
+    // Suppression must be visible in every output format — otherwise a typo'd
+    // rule is indistinguishable from a working one.
+    if suppressed_warnings > 0 {
+        let note = format!("{suppressed_warnings} warning(s) suppressed by .specsyncignore");
+        if collect {
+            all_notices.push(note);
+        } else {
+            println!("\n{} {note}", "ℹ".cyan());
         }
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,11 +1,12 @@
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 /// A column extracted from SQL schema files.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaColumn {
     pub name: String,
     /// Normalised to uppercase (e.g. "INTEGER", "TEXT").
@@ -16,7 +17,7 @@ pub struct SchemaColumn {
 }
 
 /// All columns for a single table, built by replaying migrations in order.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SchemaTable {
     pub columns: Vec<SchemaColumn>,
 }
@@ -29,65 +30,307 @@ impl SchemaTable {
 }
 
 /// A column documented in a spec's ### Schema section.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpecColumn {
     pub name: String,
     /// Raw type string from the spec (e.g. "INTEGER", "TEXT").
     pub col_type: String,
 }
 
+/// Stable categories for schema-loading and replay failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaErrorKind {
+    MissingDirectory,
+    ReadDirectory,
+    ReadEntry,
+    ReadFile,
+    MalformedStatement,
+    MissingTable,
+    DuplicateTable,
+    RenameCollision,
+    MissingColumn,
+    DuplicateColumn,
+}
+
+/// A path- and source-position-aware schema loading or replay failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaError {
+    pub kind: SchemaErrorKind,
+    pub path: PathBuf,
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+impl fmt::Display for SchemaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.line == 0 {
+            write!(formatter, "{}: {}", self.path.display(), self.message)
+        } else {
+            write!(
+                formatter,
+                "{}:{}:{}: {}",
+                self.path.display(),
+                self.line,
+                self.column,
+                self.message
+            )
+        }
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
+impl SchemaError {
+    fn for_path(kind: SchemaErrorKind, path: &Path, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            path: path.to_path_buf(),
+            line: 0,
+            column: 0,
+            message: message.into(),
+        }
+    }
+
+    fn at(
+        kind: SchemaErrorKind,
+        path: &Path,
+        sql: &str,
+        offset: usize,
+        message: impl Into<String>,
+    ) -> Self {
+        let bounded_offset = offset.min(sql.len());
+        let before = &sql[..bounded_offset];
+        let line = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
+        let column = before
+            .rsplit_once('\n')
+            .map(|(_, tail)| tail.chars().count() + 1)
+            .unwrap_or_else(|| before.chars().count() + 1);
+
+        Self {
+            kind,
+            path: path.to_path_buf(),
+            line,
+            column,
+            message: message.into(),
+        }
+    }
+}
+
+/// The current canonical schema state after deterministic migration replay.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SchemaSnapshot {
+    pub tables: HashMap<String, SchemaTable>,
+    pub retired_tables: HashSet<String>,
+}
+
 // ─── SQL Parsing ─────────────────────────────────────────────────────────
 
-/// Table-name token: double-quoted, backtick-quoted, bracket-quoted, or a bare
-/// (optionally schema-qualified) identifier.
-const TABLE_NAME: &str = r#"(?:"[^"]+"|`[^`]+`|\[[^\]]+\]|[\w.]+)"#;
+/// One SQL identifier segment: ANSI double quotes, MySQL backticks, SQL Server
+/// brackets, or a conservative bare identifier.
+const IDENTIFIER_SEGMENT: &str =
+    r#"(?:"(?:[^"]|"")+"|`(?:[^`]|``)+`|\[(?:[^\]]|\]\])+\]|[A-Za-z_][A-Za-z0-9_$]*)"#;
 
-fn table_name_regex(pattern: &str) -> Regex {
-    Regex::new(&pattern.replace("{NAME}", TABLE_NAME)).unwrap()
+fn schema_regex(pattern: &str) -> Regex {
+    let qualified_name = format!("{IDENTIFIER_SEGMENT}(?:\\s*\\.\\s*{IDENTIFIER_SEGMENT})*");
+    let expanded = pattern
+        .replace("{NAME}", &qualified_name)
+        .replace("{IDENT}", IDENTIFIER_SEGMENT);
+    Regex::new(&expanded).expect("static schema regex must compile")
 }
 
-/// Normalize a table reference for comparison: strip per-segment quoting
-/// (`"quoted"`, `` `backtick` ``, `[bracket]`) and lowercase, so SQL quoting
-/// style and case don't change identity. `public."Users"` → `public.users`.
-pub fn normalize_table_name(raw: &str) -> String {
-    raw.split('.')
-        .map(|segment| {
-            let s = segment.trim();
-            let unquoted = s
-                .strip_prefix('"')
-                .and_then(|v| v.strip_suffix('"'))
-                .or_else(|| s.strip_prefix('`').and_then(|v| v.strip_suffix('`')))
-                .or_else(|| s.strip_prefix('[').and_then(|v| v.strip_suffix(']')))
-                .unwrap_or(s);
-            unquoted.to_ascii_lowercase()
-        })
-        .collect::<Vec<_>>()
-        .join(".")
-}
+static DDL_START_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)\b(?:CREATE\s+(?:OR\s+REPLACE\s+)?(?:VIRTUAL\s+)?TABLE|ALTER\s+TABLE|DROP\s+TABLE)\b",
+    )
+    .expect("static DDL start regex must compile")
+});
 
 static CREATE_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    table_name_regex(r"(?i)CREATE\s+(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?({NAME})\s*\(")
+    schema_regex(
+        r"(?is)^CREATE\s+(?P<replace>OR\s+REPLACE\s+)?TABLE\s+(?P<if_not_exists>IF\s+NOT\s+EXISTS\s+)?(?P<table>{NAME})\s*\(",
+    )
+});
+
+static CREATE_VIRTUAL_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    schema_regex(
+        r"(?is)^CREATE\s+VIRTUAL\s+TABLE\s+(?P<if_not_exists>IF\s+NOT\s+EXISTS\s+)?(?P<table>{NAME})\s+USING\s+[A-Za-z_][A-Za-z0-9_]*",
+    )
 });
 
 static ALTER_ADD_RE: LazyLock<Regex> = LazyLock::new(|| {
-    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+ADD\s+(?:COLUMN\s+)?(\w+)\s+(\w+)")
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+ADD\s+(?:COLUMN\s+)?(?P<column>{IDENT})\s+(?P<type>[A-Za-z_][A-Za-z0-9_]*(?:\s*\([^)]*\))?)",
+    )
 });
 
 static DROP_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    table_name_regex(r"(?i)DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?({NAME})")
+    schema_regex(r"(?is)^DROP\s+TABLE\s+(?P<if_exists>IF\s+EXISTS\s+)?(?P<table>{NAME})(?:\s|$)")
 });
 
 static ALTER_DROP_COL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+DROP\s+(?:COLUMN\s+)?(\w+)")
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+DROP\s+(?:COLUMN\s+)?(?P<column>{IDENT})(?:\s|$)",
+    )
 });
 
 static ALTER_RENAME_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+RENAME\s+TO\s+({NAME})")
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+RENAME\s+TO\s+(?P<new_table>{NAME})(?:\s|$)",
+    )
 });
 
 static ALTER_RENAME_COL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+RENAME\s+(?:COLUMN\s+)?(\w+)\s+TO\s+(\w+)")
+    schema_regex(
+        r"(?is)^ALTER\s+TABLE\s+(?P<table>{NAME})\s+RENAME\s+(?:COLUMN\s+)?(?P<column>{IDENT})\s+TO\s+(?P<new_column>{IDENT})(?:\s|$)",
+    )
 });
+
+/// Return a canonical table identity by parsing qualified identifier segments,
+/// unescaping each supported quoting style, and applying Unicode lowercase.
+pub fn canonicalize_table_name(raw: &str) -> Result<String, String> {
+    let segments = split_table_identifier_segments(raw)?;
+    let canonical_segments = segments
+        .iter()
+        .map(|segment| normalize_identifier_segment(segment))
+        .map(|result| result.map(|segment| render_canonical_table_segment(&segment)))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(canonical_segments.join("."))
+}
+
+/// Return the canonical final identifier segment of a qualified table name.
+/// Validator code uses this for unqualified declarations instead of splitting
+/// on `.`, which would corrupt a quoted identifier that itself contains a dot.
+#[allow(dead_code)] // Consumed by the validator restack built on this schema slice.
+pub fn canonical_table_leaf(raw: &str) -> Result<String, String> {
+    let segments = split_table_identifier_segments(raw)?;
+    let last = segments
+        .last()
+        .ok_or_else(|| format!("table identifier `{raw}` has no segments"))?;
+    normalize_identifier_segment(last).map(|segment| render_canonical_table_segment(&segment))
+}
+
+fn split_table_identifier_segments(raw: &str) -> Result<Vec<String>, String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut characters = raw.chars().peekable();
+
+    while let Some(character) = characters.next() {
+        match quote {
+            Some('"') if character == '"' => {
+                current.push(character);
+                if characters.peek() == Some(&'"') {
+                    current.push(characters.next().unwrap_or('"'));
+                } else {
+                    quote = None;
+                }
+            }
+            Some('`') if character == '`' => {
+                current.push(character);
+                if characters.peek() == Some(&'`') {
+                    current.push(characters.next().unwrap_or('`'));
+                } else {
+                    quote = None;
+                }
+            }
+            Some(']') if character == ']' => {
+                current.push(character);
+                if characters.peek() == Some(&']') {
+                    current.push(characters.next().unwrap_or(']'));
+                } else {
+                    quote = None;
+                }
+            }
+            Some(_) => current.push(character),
+            None if character == '.' => {
+                if current.trim().is_empty() {
+                    return Err(format!("empty table identifier segment in `{raw}`"));
+                }
+                segments.push(std::mem::take(&mut current));
+            }
+            None if character == '"' || character == '`' => {
+                quote = Some(character);
+                current.push(character);
+            }
+            None if character == '[' => {
+                quote = Some(']');
+                current.push(character);
+            }
+            None => current.push(character),
+        }
+    }
+
+    if quote.is_some() {
+        return Err(format!("unterminated quoted table identifier `{raw}`"));
+    }
+    if current.trim().is_empty() {
+        return Err(format!("empty table identifier segment in `{raw}`"));
+    }
+    segments.push(current);
+    Ok(segments)
+}
+
+fn render_canonical_table_segment(segment: &str) -> String {
+    if is_bare_identifier(segment) {
+        segment.to_string()
+    } else {
+        format!("\"{}\"", segment.replace('"', "\"\""))
+    }
+}
+
+fn normalize_identifier_segment(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("identifier segment is empty".to_string());
+    }
+
+    let unquoted = if let Some(inner) = trimmed
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+    {
+        inner.replace("\"\"", "\"")
+    } else if let Some(inner) = trimmed
+        .strip_prefix('`')
+        .and_then(|value| value.strip_suffix('`'))
+    {
+        inner.replace("``", "`")
+    } else if let Some(inner) = trimmed
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        inner.replace("]]", "]")
+    } else {
+        if !is_bare_identifier(trimmed) {
+            return Err(format!("malformed identifier segment `{raw}`"));
+        }
+        trimmed.to_string()
+    };
+
+    if unquoted.is_empty() {
+        return Err(format!("identifier segment `{raw}` is empty"));
+    }
+    Ok(unquoted.to_lowercase())
+}
+
+fn is_bare_identifier(identifier: &str) -> bool {
+    let mut characters = identifier.chars();
+    characters
+        .next()
+        .map(|first| first == '_' || first.is_ascii_alphabetic())
+        .unwrap_or(false)
+        && characters.all(|character| {
+            character == '_' || character == '$' || character.is_ascii_alphanumeric()
+        })
+}
+
+/// Normalize a valid table reference for comparison. Invalid input is lowered
+/// without structural rewriting; fallible replay uses `canonicalize_table_name`
+/// and reports the malformed identifier instead.
+#[allow(dead_code)] // Used by the validator restack that consumes this schema slice.
+pub fn normalize_table_name(raw: &str) -> String {
+    canonicalize_table_name(raw).unwrap_or_else(|_| raw.trim().to_lowercase())
+}
 
 /// File extensions that may contain embedded SQL statements.
 const SQL_EXTENSIONS: &[&str] = &[
@@ -96,207 +339,763 @@ const SQL_EXTENSIONS: &[&str] = &[
 ];
 
 /// Build a complete schema map from SQL/migration files in the given directory.
-/// Files are sorted by name so migrations replay in order.
+/// This compatibility wrapper returns an empty map on error. Validation code
+/// must call `build_schema_snapshot` so malformed or unreadable migrations
+/// cannot become a vacuous success.
 pub fn build_schema(schema_dir: &Path) -> HashMap<String, SchemaTable> {
-    build_schema_with_retired(schema_dir).0
+    build_schema_snapshot(schema_dir)
+        .map(|snapshot| snapshot.tables)
+        .unwrap_or_default()
 }
 
-/// Like `build_schema`, but also returns the normalized names of tables that
-/// were retired by `DROP TABLE` or renamed away by `ALTER TABLE ... RENAME TO`
-/// (and never recreated). Existence checks use this so a CREATE-pattern scan
-/// cannot resurrect retired tables.
+/// Compatibility wrapper exposing retired names to older validator code.
+/// Validation code should migrate to `build_schema_snapshot`.
+#[allow(dead_code)] // Used by the validator restack until it adopts SchemaSnapshot.
 pub fn build_schema_with_retired(
     schema_dir: &Path,
 ) -> (HashMap<String, SchemaTable>, HashSet<String>) {
-    let mut tables: HashMap<String, SchemaTable> = HashMap::new();
-    let mut retired: HashSet<String> = HashSet::new();
-
-    if !schema_dir.exists() {
-        return (tables, retired);
+    match build_schema_snapshot(schema_dir) {
+        Ok(snapshot) => (snapshot.tables, snapshot.retired_tables),
+        Err(_) => (HashMap::new(), HashSet::new()),
     }
-
-    // Collect and sort files for deterministic migration ordering.
-    let mut files: Vec<_> = fs::read_dir(schema_dir)
-        .into_iter()
-        .flatten()
-        .flatten()
-        .filter(|e| {
-            let ext = e
-                .path()
-                .extension()
-                .and_then(|x| x.to_str())
-                .unwrap_or("")
-                .to_string();
-            SQL_EXTENSIONS.contains(&ext.as_str())
-        })
-        .collect();
-    files.sort_by_key(|e| e.file_name());
-
-    for entry in &files {
-        let content = match fs::read_to_string(entry.path()) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        parse_sql_into_tracked(&content, &mut tables, &mut retired);
-    }
-
-    (tables, retired)
 }
 
-/// Return an error message for each schema/migration file that EXISTS in
-/// `schema_dir` but could not be read as UTF-8. `build_schema` silently skips such
-/// a file (`Err(_) => continue`), which makes its tables/columns vanish and can
-/// silently disable DB validation — if every schema file is unreadable, the
-/// discovered set is empty and the `db_tables`/column checks become a no-op with
-/// no signal. The validation gate surfaces these so an unreadable migration fails
-/// loud instead of quietly weakening the guarantee. Scans the same files
-/// `build_schema` would (matching `SQL_EXTENSIONS`); returns an empty vec when the
-/// directory is absent (schema is simply not configured for this project).
-pub fn schema_read_errors(schema_dir: &Path) -> Vec<String> {
-    let mut errors = Vec::new();
-    if !schema_dir.exists() {
-        return errors;
-    }
+/// Build one deterministic, fallible schema snapshot.
+///
+/// Files are sorted by filename and every supported DDL statement is replayed
+/// in byte order within each file. Directory, entry, UTF-8, malformed-DDL,
+/// missing-object, and canonical-name collision failures are returned instead
+/// of being collapsed into an empty schema.
+pub fn build_schema_snapshot(schema_dir: &Path) -> Result<SchemaSnapshot, SchemaError> {
+    let read_dir = fs::read_dir(schema_dir).map_err(|error| {
+        let kind = if error.kind() == std::io::ErrorKind::NotFound {
+            SchemaErrorKind::MissingDirectory
+        } else {
+            SchemaErrorKind::ReadDirectory
+        };
+        SchemaError::for_path(
+            kind,
+            schema_dir,
+            format!("schema directory could not be read: {error}"),
+        )
+    })?;
 
-    // A `schema_dir` that exists but cannot be enumerated (unreadable, or a file
-    // rather than a directory) makes `read_dir` return `Err`. Ignoring it would be
-    // the same fail-open this function exists to close: schema discovery would come
-    // back empty and the `db_tables`/column checks would be silently skipped. Surface
-    // it as a hard error instead.
-    let read_dir = match fs::read_dir(schema_dir) {
-        Ok(read_dir) => read_dir,
-        Err(err) => {
-            errors.push(format!(
-                "Schema directory `{}` could not be read ({err}); DB schema validation would be incomplete",
-                schema_dir.display()
-            ));
-            return errors;
-        }
-    };
-
-    let mut files: Vec<_> = read_dir
-        .flatten()
-        .filter(|e| {
-            e.path()
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .map(|ext| SQL_EXTENSIONS.contains(&ext))
-                .unwrap_or(false)
-        })
-        .collect();
-    files.sort_by_key(|e| e.file_name());
-
-    for entry in &files {
+    let mut files = Vec::new();
+    for entry in read_dir {
+        let entry = entry.map_err(|error| {
+            SchemaError::for_path(
+                SchemaErrorKind::ReadEntry,
+                schema_dir,
+                format!("schema directory entry could not be read: {error}"),
+            )
+        })?;
         let path = entry.path();
-        if path.is_file() && fs::read_to_string(&path).is_err() {
-            let name = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("<unknown>");
-            errors.push(format!(
-                "Schema/migration file `{name}` could not be read as UTF-8; DB schema validation would be incomplete"
-            ));
+        let supported = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| SQL_EXTENSIONS.contains(&extension))
+            .unwrap_or(false);
+        if supported && path.is_file() {
+            files.push(path);
         }
     }
+    files.sort();
 
-    errors
+    let mut snapshot = SchemaSnapshot::default();
+    for path in files {
+        let content = fs::read_to_string(&path).map_err(|error| {
+            SchemaError::for_path(
+                SchemaErrorKind::ReadFile,
+                &path,
+                format!("schema/migration file could not be read as UTF-8: {error}"),
+            )
+        })?;
+        replay_sql(&path, &content, &mut snapshot)?;
+    }
+
+    Ok(snapshot)
+}
+
+/// Compatibility diagnostics for command paths that have not yet adopted the
+/// fallible snapshot directly.
+pub fn schema_read_errors(schema_dir: &Path) -> Vec<String> {
+    match build_schema_snapshot(schema_dir) {
+        Ok(_) => Vec::new(),
+        Err(error) => vec![error.to_string()],
+    }
 }
 
 /// Parse SQL content and merge discovered tables/columns into the map.
 #[cfg(test)]
 fn parse_sql_into(sql: &str, tables: &mut HashMap<String, SchemaTable>) {
-    let mut retired = HashSet::new();
-    parse_sql_into_tracked(sql, tables, &mut retired);
+    let mut snapshot = SchemaSnapshot {
+        tables: std::mem::take(tables),
+        retired_tables: HashSet::new(),
+    };
+    if let Err(error) = replay_sql(Path::new("<test>"), sql, &mut snapshot) {
+        panic!("test SQL must replay successfully: {error}");
+    }
+    *tables = snapshot.tables;
 }
 
-/// Like `parse_sql_into`, but tracks tables retired by DROP/RENAME.
-fn parse_sql_into_tracked(
-    sql: &str,
-    tables: &mut HashMap<String, SchemaTable>,
-    retired: &mut HashSet<String>,
-) {
-    // Handle CREATE TABLE statements
-    for cap in CREATE_TABLE_RE.captures_iter(sql) {
-        let table_name = normalize_table_name(&cap[1]);
-        let start = cap.get(0).unwrap().end(); // position after opening paren
+#[derive(Debug)]
+enum SchemaOperation {
+    CreateTable {
+        table: String,
+        columns: Vec<SchemaColumn>,
+        if_not_exists: bool,
+        replace: bool,
+    },
+    DropTable {
+        table: String,
+        if_exists: bool,
+    },
+    RenameTable {
+        table: String,
+        new_table: String,
+    },
+    AddColumn {
+        table: String,
+        column: SchemaColumn,
+    },
+    DropColumn {
+        table: String,
+        column: String,
+    },
+    RenameColumn {
+        table: String,
+        column: String,
+        new_column: String,
+    },
+}
 
-        // Find matching closing paren (handles nested parens for CHECK constraints etc.)
-        if let Some(body) = extract_paren_body(sql, start) {
-            let columns = parse_column_defs(&body);
-            retired.remove(&table_name);
-            let entry = tables.entry(table_name).or_default();
-            // CREATE TABLE replaces any prior definition (e.g. CREATE OR REPLACE)
-            entry.columns = columns;
+fn replay_sql(path: &Path, sql: &str, snapshot: &mut SchemaSnapshot) -> Result<(), SchemaError> {
+    let searchable = mask_sql_comments(sql);
+    let candidate_offsets: Vec<usize> = DDL_START_RE
+        .find_iter(&searchable)
+        .map(|candidate| candidate.start())
+        .collect();
+
+    let mut consumed_until = 0;
+    for (candidate_index, offset) in candidate_offsets.iter().copied().enumerate() {
+        if offset < consumed_until {
+            continue;
         }
-    }
-
-    // Handle ALTER TABLE ADD COLUMN
-    for cap in ALTER_ADD_RE.captures_iter(sql) {
-        let table_name = normalize_table_name(&cap[1]);
-        let col_name = cap[2].to_string();
-        let col_type = cap[3].to_uppercase();
-
-        // Get the full ALTER statement for constraint analysis
-        let full_match_start = cap.get(0).unwrap().start();
-        let rest = &sql[full_match_start..];
-        let stmt_end = rest.find(';').unwrap_or(rest.len());
-        let full_stmt = &rest[..stmt_end].to_uppercase();
-
-        let nullable = !full_stmt.contains("NOT NULL");
-        let has_default = full_stmt.contains("DEFAULT");
-        let is_primary_key = full_stmt.contains("PRIMARY KEY");
-
-        let entry = tables.entry(table_name).or_default();
-        // Only add if column doesn't already exist (idempotent)
-        if !entry.columns.iter().any(|c| c.name == col_name) {
-            entry.columns.push(SchemaColumn {
-                name: col_name,
-                col_type,
-                nullable,
-                has_default,
-                is_primary_key,
-            });
-        }
-    }
-
-    // Handle DROP TABLE
-    for cap in DROP_TABLE_RE.captures_iter(sql) {
-        let table_name = normalize_table_name(&cap[1]);
-        tables.remove(&table_name);
-        retired.insert(table_name);
-    }
-
-    // Handle ALTER TABLE DROP COLUMN
-    for cap in ALTER_DROP_COL_RE.captures_iter(sql) {
-        let table_name = normalize_table_name(&cap[1]);
-        let col_name = cap[2].to_string();
-        if let Some(table) = tables.get_mut(&table_name) {
-            table.columns.retain(|c| c.name != col_name);
-        }
-    }
-
-    // Handle ALTER TABLE RENAME TO
-    for cap in ALTER_RENAME_TABLE_RE.captures_iter(sql) {
-        let old_name = normalize_table_name(&cap[1]);
-        let new_name = normalize_table_name(&cap[2]);
-        if let Some(table) = tables.remove(&old_name) {
-            retired.insert(old_name);
-            retired.remove(&new_name);
-            tables.insert(new_name, table);
-        }
-    }
-
-    // Handle ALTER TABLE RENAME COLUMN
-    for cap in ALTER_RENAME_COL_RE.captures_iter(sql) {
-        let table_name = normalize_table_name(&cap[1]);
-        let old_col = cap[2].to_string();
-        let new_col = cap[3].to_string();
-        if let Some(table) = tables.get_mut(&table_name)
-            && let Some(col) = table.columns.iter_mut().find(|c| c.name == old_col)
+        let end = find_statement_end(sql, offset, sql.len());
+        for nested_offset in candidate_offsets
+            .iter()
+            .copied()
+            .skip(candidate_index + 1)
+            .take_while(|nested_offset| *nested_offset < end)
         {
-            col.name = new_col;
+            if scan_state_at(sql, offset, nested_offset) == SqlScanState::Normal {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MalformedStatement,
+                    path,
+                    sql,
+                    nested_offset,
+                    "supported DDL statement starts before the previous statement terminates",
+                ));
+            }
+        }
+        let statement = &sql[offset..end];
+        let operation = parse_operation(path, sql, offset, statement)?;
+        apply_operation(path, sql, offset, snapshot, operation)?;
+        consumed_until = end.saturating_add(1);
+    }
+
+    Ok(())
+}
+
+fn parse_operation(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+) -> Result<SchemaOperation, SchemaError> {
+    let upper = statement.to_uppercase();
+
+    if upper.starts_with("CREATE VIRTUAL TABLE") {
+        let captures = CREATE_VIRTUAL_TABLE_RE.captures(statement).ok_or_else(|| {
+            malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "malformed CREATE VIRTUAL TABLE",
+            )
+        })?;
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        return Ok(SchemaOperation::CreateTable {
+            table,
+            columns: Vec::new(),
+            if_not_exists: captures.name("if_not_exists").is_some(),
+            replace: false,
+        });
+    }
+
+    if upper.starts_with("CREATE") {
+        let captures = CREATE_TABLE_RE.captures(statement).ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "malformed CREATE TABLE")
+        })?;
+        if captures.name("replace").is_some() && captures.name("if_not_exists").is_some() {
+            return Err(malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "CREATE TABLE cannot combine OR REPLACE with IF NOT EXISTS",
+            ));
+        }
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let opening_parenthesis = captures
+            .get(0)
+            .map(|matched| matched.end().saturating_sub(1))
+            .ok_or_else(|| {
+                malformed_statement(path, sql, offset, statement, "missing CREATE TABLE body")
+            })?;
+        let body = extract_paren_body(statement, opening_parenthesis + 1).ok_or_else(|| {
+            malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "CREATE TABLE has unmatched parentheses",
+            )
+        })?;
+        return Ok(SchemaOperation::CreateTable {
+            table,
+            columns: parse_column_defs(&body),
+            if_not_exists: captures.name("if_not_exists").is_some(),
+            replace: captures.name("replace").is_some(),
+        });
+    }
+
+    if upper.starts_with("DROP TABLE") {
+        let captures = DROP_TABLE_RE.captures(statement).ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "malformed DROP TABLE")
+        })?;
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        return Ok(SchemaOperation::DropTable {
+            table,
+            if_exists: captures.name("if_exists").is_some(),
+        });
+    }
+
+    if let Some(captures) = ALTER_RENAME_COL_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let column = capture_identifier(path, sql, offset, statement, &captures, "column")?;
+        let new_column = capture_identifier(path, sql, offset, statement, &captures, "new_column")?;
+        return Ok(SchemaOperation::RenameColumn {
+            table,
+            column,
+            new_column,
+        });
+    }
+
+    if let Some(captures) = ALTER_RENAME_TABLE_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let new_table = capture_table_name(path, sql, offset, statement, &captures, "new_table")?;
+        return Ok(SchemaOperation::RenameTable { table, new_table });
+    }
+
+    if let Some(captures) = ALTER_ADD_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let column_name = capture_identifier(path, sql, offset, statement, &captures, "column")?;
+        if is_sql_keyword(&column_name) {
+            return Err(malformed_statement(
+                path,
+                sql,
+                offset,
+                statement,
+                "ALTER TABLE ADD does not contain a valid column name",
+            ));
+        }
+        let column_type = captures
+            .name("type")
+            .map(|matched| matched.as_str().trim().to_uppercase())
+            .ok_or_else(|| {
+                malformed_statement(
+                    path,
+                    sql,
+                    offset,
+                    statement,
+                    "ALTER TABLE ADD is missing a column type",
+                )
+            })?;
+        return Ok(SchemaOperation::AddColumn {
+            table,
+            column: SchemaColumn {
+                name: column_name,
+                col_type: column_type,
+                nullable: !upper.contains("NOT NULL"),
+                has_default: upper.contains("DEFAULT"),
+                is_primary_key: upper.contains("PRIMARY KEY"),
+            },
+        });
+    }
+
+    if let Some(captures) = ALTER_DROP_COL_RE.captures(statement) {
+        let table = capture_table_name(path, sql, offset, statement, &captures, "table")?;
+        let column = capture_identifier(path, sql, offset, statement, &captures, "column")?;
+        return Ok(SchemaOperation::DropColumn { table, column });
+    }
+
+    Err(malformed_statement(
+        path,
+        sql,
+        offset,
+        statement,
+        "unsupported or malformed ALTER TABLE statement",
+    ))
+}
+
+fn capture_table_name(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+    captures: &regex::Captures<'_>,
+    name: &str,
+) -> Result<String, SchemaError> {
+    let raw = captures
+        .name(name)
+        .map(|matched| matched.as_str())
+        .ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "table identifier is missing")
+        })?;
+    canonicalize_table_name(raw)
+        .map_err(|message| malformed_statement(path, sql, offset, statement, message))
+}
+
+fn capture_identifier(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+    captures: &regex::Captures<'_>,
+    name: &str,
+) -> Result<String, SchemaError> {
+    let raw = captures
+        .name(name)
+        .map(|matched| matched.as_str())
+        .ok_or_else(|| {
+            malformed_statement(path, sql, offset, statement, "column identifier is missing")
+        })?;
+    normalize_identifier_segment(raw)
+        .map_err(|message| malformed_statement(path, sql, offset, statement, message))
+}
+
+fn malformed_statement(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    statement: &str,
+    reason: impl AsRef<str>,
+) -> SchemaError {
+    let compact = statement.split_whitespace().collect::<Vec<_>>().join(" ");
+    let preview: String = compact.chars().take(120).collect();
+    SchemaError::at(
+        SchemaErrorKind::MalformedStatement,
+        path,
+        sql,
+        offset,
+        format!("{}: `{preview}`", reason.as_ref()),
+    )
+}
+
+fn apply_operation(
+    path: &Path,
+    sql: &str,
+    offset: usize,
+    snapshot: &mut SchemaSnapshot,
+    operation: SchemaOperation,
+) -> Result<(), SchemaError> {
+    match operation {
+        SchemaOperation::CreateTable {
+            table,
+            columns,
+            if_not_exists,
+            replace,
+        } => {
+            if snapshot.tables.contains_key(&table) && if_not_exists {
+                return Ok(());
+            }
+            if snapshot.tables.contains_key(&table) && !replace {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::DuplicateTable,
+                    path,
+                    sql,
+                    offset,
+                    format!(
+                        "CREATE TABLE collides with existing canonical table `{table}`; use IF NOT EXISTS or OR REPLACE explicitly"
+                    ),
+                ));
+            }
+            snapshot.retired_tables.remove(&table);
+            snapshot.tables.insert(table, SchemaTable { columns });
+        }
+        SchemaOperation::DropTable { table, if_exists } => {
+            if snapshot.tables.remove(&table).is_none() {
+                if if_exists {
+                    return Ok(());
+                }
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("DROP TABLE references missing canonical table `{table}`"),
+                ));
+            }
+            snapshot.retired_tables.insert(table);
+        }
+        SchemaOperation::RenameTable { table, new_table } => {
+            if !snapshot.tables.contains_key(&table) {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE RENAME references missing canonical table `{table}`"),
+                ));
+            }
+            if table == new_table || snapshot.tables.contains_key(&new_table) {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::RenameCollision,
+                    path,
+                    sql,
+                    offset,
+                    format!(
+                        "ALTER TABLE RENAME target `{new_table}` collides with an existing canonical table"
+                    ),
+                ));
+            }
+            let Some(schema_table) = snapshot.tables.remove(&table) else {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE RENAME references missing canonical table `{table}`"),
+                ));
+            };
+            snapshot.retired_tables.insert(table);
+            snapshot.retired_tables.remove(&new_table);
+            snapshot.tables.insert(new_table, schema_table);
+        }
+        SchemaOperation::AddColumn { table, column } => {
+            let schema_table = snapshot.tables.get_mut(&table).ok_or_else(|| {
+                SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE ADD references missing canonical table `{table}`"),
+                )
+            })?;
+            if !schema_table
+                .columns
+                .iter()
+                .any(|existing| existing.name == column.name)
+            {
+                schema_table.columns.push(column);
+            }
+        }
+        SchemaOperation::DropColumn { table, column } => {
+            let schema_table = snapshot.tables.get_mut(&table).ok_or_else(|| {
+                SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE DROP references missing canonical table `{table}`"),
+                )
+            })?;
+            let original_len = schema_table.columns.len();
+            schema_table
+                .columns
+                .retain(|existing| existing.name != column);
+            if schema_table.columns.len() == original_len {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::MissingColumn,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE DROP references missing column `{table}.{column}`"),
+                ));
+            }
+        }
+        SchemaOperation::RenameColumn {
+            table,
+            column,
+            new_column,
+        } => {
+            let schema_table = snapshot.tables.get_mut(&table).ok_or_else(|| {
+                SchemaError::at(
+                    SchemaErrorKind::MissingTable,
+                    path,
+                    sql,
+                    offset,
+                    format!("ALTER TABLE RENAME references missing canonical table `{table}`"),
+                )
+            })?;
+            if schema_table
+                .columns
+                .iter()
+                .any(|existing| existing.name == new_column)
+            {
+                return Err(SchemaError::at(
+                    SchemaErrorKind::DuplicateColumn,
+                    path,
+                    sql,
+                    offset,
+                    format!(
+                        "ALTER TABLE RENAME target column `{table}.{new_column}` already exists"
+                    ),
+                ));
+            }
+            let column_to_rename = schema_table
+                .columns
+                .iter_mut()
+                .find(|existing| existing.name == column)
+                .ok_or_else(|| {
+                    SchemaError::at(
+                        SchemaErrorKind::MissingColumn,
+                        path,
+                        sql,
+                        offset,
+                        format!("ALTER TABLE RENAME references missing column `{table}.{column}`"),
+                    )
+                })?;
+            column_to_rename.name = new_column;
         }
     }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqlScanState {
+    Normal,
+    SingleQuote,
+    DoubleQuote,
+    Backtick,
+    Bracket,
+    LineComment,
+    BlockComment,
+}
+
+fn mask_sql_comments(sql: &str) -> String {
+    let original = sql.as_bytes();
+    let mut masked = original.to_vec();
+    let mut state = SqlScanState::Normal;
+    let mut index = 0;
+
+    while index < original.len() {
+        let current = original[index];
+        let next = original.get(index + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                masked[index] = b' ';
+                masked[index + 1] = b' ';
+                index += 2;
+                state = SqlScanState::LineComment;
+                continue;
+            }
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                masked[index] = b' ';
+                masked[index + 1] = b' ';
+                index += 2;
+                state = SqlScanState::BlockComment;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment => {
+                if current == b'\n' {
+                    state = SqlScanState::Normal;
+                } else {
+                    masked[index] = b' ';
+                }
+            }
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                masked[index] = b' ';
+                masked[index + 1] = b' ';
+                index += 2;
+                state = SqlScanState::Normal;
+                continue;
+            }
+            SqlScanState::BlockComment => masked[index] = b' ',
+            _ => {}
+        }
+        index += 1;
+    }
+
+    String::from_utf8(masked).unwrap_or_else(|_| sql.to_string())
+}
+
+fn find_statement_end(sql: &str, start: usize, limit: usize) -> usize {
+    let bytes = sql.as_bytes();
+    let mut state = SqlScanState::Normal;
+    let mut index = start;
+    let bounded_limit = limit.min(bytes.len());
+
+    while index < bounded_limit {
+        let current = bytes[index];
+        let next = bytes.get(index + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b';' => return index,
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                state = SqlScanState::LineComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                state = SqlScanState::BlockComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment if current == b'\n' => state = SqlScanState::Normal,
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                state = SqlScanState::Normal;
+                index += 2;
+                continue;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    bounded_limit
+}
+
+fn scan_state_at(sql: &str, start: usize, target: usize) -> SqlScanState {
+    let bytes = sql.as_bytes();
+    let mut state = SqlScanState::Normal;
+    let mut index = start;
+    let bounded_target = target.min(bytes.len());
+
+    while index < bounded_target {
+        let current = bytes[index];
+        let next = bytes.get(index + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                state = SqlScanState::LineComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                state = SqlScanState::BlockComment;
+                index += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    index += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment if current == b'\n' => state = SqlScanState::Normal,
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                state = SqlScanState::Normal;
+                index += 2;
+                continue;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    state
 }
 
 /// Extract text between the opening paren (at `start`) and its matching close.
@@ -304,29 +1103,61 @@ fn extract_paren_body(sql: &str, start: usize) -> Option<String> {
     let bytes = sql.as_bytes();
     let mut depth = 1;
     let mut i = start;
+    let mut state = SqlScanState::Normal;
+
     while i < bytes.len() && depth > 0 {
-        match bytes[i] {
-            b'(' => depth += 1,
-            b')' => depth -= 1,
-            b'\'' => {
-                // Skip string literal
-                i += 1;
-                while i < bytes.len() {
-                    if bytes[i] == b'\'' {
-                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
-                            i += 2; // escaped quote
-                            continue;
-                        }
-                        break;
-                    }
-                    i += 1;
-                }
+        let current = bytes[i];
+        let next = bytes.get(i + 1).copied();
+        match state {
+            SqlScanState::Normal if current == b'(' => depth += 1,
+            SqlScanState::Normal if current == b')' => depth -= 1,
+            SqlScanState::Normal if current == b'-' && next == Some(b'-') => {
+                state = SqlScanState::LineComment;
+                i += 2;
+                continue;
             }
-            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
-                // Skip line comment
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
+            SqlScanState::Normal if current == b'/' && next == Some(b'*') => {
+                state = SqlScanState::BlockComment;
+                i += 2;
+                continue;
+            }
+            SqlScanState::Normal if current == b'\'' => state = SqlScanState::SingleQuote,
+            SqlScanState::Normal if current == b'"' => state = SqlScanState::DoubleQuote,
+            SqlScanState::Normal if current == b'`' => state = SqlScanState::Backtick,
+            SqlScanState::Normal if current == b'[' => state = SqlScanState::Bracket,
+            SqlScanState::SingleQuote if current == b'\'' => {
+                if next == Some(b'\'') {
+                    i += 2;
+                    continue;
                 }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::DoubleQuote if current == b'"' => {
+                if next == Some(b'"') {
+                    i += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Backtick if current == b'`' => {
+                if next == Some(b'`') {
+                    i += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::Bracket if current == b']' => {
+                if next == Some(b']') {
+                    i += 2;
+                    continue;
+                }
+                state = SqlScanState::Normal;
+            }
+            SqlScanState::LineComment if current == b'\n' => state = SqlScanState::Normal,
+            SqlScanState::BlockComment if current == b'*' && next == Some(b'/') => {
+                state = SqlScanState::Normal;
+                i += 2;
+                continue;
             }
             _ => {}
         }
@@ -664,16 +1495,16 @@ CREATE TABLE messages (
 
     #[test]
     fn test_parse_create_virtual_table() {
-        // Virtual tables use USING syntax — the paren is after the module name,
-        // not directly after the table name. Our regex requires `table_name (`
-        // so virtual tables are intentionally skipped for column parsing.
-        // Table *existence* is still caught by get_schema_table_names() which
-        // has a separate regex that handles VIRTUAL TABLE.
+        // Virtual tables use USING syntax, so their columns are not parsed.
+        // The snapshot still records table existence instead of relying on a
+        // separate CREATE-pattern scan that could diverge from replay.
         let sql = "CREATE VIRTUAL TABLE search_idx USING fts5(content, sender);";
         let mut tables = HashMap::new();
         parse_sql_into(sql, &mut tables);
-        // Virtual tables won't be parsed for columns (different syntax)
-        assert!(!tables.contains_key("search_idx"));
+        let table = tables
+            .get("search_idx")
+            .expect("virtual table existence must be represented");
+        assert!(table.columns.is_empty());
     }
 
     #[test]
@@ -814,8 +1645,10 @@ Something
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
 
-        // Absent dir → no errors (schema simply not configured).
-        assert!(schema_read_errors(Path::new("/nonexistent/path")).is_empty());
+        // A configured but absent directory must fail loud.
+        let missing = schema_read_errors(Path::new("/nonexistent/path"));
+        assert_eq!(missing.len(), 1);
+        assert!(missing[0].contains("schema directory could not be read"));
 
         // A readable migration → no error.
         fs::write(dir.join("001_ok.sql"), "CREATE TABLE t (id INTEGER);").unwrap();
@@ -872,6 +1705,200 @@ Something
         assert_eq!(t.columns[1].name, "name");
         assert_eq!(t.columns[2].name, "price");
         assert_eq!(t.columns[2].col_type, "REAL");
+    }
+
+    #[test]
+    fn test_build_schema_snapshot_missing_directory_is_error() {
+        let error = build_schema_snapshot(Path::new("/nonexistent/path"))
+            .expect_err("a configured missing directory must not become an empty snapshot");
+        assert_eq!(error.kind, SchemaErrorKind::MissingDirectory);
+        assert_eq!(error.line, 0);
+        assert!(error.message.contains("schema directory could not be read"));
+    }
+
+    #[test]
+    fn test_build_schema_snapshot_reports_malformed_sql_with_path_and_position() {
+        let tmp = tempfile::tempdir().unwrap();
+        let migration = tmp.path().join("002_broken.sql");
+        fs::write(
+            &migration,
+            "\n-- a preceding line\nCREATE TABLE broken (id INTEGER;\n",
+        )
+        .unwrap();
+
+        let error = build_schema_snapshot(tmp.path())
+            .expect_err("malformed supported DDL must fail the snapshot");
+        assert_eq!(error.kind, SchemaErrorKind::MalformedStatement);
+        assert_eq!(error.path, migration);
+        assert_eq!(error.line, 3);
+        assert_eq!(error.column, 1);
+        assert!(error.message.contains("unmatched parentheses"));
+        assert!(error.message.contains("CREATE TABLE broken"));
+    }
+
+    #[test]
+    fn test_replay_rejects_unterminated_statement_before_later_ddl() {
+        let sql = r#"
+CREATE TABLE first_table (id INTEGER PRIMARY KEY)
+CREATE TABLE second_table (id INTEGER PRIMARY KEY);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        let error = replay_sql(Path::new("001_broken.sql"), sql, &mut snapshot)
+            .expect_err("a missing statement terminator must not hide later DDL");
+
+        assert_eq!(error.kind, SchemaErrorKind::MalformedStatement);
+        assert_eq!(error.line, 3);
+        assert!(
+            error
+                .message
+                .contains("before the previous statement terminates")
+        );
+        assert!(snapshot.tables.is_empty());
+    }
+
+    #[test]
+    fn test_replay_ignores_commented_and_string_literal_ddl() {
+        let sql = r#"
+-- DROP TABLE notes;
+/* ALTER TABLE notes RENAME TO hidden_notes; */
+CREATE TABLE notes (
+    id INTEGER PRIMARY KEY,
+    message TEXT DEFAULT 'DROP TABLE notes;'
+);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_notes.sql"), sql, &mut snapshot).unwrap();
+
+        let notes = snapshot.tables.get("notes").expect("notes must remain");
+        assert_eq!(notes.column_names(), vec!["id", "message"]);
+        assert!(snapshot.retired_tables.is_empty());
+    }
+
+    #[test]
+    fn test_replay_respects_drop_then_recreate_within_one_file() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+DROP TABLE users;
+CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL);
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+
+        let users = tables
+            .get("users")
+            .expect("the later CREATE must recreate the dropped table");
+        assert_eq!(users.column_names(), vec!["id", "email"]);
+    }
+
+    #[test]
+    fn test_replay_respects_recreate_after_rename_within_one_file() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE users RENAME TO archived_users;
+CREATE TABLE users (id INTEGER PRIMARY KEY, replacement TEXT);
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+
+        assert!(
+            tables.contains_key("archived_users"),
+            "the renamed table must remain in the final snapshot"
+        );
+        let users = tables
+            .get("users")
+            .expect("the later CREATE must create a new users table");
+        assert_eq!(users.column_names(), vec!["id", "replacement"]);
+    }
+
+    #[test]
+    fn test_replay_recreate_clears_retired_identity() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+DROP TABLE users;
+CREATE TABLE users (id INTEGER PRIMARY KEY, replacement TEXT);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_users.sql"), sql, &mut snapshot).unwrap();
+
+        assert!(snapshot.tables.contains_key("users"));
+        assert!(!snapshot.retired_tables.contains("users"));
+    }
+
+    #[test]
+    fn test_replay_duplicate_canonical_create_is_a_non_mutating_error() {
+        let sql = r#"
+CREATE TABLE "Users" (id INTEGER PRIMARY KEY);
+CREATE TABLE users (replacement TEXT);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        let error = replay_sql(Path::new("001_users.sql"), sql, &mut snapshot)
+            .expect_err("canonical duplicate CREATE must not overwrite the first table");
+
+        assert_eq!(error.kind, SchemaErrorKind::DuplicateTable);
+        assert_eq!(error.line, 3);
+        assert!(error.message.contains("canonical table `users`"));
+        let users = snapshot.tables.get("users").unwrap();
+        assert_eq!(users.column_names(), vec!["id"]);
+    }
+
+    #[test]
+    fn test_replay_if_not_exists_preserves_the_existing_table() {
+        let sql = r#"
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS "Users" (replacement TEXT);
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_users.sql"), sql, &mut snapshot).unwrap();
+
+        let users = snapshot.tables.get("users").unwrap();
+        assert_eq!(users.column_names(), vec!["id"]);
+    }
+
+    #[test]
+    fn test_replay_rename_collision_is_a_non_mutating_error() {
+        let sql = r#"
+CREATE TABLE source_table (id INTEGER PRIMARY KEY);
+CREATE TABLE target_table (id INTEGER PRIMARY KEY);
+ALTER TABLE source_table RENAME TO target_table;
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        let error = replay_sql(Path::new("001_tables.sql"), sql, &mut snapshot)
+            .expect_err("rename target collisions must not discard either table");
+
+        assert_eq!(error.kind, SchemaErrorKind::RenameCollision);
+        assert_eq!(error.line, 4);
+        assert!(snapshot.tables.contains_key("source_table"));
+        assert!(snapshot.tables.contains_key("target_table"));
+        assert!(snapshot.retired_tables.is_empty());
+    }
+
+    #[test]
+    fn test_replay_missing_drop_and_rename_sources_fail_truthfully() {
+        let mut snapshot = SchemaSnapshot::default();
+        let drop_error = replay_sql(
+            Path::new("001_drop.sql"),
+            "DROP TABLE missing;",
+            &mut snapshot,
+        )
+        .expect_err("plain DROP of a missing table must fail");
+        assert_eq!(drop_error.kind, SchemaErrorKind::MissingTable);
+        assert!(drop_error.message.contains("DROP TABLE"));
+
+        replay_sql(
+            Path::new("002_drop.sql"),
+            "DROP TABLE IF EXISTS missing;",
+            &mut snapshot,
+        )
+        .unwrap();
+
+        let rename_error = replay_sql(
+            Path::new("003_rename.sql"),
+            "ALTER TABLE missing RENAME TO replacement;",
+            &mut snapshot,
+        )
+        .expect_err("rename of a missing table must fail");
+        assert_eq!(rename_error.kind, SchemaErrorKind::MissingTable);
+        assert!(rename_error.message.contains("RENAME"));
     }
 
     #[test]
@@ -963,6 +1990,35 @@ CREATE TABLE MixedCase (id INTEGER PRIMARY KEY);
         assert_eq!(normalize_table_name("`Users`"), "users");
         assert_eq!(normalize_table_name("public.\"Users\""), "public.users");
         assert_eq!(normalize_table_name("PUBLIC.USERS"), "public.users");
+        assert_eq!(
+            canonicalize_table_name(" public . \"User.Events\" ").unwrap(),
+            "public.\"user.events\""
+        );
+        assert_eq!(
+            canonicalize_table_name("[Sales].[Order]]History]").unwrap(),
+            "sales.\"order]history\""
+        );
+        assert_eq!(
+            canonical_table_leaf("public.\"User.Events\"").unwrap(),
+            "\"user.events\""
+        );
+        assert!(canonicalize_table_name("users\"").is_err());
+        assert!(canonicalize_table_name("public..users").is_err());
+    }
+
+    #[test]
+    fn test_quoted_qualified_names_replay_through_rename_and_drop() {
+        let sql = r#"
+CREATE TABLE public."Users" (id INTEGER PRIMARY KEY);
+ALTER TABLE public."Users" RENAME TO archive.`Users`;
+DROP TABLE archive.[Users];
+"#;
+        let mut snapshot = SchemaSnapshot::default();
+        replay_sql(Path::new("001_qualified.sql"), sql, &mut snapshot).unwrap();
+
+        assert!(snapshot.tables.is_empty());
+        assert!(snapshot.retired_tables.contains("public.users"));
+        assert!(snapshot.retired_tables.contains("archive.users"));
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,5 @@
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::sync::LazyLock;
@@ -38,26 +38,55 @@ pub struct SpecColumn {
 
 // ─── SQL Parsing ─────────────────────────────────────────────────────────
 
+/// Table-name token: double-quoted, backtick-quoted, bracket-quoted, or a bare
+/// (optionally schema-qualified) identifier.
+const TABLE_NAME: &str = r#"(?:"[^"]+"|`[^`]+`|\[[^\]]+\]|[\w.]+)"#;
+
+fn table_name_regex(pattern: &str) -> Regex {
+    Regex::new(&pattern.replace("{NAME}", TABLE_NAME)).unwrap()
+}
+
+/// Normalize a table reference for comparison: strip per-segment quoting
+/// (`"quoted"`, `` `backtick` ``, `[bracket]`) and lowercase, so SQL quoting
+/// style and case don't change identity. `public."Users"` → `public.users`.
+pub fn normalize_table_name(raw: &str) -> String {
+    raw.split('.')
+        .map(|segment| {
+            let s = segment.trim();
+            let unquoted = s
+                .strip_prefix('"')
+                .and_then(|v| v.strip_suffix('"'))
+                .or_else(|| s.strip_prefix('`').and_then(|v| v.strip_suffix('`')))
+                .or_else(|| s.strip_prefix('[').and_then(|v| v.strip_suffix(']')))
+                .unwrap_or(s);
+            unquoted.to_ascii_lowercase()
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 static CREATE_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)CREATE\s+(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(").unwrap()
+    table_name_regex(r"(?i)CREATE\s+(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?({NAME})\s*\(")
 });
 
 static ALTER_ADD_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)\s+(\w+)").unwrap()
+    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+ADD\s+(?:COLUMN\s+)?(\w+)\s+(\w+)")
 });
 
-static DROP_TABLE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\w+)").unwrap());
+static DROP_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    table_name_regex(r"(?i)DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?({NAME})")
+});
 
 static ALTER_DROP_COL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+DROP\s+(?:COLUMN\s+)?(\w+)").unwrap()
+    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+DROP\s+(?:COLUMN\s+)?(\w+)")
 });
 
-static ALTER_RENAME_TABLE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+RENAME\s+TO\s+(\w+)").unwrap());
+static ALTER_RENAME_TABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+RENAME\s+TO\s+({NAME})")
+});
 
 static ALTER_RENAME_COL_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+RENAME\s+(?:COLUMN\s+)?(\w+)\s+TO\s+(\w+)").unwrap()
+    table_name_regex(r"(?i)ALTER\s+TABLE\s+({NAME})\s+RENAME\s+(?:COLUMN\s+)?(\w+)\s+TO\s+(\w+)")
 });
 
 /// File extensions that may contain embedded SQL statements.
@@ -69,10 +98,21 @@ const SQL_EXTENSIONS: &[&str] = &[
 /// Build a complete schema map from SQL/migration files in the given directory.
 /// Files are sorted by name so migrations replay in order.
 pub fn build_schema(schema_dir: &Path) -> HashMap<String, SchemaTable> {
+    build_schema_with_retired(schema_dir).0
+}
+
+/// Like `build_schema`, but also returns the normalized names of tables that
+/// were retired by `DROP TABLE` or renamed away by `ALTER TABLE ... RENAME TO`
+/// (and never recreated). Existence checks use this so a CREATE-pattern scan
+/// cannot resurrect retired tables.
+pub fn build_schema_with_retired(
+    schema_dir: &Path,
+) -> (HashMap<String, SchemaTable>, HashSet<String>) {
     let mut tables: HashMap<String, SchemaTable> = HashMap::new();
+    let mut retired: HashSet<String> = HashSet::new();
 
     if !schema_dir.exists() {
-        return tables;
+        return (tables, retired);
     }
 
     // Collect and sort files for deterministic migration ordering.
@@ -97,10 +137,10 @@ pub fn build_schema(schema_dir: &Path) -> HashMap<String, SchemaTable> {
             Ok(c) => c,
             Err(_) => continue,
         };
-        parse_sql_into(&content, &mut tables);
+        parse_sql_into_tracked(&content, &mut tables, &mut retired);
     }
 
-    tables
+    (tables, retired)
 }
 
 /// Return an error message for each schema/migration file that EXISTS in
@@ -163,15 +203,27 @@ pub fn schema_read_errors(schema_dir: &Path) -> Vec<String> {
 }
 
 /// Parse SQL content and merge discovered tables/columns into the map.
+#[cfg(test)]
 fn parse_sql_into(sql: &str, tables: &mut HashMap<String, SchemaTable>) {
+    let mut retired = HashSet::new();
+    parse_sql_into_tracked(sql, tables, &mut retired);
+}
+
+/// Like `parse_sql_into`, but tracks tables retired by DROP/RENAME.
+fn parse_sql_into_tracked(
+    sql: &str,
+    tables: &mut HashMap<String, SchemaTable>,
+    retired: &mut HashSet<String>,
+) {
     // Handle CREATE TABLE statements
     for cap in CREATE_TABLE_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
+        let table_name = normalize_table_name(&cap[1]);
         let start = cap.get(0).unwrap().end(); // position after opening paren
 
         // Find matching closing paren (handles nested parens for CHECK constraints etc.)
         if let Some(body) = extract_paren_body(sql, start) {
             let columns = parse_column_defs(&body);
+            retired.remove(&table_name);
             let entry = tables.entry(table_name).or_default();
             // CREATE TABLE replaces any prior definition (e.g. CREATE OR REPLACE)
             entry.columns = columns;
@@ -180,7 +232,7 @@ fn parse_sql_into(sql: &str, tables: &mut HashMap<String, SchemaTable>) {
 
     // Handle ALTER TABLE ADD COLUMN
     for cap in ALTER_ADD_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
+        let table_name = normalize_table_name(&cap[1]);
         let col_name = cap[2].to_string();
         let col_type = cap[3].to_uppercase();
 
@@ -209,13 +261,14 @@ fn parse_sql_into(sql: &str, tables: &mut HashMap<String, SchemaTable>) {
 
     // Handle DROP TABLE
     for cap in DROP_TABLE_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
+        let table_name = normalize_table_name(&cap[1]);
         tables.remove(&table_name);
+        retired.insert(table_name);
     }
 
     // Handle ALTER TABLE DROP COLUMN
     for cap in ALTER_DROP_COL_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
+        let table_name = normalize_table_name(&cap[1]);
         let col_name = cap[2].to_string();
         if let Some(table) = tables.get_mut(&table_name) {
             table.columns.retain(|c| c.name != col_name);
@@ -224,16 +277,18 @@ fn parse_sql_into(sql: &str, tables: &mut HashMap<String, SchemaTable>) {
 
     // Handle ALTER TABLE RENAME TO
     for cap in ALTER_RENAME_TABLE_RE.captures_iter(sql) {
-        let old_name = cap[1].to_string();
-        let new_name = cap[2].to_string();
+        let old_name = normalize_table_name(&cap[1]);
+        let new_name = normalize_table_name(&cap[2]);
         if let Some(table) = tables.remove(&old_name) {
+            retired.insert(old_name);
+            retired.remove(&new_name);
             tables.insert(new_name, table);
         }
     }
 
     // Handle ALTER TABLE RENAME COLUMN
     for cap in ALTER_RENAME_COL_RE.captures_iter(sql) {
-        let table_name = cap[1].to_string();
+        let table_name = normalize_table_name(&cap[1]);
         let old_col = cap[2].to_string();
         let new_col = cap[3].to_string();
         if let Some(table) = tables.get_mut(&table_name)
@@ -881,6 +936,48 @@ ALTER TABLE items RENAME COLUMN old_col TO new_col;
         assert_eq!(t.columns.len(), 2);
         assert_eq!(t.columns[1].name, "new_col");
         assert_eq!(t.columns[1].col_type, "TEXT");
+    }
+
+    #[test]
+    fn test_quoted_and_schema_qualified_table_names() {
+        let sql = r#"
+CREATE TABLE "quoted" (id INTEGER PRIMARY KEY);
+CREATE TABLE `backtick` (id INTEGER PRIMARY KEY);
+CREATE TABLE public.schema_table (id INTEGER PRIMARY KEY);
+CREATE TABLE MixedCase (id INTEGER PRIMARY KEY);
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+        assert!(tables.contains_key("quoted"), "tables: {:?}", tables.keys());
+        assert!(tables.contains_key("backtick"));
+        assert!(tables.contains_key("public.schema_table"));
+        // Comparison is case-insensitive: stored normalized.
+        assert!(tables.contains_key("mixedcase"));
+        assert!(!tables.contains_key("MixedCase"));
+    }
+
+    #[test]
+    fn test_normalize_table_name() {
+        assert_eq!(normalize_table_name("users"), "users");
+        assert_eq!(normalize_table_name("\"Users\""), "users");
+        assert_eq!(normalize_table_name("`Users`"), "users");
+        assert_eq!(normalize_table_name("public.\"Users\""), "public.users");
+        assert_eq!(normalize_table_name("PUBLIC.USERS"), "public.users");
+    }
+
+    #[test]
+    fn test_rename_and_drop_apply_to_quoted_names() {
+        let sql = r#"
+CREATE TABLE "old_name" (id INTEGER PRIMARY KEY);
+ALTER TABLE "old_name" RENAME TO "new_name";
+CREATE TABLE `doomed` (id INTEGER PRIMARY KEY);
+DROP TABLE `doomed`;
+"#;
+        let mut tables = HashMap::new();
+        parse_sql_into(sql, &mut tables);
+        assert!(!tables.contains_key("old_name"));
+        assert!(tables.contains_key("new_name"));
+        assert!(!tables.contains_key("doomed"));
     }
 
     #[test]

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -1380,7 +1380,7 @@ fn check_gates_on_unreadable_schema_file() {
         .assert()
         .failure()
         .stdout(predicate::str::contains(
-            "could not be read as UTF-8; DB schema",
+            "schema/migration file could not be read as UTF-8",
         ));
 }
 
@@ -1413,7 +1413,7 @@ fn check_no_schema_error_for_readable_migration() {
         .current_dir(root)
         .arg("check")
         .assert()
-        .stdout(predicate::str::contains("could not be read as UTF-8; DB schema").not());
+        .stdout(predicate::str::contains("schema/migration file could not be read as UTF-8").not());
 }
 
 // ─── config: multi-line TOML arrays are not corrupted ────────────────────


### PR DESCRIPTION
## Problem

`db_tables` validation silently passed in four situations:

1. **Dropped/renamed tables resurrected**: table discovery was a CREATE-pattern scan, so `DROP TABLE doomed` and `ALTER TABLE old_users RENAME TO users` left `doomed`/`old_users` in the discovered set — specs referencing dead tables passed.
2. **Quoting/case/schema prefixes**: `"Users"`, `` `users` ``, `USERS`, and `public.users` were treated as different tables.
3. **Missing `schema_dir` / uncompilable `schema_pattern`**: discovery returned an empty set and every declared table vacuously passed with no signal.
4. **Unreadable migration files**: silently skipped, vanishing tables and potentially no-op'ing all DB validation.

## Repro (fixture: `/var/tmp/scratch/w2/435/`)

```sql
-- migrations/001_init.sql
CREATE TABLE old_users (id INTEGER PRIMARY KEY);
CREATE TABLE doomed (id INTEGER);
-- migrations/002_migrate.sql
ALTER TABLE old_users RENAME TO users;
DROP TABLE doomed;
```
Spec declares `db_tables: [old_users, doomed, users]`.

- **Before**: all three pass — `old_users` and `doomed` are phantom-validated.
- **After**: `old_users` and `doomed` are "DB table not found in schema" errors; `users` passes. Quoted/cased/qualified spellings (`"USERS"`, `public.users`) match.

## Root cause

`get_schema_table_names` used a naive CREATE-only regex scan over migration files with no replay semantics and no name normalization, and every failure mode of the discovery path (missing dir, bad regex, unreadable file) was designed to fail open to an empty set.

## Fix

- `schema.rs`: migrations replay in filename order via `build_schema_with_retired` — `DROP TABLE` and `ALTER TABLE ... RENAME TO` retire names (returned alongside the table map); `normalize_table_name` strips per-segment quoting and lowercases; `schema_read_errors` flags unreadable migration files and unenumerable schema dirs.
- `validator.rs`: `get_schema_table_names` is replay-based (a `schema_pattern` scan can only ADD names, never resurrect retired ones); `schema_config_problems` (missing schema_dir / bad schema_pattern); `schema_table_exists` (normalized comparison, unqualified name matches schema-qualified discovered name); a `db_tables`-declaring spec with no configured `schema_dir` now warns visibly instead of skipping silently.
- `commands/mod.rs`: `run_validation` surfaces schema config problems and schema read errors once, project-level, as hard errors.

## Tests (all in-file, all passing)

`test_get_schema_table_names_rename_and_drop_applied`, `test_schema_table_exists_quoting_case_and_schema_prefix`, `test_schema_config_problems_loud`, `test_validate_spec_db_tables_warn_when_no_schema_dir_and_error_on_phantom` (validator.rs); `test_quoted_and_schema_qualified_table_names`, `test_normalize_table_name`, `test_rename_and_drop_apply_to_quoted_names`, `test_schema_read_errors_flags_only_unreadable`, `test_schema_read_errors_flags_unenumerable_dir` (schema.rs).

## File overlap note

`src/validator.rs` (which contains the validator-side half of this fix) ships in PR #453 (`fix/436-frontmatter-validation`) — that issue most owns the file; the whole current file there includes these #435 changes. `src/commands/mod.rs` also contains the #420 "N warning(s) suppressed by .specsyncignore" visibility line, noted in the #420 PR. This PR ships `src/schema.rs` and `src/commands/mod.rs` in full.

Full suite: 1743 passed, 1 pre-existing root-only failure (unrelated). `clippy --all-targets -- -D warnings` clean.

Closes #435