### PR TITLE
fix: .specsyncignore silently inert for BOM'd/corrupt/typo'd rules (closes #420)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -283,6 +283,7 @@ pub fn run_validation(
     let mut all_errors: Vec<String> = Vec::new();
     let mut all_warnings: Vec<String> = Vec::new();
     let mut all_notices: Vec<String> = Vec::new();
+    let mut suppressed_warnings = 0usize;
     let mut file_owners: HashMap<String, Vec<String>> = HashMap::new();
     let mut spec_files_by_path: HashMap<PathBuf, HashSet<String>> = HashMap::new();
     for spec_file in ownership_spec_files {
@@ -352,12 +353,18 @@ pub fn run_validation(
             .map(|content| IgnoreRules::parse_inline(&content))
             .unwrap_or_default();
 
-        // Filter out suppressed warnings
-        let filtered_warnings: Vec<&String> = result
-            .warnings
-            .iter()
-            .filter(|w| !ignore_rules.is_suppressed(w, &result.spec_path, &inline_ignores))
-            .collect();
+        // Filter all configured suppressions, but attribute the visibility
+        // count only to project-file rules. Inline directives remain local to
+        // the spec and must not be reported as `.specsyncignore` activity.
+        let no_inline_ignores = HashSet::new();
+        let mut filtered_warnings: Vec<&String> = Vec::new();
+        for warning in &result.warnings {
+            if ignore_rules.is_suppressed(warning, &result.spec_path, &no_inline_ignores) {
+                suppressed_warnings += 1;
+            } else if !ignore_rules.is_suppressed(warning, &result.spec_path, &inline_ignores) {
+                filtered_warnings.push(warning);
+            }
+        }
 
         if collect {
             let prefix = &result.spec_path;
@@ -478,6 +485,10 @@ pub fn run_validation(
                     .map(|c| c.is_ascii_digit())
                     .unwrap_or(false)
         });
+        let suppressed_api_summary = result.export_summary.as_ref().is_some_and(|summary| {
+            result.warnings.iter().any(|warning| warning == summary)
+                && ignore_rules.is_suppressed(summary, &result.spec_path, &inline_ignores)
+        });
         if is_draft {
             println!(
                 "  {} Export validation skipped (status: draft)",
@@ -488,7 +499,7 @@ pub fn run_validation(
             // warning — print it as one so the summary's warning count matches
             // the number of ⚠ lines shown.
             println!("  {} {line}", "⚠".yellow());
-        } else if let Some(ref summary) = result.export_summary {
+        } else if !suppressed_api_summary && let Some(ref summary) = result.export_summary {
             println!("  {} {summary}", "✓".green());
         }
 
@@ -638,6 +649,28 @@ pub fn run_validation(
             } else {
                 println!("\n{} {err}", "✗".red());
             }
+        }
+    }
+
+    // .specsyncignore problems (unknown categories, invalid UTF-8 lines):
+    // dead rules must be visible, not silently inert.
+    for warning in &ignore_rules.warnings {
+        total_warnings += 1;
+        if collect {
+            all_warnings.push(warning.clone());
+        } else {
+            println!("\n{} {warning}", "⚠".yellow());
+        }
+    }
+
+    // Suppression must be visible in every output format — otherwise a typo'd
+    // rule is indistinguishable from a working one.
+    if suppressed_warnings > 0 {
+        let notice = format!("{suppressed_warnings} warning(s) suppressed by .specsyncignore");
+        if collect {
+            all_notices.push(notice);
+        } else {
+            println!("\n{} {notice}", "ℹ".cyan());
         }
     }
 

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -89,10 +89,15 @@ impl WarningCategory {
         }
         // The partial-coverage summary `N/M exports documented` — suppressible
         // so acknowledging undocumented exports can yield a clean --strict run.
-        if warning.ends_with("exports documented")
-            && warning
-                .split_once('/')
-                .is_some_and(|(n, _)| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
+        if warning
+            .strip_suffix(" exports documented")
+            .and_then(|counts| counts.split_once('/'))
+            .is_some_and(|(documented, total)| {
+                !documented.is_empty()
+                    && documented.chars().all(|c| c.is_ascii_digit())
+                    && !total.is_empty()
+                    && total.chars().all(|c| c.is_ascii_digit())
+            })
         {
             return Some(Self::ExportsDocumented);
         }
@@ -427,6 +432,19 @@ mod tests {
             WarningCategory::classify("Undocumented export 'foo' from src/a.ts"),
             Some(WarningCategory::ExportsDocumented)
         );
+        for malformed in [
+            "2/x exports documented",
+            "/5 exports documented",
+            "2/ exports documented",
+            "prefix 2/5 exports documented",
+            "2/5 exports documented later",
+        ] {
+            assert_eq!(
+                WarningCategory::classify(malformed),
+                None,
+                "malformed summary must not be suppressible: {malformed}"
+            );
+        }
     }
 
     #[test]
@@ -434,11 +452,7 @@ mod tests {
         let mut rules = IgnoreRules::default();
         rules.global.insert(WarningCategory::ExportsDocumented);
         let inline = HashSet::new();
-        assert!(rules.is_suppressed(
-            "2/5 exports documented",
-            "specs/a/a.spec.md",
-            &inline,
-        ));
+        assert!(rules.is_suppressed("2/5 exports documented", "specs/a/a.spec.md", &inline,));
     }
 
     #[test]
@@ -485,7 +499,8 @@ mod tests {
         .unwrap();
         let rules = IgnoreRules::load(tmp.path());
         assert!(
-            rules.per_spec
+            rules
+                .per_spec
                 .get("specs/legacy/")
                 .is_some_and(|cats| cats.contains(&WarningCategory::UndocumentedExport)),
             "path:category order must work: {rules:?}"

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -18,6 +18,8 @@ pub enum WarningCategory {
     SpecSize,
     MinInvariants,
     RequireDependsOn,
+    /// The `N/M exports documented` partial-coverage summary warning.
+    ExportsDocumented,
 }
 
 impl WarningCategory {
@@ -37,6 +39,7 @@ impl WarningCategory {
             "spec-size" => Some(Self::SpecSize),
             "min-invariants" | "invariants" => Some(Self::MinInvariants),
             "require-depends-on" | "depends-on" => Some(Self::RequireDependsOn),
+            "exports-documented" => Some(Self::ExportsDocumented),
             _ => None,
         }
     }
@@ -84,6 +87,15 @@ impl WarningCategory {
         if warning.contains("rule: require_depends_on") {
             return Some(Self::RequireDependsOn);
         }
+        // The partial-coverage summary `N/M exports documented` — suppressible
+        // so acknowledging undocumented exports can yield a clean --strict run.
+        if warning.ends_with("exports documented")
+            && warning
+                .split_once('/')
+                .is_some_and(|(n, _)| !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()))
+        {
+            return Some(Self::ExportsDocumented);
+        }
         None
     }
 }
@@ -95,6 +107,10 @@ pub struct IgnoreRules {
     pub global: HashSet<WarningCategory>,
     /// Categories suppressed for specific spec paths.
     pub per_spec: std::collections::HashMap<String, HashSet<WarningCategory>>,
+    /// Problems found while loading (invalid UTF-8 lines, unmatchable
+    /// patterns). Surfaced by the caller so dead/typo'd rules are visible
+    /// instead of silently doing nothing.
+    pub warnings: Vec<String>,
 }
 
 impl IgnoreRules {
@@ -106,17 +122,37 @@ impl IgnoreRules {
     /// requirements-companion           # suppress globally
     /// stub-section:specs/auth/         # suppress for specs under this path
     /// undocumented-export:specs/api.spec.md  # suppress for specific spec
+    /// specs/api.spec.md:undocumented-export  # path:first order also accepted
     /// ```
+    ///
+    /// A leading UTF-8 BOM is tolerated. One invalid-UTF-8 line is skipped
+    /// with a warning rather than poisoning the whole file. Lines that match
+    /// no known category produce a warning — a suppression that can never
+    /// fire must be visible.
     pub fn load(root: &Path) -> Self {
         let mut rules = Self::default();
         let ignore_path = root.join(".specsyncignore");
-        let content = match fs::read_to_string(&ignore_path) {
-            Ok(c) => c,
+        let bytes = match fs::read(&ignore_path) {
+            Ok(b) => b,
             Err(_) => return rules,
         };
+        // A UTF-8 BOM is a non-semantic encoding marker; left in place it
+        // silently disables the first pattern.
+        let bytes: &[u8] = bytes
+            .strip_prefix(b"\xef\xbb\xbf")
+            .unwrap_or(bytes.as_slice());
 
-        for line in content.lines() {
-            let line = line.trim();
+        for (index, raw_line) in bytes.split(|b| *b == b'\n').enumerate() {
+            let line_no = index + 1;
+            let line = match std::str::from_utf8(raw_line) {
+                Ok(l) => l.trim(),
+                Err(_) => {
+                    rules.warnings.push(format!(
+                        ".specsyncignore line {line_no} is not valid UTF-8 — skipped"
+                    ));
+                    continue;
+                }
+            };
             // Skip empty lines and comments
             if line.is_empty() || line.starts_with('#') {
                 continue;
@@ -124,16 +160,42 @@ impl IgnoreRules {
 
             // Strip inline comments
             let line = line.split('#').next().unwrap_or(line).trim();
+            if line.is_empty() {
+                continue;
+            }
 
-            if let Some((category_str, spec_pattern)) = line.split_once(':') {
-                // Per-spec rule: category:path
-                if let Some(category) = WarningCategory::from_str(category_str) {
-                    let pattern = spec_pattern.trim().to_string();
-                    rules.per_spec.entry(pattern).or_default().insert(category);
+            if let Some((left, right)) = line.split_once(':') {
+                // Per-spec rule. Accept both `category:path` and the documented
+                // `path:category` order — whichever side names a known
+                // category is the category; the other side is the path.
+                let (category, pattern) = match (
+                    WarningCategory::from_str(left),
+                    WarningCategory::from_str(right),
+                ) {
+                    (Some(category), _) => (category, right),
+                    (None, Some(category)) => (category, left),
+                    (None, None) => {
+                        rules.warnings.push(format!(
+                            ".specsyncignore line {line_no} has no known warning category: `{line}`"
+                        ));
+                        continue;
+                    }
+                };
+                let pattern = pattern.trim().to_string();
+                if pattern.is_empty() {
+                    rules.warnings.push(format!(
+                        ".specsyncignore line {line_no} has an empty spec path: `{line}`"
+                    ));
+                    continue;
                 }
+                rules.per_spec.entry(pattern).or_default().insert(category);
             } else if let Some(category) = WarningCategory::from_str(line) {
                 // Global rule
                 rules.global.insert(category);
+            } else {
+                rules.warnings.push(format!(
+                    ".specsyncignore line {line_no} matches no warning category: `{line}`"
+                ));
             }
         }
 
@@ -348,6 +410,114 @@ mod tests {
         assert!(!rules.global.contains(&WarningCategory::StubSection));
         assert!(rules.per_spec.contains_key("specs/legacy/"));
         assert!(rules.per_spec["specs/legacy/"].contains(&WarningCategory::StubSection));
+    }
+
+    #[test]
+    fn test_classify_exports_documented_summary() {
+        assert_eq!(
+            WarningCategory::classify("2/5 exports documented"),
+            Some(WarningCategory::ExportsDocumented)
+        );
+        assert_eq!(
+            WarningCategory::from_str("exports-documented"),
+            Some(WarningCategory::ExportsDocumented)
+        );
+        // Not a summary — unrelated prose must not match.
+        assert_ne!(
+            WarningCategory::classify("Undocumented export 'foo' from src/a.ts"),
+            Some(WarningCategory::ExportsDocumented)
+        );
+    }
+
+    #[test]
+    fn test_exports_documented_summary_suppressible() {
+        let mut rules = IgnoreRules::default();
+        rules.global.insert(WarningCategory::ExportsDocumented);
+        let inline = HashSet::new();
+        assert!(rules.is_suppressed(
+            "2/5 exports documented",
+            "specs/a/a.spec.md",
+            &inline,
+        ));
+    }
+
+    #[test]
+    fn test_load_tolerates_utf8_bom() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".specsyncignore"),
+            "\u{feff}undocumented-export\n",
+        )
+        .unwrap();
+        let rules = IgnoreRules::load(tmp.path());
+        assert!(
+            rules.global.contains(&WarningCategory::UndocumentedExport),
+            "a BOM must not disable the first pattern: {rules:?}"
+        );
+        assert!(rules.warnings.is_empty(), "{:?}", rules.warnings);
+    }
+
+    #[test]
+    fn test_load_invalid_utf8_line_skipped_not_poisoning() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut bytes = b"undocumented-export\n".to_vec();
+        bytes.extend_from_slice(b"bad-\xff\xfe-line\n");
+        bytes.extend_from_slice(b"changelog\n");
+        std::fs::write(tmp.path().join(".specsyncignore"), bytes).unwrap();
+
+        let rules = IgnoreRules::load(tmp.path());
+        // The valid lines still apply...
+        assert!(rules.global.contains(&WarningCategory::UndocumentedExport));
+        assert!(rules.global.contains(&WarningCategory::ChangelogEntries));
+        // ...and the corrupt line is reported, not silent.
+        assert_eq!(rules.warnings.len(), 1, "{:?}", rules.warnings);
+        assert!(rules.warnings[0].contains("not valid UTF-8"));
+        assert!(rules.warnings[0].contains("line 2"));
+    }
+
+    #[test]
+    fn test_load_per_spec_path_first_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".specsyncignore"),
+            "specs/legacy/:undocumented-export\n",
+        )
+        .unwrap();
+        let rules = IgnoreRules::load(tmp.path());
+        assert!(
+            rules.per_spec
+                .get("specs/legacy/")
+                .is_some_and(|cats| cats.contains(&WarningCategory::UndocumentedExport)),
+            "path:category order must work: {rules:?}"
+        );
+    }
+
+    #[test]
+    fn test_load_warns_on_unmatchable_pattern() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".specsyncignore"),
+            "undocumanted-export\nmain:undocumented\n",
+        )
+        .unwrap();
+        let rules = IgnoreRules::load(tmp.path());
+        // Typo'd category warns with the offending line.
+        assert!(
+            rules
+                .warnings
+                .iter()
+                .any(|w| w.contains("undocumanted-export") && w.contains("line 1")),
+            "{:?}",
+            rules.warnings
+        );
+        // `main:undocumented` — "undocumented" is a known category alias and
+        // "main" is not, so this parses as per-spec pattern "main". Both sides
+        // unresolvable would warn instead.
+        assert!(
+            rules.per_spec.contains_key("main")
+                || rules.warnings.iter().any(|w| w.contains("line 2")),
+            "{rules:?}"
+        );
     }
 
     #[test]

--- a/tests/integration/check.rs
+++ b/tests/integration/check.rs
@@ -33,6 +33,129 @@ fn check_valid_project_passes() {
 }
 
 #[test]
+fn specsyncignore_suppression_is_strict_clean_and_visible() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_minimal_project(&tmp);
+    fs::write(
+        root.join("specs/auth/auth.spec.md"),
+        complete_coverage_spec("auth", &["src/auth/service.ts"]),
+    )
+    .unwrap();
+    fs::write(
+        root.join(".specsyncignore"),
+        "\u{feff}exports-documented\nspecs/auth/auth.spec.md:undocumented-export\n",
+    )
+    .unwrap();
+
+    specsync()
+        .args(["check", "--strict", "--force"])
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "3 warning(s) suppressed by .specsyncignore",
+        ))
+        .stdout(predicate::str::contains("Undocumented export").not())
+        .stdout(predicate::str::contains("0/2 exports documented").not());
+}
+
+#[test]
+fn specsyncignore_diagnostics_and_suppression_are_visible_in_all_formats() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_minimal_project(&tmp);
+    fs::write(
+        root.join("specs/auth/auth.spec.md"),
+        complete_coverage_spec("auth", &["src/auth/service.ts"]),
+    )
+    .unwrap();
+    let mut ignore = b"\xef\xbb\xbfexports-documented\n\
+        specs/auth/auth.spec.md:undocumented-export\n\
+        undocumanted-export\n"
+        .to_vec();
+    ignore.extend_from_slice(b"invalid-\xff-line\n");
+    fs::write(root.join(".specsyncignore"), ignore).unwrap();
+
+    let text = specsync()
+        .args(["check", "--force"])
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(text).unwrap();
+    assert!(text.contains("matches no warning category: `undocumanted-export`"));
+    assert!(text.contains("line 4 is not valid UTF-8"));
+    assert!(text.contains("3 warning(s) suppressed by .specsyncignore"));
+    assert!(!text.contains("Undocumented export"));
+    assert!(!text.contains("0/2 exports documented"));
+
+    let json = specsync()
+        .args(["check", "--force", "--format", "json"])
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value =
+        serde_json::from_slice(&json).expect("ignore diagnostics must preserve valid JSON");
+    assert!(json["warnings"].as_array().unwrap().iter().any(|warning| {
+        warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("undocumanted-export"))
+    }));
+    assert!(json["warnings"].as_array().unwrap().iter().any(|warning| {
+        warning
+            .as_str()
+            .is_some_and(|warning| warning.contains("not valid UTF-8"))
+    }));
+    assert!(json["notices"].as_array().unwrap().iter().any(|notice| {
+        notice
+            .as_str()
+            .is_some_and(|notice| notice.contains("3 warning(s) suppressed"))
+    }));
+
+    for format in ["markdown", "github"] {
+        specsync()
+            .args(["check", "--force", "--format", format])
+            .arg("--root")
+            .arg(&root)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("undocumanted-export"))
+            .stdout(predicate::str::contains("not valid UTF-8"))
+            .stdout(predicate::str::contains(
+                "3 warning(s) suppressed by .specsyncignore",
+            ));
+    }
+}
+
+#[test]
+fn inline_suppression_is_not_attributed_to_specsyncignore() {
+    let tmp = TempDir::new().unwrap();
+    let root = setup_minimal_project(&tmp);
+    let spec = complete_coverage_spec("auth", &["src/auth/service.ts"]).replace(
+        "## Invariants",
+        "<!-- specsync-ignore: exports-documented, undocumented-export -->\n\n## Invariants",
+    );
+    fs::write(root.join("specs/auth/auth.spec.md"), spec).unwrap();
+
+    specsync()
+        .args(["check", "--strict", "--force"])
+        .arg("--root")
+        .arg(&root)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Undocumented export").not())
+        .stdout(predicate::str::contains("0/2 exports documented").not())
+        .stdout(predicate::str::contains("suppressed by .specsyncignore").not());
+}
+
+#[test]
 fn sdd_failure_json_preserves_check_schema() {
     let tmp = TempDir::new().unwrap();
     let root = setup_minimal_project(&tmp);


### PR DESCRIPTION
## Problem

`.specsyncignore` had several silent-failure modes:

- A **UTF-8 BOM** silently disabled the first rule in the file.
- **One invalid-UTF-8 line** poisoned the whole file — every rule was dropped.
- Only one per-spec syntax order was accepted (`category:path`); the documented `path:category` order was ignored.
- **Typo'd/unmatchable rules did nothing** — indistinguishable from working suppression.
- The `N/M exports documented` partial-coverage summary warning had no category and could not be suppressed, so acknowledging undocumented exports could never yield a clean `--strict` run.
- Suppression itself was invisible: no way to tell how many warnings a rule swallowed.

## Repro (fixture: `/var/tmp/scratch/w2/420/`)

```
<BOOM>exports-documented
specs/ig/ig.spec.md: undocumented-export
undocumanted-export        # typo
```

- **Before**: BOM disables rule 1; the typo vanishes silently; the summary warning is unsuppressible either way.
- **After**: both valid rules apply (either syntax order), the typo'd line produces `.specsyncignore line 3 matches no warning category: 'undocumanted-export'`, the summary is suppressible via the new `exports-documented` category, and the check output ends with `ℹ N warning(s) suppressed by .specsyncignore`.

## Root cause

`IgnoreRules::load` read the file as one UTF-8 string (BOM and corrupt lines poisoned everything), accepted only one colon-order, and had no channel to report dead rules.

## Fix

- `ignore.rs`: BOM strip; per-line UTF-8 with a warning per skipped line; both per-spec orders (whichever side names a known category wins); unmatchable-line warnings; new `ExportsDocumented` category (classify `N/M exports documented` + `from_str("exports-documented")`).
- `commands/mod.rs`: surfaces `ignore_rules.warnings` in every output format and prints `N warning(s) suppressed by .specsyncignore`.

## Tests (all in-file, all passing)

`test_load_tolerates_utf8_bom`, `test_load_invalid_utf8_line_skipped_not_poisoning`, `test_load_per_spec_path_first_order`, `test_load_warns_on_unmatchable_pattern`, `test_classify_exports_documented_summary`, `test_exports_documented_summary_suppressible`.

## File overlap note

`src/commands/mod.rs` ships in PR #455 (`fix/435-db-schema-validation`) — the whole current file there includes this visibility change. This PR ships `src/ignore.rs` in full.

Full suite: 1743 passed, 1 pre-existing root-only failure (unrelated). `clippy --all-targets -- -D warnings` clean.

Closes #420