### PR TITLE
fix: honest init detection, --repair path, registry name escaping (closes #440)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1157,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "toml",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-commonlisp",
@@ -1290,6 +1300,45 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tree-sitter"
@@ -1817,6 +1866,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tree-sitter-commonlisp = "0.4.1"
 tree-sitter-scheme = "0.24.7"
 tree-sitter-elisp = "1.6.1"
 tree-sitter-perl = "1.1.2"
+toml = "1.1.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/specs/cli/cli.spec.md
+++ b/specs/cli/cli.spec.md
@@ -1,10 +1,11 @@
 ---
 module: cli
-version: 10
+version: 11
 status: stable
 files:
   - src/main.rs
 db_tables: []
+implements: [440]
 tracks: [120]
 depends_on:
   - specs/agents/agents.spec.md
@@ -62,14 +63,14 @@ Clap derive types define the root `Cli`, the `Command` namespace, and focused ac
 | check | Validate all specs against source code (default when no subcommand given) | --strict, --require-coverage N, --json, --fix, --force, --create-issues, --explain, [SPEC...] |
 | coverage | Show file and module coverage report | --strict, --require-coverage N, --json |
 | generate | Deterministically scaffold spec files for unspecced modules | --uncovered, --batch MODULE... |
-| init | Create the 5.0 `.specsync/` layout, TOML config, SDD policy, and version stamp | — |
+| init | Create or additively repair the 5.0 `.specsync/` layout | --repair |
 | change | Manage the verified SDD lifecycle, interviews, approvals, verification, acceptance, adoption, and archive | new, answer, approve, start, verify, accept, archive, adopt |
 | score | Score spec quality (0–100) with letter grades and suggestions | --json, --explain, [SPEC...] |
 | watch | Watch spec and source files, re-running check on changes | --strict, --require-coverage N |
 | mcp | Run as an MCP (Model Context Protocol) server over stdio | — |
 | add-spec | Scaffold a new spec with companion files (tasks.md, context.md) | name positional arg |
 | scaffold | Full scaffold: spec + companions + source detection + registry entry | name, --dir PATH, --template PATH |
-| init-registry | Generate a specsync-registry.toml for cross-project references | --name |
+| init-registry | Generate a safe registry once for cross-project references | --name |
 | resolve | Resolve cross-project spec references in depends_on | --remote (enables network fetches) |
 | diff | Show export changes since a git ref (useful for CI/PR comments) | --base REF (default: HEAD), --json |
 | hooks install | Install agent instructions and/or git hooks | --claude, --cursor, --copilot, --agents, --precommit, --claude-code-hook |
@@ -95,7 +96,7 @@ Clap derive types define the root `Cli`, the `Command` namespace, and focused ac
 | --strict | bool | false | Treat warnings as errors (exit 1) |
 | --require-coverage | Option usize | None | Fail if file coverage percent is below threshold |
 | --root | Option PathBuf | cwd | Project root directory |
-| --format | text\|json\|markdown | text | Output format: colored text, machine-readable JSON, or markdown |
+| --format | text\|json\|markdown\|github\|table\|csv | text | Output format |
 | --json | bool | false | Shorthand for `--format json` |
 | --enforcement | Option EnforcementMode | None | Override configured enforcement mode (warn, enforce-new, strict) |
 | --force | bool | false | Bypass hash cache and re-validate all specs |
@@ -144,8 +145,8 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 3. `--strict` causes warnings to produce a non-zero exit code
 4. `--require-coverage N` causes exit 1 if file coverage percent < N
 5. `--json` switches all output to machine-readable JSON (no ANSI colors)
-6. `cmd_init` is idempotent and never overwrites current or legacy project configuration
-7. `cmd_init_registry` is idempotent — does nothing if `specsync-registry.toml` already exists
+6. `cmd_init` is idempotent, supports additive `--repair`, and never overwrites current or legacy project configuration
+7. `cmd_init_registry` reports valid existing files as unchanged no-ops and fails visibly on invalid existing files without overwriting
 8. `cmd_add_spec` generates companion files even if the spec already exists
 9. `cmd_generate` re-runs validation after generating new specs to include them in the summary
 10. `cmd_resolve --remote` performs network calls; without the flag, cross-project refs are listed but not verified
@@ -189,6 +190,12 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 - **Given** a config (v4 `.specsync/config.toml` or legacy `specsync.json`) already exists
 - **When** `specsync init` is run
 - **Then** prints an "already exists" message and returns without modifying it
+
+### Scenario: Structured init repair
+
+- **Given** a valid project config with missing support files
+- **When** `specsync init --repair --format json` is run
+- **Then** one JSON value reports the restored paths and unchanged config state
 
 ### Scenario: Coverage threshold
 
@@ -260,6 +267,7 @@ All functions in main.rs are private (no pub keyword). Key internal functions:
 | Failed to create spec directory | Prints error to stderr and exits 1 |
 | Failed to write spec file | Prints error to stderr and exits 1 |
 | Failed to write `specsync-registry.toml` | Prints error to stderr and exits 1 |
+| Init or init-registry structured failure | Emits one format-aware failure outcome and exits 1 |
 | No spec files found (non-generate commands) | Prints guidance message and exits 0 |
 
 ## Performance Requirements
@@ -373,3 +381,4 @@ update is an explicit implementation edit because semantic section deltas do not
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-14 | CHG-0025-address-all-unresolved-review-feedback-on-pr-366: Address all unresolved review feedback on PR 366 |
 | 2026-07-14 | CHG-0029-address-all-remaining-review-feedback-from-pr-366: Address all remaining review feedback from PR 366 |
+| 2026-07-26 | v11: Dispatch additive init repair and format-aware init/registry outcomes (#440) |

--- a/specs/cli/context.md
+++ b/specs/cli/context.md
@@ -9,6 +9,7 @@ spec: cli.spec.md
 - **JSON mode**: `--json` is a global flag so all commands can produce machine-readable output for CI/scripting.
 - **Strict mode**: `--strict` converts warnings to errors, useful for CI pipelines that want zero-warning enforcement.
 - **Idempotent init**: Both `init` and `init-registry` check for existing files before writing, preventing accidental overwrites.
+- **Truthful initialization outcomes**: The dispatcher projects global output format into both initialization commands; `init --repair` is additive and structured failures retain non-zero exits.
 - **No network by default**: `resolve` only performs network calls with `--remote`, keeping default behavior offline and fast.
 - **Hook targets**: When no specific `--claude`/`--cursor`/etc. flags are given, an empty targets vec signals "all targets" to the hooks module.
 - **Panic guard**: `main()` wraps `run()` in `std::panic::catch_unwind` and prints a "please report it" message with the issue tracker URL instead of a raw backtrace.
@@ -22,7 +23,7 @@ spec: cli.spec.md
 
 ## Current Status
 
-Fully implemented. The CLI exposes deterministic validation/generation, complete lifecycle/change commands, and native Agents/MCP integration without embedded inference configuration.
+Fully implemented. The CLI exposes deterministic validation/generation, additive initialization repair, complete lifecycle/change commands, and native Agents/MCP integration without embedded inference configuration.
 
 ## Notes
 

--- a/specs/cli/requirements.md
+++ b/specs/cli/requirements.md
@@ -82,3 +82,13 @@ Acceptance Criteria
 - The process emits one contextual diagnostic and exits non-zero.
 - Commands outside the lifecycle boundary preserve current dispatch behavior.
 
+### REQ-cli-005
+
+The root CLI SHALL dispatch initialization creation, repair, and registry generation with the selected global output format and truthful exit behavior.
+
+Acceptance Criteria
+
+- `Command::Init { repair }` forwards the flag and resolved global format.
+- `InitRegistry` forwards the resolved global format.
+- Structured success/no-op/failure output remains parseable and handler failures exit non-zero.
+- Interactive bootstrap is limited to text-mode fresh initialization.

--- a/specs/cli/tasks.md
+++ b/specs/cli/tasks.md
@@ -20,6 +20,7 @@ spec: cli.spec.md
 - [x] Remove embedded provider/model generation flags and preserve deterministic agent integrations
 - [x] Wrap `run()` in `catch_unwind` so panics surface a friendly bug-report message
 - [x] Block inherited verification recursion before dispatching `change` or `lifecycle` subcommands
+- [x] Dispatch `init --repair` and format-aware init/init-registry outcomes
 
 ## Gaps
 

--- a/specs/cli/testing.md
+++ b/specs/cli/testing.md
@@ -16,6 +16,7 @@ spec: cli.spec.md
 | `tests/integration.rs` | cargo test --test integration require_coverage_on_coverage_subcommand | End-to-end fixture: `require_coverage_on_coverage_subcommand` |
 | `tests/integration.rs` | cargo test --test integration strict_on_coverage_subcommand | End-to-end fixture: `strict_on_coverage_subcommand` |
 | `tests/integration.rs` | cargo test --test integration toml_config_is_loaded | End-to-end fixture: `toml_config_is_loaded` |
+| Init dispatch/output | `cargo test --test integration init_` | Repair flag, JSON projection, no-op/failure exits, non-interactive structured output |
 
 ## Behavioral Verification
 
@@ -25,6 +26,7 @@ spec: cli.spec.md
 | Strict mode with warnings | specs have undocumented exports (warnings but no errors) | `specsync check --strict` is run | the process exits with code 1 |
 | JSON output | `--json` flag is passed | any command runs | output is valid JSON with no ANSI escape codes |
 | Init idempotency | `specsync.json` already exists in the project root | `specsync init` is run | prints "specsync.json already exists" and returns without modifying it |
+| Init repair JSON | valid config plus missing support files | `specsync init --repair --json` | one parseable outcome lists restored paths and exits 0 |
 | Coverage threshold | file coverage is 80% | `specsync check --require-coverage 90` is run | the process exits with code 1 and prints the unspecced files |
 | Deterministic generate | uncovered modules exist | `specsync generate` is run | local template specs and companions are created |
 | Retired provider/model flags | user supplies `--provider` or `--model` | Clap parses arguments | unknown arguments are rejected |

--- a/specs/cli_args/cli_args.spec.md
+++ b/specs/cli_args/cli_args.spec.md
@@ -1,10 +1,11 @@
 ---
 module: cli_args
-version: 12
+version: 13
 status: stable
 files:
   - src/cli.rs
 db_tables: []
+implements: [440]
 tracks: []
 depends_on:
   - specs/types/types.spec.md
@@ -48,6 +49,7 @@ Defines the complete CLI argument grammar, including stale-only accepted-change 
 10. `ChangeAction::CorrectOwner` requires actor and reason, plus a non-empty batch selection from repeated `--path`/`--spec` pairs, `--manifest`, or `--all-missing` with one `--spec`
 11. Conflicting or empty `correct-owner` selection modes fail in Clap before domain mutation
 12. `Migrate` accepts an optional source-family positional; unknown families fail through deterministic validation before any mutation.
+13. `Init` carries an explicit `--repair` boolean; global `--json`/`--format` continue to apply to `init` and `init-registry`.
 
 ## Behavioral Examples
 
@@ -86,6 +88,7 @@ Defines the complete CLI argument grammar, including stale-only accepted-change 
 | `change reopen` without `--actor` or `--reason` | Clap names the missing required argument and exits non-zero |
 | `change correct-owner` without actor, reason, or any batch selection | Clap names the missing required argument and exits non-zero |
 | `change correct-owner` with conflicting `--all-missing`, `--manifest`, and `--path` modes | Clap rejects the conflicting selection before domain mutation |
+| Unknown init flag (including `--force`) | Clap rejects it and names `--repair` as the supported repair surface |
 
 ## Dependencies
 
@@ -122,3 +125,4 @@ Defines the complete CLI argument grammar, including stale-only accepted-change 
 | 2026-07-15 | CHG-0047-permit-audited-deterministic-ownership-corrections-for-reopened-already-applied: Permit audited deterministic ownership corrections for reopened already-applied changes |
 | 2026-07-19 | CHG-0055-batch-mode-for-change-correct-owner-so-multiple-omitted-exact-canonical-owners-c: Batch mode for change correct-owner so multiple omitted exact canonical owners can be audited and appended in one transactional correction before a single reapprove-verify-accept cycle |
 | 2026-07-19 | CHG-0057-add-a-native-migration-path-for-5-0-1-era-change-ledgers-that-backfills-the-5-1: Add a native migration path for 5.0.1-era change ledgers that backfills the 5.1 reopening stale and current acceptance-input digest fields idempotently with a closing-digest verification pass, and surfaces an actionable migrate hint when check encounters the 5.0.1 reopening schema |
+| 2026-07-26 | v13: Add the explicit `init --repair` grammar and preserve global format projection (#440) |

--- a/specs/cli_args/context.md
+++ b/specs/cli_args/context.md
@@ -11,6 +11,7 @@ spec: cli_args.spec.md
 - Accepted-change reopen is explicit and auditable: the grammar requires both `--actor` and `--reason`.
 - Accepted metadata correction is explicit and auditable: `change correct` restricts fields to `public_contract` or `architecture_risk`, values to `yes` or `no`, and requires both `--actor` and `--reason`.
 - Acceptance-owner correction is explicit and auditable: `change correct-owner` requires actor and reason plus a batch selection from repeated `--path`/`--spec`, `--manifest`, or `--all-missing`.
+- Initialization repair is explicit and non-clobbering through `init --repair`; global output flags apply unchanged.
 
 ## Files to Read First
 
@@ -22,3 +23,4 @@ spec: cli_args.spec.md
 
 Stable deterministic grammar for the core and agent-native integrations. Help text names the canonical `.specsync/config.toml` layout and all required `new --full` companions; accepted evidence can be reopened, supported accepted classification metadata corrected, or an exact acceptance owner repaired only with explicit audit inputs.
 `Migrate` gains an optional source-family positional restricted to `5.0` by the Clap grammar; unknown families fail validation before any mutation, and bare `migrate` keeps the v3→v4 default.
+`Init` now carries the single supported `--repair` flag; there is no destructive force mode.

--- a/specs/cli_args/requirements.md
+++ b/specs/cli_args/requirements.md
@@ -90,3 +90,13 @@ Acceptance Criteria
   mutation.
 - `--dry-run` and `--no-backup` remain accepted in both modes.
 
+### REQ-cli-args-008
+
+The shared CLI grammar SHALL expose additive initialization repair without a destructive overwrite mode.
+
+Acceptance Criteria
+
+- `specsync init --repair` parses as `Command::Init { repair: true }`.
+- Bare `specsync init` preserves `repair: false`.
+- Global `--json` and every `--format` value remain available before or after `init` and `init-registry`.
+- No `--force` or config-overwrite initialization flag is accepted.

--- a/specs/cli_args/tasks.md
+++ b/specs/cli_args/tasks.md
@@ -17,3 +17,4 @@ spec: cli_args.spec.md
 - [x] Add exact path/spec grammar and required audit inputs for acceptance-owner correction
 - [x] Add batch selection grammar for correct-owner (repeated path/spec, manifest, all-missing)
 - [x] Add optional migrate source-family positional for the 5.0 ledger backfill
+- [x] Add explicit `init --repair` grammar without a destructive force mode

--- a/specs/cli_args/testing.md
+++ b/specs/cli_args/testing.md
@@ -21,3 +21,5 @@ spec: cli_args.spec.md
 | `change correct-owner` with repeated `--path`, `--manifest`, or `--all-missing` | Parses batch selection grammar (`REQ-cli-args-006`) |
 | `migrate 5.0 [--dry-run]` | Parses the ledger backfill mode (`REQ-cli-args-007`) |
 | `migrate 9.9` | Clap rejects the unknown source family before domain mutation |
+| `init --repair --json` | Parses repair plus global structured output (`REQ-cli-args-008`) |
+| `init --force` | Clap rejects the unsupported destructive flag |

--- a/specs/cmd_init/cmd_init.spec.md
+++ b/specs/cmd_init/cmd_init.spec.md
@@ -1,10 +1,11 @@
 ---
 module: cmd_init
-version: 8
+version: 9
 status: stable
 files:
   - src/commands/init.rs
 db_tables: []
+implements: [440]
 tracks: []
 depends_on:
   - specs/config/config.spec.md
@@ -15,7 +16,7 @@ depends_on:
 
 ## Purpose
 
-Implements `specsync init`. Creates the 5.0 `.specsync/` layout with detected source directories, canonical TOML configuration, SDD policy, version stamp, local-state ignore rules, lifecycle/change/archive directories, and optional guided agent/change bootstrap.
+Implements `specsync init` and `init --repair`. Creates the 5.0 `.specsync/` layout with truthful source detection, canonical TOML configuration, SDD policy, version stamp, local-state ignore rules, lifecycle/change/archive directories, structured outcomes, and optional guided agent/change bootstrap.
 
 ## Public API
 
@@ -23,37 +24,50 @@ Implements `specsync init`. Creates the 5.0 `.specsync/` layout with detected so
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `cmd_init` | `root: &Path` | `()` | Create the 5.0 `.specsync/` layout, TOML config, SDD policy, and detected verification command |
+| `cmd_init` | `root: &Path, repair: bool, format: OutputFormat` | `()` | Create, inspect, or repair the 5.0 `.specsync/` layout and render a format-aware outcome |
 | `ensure_hashes_gitignored` | `root: &Path` | `Result<bool, String>` | Add `.specsync/hashes.json` to the root `.gitignore` (idempotent); returns `Ok(true)` if the entry was added, `Ok(false)` if already present, `Err` if the write fails |
 
 ## Invariants
 
-1. Auto-detects source directories via `config::detect_source_dirs()`.
+1. Auto-detects source directories via `config::detect_source_dirs_with_confidence()` and never labels the fallback as detected.
 2. Never overwrites an existing current or legacy configuration; legacy configurations receive a migration hint.
 3. Writes the 5.0 policy, version, and layout deterministically without blocking in non-interactive environments.
 4. Local hash cache, lifecycle lock, and transaction journal files are ignored and never treated as portable project state.
 5. Re-running initialization is idempotent.
+6. `--repair` validates the existing config before mutation, restores only missing support artifacts, and never rewrites config or specs.
+7. Nested initialization is rejected when an initialized ancestor exists.
+8. Predictable blocking paths are preflighted before layout creation so failures do not leave partial directories.
+9. JSON, Markdown/GitHub, table, and CSV formats emit a single truthful command outcome; structured modes never launch interactive bootstrap prompts.
 
 ## Behavioral Examples
 
 ### Scenario: First init
 
 - **Given** no config exists
-- **When** `cmd_init(root)` runs
+- **When** `cmd_init(root, false, Text)` runs
 - **Then** creates `.specsync/config.toml`, `.specsync/version`, `.specsync/.gitignore`, and the `lifecycle/`, `changes/`, `archive/` directories
 
 ### Scenario: Config exists
 
 - **Given** `.specsync/config.toml` (or a legacy config) already exists
-- **When** `cmd_init(root)` runs
+- **When** `cmd_init(root, false, Text)` runs
 - **Then** prints message and returns without changes
+
+### Scenario: Repair partial layout
+
+- **Given** a valid config with missing version, local ignore, policy, or lifecycle directories
+- **When** `cmd_init(root, true, Json)` runs
+- **Then** restores only missing support artifacts, reports each restored path, and leaves config/spec bytes unchanged
 
 ## Error Cases
 
 | Condition | Behavior |
 |-----------|----------|
 | File write fails | Exits 1 |
-| No source dirs detected | Creates TOML config with `source_dirs = ["src"]` fallback |
+| No source dirs detected | Creates TOML config with `source_dirs = ["src"]` and explicitly reports that it is a fallback |
+| Existing config is malformed or has a wrong known path-field type | Exits 1 before repair writes |
+| Initialized ancestor exists | Exits 1 and reports the ancestor without creating nested metadata |
+| Expected support directory is blocked by a file/symlink | Exits 1 before any layout write |
 
 ## Dependencies
 
@@ -61,7 +75,7 @@ Implements `specsync init`. Creates the 5.0 `.specsync/` layout with detected so
 
 | Module | What is used |
 |--------|-------------|
-| config | `detect_source_dirs`, `config_to_toml` |
+| config | `detect_source_dirs_with_confidence`, `validate_config_file`, `config_to_toml` |
 
 **Consumed By**
 
@@ -85,3 +99,4 @@ Implementation SHALL add these canonical dependency specs to `depends_on`: `spec
 | 2026-07-11 | CHG-0004-close-final-pr-review-gaps-in-5-0-lifecycle-enforcement: Close final PR review gaps in 5.0 lifecycle enforcement |
 | 2026-07-11 | CHG-0006-close-final-specsync-5-0-evidence-monorepo-bootstrap-reporting-and-import-re: Close final SpecSync 5.0 evidence, monorepo, bootstrap, reporting, and import review gaps |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-26 | v9: Add truthful detection, audited repair semantics, ancestor/preflight safety, and structured outputs (#440) |

--- a/specs/cmd_init/context.md
+++ b/specs/cmd_init/context.md
@@ -8,6 +8,10 @@ spec: cmd_init.spec.md
 - Fresh projects write deterministic `.specsync/config.toml`, `.specsync/version`, and `.specsync/sdd.json` files.
 - `ensure_hashes_gitignored` returns `Result<bool, String>` (not `io::Error`) so the caller can print a plain warning; the io error is mapped to a "Failed to update .gitignore" string. A `.gitignore` write failure is intentionally **non-fatal** — the config is already written and the cache being un-ignored is a minor issue.
 - The repository-root `.gitignore` receives the hash-cache entry, while `.specsync/.gitignore` owns local lifecycle lock and transaction-journal entries.
+- `init --repair` is additive: it validates the selected config first, then restores only missing support artifacts. Existing config, specs, policy, and ignore files are not regenerated.
+- Expected directory/file topology is preflighted before fresh creation so a blocking file or symlink cannot leave a partially initialized layout.
+- An initialized ancestor is reported as an error before a nested `.specsync` can be created.
+- Every output format is rendered from one outcome record; JSON is a single parseable value and non-text formats skip interactive prompts.
 
 ## Files to Read First
 
@@ -16,7 +20,7 @@ spec: cmd_init.spec.md
 
 ## Current Status
 
-Implemented for 5.0. Fresh projects enable SDD, detect configured verification commands, and receive a guided terminal bootstrap; non-interactive behavior remains deterministic and covered by integration tests.
+Implemented for 5.0. Fresh projects enable SDD, repairs are additive and config-checked, fallback detection is explicit, nested projects are rejected, and structured output remains deterministic.
 
 ## Notes
 

--- a/specs/cmd_init/requirements.md
+++ b/specs/cmd_init/requirements.md
@@ -16,6 +16,10 @@ spec: cmd_init.spec.md
 - On success, init prints the created v5 layout and detected source directories.
 - After writing the config, `ensure_hashes_gitignored` adds `.specsync/hashes.json` to the root `.gitignore` (with a comment header) unless it is already present; the result is reported as a success line, a no-op, or a warning.
 - `ensure_hashes_gitignored` is idempotent: re-running never duplicates the entry.
+- Empty projects report the `src` value as a fallback rather than a detected directory.
+- `init --repair` restores missing support artifacts without rewriting config, specs, or existing ignore content.
+- An initialized ancestor prevents nested metadata creation.
+- Structured output reports created/repaired/unchanged state and failures truthfully.
 
 ## Constraints
 
@@ -60,3 +64,17 @@ Initialization SHALL enable Git-dependent SDD coverage only when the project can
 Acceptance Criteria
 - Git repositories receive normal strict SDD defaults.
 - Non-Git directories initialize successfully without an immediately impossible changed-path gate.
+
+### REQ-cmd-init-005
+
+Initialization SHALL be truthful, additive, and non-destructive across creation, inspection, and repair.
+
+Acceptance Criteria
+
+- Empty or source-free directories use `source_dirs = ["src"]` while reporting `source_dirs_detected = false`.
+- Plain re-init is byte-identical and reports an unchanged outcome.
+- `--repair` validates the selected config before writes and restores only missing support files/directories.
+- Existing config, specs, and `.gitignore` content are never clobbered.
+- Running below an initialized ancestor fails without creating nested metadata.
+- Predictable blocking file/symlink topology fails before partial layout creation.
+- JSON/Markdown/GitHub/table/CSV outputs reflect success, creation, repair, unchanged state, and errors.

--- a/specs/cmd_init/tasks.md
+++ b/specs/cmd_init/tasks.md
@@ -13,6 +13,10 @@ spec: cmd_init.spec.md
 - [x] `ensure_hashes_gitignored` adds `.specsync/hashes.json` to root `.gitignore`, idempotently, with non-fatal warning on failure.
 - [x] Inline unit tests for `ensure_hashes_gitignored`: `adds_entry_to_missing_gitignore`, `is_idempotent_when_entry_already_present`, `errors_when_gitignore_path_is_unwritable`.
 - [x] Integration coverage for config creation, no-overwrite, and source-dir auto-detection (src/lib/multi/fallback/node_modules-ignore) plus the MCP `init` tool.
+- [x] Add `init --repair` with config preflight and additive support-file restoration.
+- [x] Reject initialized ancestors and blocking layout topology before writes.
+- [x] Emit truthful structured outcomes for creation, no-op, repair, and failure.
+- [x] Preserve config/spec/root-ignore bytes across re-init and repair.
 
 ## Review Status
 

--- a/specs/cmd_init/testing.md
+++ b/specs/cmd_init/testing.md
@@ -13,11 +13,15 @@ spec: cmd_init.spec.md
 | Source detection | `init_auto_detects_src_dir`, `init_auto_detects_lib_dir`, `init_auto_detects_multiple_dirs`, `init_falls_back_to_src_when_no_source_files` |
 | Local-state ignores | `adds_entry_to_missing_gitignore`, `is_idempotent_when_entry_already_present`, `errors_when_gitignore_path_is_unwritable` |
 | MCP initialization | `mcp_tool_init_creates_config` |
+| Structured truthfulness | `init_json_reports_fallback_and_complete_outcome_truthfully`, `init_plain_reinit_is_byte_identical_and_json_reports_unchanged` |
+| Additive repair | `init_repair_restores_support_files_without_touching_owned_content`, `init_repair_rejects_corrupt_config_before_mutating_layout` |
+| Nested/blocking safety | `init_nested_project_json_fails_without_creating_nested_metadata`, `init_preflights_blocking_layout_without_partial_writes` |
 
 ## Requirement Evidence
 
 - `REQ-cmd-init-001`: `write_current_layout_creates_full_structure`, `fresh_init_is_not_legacy_layout`, and `init_enables_sdd_for_new_projects`.
 - `REQ-cmd-init-002`: current-layout integration tests assert `.specsync/config.toml`, `.specsync/sdd.json`, and the `5.0.0` version stamp.
+- `REQ-cmd-init-005`: the structured/no-op/repair/nested/blocking integration tests named above.
 
 ## Reviewer Checklist
 

--- a/specs/cmd_init_registry/cmd_init_registry.spec.md
+++ b/specs/cmd_init_registry/cmd_init_registry.spec.md
@@ -1,10 +1,11 @@
 ---
 module: cmd_init_registry
-version: 3
+version: 4
 status: stable
 files:
   - src/commands/init_registry.rs
 db_tables: []
+implements: [440]
 tracks: []
 depends_on:
   - specs/config/config.spec.md
@@ -15,7 +16,7 @@ depends_on:
 
 ## Purpose
 
-Implements the `specsync init-registry` command. Creates a registry file for cross-project spec references with auto-detected entries. The registry is written to the v4 location (`.specsync/registry.toml`); the legacy root-level `specsync-registry.toml` is only used for un-migrated 3.x layouts.
+Implements the `specsync init-registry` command. Creates a safely serialized registry for cross-project spec references, validates selected config before writing, preserves existing registries, and emits truthful format-aware outcomes.
 
 ## Public API
 
@@ -23,7 +24,7 @@ Implements the `specsync init-registry` command. Creates a registry file for cro
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
-| `cmd_init_registry` | `root: &Path, name: Option<String>` | `()` | Generate registry TOML with spec entries |
+| `cmd_init_registry` | `root: &Path, name: Option<String>, format: OutputFormat` | `()` | Validate inputs/config, generate registry TOML once, and render a format-aware outcome |
 
 ## Invariants
 
@@ -31,13 +32,16 @@ Implements the `specsync init-registry` command. Creates a registry file for cro
 2. Will not overwrite an existing registry file (v4 or legacy location)
 3. `--name` overrides auto-detected project name
 4. Never recreates the legacy root-level registry in a v4 project — doing so would re-trigger the legacy-layout migration nag
+5. Empty/whitespace-only names fail before any write; arbitrary non-empty names are TOML-serialized without interpolation.
+6. Existing valid registries are byte-identical no-op successes with `created = false` and `unchanged = true`; existing invalid/inert files fail visibly.
+7. JSON, Markdown/GitHub, table, and CSV output carry the same created/unchanged/error semantics.
 
 ## Behavioral Examples
 
 ### Scenario: Generate registry
 
 - **Given** 25 specs, no existing registry
-- **When** `cmd_init_registry(root, None)` runs
+- **When** `cmd_init_registry(root, None, Text)` runs
 - **Then** creates TOML with 25 entries at `.specsync/registry.toml` (or `specsync-registry.toml` on a legacy 3.x layout)
 
 ## Error Cases
@@ -45,6 +49,9 @@ Implements the `specsync init-registry` command. Creates a registry file for cro
 | Condition | Behavior |
 |-----------|----------|
 | Registry exists | Early return |
+| Registry exists but is malformed or inert | Exits 1 without overwriting |
+| Empty/whitespace-only `--name` | Exits 1 before creating the registry |
+| Selected config is malformed or has wrong known path-field shapes | Exits 1 before creating the registry |
 | Write fails | Exits 1 |
 
 ## Dependencies
@@ -69,3 +76,4 @@ Implements the `specsync init-registry` command. Creates a registry file for cro
 | 2026-04-09 | Initial spec |
 | 2026-06-11 | v2: Write to v4 `.specsync/registry.toml` (legacy root path only for un-migrated 3.x projects) |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
+| 2026-07-26 | v4: Add safe name/key serialization, config preflight, truthful no-op/failure behavior, and structured output (#440) |

--- a/specs/cmd_init_registry/context.md
+++ b/specs/cmd_init_registry/context.md
@@ -7,6 +7,10 @@ spec: cmd_init_registry.spec.md
 - The command is a thin wrapper around `registry::generate_registry`; all spec discovery and TOML rendering live in the `registry` module. This command only resolves the project name, guards against overwrite, and writes the file.
 - Project name defaults to the root directory's file name (`root.file_name()`), with `"project"` as a last-resort fallback, so the registry is usable even when run from an oddly-named or root path.
 - Like `init`, it refuses to overwrite an existing `specsync-registry.toml` and simply reports that it already exists.
+- Name validation happens before the existing-file guard so invalid CLI input is never silently ignored.
+- Existing registries are parsed before reporting an idempotent no-op; malformed/inert files fail visibly and remain untouched.
+- Selected config syntax/path-field shapes are checked before generation.
+- All output formats render one outcome record with explicit created/unchanged/failure state.
 
 ## Files to Read First
 
@@ -16,7 +20,7 @@ spec: cmd_init_registry.spec.md
 
 ## Current Status
 
-Implemented and stable. No tests target this file directly; the registry-rendering logic is covered by the `registry` module's own tests.
+Implemented and stable. Integration coverage exercises creation, valid existing no-op, invalid names, hostile TOML values/keys, and JSON output.
 
 ## Notes
 

--- a/specs/cmd_init_registry/requirements.md
+++ b/specs/cmd_init_registry/requirements.md
@@ -14,6 +14,10 @@ spec: cmd_init_registry.spec.md
 - The project name is `name` when provided; otherwise the root directory's file name, falling back to `"project"` when that cannot be determined.
 - If `specsync-registry.toml` already exists, the command prints a message and returns without writing.
 - On success, prints "Created specsync-registry.toml".
+- Empty/whitespace-only names fail without output files.
+- Hostile names and module keys serialize as literal TOML values/keys.
+- Existing valid registries are unchanged visible no-ops; invalid existing files fail visibly.
+- Structured output exposes `success`, `created`, and `unchanged`.
 
 ## Constraints
 
@@ -36,3 +40,15 @@ Acceptance Criteria
 - If `specsync-registry.toml` already exists, the command prints a message and returns without writing.
 - On success, prints "Created specsync-registry.toml".
 
+### REQ-cmd-init-registry-002
+
+Registry initialization SHALL validate inputs and selected configuration, serialize TOML safely, and report every no-op or failure truthfully.
+
+Acceptance Criteria
+
+- Blank names fail before reading/writing registry state.
+- Selected config syntax and known path-field shapes are checked before creation.
+- Generated names, module keys, and paths round-trip literally without TOML injection.
+- Existing valid registries remain byte-identical and report `created = false`, `unchanged = true`.
+- Existing malformed/inert registries fail without overwrite.
+- JSON/Markdown/GitHub/table/CSV outputs distinguish created, unchanged, and failed outcomes.

--- a/specs/cmd_init_registry/tasks.md
+++ b/specs/cmd_init_registry/tasks.md
@@ -6,20 +6,18 @@ spec: cmd_init_registry.spec.md
 
 - [x] Add integration coverage for `init-registry` creation and no-overwrite behavior — Evidence: `init_registry_uses_v4_path_in_migrated_project`, `init_registry_keeps_legacy_path_for_legacy_project`, and `init_registry_is_idempotent_for_v4_registry`.
 
-## Post-5.0 Test Debt
-
-- [ ] Add integration coverage for the `init-registry --name` override.
-
 ## Done
 
 - [x] `cmd_init_registry` writes `specsync-registry.toml` via `registry::generate_registry`.
 - [x] Project name resolution: `--name` → root dir name → `"project"`.
 - [x] No-overwrite guard when the registry already exists.
 - [x] Write-failure path prints an error and exits 1.
+- [x] Integration coverage for `--name`, structured create/no-op output, blank-name rejection, and hostile TOML serialization.
+- [x] Validate existing registries/config before claiming success or writing.
 
 ## Gaps
 
-- No integration or inline unit tests target `src/commands/init_registry.rs`. Registry generation logic itself is covered in the `registry` module's tests.
+- No platform-specific permission-denied fixture; portable blocking-path and create-new behavior cover deterministic write failures.
 
 ## Review Status
 

--- a/specs/cmd_init_registry/testing.md
+++ b/specs/cmd_init_registry/testing.md
@@ -6,12 +6,12 @@ spec: cmd_init_registry.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/commands/init_registry.rs` | (none) | No inline `#[cfg(test)]` module and no integration fixtures target this command. |
-| `src/registry.rs` | cargo test registry | The `registry` module owns tests for `generate_registry`; verify entry discovery and TOML shape there. |
+| `src/commands/init_registry.rs` | `cargo test --test integration init_registry_` | Creation, no-overwrite, structured outcomes, blank-name rejection, hostile serialization |
+| `src/registry.rs` | `cargo test registry::` | Checked parsing, safe generation, entry discovery, exact module identity |
 
 ## Coverage Gaps
 
-- No fixture creates a registry and asserts its contents. Add an integration test that: (1) runs `init-registry` in a project with a few specs and checks `specsync-registry.toml` is written with one entry per spec, (2) verifies `--name` sets the project name, and (3) verifies a second run does not overwrite the existing file.
+- Permission-denied behavior remains platform-dependent; deterministic blocking/create-new failures provide portable coverage.
 
 ## Behavioral Verification
 
@@ -20,13 +20,15 @@ spec: cmd_init_registry.spec.md
 | Generate registry | a project with N specs, no existing registry | `specsync init-registry` | Writes `specsync-registry.toml` (one entry per discovered spec); prints "Created specsync-registry.toml". |
 | Name override | any project | `specsync init-registry --name my-lib` | Registry's project name is `my-lib` instead of the directory name. |
 | Registry exists | `specsync-registry.toml` already present | `specsync init-registry` | Prints "specsync-registry.toml already exists" and writes nothing. |
+| Hostile name/key | quotes/newlines in name and `api.v2` module | `specsync init-registry --name ...` | Valid TOML, literal values, no injected mapping |
 
 ## Regression Matrix
 
 | Case | Required Behavior | Test Obligation |
 |------|-------------------|-----------------|
-| Registry already exists | Early return, no overwrite | Add a fixture before changing the overwrite guard. |
-| `--name` provided | Used as the project name | Add a fixture before changing name resolution. |
+| Registry already exists | Visible unchanged success only when valid | `init_registry_json_reports_create_and_existing_noop_truthfully` |
+| `--name` provided | Used literally as the project name | `init_registry_serializes_hostile_name_and_module_key_as_valid_toml` |
+| Blank `--name` | Exit 1, structured error, no output file | `init_registry_rejects_blank_name_as_structured_failure_without_output_file` |
 | Name not provided | Defaults to root dir name, then `"project"` | Add a fixture before changing the fallback chain. |
 | Write fails | Prints error, exits 1 | Add a focused assertion before changing the write path. |
 

--- a/specs/config/config.spec.md
+++ b/specs/config/config.spec.md
@@ -1,10 +1,11 @@
 ---
 module: config
-version: 8
+version: 9
 status: stable
 files:
   - src/config.rs
 db_tables: []
+implements: [440]
 tracks: [31]
 depends_on:
   - specs/types/types.spec.md
@@ -27,12 +28,14 @@ Loads canonical project configuration from `.specsync/config.toml`, with compati
 | `load_config` | `root: &Path` | `SpecSyncConfig` | Load configuration in canonical-to-legacy precedence order, falling back to defaults with auto-detected source directories |
 | `load_config_from_path` | `config_path: &Path, root: &Path` | `SpecSyncConfig` | Load config from a specific file path (JSON or TOML based on extension), used by migration |
 | `detect_source_dirs` | `root: &Path` | `Vec<String>` | Auto-detect source directories by scanning for supported language files up to 3 levels deep |
+| `detect_source_dirs_with_confidence` | `root: &Path` | `(Vec<String>, bool)` | Return detected source directories plus whether they were genuinely discovered rather than the `src` fallback |
 | `default_schema_pattern` | — | `&'static str` | Returns the default regex for SQL CREATE TABLE extraction |
 | `discover_manifest_modules` | `root: &Path` | `ManifestDiscovery` | Discover modules from manifest files (Package.swift, Cargo.toml, etc.) |
 | `is_legacy_layout` | `root: &Path` | `bool` | Detect whether a project uses a legacy 3.x layout (root-level config files without `.specsync/version` stamp) |
 | `config_to_toml` | `config: &SpecSyncConfig` | `String` | Serialize a `SpecSyncConfig` to the current canonical `.specsync/config.toml` format |
 | `config_to_toml_lossy_fields` | `config: &SpecSyncConfig` | `Vec<&'static str>` | List config fields `config_to_toml` cannot represent (e.g. `customRules`), so `migrate` can refuse rather than silently drop them |
 | `read_config_file` | `path: &Path` | `Option<String>` | Read a config file, dropping a leading UTF-8 BOM (lossless) so it does not attach to the first TOML key or break JSON parsing; shared by the loaders and `migrate` so config reads handle a BOM consistently. `None` if unreadable |
+| `validate_config_file` | `path: &Path` | `Result<(), String>` | Validate JSON/TOML syntax and documented path-field shapes before repair or registry initialization mutates support files |
 
 ## Invariants
 
@@ -42,10 +45,11 @@ Loads canonical project configuration from `.specsync/config.toml`, with compati
 4. 46 common build/cache directories are always excluded from source detection (node_modules, target, .git, dist, etc.)
 5. `detect_source_dirs` falls back to `["src"]` if no source files are found
 6. Root-level source files (no subdirectories) produce `["."]` as source dirs
-7. TOML parsing is zero-dependency — uses line-by-line string parsing, not a TOML library
+7. Compatibility loading preserves the existing line-oriented reader, while mutation preflight validates complete TOML syntax with the `toml` parser.
 8. The reader accepts both TOML string kinds for scalar and array values: basic `"..."` strings (backslash escapes decoded) and literal `'...'` strings (taken verbatim, no escape processing); a `#`, `,`, `[`, or `]` appearing inside either kind is treated as content, not as a comment or array structure
 9. A config file that is absent is expected — defaults apply silently. But a config file that **exists yet cannot be read** (e.g. not valid UTF-8) fails loud: a warning naming the file is printed and built-in defaults are used, rather than silently reverting to defaults (which would downgrade enforcement — strict→warn, exit 1→0 — with no signal). The same applies to the optional local override file (`config.local.toml`)
 10. Retired AI key names are ignored with migration guidance; their values are never retained, serialized, printed, or executed
+11. Canonical TOML serialization escapes every control character and quoted table-key component so detected filesystem names cannot inject configuration syntax.
 
 ## Behavioral Examples
 
@@ -81,6 +85,7 @@ Loads canonical project configuration from `.specsync/config.toml`, with compati
 | Config file absent | Silently uses `SpecSyncConfig::default()` with auto-detected source dirs (expected) |
 | Malformed JSON config | Prints warning to stderr, falls back to defaults |
 | Empty project root | Returns `["src"]` as source dirs |
+| Existing malformed config selected for repair/init-registry | Validation returns an error before support files or registries are written |
 
 ## Dependencies
 
@@ -116,6 +121,7 @@ Loads canonical project configuration from `.specsync/config.toml`, with compati
 | 2026-07-14 | CHG-0025-address-all-unresolved-review-feedback-on-pr-366: Address all unresolved review feedback on PR 366 |
 | 2026-07-14 | CHG-0034-support-extensionless-source-discovery-through-an-explicit-include-extensionless: Support extensionless source discovery through an explicit include_extensionless setting while preserving omitted and empty source_extensions defaults, with parser, scanner, strict file coverage, LOC coverage, and wizard regressions for extensionless-only and mixed projects |
 | 2026-07-14 | CHG-0039-allow-draft-specs-to-declare-planned-missing-source-mappings-without-failing-str: Allow draft specs to declare planned missing source mappings without failing strict validation while preserving path safety ownership enforcement exact coverage and complete notice contracts |
+| 2026-07-26 | v9: Expose truthful source-detection confidence, checked mutation preflight, and control-safe TOML serialization (#440) |
 
 ## Config File Structure
 

--- a/specs/config/context.md
+++ b/specs/config/context.md
@@ -8,6 +8,9 @@ spec: config.spec.md
 - Retired AI key names are recognized only to emit value-safe migration guidance, then ignored.
 - Configuration never interprets provider credentials or commands.
 - Source discovery recognizes supported language files plus default measurable HTML, HTM, and CSS content at the root or within top-level directories while preserving ignored-directory and empty-project behavior.
+- Callers that describe detection use `detect_source_dirs_with_confidence` so the compatibility `src` fallback is never reported as discovered evidence.
+- Mutating initialization commands call `validate_config_file` before repair/generation. Unknown extension keys remain allowed, while malformed syntax and wrong known path-field shapes fail before writes.
+- Canonical TOML escaping covers all control characters and quoted key components.
 
 ## Files to Read First
 
@@ -16,4 +19,4 @@ spec: config.spec.md
 
 ## Current Status
 
-Stable 5.0 secret-free configuration schema.
+Stable 5.0 secret-free configuration schema with checked mutation preflight and truthful source-detection metadata.

--- a/specs/config/requirements.md
+++ b/specs/config/requirements.md
@@ -54,3 +54,15 @@ Acceptance Criteria
 - Canonical TOML reads and emits `require_draft_files = true` without losing the value during migration.
 - Legacy JSON reads `requireDraftFiles` and recognizes it as a supported key.
 - The canonical configuration structure table documents both serialized names and behavior.
+
+### REQ-config-005
+
+Configuration discovery and serialization SHALL provide truthful, safe evidence to initialization commands.
+
+Acceptance Criteria
+
+- Source-directory discovery distinguishes real manifest/scan results from the `["src"]` compatibility fallback.
+- Existing JSON/TOML selected by a mutating initialization command is syntax-checked before any write.
+- Present `specs_dir`/`specsDir` values are non-empty strings and present source-directory lists contain only strings.
+- Unknown syntactically valid extension fields remain allowed.
+- Canonical TOML string and quoted-key output escapes every control character needed to remain valid TOML.

--- a/specs/config/tasks.md
+++ b/specs/config/tasks.md
@@ -12,3 +12,6 @@ spec: config.spec.md
 - [x] Remove embedded inference fields
 - [x] Ignore legacy AI key names with value-safe migration guidance
 - [x] Auto-detect zero-config HTML, HTM, and CSS source directories
+- [x] Distinguish actual source discovery from the empty-project `src` fallback
+- [x] Validate selected config syntax/shapes before initialization repairs or registry writes
+- [x] Serialize control characters safely in canonical TOML

--- a/specs/config/testing.md
+++ b/specs/config/testing.md
@@ -12,3 +12,6 @@ spec: config.spec.md
 | Missing config | Auto-detect source directories |
 | Static-only root or nested project | Detect `.` or the containing top-level directory from HTML, HTM, or CSS |
 | Serialization | No retired inference keys |
+| Detection confidence | Empty projects return `(["src"], false)`; real manifest/scan sources return `true` |
+| Mutation preflight | `validate_config_file_rejects_syntax_and_required_field_shapes` |
+| Control-safe TOML | `config_to_toml_escapes_every_control_character_as_valid_toml` |

--- a/specs/registry/context.md
+++ b/specs/registry/context.md
@@ -4,9 +4,9 @@ spec: registry.spec.md
 
 ## Key Decisions
 
-- **TOML registry format**: The registry uses a simple TOML file (`specsync-registry.toml`) with a `[registry]` section for metadata and a `[specs]` section mapping module names to spec file paths. This is human-readable and easy to parse.
+- **TOML registry format**: Generated registries use `[registry]` metadata plus a `[specs]` module-to-path table. The documented `[[modules]]` array-of-tables shape is accepted for compatibility.
 - **GitHub raw URL fetching**: Remote registries are fetched from GitHub's raw content URL (`raw.githubusercontent.com`) with a 10-second HTTP timeout. No authentication required for public repos.
-- **Zero-dependency TOML parsing**: Like other modules, registry parsing is line-by-line string operations rather than a TOML library.
+- **Checked TOML parsing and serialization**: Registry syntax is parsed with the `toml` crate. Known fields are validated for type and shape, duplicate mappings fail closed, and generated values/keys are encoded without interpolation.
 - **Template files excluded**: Specs starting with `_` (like `_template.spec.md`) are skipped during registry generation to keep the registry clean.
 - **Module name from frontmatter**: The registry extracts the `module` field from each spec's frontmatter rather than inferring from file paths, ensuring consistency with the spec's own identity.
 - **Alphabetical sorting**: Generated registry entries are sorted by module name for deterministic output.
@@ -17,7 +17,7 @@ spec: registry.spec.md
 
 ## Current Status
 
-Fully implemented. Local registry generation and remote fetching both work. The `resolve` CLI command uses this module for cross-project dependency validation. Inert 5.0.1-era stubs (no registry `name`, no `[specs]` mappings) load as absent through `load_local_registry` so module resolution can fall back to conventional paths.
+Fully implemented. Local registry generation and remote fetching both work. Both `[specs]` and `[[modules]]` mappings are retained. Inert 5.0.1-era stubs load as absent, malformed registries fail closed, and hostile project/module names serialize as valid TOML without identity changes.
 
 ## Notes
 

--- a/specs/registry/registry.spec.md
+++ b/specs/registry/registry.spec.md
@@ -1,10 +1,11 @@
 ---
 module: registry
-version: 5
+version: 6
 status: stable
 files:
   - src/registry.rs
 db_tables: []
+implements: [413, 440]
 tracks: [52]
 depends_on:
   - specs/types/types.spec.md
@@ -14,7 +15,7 @@ depends_on:
 
 ## Purpose
 
-Manages cross-project spec registries for dependency resolution. Generates `specsync-registry.toml` from local spec files, fetches remote registries from GitHub repos via HTTPS, and parses the TOML registry format using zero-dependency parsing.
+Manages cross-project spec registries for dependency resolution. Generates safe registry TOML from local spec files, fetches remote registries from GitHub repos via HTTPS, and parses supported registry shapes with checked TOML syntax and field validation.
 
 ## Public API
 
@@ -49,14 +50,15 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 ## Invariants
 
 1. Remote registry fetch uses a 10-second HTTP timeout
-2. Registry TOML format: `[registry]` section with `name`, `[specs]` section with `module = "path"` entries
+2. Registry TOML accepts both the emitted `[specs]` table (`module = "path"`) and the documented `[[modules]]` array-of-tables (`name` plus `spec`)
 3. `generate_registry` skips template files (names starting with `_`)
 4. Module names are extracted from spec frontmatter, not file paths
 5. Generated registry entries are sorted alphabetically by module name
 6. `RemoteRegistry::has_spec` performs exact module name matching
-7. TOML parsing is zero-dependency — uses line-by-line string parsing
+7. Registry parsing uses a real TOML parser and rejects malformed syntax, wrong known-field types or shapes, empty mapping identities or paths, and duplicate module mappings
 8. Local registry resolution prefers the v4 `.specsync/registry.toml` location; the legacy root-level `specsync-registry.toml` is only used for un-migrated 3.x layouts
-9. Inert 5.0.1-era stubs (no registry name and no `[specs]` mappings) are treated as absent; non-inert unparsable registries fail closed through `load_local_registry`
+9. Inert 5.0.1-era stubs (no registry name and no `[specs]` or `[[modules]]` mappings) are treated as absent; non-inert invalid registries fail closed through `load_local_registry`
+10. Generated project names, module keys, and spec paths are serialized as TOML strings/keys without permitting syntax injection or changing module identity.
 
 ## Behavioral Examples
 
@@ -78,6 +80,12 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 - **When** `has_spec("auth")` is called
 - **Then** returns `true`
 
+**Scenario: Generate hostile names safely**
+
+- **Given** a project name containing quotes/newlines and a module named `api.v2`
+- **When** `generate_registry` renders the registry
+- **Then** the TOML parses, the project name round-trips exactly, and `api.v2` remains one module key
+
 **Scenario: Tolerate inert 5.0.1 registry stub**
 
 - **Given** a local `.specsync/registry.toml` containing only `version = 1` and an empty `[modules]` table
@@ -90,9 +98,11 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 |-----------|----------|
 | HTTP request fails | Error: "HTTP request failed: {details}" |
 | Repo has no registry file | Error: "HTTP 404 — {repo} may not have a specsync-registry.toml" |
-| Malformed TOML (no name) | `parse_registry` returns `None` |
+| Malformed TOML | `load_local_registry` returns `Err` with the registry path and parser diagnostic |
+| Wrong known-field type or shape | `load_local_registry` returns `Err` identifying the invalid field |
+| Duplicate module mapping across supported shapes | Registry parsing fails with `duplicate module mapping` |
 | Local registry file unreadable | `load_registry` returns `None`; `load_local_registry` returns `Err` |
-| Inert legacy stub (no name, no `[specs]` mappings) | `load_local_registry` returns `Ok(None)`; `load_registry` returns `None` |
+| Inert legacy stub (no name, no `[specs]` or `[[modules]]` mappings) | `load_local_registry` returns `Ok(None)`; `load_registry` returns `None` |
 | Non-inert unparsable local registry | `load_local_registry` returns `Err`; `load_registry` returns `None` |
 
 ## Dependencies
@@ -103,6 +113,7 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 |--------|-------------|
 | types | `RegistryEntry` |
 | ureq | HTTP client for fetching remote registries |
+| toml | TOML syntax, value parsing, and safe string serialization |
 
 ### Consumed By
 
@@ -120,3 +131,4 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 | 2026-06-11 | v3: Added `local_registry_path`; `load_registry`/`register_module` now resolve the v4 `.specsync/registry.toml` location with legacy fallback |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-19 | CHG-0059-tolerate-inert-5-0-1-registry-toml-stubs-so-module-resolution-falls-back-to-defa: Tolerate inert 5.0.1 registry.toml stubs so module resolution falls back to default specs layout without failing closed on empty legacy stubs |
+| 2026-07-26 | v6: Parse both registry shapes as checked TOML and serialize hostile names, keys, and paths without injection (#413, #440) |

--- a/specs/registry/requirements.md
+++ b/specs/registry/requirements.md
@@ -17,7 +17,10 @@ spec: registry.spec.md
 - Registry entries are sorted alphabetically by module name
 - `fetch_remote_registry` uses HTTPS with a 10-second timeout
 - `RemoteRegistry::has_spec` performs exact module name matching
-- TOML parsing is zero-dependency (line-by-line string parsing)
+- Registry parsing uses a real TOML parser and validates supported field types and shapes
+- Both emitted `[specs]` mappings and documented `[[modules]]` entries are accepted
+- Generated registry names, keys, and paths are encoded without TOML injection
+- Invalid or ambiguous non-inert registries fail closed with a diagnostic
 - HTTP errors and timeouts produce clear error messages
 
 ## Constraints
@@ -44,7 +47,10 @@ Acceptance Criteria
 - Registry entries are sorted alphabetically by module name
 - `fetch_remote_registry` uses HTTPS with a 10-second timeout
 - `RemoteRegistry::has_spec` performs exact module name matching
-- TOML parsing is zero-dependency (line-by-line string parsing)
+- Registry parsing uses a real TOML parser and validates supported field types and shapes
+- Both emitted `[specs]` mappings and documented `[[modules]]` entries are accepted
+- Generated registry names, keys, and paths are encoded without TOML injection
+- Invalid or ambiguous non-inert registries fail closed with a diagnostic
 - HTTP errors and timeouts produce clear error messages
 
 ### REQ-registry-002
@@ -59,3 +65,15 @@ Acceptance Criteria
 - A file that is not inert but cannot parse as a named registry fails closed through the Result-based local loader.
 - Best-effort `load_registry` continues to return `None` for missing, inert, and unparsable content.
 
+### REQ-registry-003
+
+The registry module SHALL preserve every valid mapping in either supported TOML shape and reject invalid, ambiguous, or injection-prone registry content.
+
+Acceptance Criteria
+
+- A named `[specs]` table maps each string-valued module key to its declared spec path.
+- A named `[[modules]]` array maps each non-empty `name` to its non-empty `spec` path.
+- Malformed TOML and wrong known-field types or shapes fail closed.
+- Duplicate module names across supported shapes fail closed instead of selecting one mapping.
+- Generated project names, module keys, and paths round-trip as literal values without creating extra TOML keys or tables.
+- The nameless, mapping-free 5.0.1 `[modules]` table placeholder remains inert for compatibility.

--- a/specs/registry/tasks.md
+++ b/specs/registry/tasks.md
@@ -15,7 +15,7 @@ spec: registry.spec.md
 
 - [x] Local registry generation from specs directory
 - [x] Remote registry fetching from GitHub raw URLs
-- [x] Zero-dependency TOML parsing
+- [x] Checked TOML parsing for `[specs]` and `[[modules]]`
 - [x] Template file exclusion
 - [x] Module name extraction from frontmatter
 - [x] Alphabetically sorted output
@@ -23,12 +23,14 @@ spec: registry.spec.md
 - [x] `register_module` — idempotent append of a module entry to an existing registry
 - [x] Cross-repo content verification: `fetch_remote_spec`, `parse_remote_spec`, `RemoteSpec`
 - [x] Tolerate inert 5.0.1 registry.toml stubs via `load_local_registry`
+- [x] Fail closed on malformed TOML, invalid supported shapes, and duplicate mappings
+- [x] Serialize hostile registry names, module keys, and paths safely
 
 ## Gaps
 
 - No caching — every `resolve --remote` re-fetches all remote registries
 - Private repos are inaccessible (no auth token support)
-- No validation of registry TOML structure (malformed files fail silently)
+- No version negotiation between registry producers and consumers
 
 ## Review Status
 

--- a/specs/registry/testing.md
+++ b/specs/registry/testing.md
@@ -6,7 +6,7 @@ spec: registry.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/registry.rs` | cargo test registry:: | `test_parse_registry`, `test_parse_registry_empty`, `inert_legacy_registry_stub_is_detected`, `load_local_registry_treats_inert_stub_as_absent`, `load_local_registry_fails_closed_on_non_inert_unparsable`, `test_extract_module_name`, `test_remote_registry_has_spec` |
+| `src/registry.rs` | `cargo test registry::` | Both mapping shapes, malformed TOML, wrong types/shapes, duplicate mappings, inert stubs, safe generation, and exact key identity |
 
 ## Coverage Gaps
 
@@ -19,6 +19,7 @@ spec: registry.spec.md
 | Fetch remote registry | a GitHub repo "corvid-labs/algochat" with a `specsync-registry.toml` at root | `fetch_remote_registry("corvid-labs/algochat")` is called | returns `Ok(RemoteRegistry)` with parsed module-to-path mappings |
 | Generate registry from local specs | specs at `specs/auth/auth.spec.md` and `specs/messaging/messaging.spec.md` | `generate_registry(root, "myproject", "specs")` is called | returns TOML string with `[registry]\nname = "myproject"\n\n[specs]\nauth = "specs/auth/auth.spec.md"\nmessaging = "specs/messaging/messaging.spec.md"\n` |
 | Check module existence | a `RemoteRegistry` with specs for "auth" and "messaging" | `has_spec("auth")` is called | returns `true` |
+| Generate hostile names | quoted/newline project name plus `api.v2` module | generate and parse the registry | literal project name and exact module identity survive; no injected key appears |
 
 ## Regression Matrix
 
@@ -26,7 +27,10 @@ spec: registry.spec.md
 |------|-------------------|-----------------|
 | HTTP request fails | Error: "HTTP request failed: {details}" | Keep or add a focused assertion before changing this behavior |
 | Repo has no registry file | Error: "HTTP 404 — {repo} may not have a specsync-registry.toml" | Keep or add a focused assertion before changing this behavior |
-| Malformed TOML (no name) | `parse_registry` returns `None` | Keep or add a focused assertion before changing this behavior |
+| Malformed TOML with a surviving `name` line | `load_local_registry` returns `Err` | `load_local_registry_fails_closed_on_malformed_toml_with_name_line` |
+| Non-string `[specs]` path | field-specific parse and load error | `specs_mapping_with_non_string_path_is_an_error` |
+| Duplicate mapping across supported shapes | parse error rather than silent selection | `duplicate_mapping_across_supported_shapes_is_an_error` |
+| Dotted module identity | quoted as one TOML key | `generated_registry_quotes_non_bare_module_keys_without_changing_identity` |
 | Local registry file unreadable | `load_registry` returns `None` | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,7 +90,13 @@ pub enum Command {
         batch: Vec<String>,
     },
     /// Create .specsync/config.toml and initialize the verified SDD layout
-    Init,
+    Init {
+        /// Repair a partially-initialized project: restore missing .specsync
+        /// support files (version stamp, .gitignore, sdd.json, directories)
+        /// without touching the existing config
+        #[arg(long)]
+        repair: bool,
+    },
     /// Score spec quality (0-100) with letter grades and improvement suggestions
     Score {
         /// Show detailed per-category breakdown explaining exactly why each spec lost points
@@ -205,7 +211,10 @@ pub enum Command {
     },
     /// Quick-create a minimal spec for a module (auto-detects source files)
     New {
-        /// Module name for the new spec
+        /// Module name for the new spec.
+        /// Rules: 1-64 chars — letters, digits, `-`, `_`, `.`; must start with a
+        /// letter or digit; no spaces, path separators, or reserved names
+        /// (`change`, `specs`, Windows device names like `con`).
         name: String,
         /// Also create required companions (requirements.md, tasks.md, context.md, testing.md)
         /// and optional design.md when design artifacts are enabled

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -967,4 +967,23 @@ mod tests {
             .is_ok()
         );
     }
+
+    #[test]
+    fn init_repair_preserves_global_format_grammar_without_force_mode() {
+        let repaired = Cli::try_parse_from(["specsync", "init", "--repair", "--json"]).unwrap();
+        assert!(repaired.json);
+        assert!(matches!(
+            repaired.command,
+            Some(Command::Init { repair: true })
+        ));
+
+        let plain = Cli::try_parse_from(["specsync", "--format", "csv", "init"]).unwrap();
+        assert_eq!(plain.format, crate::types::OutputFormat::Csv);
+        assert!(matches!(
+            plain.command,
+            Some(Command::Init { repair: false })
+        ));
+
+        assert!(Cli::try_parse_from(["specsync", "init", "--force"]).is_err());
+    }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,12 +1,13 @@
 use colored::Colorize;
 use dialoguer::{Confirm, Input};
+use serde::Serialize;
 use std::fs;
-use std::io::IsTerminal;
-use std::path::Path;
+use std::io::{IsTerminal, Write};
+use std::path::{Path, PathBuf};
 use std::process;
 
-use crate::config::{config_to_toml, detect_source_dirs_with_confidence};
-use crate::types::SpecSyncConfig;
+use crate::config::{config_to_toml, detect_source_dirs_with_confidence, validate_config_file};
+use crate::types::{OutputFormat, SpecSyncConfig};
 
 /// Version stamp written to `.specsync/version` for fresh projects.
 const PROJECT_VERSION: &str = crate::change::SDD_VERSION;
@@ -19,102 +20,291 @@ const V4_DIRS: &[&str] = &[
     ".specsync/archive/changes",
 ];
 
-pub fn cmd_init(root: &Path, repair: bool, format: crate::types::OutputFormat) {
-    let json = matches!(format, crate::types::OutputFormat::Json);
+#[derive(Debug, Serialize)]
+struct InitReport {
+    command: &'static str,
+    success: bool,
+    created: bool,
+    repaired: bool,
+    unchanged: bool,
+    config: Option<String>,
+    source_dirs: Vec<String>,
+    detected: Option<bool>,
+    source_dirs_detected: Option<bool>,
+    missing: Vec<String>,
+    restored: Vec<String>,
+    warnings: Vec<String>,
+    repair_hint: Option<&'static str>,
+    migration_hint: Option<&'static str>,
+    initialized_ancestor: Option<String>,
+    error: Option<String>,
+}
+
+impl InitReport {
+    fn failure(error: String, config: Option<String>, ancestor: Option<PathBuf>) -> Self {
+        Self {
+            command: "init",
+            success: false,
+            created: false,
+            repaired: false,
+            unchanged: true,
+            config,
+            source_dirs: Vec::new(),
+            detected: None,
+            source_dirs_detected: None,
+            missing: Vec::new(),
+            restored: Vec::new(),
+            warnings: Vec::new(),
+            repair_hint: None,
+            migration_hint: None,
+            initialized_ancestor: ancestor.map(|path| path.display().to_string()),
+            error: Some(error),
+        }
+    }
+}
+
+pub fn cmd_init(root: &Path, repair: bool, format: OutputFormat) {
+    match execute_init(root, repair) {
+        Ok(report) => {
+            let should_bootstrap = report.created && matches!(format, OutputFormat::Text);
+            render_init_report(&report, format);
+            if should_bootstrap {
+                guided_sdd_bootstrap(root);
+            }
+        }
+        Err(report) => {
+            render_init_report(&report, format);
+            process::exit(1);
+        }
+    }
+}
+
+fn execute_init(root: &Path, repair: bool) -> Result<InitReport, Box<InitReport>> {
     // Refuse to clobber any existing config — current or legacy.
     let v4_toml = root.join(".specsync/config.toml");
     let v4_json = root.join(".specsync/config.json");
     let legacy_json = root.join("specsync.json");
     let legacy_toml = root.join(".specsync.toml");
     if v4_toml.exists() || v4_json.exists() {
-        let existing = if v4_toml.exists() {
-            ".specsync/config.toml"
+        let (existing, path) = if v4_toml.exists() {
+            (".specsync/config.toml", v4_toml)
         } else {
-            ".specsync/config.json"
+            (".specsync/config.json", v4_json)
         };
+        if let Err(error) = validate_config_file(&path) {
+            return Err(Box::new(InitReport::failure(
+                error,
+                Some(existing.to_string()),
+                None,
+            )));
+        }
         if repair {
-            repair_layout(root, existing, json);
-            return;
+            return repair_layout(root, existing, &path).map_err(|error| {
+                Box::new(InitReport::failure(error, Some(existing.to_string()), None))
+            });
         }
         let missing = missing_support_files(root);
-        if json {
-            println!(
-                "{}",
-                serde_json::json!({
-                    "created": false,
-                    "config": existing,
-                    "missing": missing,
-                    "repair_hint": "specsync init --repair",
-                })
-            );
-        } else {
-            println!("{existing} already exists");
-            if !missing.is_empty() {
-                println!(
-                    "  {} missing support file(s): {}",
-                    "!".yellow(),
-                    missing.join(", ")
-                );
-                println!(
-                    "  Run `specsync init --repair` to restore them (your config is left untouched)."
-                );
-            }
-        }
-        return;
+        return Ok(InitReport {
+            command: "init",
+            success: true,
+            created: false,
+            repaired: false,
+            unchanged: true,
+            config: Some(existing.to_string()),
+            source_dirs: Vec::new(),
+            detected: None,
+            source_dirs_detected: None,
+            repair_hint: (!missing.is_empty()).then_some("specsync init --repair"),
+            missing,
+            restored: Vec::new(),
+            warnings: Vec::new(),
+            migration_hint: None,
+            initialized_ancestor: None,
+            error: None,
+        });
     }
     if legacy_json.exists() {
-        println!("specsync.json already exists (legacy 3.x layout — run `specsync migrate`)");
-        return;
+        if repair {
+            return Err(Box::new(InitReport::failure(
+                "cannot repair legacy config specsync.json; run `specsync migrate` first"
+                    .to_string(),
+                Some("specsync.json".to_string()),
+                None,
+            )));
+        }
+        return Ok(legacy_init_report("specsync.json"));
     }
     if legacy_toml.exists() {
-        println!(".specsync.toml already exists (legacy 3.x layout — run `specsync migrate`)");
-        return;
+        if repair {
+            return Err(Box::new(InitReport::failure(
+                "cannot repair legacy config .specsync.toml; run `specsync migrate` first"
+                    .to_string(),
+                Some(".specsync.toml".to_string()),
+                None,
+            )));
+        }
+        return Ok(legacy_init_report(".specsync.toml"));
     }
 
     // Subdir footgun: running `init` inside a subdirectory of an initialized
     // project must not create a nested .specsync — point at the parent instead.
     if let Some(parent) = find_initialized_ancestor(root) {
-        eprintln!(
-            "{} A spec-sync project is already initialized at {} — no nested .specsync was created.",
-            "error:".red().bold(),
-            parent.display()
-        );
-        eprintln!(
-            "  Run from that root or pass `--root {}`.",
-            parent.display()
-        );
-        process::exit(1);
+        return Err(Box::new(InitReport::failure(
+            format!(
+                "a spec-sync project is already initialized at {}; no nested .specsync was created",
+                parent.display()
+            ),
+            None,
+            Some(parent),
+        )));
     }
 
     let (detected_dirs, actually_detected) = detect_source_dirs_with_confidence(root);
-    let dirs_display = detected_dirs.join(", ");
+    preflight_layout(root).map_err(|error| Box::new(InitReport::failure(error, None, None)))?;
+    for config in [
+        ".specsync/config.toml",
+        ".specsync/config.json",
+        "specsync.json",
+        ".specsync.toml",
+    ] {
+        preflight_absent_path(root, config)
+            .map_err(|error| Box::new(InitReport::failure(error, None, None)))?;
+    }
 
     if let Err(e) = write_current_layout(root, &detected_dirs) {
-        eprintln!("{} {e}", "error:".red().bold());
-        process::exit(1);
+        return Err(Box::new(InitReport::failure(e, None, None)));
     }
 
     if let Err(error) =
         crate::change::write_default_policy(root, crate::change::detect_verification_commands(root))
     {
-        eprintln!("{} {error}", "error:".red().bold());
-        process::exit(1);
+        return Err(Box::new(InitReport::failure(error, None, None)));
     }
 
-    if json {
-        println!(
-            "{}",
-            serde_json::json!({
-                "created": true,
-                "config": ".specsync/config.toml",
-                "source_dirs": detected_dirs,
-                "detected": actually_detected,
-            })
+    let mut restored = Vec::new();
+    let mut warnings = Vec::new();
+    // Ensure .specsync/hashes.json is gitignored (hash cache is local-only)
+    match ensure_hashes_gitignored(root) {
+        Ok(true) => restored.push(".gitignore entry (.specsync/hashes.json)".to_string()),
+        Ok(false) => {}
+        Err(error) => warnings.push(error),
+    }
+
+    Ok(InitReport {
+        command: "init",
+        success: true,
+        created: true,
+        repaired: false,
+        unchanged: false,
+        config: Some(".specsync/config.toml".to_string()),
+        source_dirs: detected_dirs,
+        detected: Some(actually_detected),
+        source_dirs_detected: Some(actually_detected),
+        missing: Vec::new(),
+        restored,
+        warnings,
+        repair_hint: None,
+        migration_hint: None,
+        initialized_ancestor: None,
+        error: None,
+    })
+}
+
+fn legacy_init_report(config: &str) -> InitReport {
+    InitReport {
+        command: "init",
+        success: true,
+        created: false,
+        repaired: false,
+        unchanged: true,
+        config: Some(config.to_string()),
+        source_dirs: Vec::new(),
+        detected: None,
+        source_dirs_detected: None,
+        missing: Vec::new(),
+        restored: Vec::new(),
+        warnings: Vec::new(),
+        repair_hint: None,
+        migration_hint: Some("specsync migrate"),
+        initialized_ancestor: None,
+        error: None,
+    }
+}
+
+fn render_init_report(report: &InitReport, format: OutputFormat) {
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string(report).expect("init report must serialize")
+            );
+        }
+        OutputFormat::Markdown | OutputFormat::Github => {
+            let status = if report.success { "success" } else { "failure" };
+            println!("## SpecSync init\n");
+            println!("- **Status:** {status}");
+            println!("- **Created:** {}", report.created);
+            println!("- **Repaired:** {}", report.repaired);
+            println!("- **Unchanged:** {}", report.unchanged);
+            if let Some(config) = &report.config {
+                println!("- **Config:** `{config}`");
+            }
+            if let Some(error) = &report.error {
+                println!("- **Error:** {error}");
+            }
+        }
+        OutputFormat::Table => {
+            println!("FIELD\tVALUE");
+            println!(
+                "status\t{}",
+                if report.success { "success" } else { "failure" }
+            );
+            println!("created\t{}", report.created);
+            println!("repaired\t{}", report.repaired);
+            println!("unchanged\t{}", report.unchanged);
+            if let Some(config) = &report.config {
+                println!("config\t{config}");
+            }
+            if let Some(error) = &report.error {
+                println!("error\t{error}");
+            }
+        }
+        OutputFormat::Csv => {
+            println!("command,success,created,repaired,unchanged,config,error");
+            println!(
+                "init,{},{},{},{},{},{}",
+                report.success,
+                report.created,
+                report.repaired,
+                report.unchanged,
+                csv_field(report.config.as_deref().unwrap_or_default()),
+                csv_field(report.error.as_deref().unwrap_or_default())
+            );
+        }
+        OutputFormat::Text => render_init_text(report),
+    }
+}
+
+fn render_init_text(report: &InitReport) {
+    if !report.success {
+        eprintln!(
+            "{} {}",
+            "error:".red().bold(),
+            report.error.as_deref().unwrap_or("initialization failed")
         );
-    } else {
+        if let Some(parent) = &report.initialized_ancestor {
+            eprintln!("  Run from that root or pass `--root {parent}`.");
+        }
+        return;
+    }
+
+    if report.created {
         println!("{} Created .specsync/config.toml (5.0 layout)", "✓".green());
-        if actually_detected {
-            println!("  Detected source directories: {dirs_display}");
+        if report.source_dirs_detected == Some(true) {
+            println!(
+                "  Detected source directories: {}",
+                report.source_dirs.join(", ")
+            );
         } else {
             println!(
                 "  {} No source directories detected — defaulted to source_dirs = [\"src\"].",
@@ -122,16 +312,125 @@ pub fn cmd_init(root: &Path, repair: bool, format: crate::types::OutputFormat) {
             );
             println!("  Edit .specsync/config.toml if your sources live elsewhere.");
         }
+        if report
+            .restored
+            .iter()
+            .any(|path| path == ".gitignore entry (.specsync/hashes.json)")
+        {
+            println!("{} Added .specsync/hashes.json to .gitignore", "✓".green());
+        }
+    } else if report.repaired {
+        if report.restored.is_empty() {
+            println!(
+                "{} Nothing to repair — .specsync layout is complete",
+                "✓".green()
+            );
+        } else {
+            println!("{} Repaired: {}", "✓".green(), report.restored.join(", "));
+        }
+    } else if let Some(config) = &report.config {
+        if report.migration_hint.is_some() {
+            println!("{config} already exists (legacy 3.x layout — run `specsync migrate`)");
+        } else {
+            println!("{config} already exists");
+            if !report.missing.is_empty() {
+                println!(
+                    "  {} missing support file(s): {}",
+                    "!".yellow(),
+                    report.missing.join(", ")
+                );
+                println!(
+                    "  Run `specsync init --repair` to restore them (your config is left untouched)."
+                );
+            }
+        }
     }
-
-    // Ensure .specsync/hashes.json is gitignored (hash cache is local-only)
-    match ensure_hashes_gitignored(root) {
-        Ok(true) if !json => println!("{} Added .specsync/hashes.json to .gitignore", "✓".green()),
-        Ok(_) => {}
-        Err(e) => eprintln!("{} {e}", "warning:".yellow().bold()),
+    for warning in &report.warnings {
+        eprintln!("{} {warning}", "warning:".yellow().bold());
     }
+}
 
-    guided_sdd_bootstrap(root);
+fn csv_field(value: &str) -> String {
+    if value.contains(',') || value.contains('"') || value.contains('\n') || value.contains('\r') {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+fn root_gitignore_has_hash_entry(root: &Path) -> bool {
+    fs::read(root.join(".gitignore"))
+        .ok()
+        .is_some_and(|content| gitignore_has_hash_entry(&content))
+}
+
+fn gitignore_has_hash_entry(content: &[u8]) -> bool {
+    content.split(|byte| *byte == b'\n').any(|line| {
+        let start = line
+            .iter()
+            .position(|byte| !byte.is_ascii_whitespace())
+            .unwrap_or(line.len());
+        let end = line
+            .iter()
+            .rposition(|byte| !byte.is_ascii_whitespace())
+            .map_or(start, |index| index + 1);
+        &line[start..end] == b".specsync/hashes.json"
+    })
+}
+
+fn preflight_layout(root: &Path) -> Result<(), String> {
+    preflight_directory(root, ".specsync")?;
+    for directory in V4_DIRS {
+        preflight_directory(root, directory)?;
+    }
+    for file in [
+        ".specsync/version",
+        ".specsync/.gitignore",
+        ".specsync/sdd.json",
+    ] {
+        preflight_regular_file(root, file)?;
+    }
+    Ok(())
+}
+
+fn preflight_directory(root: &Path, relative: &str) -> Result<(), String> {
+    let path = root.join(relative);
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(format!("{relative} is a symlink; expected a directory"))
+        }
+        Ok(metadata) if !metadata.is_dir() => Err(format!(
+            "{relative} blocks initialization; expected a directory"
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("failed to inspect {relative}: {error}")),
+    }
+}
+
+fn preflight_regular_file(root: &Path, relative: &str) -> Result<(), String> {
+    let path = root.join(relative);
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            Err(format!("{relative} is a symlink; expected a regular file"))
+        }
+        Ok(metadata) if !metadata.is_file() => Err(format!(
+            "{relative} blocks initialization; expected a regular file"
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("failed to inspect {relative}: {error}")),
+    }
+}
+
+fn preflight_absent_path(root: &Path, relative: &str) -> Result<(), String> {
+    match fs::symlink_metadata(root.join(relative)) {
+        Ok(_) => Err(format!(
+            "{relative} already occupies a configuration path; initialization will not overwrite it"
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("failed to inspect {relative}: {error}")),
+    }
 }
 
 /// Support files a healthy `.specsync/` layout must have; missing ones are
@@ -152,70 +451,57 @@ fn missing_support_files(root: &Path) -> Vec<String> {
             missing.push(format!("{dir}/"));
         }
     }
+    if !root_gitignore_has_hash_entry(root) {
+        missing.push(".gitignore entry (.specsync/hashes.json)".to_string());
+    }
     missing
 }
 
 /// Restore missing `.specsync/` support files without touching the existing
 /// config. Also sanity-checks that the config is at least plausible.
-fn repair_layout(root: &Path, existing_config: &str, json: bool) {
+fn repair_layout(
+    root: &Path,
+    existing_config: &str,
+    config_path: &Path,
+) -> Result<InitReport, String> {
+    validate_config_file(config_path)?;
+    preflight_layout(root)?;
+
     let mut restored: Vec<String> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
-
-    // Sanity-check the existing config so a corrupt one is diagnosed, not ignored.
-    if let Ok(content) = fs::read_to_string(root.join(existing_config))
-        && !content.contains("specs_dir")
-    {
-        warnings.push(format!(
-            "{existing_config} has no `specs_dir` key — it may be corrupt; fix or regenerate it manually"
-        ));
-    }
 
     for dir in V4_DIRS {
         let path = root.join(dir);
         if !path.is_dir() {
-            match fs::create_dir_all(&path) {
-                Ok(_) => restored.push(format!("{dir}/")),
-                Err(e) => {
-                    eprintln!("{} Failed to create {dir}: {e}", "error:".red().bold());
-                    process::exit(1);
-                }
-            }
+            fs::create_dir_all(&path)
+                .map_err(|error| format!("failed to create {dir}: {error}"))?;
+            restored.push(format!("{dir}/"));
         }
     }
 
     let version_path = root.join(".specsync/version");
     if !version_path.is_file() {
-        match fs::write(&version_path, format!("{PROJECT_VERSION}\n")) {
-            Ok(_) => restored.push(".specsync/version".to_string()),
-            Err(e) => {
-                eprintln!("{} Failed to write .specsync/version: {e}", "error:".red().bold());
-                process::exit(1);
-            }
-        }
+        write_new_file(
+            &version_path,
+            format!("{PROJECT_VERSION}\n").as_bytes(),
+            ".specsync/version",
+        )?;
+        restored.push(".specsync/version".to_string());
     }
 
     let gitignore_path = root.join(".specsync/.gitignore");
     if !gitignore_path.is_file() {
-        match fs::write(&gitignore_path, specsync_gitignore_content()) {
-            Ok(_) => restored.push(".specsync/.gitignore".to_string()),
-            Err(e) => {
-                eprintln!(
-                    "{} Failed to write .specsync/.gitignore: {e}",
-                    "error:".red().bold()
-                );
-                process::exit(1);
-            }
-        }
+        write_new_file(
+            &gitignore_path,
+            specsync_gitignore_content().as_bytes(),
+            ".specsync/.gitignore",
+        )?;
+        restored.push(".specsync/.gitignore".to_string());
     }
 
     // sdd.json — write_default_policy is a no-op when the file exists.
     let had_policy = root.join(".specsync/sdd.json").is_file();
-    if let Err(error) =
-        crate::change::write_default_policy(root, crate::change::detect_verification_commands(root))
-    {
-        eprintln!("{} {error}", "error:".red().bold());
-        process::exit(1);
-    }
+    crate::change::write_default_policy(root, crate::change::detect_verification_commands(root))?;
     if !had_policy && root.join(".specsync/sdd.json").is_file() {
         restored.push(".specsync/sdd.json".to_string());
     }
@@ -226,24 +512,24 @@ fn repair_layout(root: &Path, existing_config: &str, json: bool) {
         Err(e) => warnings.push(e),
     }
 
-    if json {
-        println!(
-            "{}",
-            serde_json::json!({
-                "repaired": restored,
-                "warnings": warnings,
-            })
-        );
-    } else {
-        if restored.is_empty() {
-            println!("{} Nothing to repair — .specsync layout is complete", "✓".green());
-        } else {
-            println!("{} Repaired: {}", "✓".green(), restored.join(", "));
-        }
-        for warning in &warnings {
-            eprintln!("{} {warning}", "warning:".yellow().bold());
-        }
-    }
+    Ok(InitReport {
+        command: "init",
+        success: true,
+        created: false,
+        repaired: true,
+        unchanged: restored.is_empty(),
+        config: Some(existing_config.to_string()),
+        source_dirs: Vec::new(),
+        detected: None,
+        source_dirs_detected: None,
+        missing: Vec::new(),
+        restored,
+        warnings,
+        repair_hint: None,
+        migration_hint: None,
+        initialized_ancestor: None,
+        error: None,
+    })
 }
 
 /// Walk up from `root` to find an ancestor directory that already contains a
@@ -343,42 +629,89 @@ fn write_current_layout(root: &Path, source_dirs: &[String]) -> Result<(), Strin
         ..Default::default()
     };
     let config_path = root.join(".specsync/config.toml");
-    fs::write(&config_path, config_to_toml(&config))
-        .map_err(|e| format!("Failed to write .specsync/config.toml: {e}"))?;
+    write_new_file(
+        &config_path,
+        config_to_toml(&config).as_bytes(),
+        ".specsync/config.toml",
+    )?;
 
     let version_path = root.join(".specsync/version");
-    fs::write(&version_path, format!("{PROJECT_VERSION}\n"))
-        .map_err(|e| format!("Failed to write .specsync/version: {e}"))?;
+    if !version_path.exists() {
+        write_new_file(
+            &version_path,
+            format!("{PROJECT_VERSION}\n").as_bytes(),
+            ".specsync/version",
+        )?;
+    }
 
     let gitignore_path = root.join(".specsync/.gitignore");
     if !gitignore_path.exists() {
-        fs::write(&gitignore_path, specsync_gitignore_content())
-            .map_err(|e| format!("Failed to write .specsync/.gitignore: {e}"))?;
+        write_new_file(
+            &gitignore_path,
+            specsync_gitignore_content().as_bytes(),
+            ".specsync/.gitignore",
+        )?;
     }
 
     Ok(())
+}
+
+fn write_new_file(path: &Path, bytes: &[u8], display: &str) -> Result<(), String> {
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .and_then(|mut file| file.write_all(bytes))
+        .map_err(|error| format!("Failed to write {display}: {error}"))
 }
 
 /// Append `.specsync/hashes.json` to the root `.gitignore` if not already present.
 /// Returns `Ok(true)` if added, `Ok(false)` if already present, `Err` on write failure.
 pub fn ensure_hashes_gitignored(root: &Path) -> Result<bool, String> {
     let gitignore_path = root.join(".gitignore");
-    let entry = ".specsync/hashes.json";
-
-    let existing = fs::read_to_string(&gitignore_path).unwrap_or_default();
-    if existing.lines().any(|line| line.trim() == entry) {
+    let existing = match fs::symlink_metadata(&gitignore_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(
+                "Refusing to update symlinked .gitignore; add .specsync/hashes.json manually"
+                    .to_string(),
+            );
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err(
+                "Refusing to update .gitignore because it is not a regular file".to_string(),
+            );
+        }
+        Ok(_) => fs::read(&gitignore_path)
+            .map_err(|error| format!("Failed to read .gitignore: {error}"))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => return Err(format!("Failed to inspect .gitignore: {error}")),
+    };
+    if gitignore_has_hash_entry(&existing) {
         return Ok(false);
     }
 
-    let mut content = existing;
-    if !content.is_empty() && !content.ends_with('\n') {
-        content.push('\n');
+    let mut addition = Vec::new();
+    if !existing.is_empty() {
+        if !existing.ends_with(b"\n") {
+            addition.push(b'\n');
+        }
+        addition.push(b'\n');
     }
-    content.push_str(&format!(
-        "\n# spec-sync hash cache (regenerated locally)\n{entry}\n"
-    ));
+    addition.extend_from_slice(
+        b"# spec-sync hash cache (regenerated locally)\n.specsync/hashes.json\n",
+    );
 
-    fs::write(&gitignore_path, content).map_err(|e| format!("Failed to update .gitignore: {e}"))?;
+    let mut options = fs::OpenOptions::new();
+    options.write(true);
+    if existing.is_empty() && !gitignore_path.exists() {
+        options.create_new(true);
+    } else {
+        options.append(true);
+    }
+    options
+        .open(&gitignore_path)
+        .and_then(|mut file| file.write_all(&addition))
+        .map_err(|error| format!("Failed to update .gitignore: {error}"))?;
     Ok(true)
 }
 
@@ -423,7 +756,37 @@ mod tests {
 
         let result = ensure_hashes_gitignored(tmp.path());
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Failed to update .gitignore"));
+        assert!(result.unwrap_err().contains("not a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_non_utf8_gitignore_bytes_when_appending() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".gitignore");
+        let original = b"target/\n\xffbinary\n";
+        fs::write(&path, original).unwrap();
+
+        assert!(ensure_hashes_gitignored(tmp.path()).unwrap());
+
+        let updated = fs::read(path).unwrap();
+        assert!(updated.starts_with(original));
+        assert!(gitignore_has_hash_entry(&updated));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_symlinked_root_gitignore_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("outside-ignore");
+        fs::write(&target, b"keep-me\n").unwrap();
+        symlink(&target, tmp.path().join(".gitignore")).unwrap();
+
+        let error = ensure_hashes_gitignored(tmp.path()).unwrap_err();
+        assert!(error.contains("symlinked .gitignore"));
+        assert_eq!(fs::read(target).unwrap(), b"keep-me\n");
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -5,7 +5,7 @@ use std::io::IsTerminal;
 use std::path::Path;
 use std::process;
 
-use crate::config::{config_to_toml, detect_source_dirs};
+use crate::config::{config_to_toml, detect_source_dirs_with_confidence};
 use crate::types::SpecSyncConfig;
 
 /// Version stamp written to `.specsync/version` for fresh projects.
@@ -19,18 +19,47 @@ const V4_DIRS: &[&str] = &[
     ".specsync/archive/changes",
 ];
 
-pub fn cmd_init(root: &Path) {
+pub fn cmd_init(root: &Path, repair: bool, format: crate::types::OutputFormat) {
+    let json = matches!(format, crate::types::OutputFormat::Json);
     // Refuse to clobber any existing config — current or legacy.
     let v4_toml = root.join(".specsync/config.toml");
     let v4_json = root.join(".specsync/config.json");
     let legacy_json = root.join("specsync.json");
     let legacy_toml = root.join(".specsync.toml");
-    if v4_toml.exists() {
-        println!(".specsync/config.toml already exists");
-        return;
-    }
-    if v4_json.exists() {
-        println!(".specsync/config.json already exists");
+    if v4_toml.exists() || v4_json.exists() {
+        let existing = if v4_toml.exists() {
+            ".specsync/config.toml"
+        } else {
+            ".specsync/config.json"
+        };
+        if repair {
+            repair_layout(root, existing, json);
+            return;
+        }
+        let missing = missing_support_files(root);
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "created": false,
+                    "config": existing,
+                    "missing": missing,
+                    "repair_hint": "specsync init --repair",
+                })
+            );
+        } else {
+            println!("{existing} already exists");
+            if !missing.is_empty() {
+                println!(
+                    "  {} missing support file(s): {}",
+                    "!".yellow(),
+                    missing.join(", ")
+                );
+                println!(
+                    "  Run `specsync init --repair` to restore them (your config is left untouched)."
+                );
+            }
+        }
         return;
     }
     if legacy_json.exists() {
@@ -42,7 +71,22 @@ pub fn cmd_init(root: &Path) {
         return;
     }
 
-    let detected_dirs = detect_source_dirs(root);
+    // Subdir footgun: running `init` inside a subdirectory of an initialized
+    // project must not create a nested .specsync — point at the parent instead.
+    if let Some(parent) = find_initialized_ancestor(root) {
+        eprintln!(
+            "{} A spec-sync project is already initialized at {} — no nested .specsync was created.",
+            "error:".red().bold(),
+            parent.display()
+        );
+        eprintln!(
+            "  Run from that root or pass `--root {}`.",
+            parent.display()
+        );
+        process::exit(1);
+    }
+
+    let (detected_dirs, actually_detected) = detect_source_dirs_with_confidence(root);
     let dirs_display = detected_dirs.join(", ");
 
     if let Err(e) = write_current_layout(root, &detected_dirs) {
@@ -57,19 +101,184 @@ pub fn cmd_init(root: &Path) {
         process::exit(1);
     }
 
-    println!("{} Created .specsync/config.toml (5.0 layout)", "✓".green());
-    println!("  Detected source directories: {dirs_display}");
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "created": true,
+                "config": ".specsync/config.toml",
+                "source_dirs": detected_dirs,
+                "detected": actually_detected,
+            })
+        );
+    } else {
+        println!("{} Created .specsync/config.toml (5.0 layout)", "✓".green());
+        if actually_detected {
+            println!("  Detected source directories: {dirs_display}");
+        } else {
+            println!(
+                "  {} No source directories detected — defaulted to source_dirs = [\"src\"].",
+                "!".yellow()
+            );
+            println!("  Edit .specsync/config.toml if your sources live elsewhere.");
+        }
+    }
 
     // Ensure .specsync/hashes.json is gitignored (hash cache is local-only)
     match ensure_hashes_gitignored(root) {
-        Ok(true) => println!("{} Added .specsync/hashes.json to .gitignore", "✓".green()),
-        Ok(false) => {}
+        Ok(true) if !json => println!("{} Added .specsync/hashes.json to .gitignore", "✓".green()),
+        Ok(_) => {}
         Err(e) => eprintln!("{} {e}", "warning:".yellow().bold()),
     }
 
     guided_sdd_bootstrap(root);
 }
 
+/// Support files a healthy `.specsync/` layout must have; missing ones are
+/// reported by re-init and restored by `init --repair`.
+fn missing_support_files(root: &Path) -> Vec<String> {
+    let mut missing = Vec::new();
+    for file in [
+        ".specsync/version",
+        ".specsync/.gitignore",
+        ".specsync/sdd.json",
+    ] {
+        if !root.join(file).is_file() {
+            missing.push(file.to_string());
+        }
+    }
+    for dir in V4_DIRS {
+        if !root.join(dir).is_dir() {
+            missing.push(format!("{dir}/"));
+        }
+    }
+    missing
+}
+
+/// Restore missing `.specsync/` support files without touching the existing
+/// config. Also sanity-checks that the config is at least plausible.
+fn repair_layout(root: &Path, existing_config: &str, json: bool) {
+    let mut restored: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Sanity-check the existing config so a corrupt one is diagnosed, not ignored.
+    if let Ok(content) = fs::read_to_string(root.join(existing_config))
+        && !content.contains("specs_dir")
+    {
+        warnings.push(format!(
+            "{existing_config} has no `specs_dir` key — it may be corrupt; fix or regenerate it manually"
+        ));
+    }
+
+    for dir in V4_DIRS {
+        let path = root.join(dir);
+        if !path.is_dir() {
+            match fs::create_dir_all(&path) {
+                Ok(_) => restored.push(format!("{dir}/")),
+                Err(e) => {
+                    eprintln!("{} Failed to create {dir}: {e}", "error:".red().bold());
+                    process::exit(1);
+                }
+            }
+        }
+    }
+
+    let version_path = root.join(".specsync/version");
+    if !version_path.is_file() {
+        match fs::write(&version_path, format!("{PROJECT_VERSION}\n")) {
+            Ok(_) => restored.push(".specsync/version".to_string()),
+            Err(e) => {
+                eprintln!("{} Failed to write .specsync/version: {e}", "error:".red().bold());
+                process::exit(1);
+            }
+        }
+    }
+
+    let gitignore_path = root.join(".specsync/.gitignore");
+    if !gitignore_path.is_file() {
+        match fs::write(&gitignore_path, specsync_gitignore_content()) {
+            Ok(_) => restored.push(".specsync/.gitignore".to_string()),
+            Err(e) => {
+                eprintln!(
+                    "{} Failed to write .specsync/.gitignore: {e}",
+                    "error:".red().bold()
+                );
+                process::exit(1);
+            }
+        }
+    }
+
+    // sdd.json — write_default_policy is a no-op when the file exists.
+    let had_policy = root.join(".specsync/sdd.json").is_file();
+    if let Err(error) =
+        crate::change::write_default_policy(root, crate::change::detect_verification_commands(root))
+    {
+        eprintln!("{} {error}", "error:".red().bold());
+        process::exit(1);
+    }
+    if !had_policy && root.join(".specsync/sdd.json").is_file() {
+        restored.push(".specsync/sdd.json".to_string());
+    }
+
+    match ensure_hashes_gitignored(root) {
+        Ok(true) => restored.push(".gitignore entry (.specsync/hashes.json)".to_string()),
+        Ok(false) => {}
+        Err(e) => warnings.push(e),
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "repaired": restored,
+                "warnings": warnings,
+            })
+        );
+    } else {
+        if restored.is_empty() {
+            println!("{} Nothing to repair — .specsync layout is complete", "✓".green());
+        } else {
+            println!("{} Repaired: {}", "✓".green(), restored.join(", "));
+        }
+        for warning in &warnings {
+            eprintln!("{} {warning}", "warning:".yellow().bold());
+        }
+    }
+}
+
+/// Walk up from `root` to find an ancestor directory that already contains a
+/// spec-sync project (any layout). Returns None when `root` is the topmost
+/// initialized directory.
+fn find_initialized_ancestor(root: &Path) -> Option<std::path::PathBuf> {
+    let abs = root.canonicalize().ok()?;
+    for ancestor in abs.ancestors().skip(1) {
+        if ancestor.join(".specsync/config.toml").is_file()
+            || ancestor.join(".specsync/config.json").is_file()
+            || ancestor.join("specsync.json").is_file()
+            || ancestor.join(".specsync.toml").is_file()
+        {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
+}
+
+/// Contents of the generated `.specsync/.gitignore`.
+fn specsync_gitignore_content() -> String {
+    [
+        "# spec-sync 5.0 — generated by `specsync init`",
+        "# Committed: config.toml, registry.toml, lifecycle/, changes/, archive/",
+        "# Ignored: backups, local config, hash cache (regenerated on each run)",
+        "",
+        "backup-3x/",
+        "config.local.toml",
+        "hashes.json",
+        "change.lock",
+        "change-transaction.json",
+        "",
+    ]
+    .join("\n")
+}
 fn guided_sdd_bootstrap(root: &Path) {
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         return;
@@ -143,20 +352,7 @@ fn write_current_layout(root: &Path, source_dirs: &[String]) -> Result<(), Strin
 
     let gitignore_path = root.join(".specsync/.gitignore");
     if !gitignore_path.exists() {
-        let content = [
-            "# spec-sync 5.0 — generated by `specsync init`",
-            "# Committed: config.toml, registry.toml, lifecycle/, changes/, archive/",
-            "# Ignored: backups, local config, hash cache (regenerated on each run)",
-            "",
-            "backup-3x/",
-            "config.local.toml",
-            "hashes.json",
-            "change.lock",
-            "change-transaction.json",
-            "",
-        ]
-        .join("\n");
-        fs::write(&gitignore_path, content)
+        fs::write(&gitignore_path, specsync_gitignore_content())
             .map_err(|e| format!("Failed to write .specsync/.gitignore: {e}"))?;
     }
 
@@ -256,7 +452,7 @@ mod tests {
     fn fresh_init_is_not_legacy_layout() {
         let tmp = TempDir::new().unwrap();
         fs::create_dir_all(tmp.path().join("src")).unwrap();
-        cmd_init(tmp.path());
+        cmd_init(tmp.path(), false, crate::types::OutputFormat::Text);
         assert!(
             !crate::config::is_legacy_layout(tmp.path()),
             "fresh init must produce a 5.0 layout that does not trigger the migration nag"
@@ -277,5 +473,46 @@ mod tests {
                 "missing source policy scope {expected}"
             );
         }
+    }
+
+    #[test]
+    fn empty_dir_init_reports_fallback_not_detection() {
+        // #440: init must not claim it "detected" src in an empty directory.
+        let tmp = TempDir::new().unwrap();
+        let (dirs, detected) = crate::config::detect_source_dirs_with_confidence(tmp.path());
+        assert_eq!(dirs, vec!["src".to_string()]);
+        assert!(!detected, "empty dir must report fallback, not detection");
+    }
+
+    #[test]
+    fn repair_restores_deleted_support_files() {
+        // #440: re-init short-circuits; --repair restores version/.gitignore/sdd.json.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        cmd_init(root, false, crate::types::OutputFormat::Text);
+        fs::remove_file(root.join(".specsync/version")).unwrap();
+        fs::remove_file(root.join(".specsync/.gitignore")).unwrap();
+        fs::remove_file(root.join(".specsync/sdd.json")).unwrap();
+        assert_eq!(missing_support_files(root).len(), 3);
+
+        cmd_init(root, true, crate::types::OutputFormat::Text);
+
+        assert!(root.join(".specsync/version").is_file());
+        assert!(root.join(".specsync/.gitignore").is_file());
+        assert!(root.join(".specsync/sdd.json").is_file());
+        assert!(missing_support_files(root).is_empty());
+    }
+
+    #[test]
+    fn find_initialized_ancestor_detects_parent_project() {
+        // #440: init in a subdir must find the parent project, not nest.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        cmd_init(root, false, crate::types::OutputFormat::Text);
+        let sub = root.join("src/deep");
+        fs::create_dir_all(&sub).unwrap();
+        let found = find_initialized_ancestor(&sub).expect("parent project detected");
+        assert_eq!(found, root.canonicalize().unwrap());
+        assert!(find_initialized_ancestor(root).is_none());
     }
 }

--- a/src/commands/init_registry.rs
+++ b/src/commands/init_registry.rs
@@ -6,7 +6,8 @@ use std::process;
 use crate::config::load_config;
 use crate::registry;
 
-pub fn cmd_init_registry(root: &Path, name: Option<String>) {
+pub fn cmd_init_registry(root: &Path, name: Option<String>, format: crate::types::OutputFormat) {
+    let json = matches!(format, crate::types::OutputFormat::Json);
     // Respect the project layout: v4 projects get .specsync/registry.toml,
     // un-migrated 3.x projects keep the legacy root-level file.
     let registry_path = registry::local_registry_path(root);
@@ -18,7 +19,15 @@ pub fn cmd_init_registry(root: &Path, name: Option<String>) {
         .to_string()
         .replace('\\', "/");
     if registry_path.exists() {
-        println!("{rel_display} already exists");
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({"created": false, "registry": rel_display})
+            );
+        } else {
+            println!("{rel_display} already exists — nothing to do");
+            println!("  Delete it first (or edit it by hand) to regenerate.");
+        }
         return;
     }
 
@@ -29,6 +38,13 @@ pub fn cmd_init_registry(root: &Path, name: Option<String>) {
             .unwrap_or("project")
             .to_string()
     });
+    if project_name.trim().is_empty() {
+        eprintln!(
+            "{} Registry name must not be empty — pass --name with a non-empty project name.",
+            "Error:".red()
+        );
+        process::exit(1);
+    }
 
     let content = registry::generate_registry(root, &project_name, &config.specs_dir);
     if let Some(parent) = registry_path.parent()
@@ -39,7 +55,14 @@ pub fn cmd_init_registry(root: &Path, name: Option<String>) {
     }
     match fs::write(&registry_path, &content) {
         Ok(_) => {
-            println!("{} Created {rel_display}", "✓".green());
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({"created": true, "registry": rel_display, "name": project_name})
+                );
+            } else {
+                println!("{} Created {rel_display}", "✓".green());
+            }
         }
         Err(e) => {
             eprintln!("Failed to write {rel_display}: {e}");

--- a/src/commands/init_registry.rs
+++ b/src/commands/init_registry.rs
@@ -1,13 +1,53 @@
 use colored::Colorize;
+use serde::Serialize;
 use std::fs;
+use std::io::Write;
 use std::path::Path;
 use std::process;
 
-use crate::config::load_config;
+use crate::config::{load_config, validate_config_file};
 use crate::registry;
+use crate::types::OutputFormat;
 
-pub fn cmd_init_registry(root: &Path, name: Option<String>, format: crate::types::OutputFormat) {
-    let json = matches!(format, crate::types::OutputFormat::Json);
+#[derive(Debug, Serialize)]
+struct InitRegistryReport {
+    command: &'static str,
+    success: bool,
+    created: bool,
+    unchanged: bool,
+    registry: String,
+    name: Option<String>,
+    error: Option<String>,
+}
+
+impl InitRegistryReport {
+    fn failure(registry: String, error: String) -> Self {
+        Self {
+            command: "init-registry",
+            success: false,
+            created: false,
+            unchanged: true,
+            registry,
+            name: None,
+            error: Some(error),
+        }
+    }
+}
+
+pub fn cmd_init_registry(root: &Path, name: Option<String>, format: OutputFormat) {
+    match execute_init_registry(root, name) {
+        Ok(report) => render_init_registry_report(&report, format),
+        Err(report) => {
+            render_init_registry_report(&report, format);
+            process::exit(1);
+        }
+    }
+}
+
+fn execute_init_registry(
+    root: &Path,
+    name: Option<String>,
+) -> Result<InitRegistryReport, InitRegistryReport> {
     // Respect the project layout: v4 projects get .specsync/registry.toml,
     // un-migrated 3.x projects keep the legacy root-level file.
     let registry_path = registry::local_registry_path(root);
@@ -18,55 +58,171 @@ pub fn cmd_init_registry(root: &Path, name: Option<String>, format: crate::types
         .display()
         .to_string()
         .replace('\\', "/");
-    if registry_path.exists() {
-        if json {
-            println!(
-                "{}",
-                serde_json::json!({"created": false, "registry": rel_display})
-            );
-        } else {
-            println!("{rel_display} already exists — nothing to do");
-            println!("  Delete it first (or edit it by hand) to regenerate.");
-        }
-        return;
-    }
-
-    let config = load_config(root);
     let project_name = name.unwrap_or_else(|| {
         root.file_name()
-            .and_then(|n| n.to_str())
+            .and_then(|value| value.to_str())
             .unwrap_or("project")
             .to_string()
     });
     if project_name.trim().is_empty() {
-        eprintln!(
-            "{} Registry name must not be empty — pass --name with a non-empty project name.",
-            "Error:".red()
-        );
-        process::exit(1);
+        return Err(InitRegistryReport::failure(
+            rel_display,
+            "registry name must not be empty; pass --name with a non-empty project name"
+                .to_string(),
+        ));
     }
 
-    let content = registry::generate_registry(root, &project_name, &config.specs_dir);
-    if let Some(parent) = registry_path.parent()
-        && let Err(e) = fs::create_dir_all(parent)
-    {
-        eprintln!("Failed to create {}: {e}", parent.display());
-        process::exit(1);
+    if registry_path.exists() {
+        return match registry::load_local_registry(root) {
+            Ok(Some(existing)) => Ok(InitRegistryReport {
+                command: "init-registry",
+                success: true,
+                created: false,
+                unchanged: true,
+                registry: rel_display,
+                name: Some(existing.name),
+                error: None,
+            }),
+            Ok(None) => Err(InitRegistryReport::failure(
+                rel_display,
+                "registry already exists but is inert; repair or remove it explicitly".to_string(),
+            )),
+            Err(error) => Err(InitRegistryReport::failure(rel_display, error)),
+        };
     }
-    match fs::write(&registry_path, &content) {
-        Ok(_) => {
-            if json {
-                println!(
-                    "{}",
-                    serde_json::json!({"created": true, "registry": rel_display, "name": project_name})
-                );
-            } else {
-                println!("{} Created {rel_display}", "✓".green());
+
+    if let Some(config_path) = existing_config_path(root)
+        && let Err(error) = validate_config_file(&config_path)
+    {
+        return Err(InitRegistryReport::failure(rel_display, error));
+    }
+    let config = load_config(root);
+    let content = registry::generate_registry(root, &project_name, &config.specs_dir);
+    if let Err(error) = toml::from_str::<toml::Value>(&content) {
+        return Err(InitRegistryReport::failure(
+            rel_display,
+            format!("generated registry is invalid TOML: {error}"),
+        ));
+    }
+    if let Some(parent) = registry_path.parent()
+        && let Err(error) = fs::create_dir_all(parent)
+    {
+        return Err(InitRegistryReport::failure(
+            rel_display,
+            format!("failed to create {}: {error}", parent.display()),
+        ));
+    }
+
+    let write_result = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&registry_path)
+        .and_then(|mut file| file.write_all(content.as_bytes()));
+    match write_result {
+        Ok(()) => Ok(InitRegistryReport {
+            command: "init-registry",
+            success: true,
+            created: true,
+            unchanged: false,
+            registry: rel_display,
+            name: Some(project_name),
+            error: None,
+        }),
+        Err(error) => Err(InitRegistryReport::failure(
+            rel_display,
+            format!("failed to write registry: {error}"),
+        )),
+    }
+}
+
+fn existing_config_path(root: &Path) -> Option<std::path::PathBuf> {
+    [
+        ".specsync/config.toml",
+        ".specsync/config.json",
+        ".specsync.toml",
+        "specsync.json",
+    ]
+    .into_iter()
+    .map(|relative| root.join(relative))
+    .find(|path| path.exists())
+}
+
+fn render_init_registry_report(report: &InitRegistryReport, format: OutputFormat) {
+    match format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string(report).expect("init-registry report must serialize")
+            );
+        }
+        OutputFormat::Markdown | OutputFormat::Github => {
+            println!("## SpecSync init-registry\n");
+            println!(
+                "- **Status:** {}",
+                if report.success { "success" } else { "failure" }
+            );
+            println!("- **Created:** {}", report.created);
+            println!("- **Unchanged:** {}", report.unchanged);
+            println!("- **Registry:** `{}`", report.registry);
+            if let Some(name) = &report.name {
+                println!("- **Name:** `{name}`");
+            }
+            if let Some(error) = &report.error {
+                println!("- **Error:** {error}");
             }
         }
-        Err(e) => {
-            eprintln!("Failed to write {rel_display}: {e}");
-            process::exit(1);
+        OutputFormat::Table => {
+            println!("FIELD\tVALUE");
+            println!(
+                "status\t{}",
+                if report.success { "success" } else { "failure" }
+            );
+            println!("created\t{}", report.created);
+            println!("unchanged\t{}", report.unchanged);
+            println!("registry\t{}", report.registry);
+            if let Some(name) = &report.name {
+                println!("name\t{name}");
+            }
+            if let Some(error) = &report.error {
+                println!("error\t{error}");
+            }
         }
+        OutputFormat::Csv => {
+            println!("command,success,created,unchanged,registry,name,error");
+            println!(
+                "init-registry,{},{},{},{},{},{}",
+                report.success,
+                report.created,
+                report.unchanged,
+                csv_field(&report.registry),
+                csv_field(report.name.as_deref().unwrap_or_default()),
+                csv_field(report.error.as_deref().unwrap_or_default())
+            );
+        }
+        OutputFormat::Text => {
+            if !report.success {
+                eprintln!(
+                    "{} {}",
+                    "Error:".red(),
+                    report
+                        .error
+                        .as_deref()
+                        .unwrap_or("registry initialization failed")
+                );
+            } else if report.created {
+                println!("{} Created {}", "✓".green(), report.registry);
+            } else {
+                println!("{} already exists — nothing to do", report.registry);
+                println!("  Delete it first (or edit it by hand) to regenerate.");
+            }
+        }
+    }
+}
+
+fn csv_field(value: &str) -> String {
+    if value.contains(',') || value.contains('"') || value.contains('\n') || value.contains('\r') {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,38 @@ pub fn discover_manifest_modules(root: &Path) -> manifest::ManifestDiscovery {
 
 /// Scan-based source directory detection (fallback when no manifests found).
 fn detect_source_dirs_by_scan(root: &Path) -> Vec<String> {
+    let detected = scan_source_dirs(root);
+    if detected.is_empty() {
+        // Fallback to "src" if nothing detected
+        return vec!["src".to_string()];
+    }
+    detected
+}
+
+/// Like [`detect_source_dirs`], but also reports whether any source
+/// directories were actually detected. `false` means the `["src"]` fallback
+/// was used — callers (e.g. `init`) must not present it as "detected".
+pub fn detect_source_dirs_with_confidence(root: &Path) -> (Vec<String>, bool) {
+    // Manifest-aware detection first
+    let manifest_discovery = manifest::discover_from_manifests(root);
+    if !manifest_discovery.source_dirs.is_empty() {
+        let mut dirs = manifest_discovery.source_dirs;
+        dirs.sort();
+        dirs.dedup();
+        return (dirs, true);
+    }
+
+    let scanned = scan_source_dirs(root);
+    if scanned.is_empty() {
+        (vec!["src".to_string()], false)
+    } else {
+        (scanned, true)
+    }
+}
+
+/// Raw directory scan with no fallback — returns an empty vector when no
+/// source directories or root-level source files are found.
+fn scan_source_dirs(root: &Path) -> Vec<String> {
     let ignored: HashSet<&str> = IGNORED_DIRS.iter().copied().collect();
     let mut source_dirs: Vec<String> = Vec::new();
     let mut has_root_source_files = false;
@@ -81,7 +113,7 @@ fn detect_source_dirs_by_scan(root: &Path) -> Vec<String> {
     // Check immediate children of root
     let entries = match fs::read_dir(root) {
         Ok(e) => e,
-        Err(_) => return vec!["src".to_string()],
+        Err(_) => return Vec::new(),
     };
 
     for entry in entries.flatten() {
@@ -110,15 +142,9 @@ fn detect_source_dirs_by_scan(root: &Path) -> Vec<String> {
         return vec![".".to_string()];
     }
 
-    if source_dirs.is_empty() {
-        // Fallback to "src" if nothing detected
-        return vec!["src".to_string()];
-    }
-
     source_dirs.sort();
     source_dirs
 }
-
 /// Check if a directory contains source files, scanning up to `max_depth` levels.
 fn dir_contains_source_files(dir: &Path, ignored: &HashSet<&str>, max_depth: usize) -> bool {
     for entry in WalkDir::new(dir)

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,6 +195,131 @@ pub fn read_config_file(path: &Path) -> Option<String> {
     })
 }
 
+/// Validate that an existing configuration file is readable, syntactically
+/// valid, and gives known path fields their documented shapes.
+///
+/// This intentionally does not reject unknown extension keys. It only prevents
+/// `init --repair` from claiming success while a malformed or wrongly typed
+/// canonical config remains unusable.
+pub fn validate_config_file(path: &Path) -> Result<(), String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read config {}: {error}", path.display()))?;
+    let is_json = path.extension().and_then(|extension| extension.to_str()) == Some("json");
+    if is_json {
+        let value: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|error| format!("invalid JSON config {}: {error}", path.display()))?;
+        let object = value.as_object().ok_or_else(|| {
+            format!(
+                "invalid JSON config {}: root must be an object",
+                path.display()
+            )
+        })?;
+        if let Some(specs_dir) = object.get("specsDir").or_else(|| object.get("specs_dir")) {
+            required_nonempty_config_string(specs_dir.as_str(), path, "specsDir")?;
+        }
+        if let Some(source_dirs) = object
+            .get("sourceDirs")
+            .or_else(|| object.get("source_dirs"))
+        {
+            validate_config_string_array(source_dirs, path, "sourceDirs")?;
+        }
+        return Ok(());
+    }
+
+    let value: toml::Value = toml::from_str(&content)
+        .map_err(|error| format!("invalid TOML config {}: {error}", path.display()))?;
+    let table = value.as_table().ok_or_else(|| {
+        format!(
+            "invalid TOML config {}: root must be a table",
+            path.display()
+        )
+    })?;
+    if let Some(specs_dir) = table.get("specs_dir") {
+        required_nonempty_config_string(specs_dir.as_str(), path, "specs_dir")?;
+    }
+    if let Some(source_dirs) = table.get("source_dirs") {
+        validate_config_string_array(source_dirs, path, "source_dirs")?;
+    }
+    Ok(())
+}
+
+fn required_nonempty_config_string(
+    value: Option<&str>,
+    path: &Path,
+    field: &str,
+) -> Result<(), String> {
+    match value {
+        Some(value) if !value.trim().is_empty() => Ok(()),
+        Some(_) => Err(format!(
+            "invalid config {}: `{field}` must not be empty",
+            path.display()
+        )),
+        None => Err(format!(
+            "invalid config {}: `{field}` must be a string",
+            path.display()
+        )),
+    }
+}
+
+fn validate_config_string_array(
+    value: &impl ConfigArrayValue,
+    path: &Path,
+    field: &str,
+) -> Result<(), String> {
+    let Some(items) = value.config_array() else {
+        return Err(format!(
+            "invalid config {}: `{field}` must be an array of strings",
+            path.display()
+        ));
+    };
+    if items.iter().all(|item| item.config_string().is_some()) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid config {}: `{field}` must contain only strings",
+            path.display()
+        ))
+    }
+}
+
+trait ConfigArrayValue {
+    type Item: ConfigStringValue;
+
+    fn config_array(&self) -> Option<&Vec<Self::Item>>;
+}
+
+trait ConfigStringValue {
+    fn config_string(&self) -> Option<&str>;
+}
+
+impl ConfigArrayValue for serde_json::Value {
+    type Item = serde_json::Value;
+
+    fn config_array(&self) -> Option<&Vec<Self::Item>> {
+        self.as_array()
+    }
+}
+
+impl ConfigStringValue for serde_json::Value {
+    fn config_string(&self) -> Option<&str> {
+        self.as_str()
+    }
+}
+
+impl ConfigArrayValue for toml::Value {
+    type Item = toml::Value;
+
+    fn config_array(&self) -> Option<&Vec<Self::Item>> {
+        self.as_array()
+    }
+}
+
+impl ConfigStringValue for toml::Value {
+    fn config_string(&self) -> Option<&str> {
+        self.as_str()
+    }
+}
+
 /// Load config from a specific file path (JSON or TOML based on extension).
 /// Used by migration to convert a known source file rather than relying on precedence.
 pub fn load_config_from_path(config_path: &Path, root: &Path) -> SpecSyncConfig {
@@ -320,11 +445,23 @@ pub fn is_legacy_layout(root: &Path) -> bool {
 
 /// Escape a string value for safe embedding in a TOML quoted string.
 fn toml_escape(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
+    let mut escaped = String::with_capacity(s.len());
+    for character in s.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\u{08}' => escaped.push_str("\\b"),
+            '\t' => escaped.push_str("\\t"),
+            '\n' => escaped.push_str("\\n"),
+            '\u{0C}' => escaped.push_str("\\f"),
+            '\r' => escaped.push_str("\\r"),
+            control if control.is_control() => {
+                escaped.push_str(&format!("\\u{:04X}", control as u32));
+            }
+            value => escaped.push(value),
+        }
+    }
+    escaped
 }
 
 /// Format a `name = ["a", "b"]` TOML array line (an empty slice → `name = []`).
@@ -2483,5 +2620,44 @@ verify_issues = false
         )
         .unwrap();
         assert_eq!(config_to_toml_lossy_fields(&config), vec!["customRules"]);
+    }
+
+    #[test]
+    fn validate_config_file_rejects_syntax_and_required_field_shapes() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let toml_path = temp.path().join("config.toml");
+        fs::write(
+            &toml_path,
+            "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+        )
+        .unwrap();
+        validate_config_file(&toml_path).expect("canonical TOML must validate");
+
+        fs::write(&toml_path, "specs_dir = [\"wrong\"]\n").unwrap();
+        let error = validate_config_file(&toml_path).unwrap_err();
+        assert!(error.contains("`specs_dir` must be a string"), "{error}");
+
+        let json_path = temp.path().join("config.json");
+        fs::write(&json_path, r#"{"specsDir":"specs","sourceDirs":["src"]}"#).unwrap();
+        validate_config_file(&json_path).expect("canonical JSON must validate");
+
+        fs::write(&json_path, r#"{"specsDir":"specs","sourceDirs":[1]}"#).unwrap();
+        let error = validate_config_file(&json_path).unwrap_err();
+        assert!(error.contains("sourceDirs"), "{error}");
+    }
+
+    #[test]
+    fn config_to_toml_escapes_every_control_character_as_valid_toml() {
+        let config = SpecSyncConfig {
+            source_dirs: vec!["src\u{0000}\u{0008}\u{000c}\u{0085}".to_string()],
+            ..SpecSyncConfig::default()
+        };
+        let serialized = config_to_toml(&config);
+        let parsed: toml::Value =
+            toml::from_str(&serialized).expect("serialized config must be valid TOML");
+        assert_eq!(
+            parsed["source_dirs"][0].as_str(),
+            Some("src\u{0000}\u{0008}\u{000c}\u{0085}")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn run() {
     }
 
     match command {
-        Command::Init => commands::init::cmd_init(&root),
+        Command::Init { repair } => commands::init::cmd_init(&root, repair, format),
         Command::Check {
             fix,
             dry_run,
@@ -167,7 +167,7 @@ fn run() {
             dir,
             template,
         } => commands::scaffold::cmd_scaffold(&root, &name, dir, template),
-        Command::InitRegistry { name } => commands::init_registry::cmd_init_registry(&root, name),
+        Command::InitRegistry { name } => commands::init_registry::cmd_init_registry(&root, name, format),
         Command::Resolve {
             remote,
             verify,

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,9 @@ fn run() {
             dir,
             template,
         } => commands::scaffold::cmd_scaffold(&root, &name, dir, template),
-        Command::InitRegistry { name } => commands::init_registry::cmd_init_registry(&root, name, format),
+        Command::InitRegistry { name } => {
+            commands::init_registry::cmd_init_registry(&root, name, format)
+        }
         Command::Resolve {
             remote,
             verify,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -156,8 +156,12 @@ pub fn fetch_remote_registry(repo: &str) -> Result<RemoteRegistry, String> {
 /// Matches inert 5.0.1-era placeholders such as `version = 1` plus an empty
 /// `[modules]` table that never carried module authority under 5.1.x parsing.
 pub fn is_inert_legacy_registry_stub(content: &str) -> bool {
-    let (name, specs) = scan_registry_fields(content);
-    name.is_empty() && specs.is_empty()
+    match parse_registry_toml(content) {
+        Ok((name, specs)) => name.is_empty() && specs.is_empty(),
+        // Malformed TOML is not inert — it must fail closed in
+        // load_local_registry, not silently vanish.
+        Err(_) => false,
+    }
 }
 
 /// Load the local registry with explicit missing/inert/invalid discrimination.
@@ -189,49 +193,75 @@ pub fn load_registry(root: &Path) -> Option<RegistryEntry> {
     load_local_registry(root).ok().flatten()
 }
 
-/// Scan registry TOML for a `name` value and `[specs]` mappings.
-fn scan_registry_fields(content: &str) -> (String, Vec<(String, String)>) {
+/// Parse registry TOML into `(name, spec mappings)` with a real TOML parser.
+///
+/// Two mapping shapes are supported:
+/// - the generated `[specs]` table (`module = "path"`), emitted by
+///   `init-registry` / `generate_registry`
+/// - the documented `[[modules]]` array-of-tables (`name` + `spec` keys) from
+///   `cross-project-refs.md`
+///
+/// The registry `name` is read from `[registry] name` first, then a top-level
+/// `name`. Returns `Err` on malformed TOML or malformed `[[modules]]` entries
+/// so callers fail closed instead of silently dropping mappings.
+fn parse_registry_toml(content: &str) -> Result<(String, Vec<(String, String)>), String> {
+    let value: toml::Value =
+        toml::from_str(content).map_err(|e| format!("invalid TOML: {e}"))?;
+
     let mut name = String::new();
-    let mut specs = Vec::new();
-    let mut in_specs = false;
+    if let Some(n) = value.get("name").and_then(|v| v.as_str()) {
+        name = n.to_string();
+    }
+    if let Some(n) = value
+        .get("registry")
+        .and_then(|r| r.get("name"))
+        .and_then(|v| v.as_str())
+    {
+        name = n.to_string();
+    }
 
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
+    let mut specs: Vec<(String, String)> = Vec::new();
 
-        if line.starts_with('[') && line.ends_with(']') {
-            in_specs = line == "[specs]";
-            continue;
-        }
-
-        if let Some(eq_pos) = line.find('=') {
-            let key = line[..eq_pos].trim();
-            let value = line[eq_pos + 1..].trim();
-            let value = value.trim_matches('"');
-
-            if in_specs {
-                specs.push((key.to_string(), value.to_string()));
-            } else if key == "name" && !value.is_empty() {
-                name = value.to_string();
+    // Generated shape: [specs] table of module = "path".
+    if let Some(table) = value.get("specs").and_then(|v| v.as_table()) {
+        for (module, path) in table {
+            if let Some(path) = path.as_str() {
+                specs.push((module.clone(), path.to_string()));
             }
         }
     }
 
-    (name, specs)
+    // Documented shape: [[modules]] array of { name, spec }.
+    if let Some(modules) = value.get("modules").and_then(|v| v.as_array()) {
+        for module in modules {
+            let module_name = module.get("name").and_then(|v| v.as_str());
+            let spec_path = module.get("spec").and_then(|v| v.as_str());
+            match (module_name, spec_path) {
+                (Some(m), Some(p)) => specs.push((m.to_string(), p.to_string())),
+                _ => {
+                    return Err(
+                        "every [[modules]] entry needs both `name` and `spec` keys".to_string()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok((name, specs))
 }
 
 /// Parse registry TOML content.
+///
+/// Returns `None` when the content is malformed TOML or carries no registry
+/// `name` — callers treat that as "failed to parse" and fail closed.
 fn parse_registry(content: &str) -> Option<RegistryEntry> {
-    let (name, specs) = scan_registry_fields(content);
+    let (name, specs) = parse_registry_toml(content).ok()?;
     if name.is_empty() {
         return None;
     }
 
     Some(RegistryEntry { name, specs })
 }
-
 /// Generate a registry file by scanning for spec files.
 pub fn generate_registry(root: &Path, project_name: &str, specs_dir: &str) -> String {
     let specs_path = root.join(specs_dir);
@@ -272,13 +302,33 @@ pub fn generate_registry(root: &Path, project_name: &str, specs_dir: &str) -> St
 
     let mut output = String::new();
     output.push_str("[registry]\n");
-    output.push_str(&format!("name = \"{project_name}\"\n"));
+    output.push_str(&format!("name = \"{}\"\n", toml_escape(project_name)));
     output.push_str("\n[specs]\n");
     for (module, path) in &specs {
-        output.push_str(&format!("{module} = \"{path}\"\n"));
+        output.push_str(&format!("{module} = \"{}\"\n", toml_escape(path)));
     }
 
     output
+}
+
+/// Escape a string for embedding inside a TOML basic string (`"..."`).
+/// Without this, a project name containing `"`, `\`, or control characters
+/// (e.g. newlines) produces a registry that fails TOML parsing — or worse,
+/// injects extra keys into it.
+fn toml_escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Add a module entry to an existing local registry file
@@ -448,5 +498,51 @@ messaging = "specs/messaging/messaging.spec.md"
         assert!(reg.has_spec("auth"));
         assert!(reg.has_spec("messaging"));
         assert!(!reg.has_spec("nonexistent"));
+    }
+
+    #[test]
+    fn generate_registry_escapes_toml_injection() {
+        // #440: a --name with quotes/newlines must produce valid TOML.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let content = generate_registry(tmp.path(), "evil\"\n[specs]\npwned=\"x", "specs");
+        let parsed: Result<toml::Value, toml::de::Error> = toml::from_str(&content);
+        assert!(parsed.is_ok(), "generated registry must be valid TOML: {content}");
+        // No injected [specs] key survived.
+        let value = parsed.unwrap();
+        assert!(value.get("specs").is_none() || value["specs"].get("pwned").is_none());
+    }
+
+    #[test]
+    fn parse_registry_supports_documented_modules_shape() {
+        // #413 facet 1: [[modules]] array-of-tables must not drop mappings.
+        let content = "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\nspec = \"custom/lib.spec.md\"\n";
+        let entry = parse_registry(content).expect("documented shape parses");
+        assert_eq!(entry.name, "probe");
+        assert_eq!(
+            entry.specs,
+            vec![("lib".to_string(), "custom/lib.spec.md".to_string())]
+        );
+    }
+
+    #[test]
+    fn load_local_registry_fails_closed_on_malformed_toml_with_name_line() {
+        // #413 facet 2: `name = {{{` is not valid TOML and must not parse.
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(root.join(".specsync/registry.toml"), "version = 1\nname = {{{\n").unwrap();
+
+        assert!(!is_inert_legacy_registry_stub(
+            "version = 1\nname = {{{\n"
+        ));
+        let error = load_local_registry(root).unwrap_err();
+        assert!(error.contains("failed to parse local registry"), "{error}");
+    }
+
+    #[test]
+    fn modules_entry_missing_spec_key_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\n";
+        assert!(parse_registry(content).is_none());
+        assert!(!is_inert_legacy_registry_stub(content));
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -179,9 +179,15 @@ pub fn load_local_registry(root: &Path) -> Result<Option<RegistryEntry>, String>
     if is_inert_legacy_registry_stub(&content) {
         return Ok(None);
     }
-    parse_registry(&content)
-        .map(Some)
-        .ok_or_else(|| format!("failed to parse local registry {}", path.display()))
+    let (name, specs) = parse_registry_toml(&content)
+        .map_err(|error| format!("failed to parse local registry {}: {error}", path.display()))?;
+    if name.is_empty() {
+        return Err(format!(
+            "failed to parse local registry {}: registry name is required",
+            path.display()
+        ));
+    }
+    Ok(Some(RegistryEntry { name, specs }))
 }
 
 /// Load a registry from the local registry file
@@ -205,49 +211,106 @@ pub fn load_registry(root: &Path) -> Option<RegistryEntry> {
 /// `name`. Returns `Err` on malformed TOML or malformed `[[modules]]` entries
 /// so callers fail closed instead of silently dropping mappings.
 fn parse_registry_toml(content: &str) -> Result<(String, Vec<(String, String)>), String> {
-    let value: toml::Value =
-        toml::from_str(content).map_err(|e| format!("invalid TOML: {e}"))?;
+    let value: toml::Value = toml::from_str(content).map_err(|e| format!("invalid TOML: {e}"))?;
+    let root = value
+        .as_table()
+        .ok_or_else(|| "registry root must be a TOML table".to_string())?;
 
-    let mut name = String::new();
-    if let Some(n) = value.get("name").and_then(|v| v.as_str()) {
-        name = n.to_string();
-    }
-    if let Some(n) = value
-        .get("registry")
-        .and_then(|r| r.get("name"))
-        .and_then(|v| v.as_str())
-    {
-        name = n.to_string();
+    let mut name = match root.get("name") {
+        Some(value) => Some(required_registry_string(value, "`name`")?.to_string()),
+        None => None,
+    };
+    if let Some(registry_value) = root.get("registry") {
+        let registry = registry_value
+            .as_table()
+            .ok_or_else(|| "`registry` must be a table".to_string())?;
+        if let Some(registry_name_value) = registry.get("name") {
+            let registry_name = required_registry_string(registry_name_value, "`registry.name`")?;
+            if let Some(top_level_name) = &name
+                && top_level_name != registry_name
+            {
+                return Err("top-level `name` conflicts with `[registry].name`".to_string());
+            }
+            name = Some(registry_name.to_string());
+        }
     }
 
-    let mut specs: Vec<(String, String)> = Vec::new();
+    let mut specs = Vec::new();
+    let mut seen_modules = std::collections::HashSet::new();
 
     // Generated shape: [specs] table of module = "path".
-    if let Some(table) = value.get("specs").and_then(|v| v.as_table()) {
-        for (module, path) in table {
-            if let Some(path) = path.as_str() {
-                specs.push((module.clone(), path.to_string()));
-            }
+    if let Some(specs_value) = root.get("specs") {
+        let table = specs_value
+            .as_table()
+            .ok_or_else(|| "`specs` must be a table".to_string())?;
+        for (module, path_value) in table {
+            let field = format!("`[specs].{module}`");
+            let path = required_registry_string(path_value, &field)?;
+            insert_registry_mapping(&mut specs, &mut seen_modules, module, path)?;
         }
     }
 
     // Documented shape: [[modules]] array of { name, spec }.
-    if let Some(modules) = value.get("modules").and_then(|v| v.as_array()) {
-        for module in modules {
-            let module_name = module.get("name").and_then(|v| v.as_str());
-            let spec_path = module.get("spec").and_then(|v| v.as_str());
-            match (module_name, spec_path) {
-                (Some(m), Some(p)) => specs.push((m.to_string(), p.to_string())),
-                _ => {
-                    return Err(
-                        "every [[modules]] entry needs both `name` and `spec` keys".to_string()
-                    );
-                }
+    if let Some(modules_value) = root.get("modules") {
+        if let Some(modules) = modules_value.as_array() {
+            for (index, module_value) in modules.iter().enumerate() {
+                let module = module_value
+                    .as_table()
+                    .ok_or_else(|| format!("`modules[{index}]` must be a table"))?;
+                let module_name = module
+                    .get("name")
+                    .ok_or_else(|| format!("`modules[{index}].name` is required"))
+                    .and_then(|value| {
+                        required_registry_string(value, &format!("`modules[{index}].name`"))
+                    })?;
+                let spec_path = module
+                    .get("spec")
+                    .ok_or_else(|| format!("`modules[{index}].spec` is required"))
+                    .and_then(|value| {
+                        required_registry_string(value, &format!("`modules[{index}].spec`"))
+                    })?;
+                insert_registry_mapping(&mut specs, &mut seen_modules, module_name, spec_path)?;
             }
+        } else if modules_value
+            .as_table()
+            .is_some_and(|table| table.is_empty())
+            && name.is_none()
+            && specs.is_empty()
+        {
+            // A 5.0.1 migration placeholder used an empty `[modules]` table.
+            // Preserve that exact nameless, mapping-free shape as inert.
+        } else {
+            return Err("`modules` must be an array of tables".to_string());
         }
     }
 
-    Ok((name, specs))
+    Ok((name.unwrap_or_default(), specs))
+}
+
+fn required_registry_string<'a>(value: &'a toml::Value, field: &str) -> Result<&'a str, String> {
+    let string = value
+        .as_str()
+        .ok_or_else(|| format!("{field} must be a string"))?;
+    if string.is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    Ok(string)
+}
+
+fn insert_registry_mapping(
+    specs: &mut Vec<(String, String)>,
+    seen_modules: &mut std::collections::HashSet<String>,
+    module: &str,
+    path: &str,
+) -> Result<(), String> {
+    if module.is_empty() {
+        return Err("module mapping name must not be empty".to_string());
+    }
+    if !seen_modules.insert(module.to_string()) {
+        return Err(format!("duplicate module mapping `{module}`"));
+    }
+    specs.push((module.to_string(), path.to_string()));
+    Ok(())
 }
 
 /// Parse registry TOML content.
@@ -302,33 +365,31 @@ pub fn generate_registry(root: &Path, project_name: &str, specs_dir: &str) -> St
 
     let mut output = String::new();
     output.push_str("[registry]\n");
-    output.push_str(&format!("name = \"{}\"\n", toml_escape(project_name)));
+    output.push_str(&format!("name = {}\n", toml_string(project_name)));
     output.push_str("\n[specs]\n");
     for (module, path) in &specs {
-        output.push_str(&format!("{module} = \"{}\"\n", toml_escape(path)));
+        output.push_str(&format!("{} = {}\n", toml_key(module), toml_string(path)));
     }
 
     output
 }
 
-/// Escape a string for embedding inside a TOML basic string (`"..."`).
-/// Without this, a project name containing `"`, `\`, or control characters
-/// (e.g. newlines) produces a registry that fails TOML parsing — or worse,
-/// injects extra keys into it.
-fn toml_escape(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if c.is_control() => out.push_str(&format!("\\u{:04X}", c as u32)),
-            c => out.push(c),
-        }
+/// Serialize a TOML string with the parser library used to read registries.
+fn toml_string(value: &str) -> String {
+    toml::Value::String(value.to_string()).to_string()
+}
+
+/// Emit a bare key when safe and a quoted TOML key otherwise.
+fn toml_key(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    {
+        value.to_string()
+    } else {
+        toml_string(value)
     }
-    out
 }
 
 /// Add a module entry to an existing local registry file
@@ -506,7 +567,10 @@ messaging = "specs/messaging/messaging.spec.md"
         let tmp = tempfile::TempDir::new().unwrap();
         let content = generate_registry(tmp.path(), "evil\"\n[specs]\npwned=\"x", "specs");
         let parsed: Result<toml::Value, toml::de::Error> = toml::from_str(&content);
-        assert!(parsed.is_ok(), "generated registry must be valid TOML: {content}");
+        assert!(
+            parsed.is_ok(),
+            "generated registry must be valid TOML: {content}"
+        );
         // No injected [specs] key survived.
         let value = parsed.unwrap();
         assert!(value.get("specs").is_none() || value["specs"].get("pwned").is_none());
@@ -525,16 +589,37 @@ messaging = "specs/messaging/messaging.spec.md"
     }
 
     #[test]
+    fn load_local_registry_retains_documented_modules_mapping() {
+        let temp = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(temp.path().join(".specsync")).unwrap();
+        fs::write(
+            temp.path().join(".specsync/registry.toml"),
+            "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\nspec = \"custom/lib.spec.md\"\n",
+        )
+        .unwrap();
+
+        let entry = load_local_registry(temp.path())
+            .expect("documented shape must be valid")
+            .expect("named registry must load");
+        assert_eq!(
+            entry.specs,
+            vec![("lib".to_string(), "custom/lib.spec.md".to_string())]
+        );
+    }
+
+    #[test]
     fn load_local_registry_fails_closed_on_malformed_toml_with_name_line() {
         // #413 facet 2: `name = {{{` is not valid TOML and must not parse.
         let temp = tempfile::TempDir::new().unwrap();
         let root = temp.path();
         fs::create_dir_all(root.join(".specsync")).unwrap();
-        fs::write(root.join(".specsync/registry.toml"), "version = 1\nname = {{{\n").unwrap();
+        fs::write(
+            root.join(".specsync/registry.toml"),
+            "version = 1\nname = {{{\n",
+        )
+        .unwrap();
 
-        assert!(!is_inert_legacy_registry_stub(
-            "version = 1\nname = {{{\n"
-        ));
+        assert!(!is_inert_legacy_registry_stub("version = 1\nname = {{{\n"));
         let error = load_local_registry(root).unwrap_err();
         assert!(error.contains("failed to parse local registry"), "{error}");
     }
@@ -544,5 +629,63 @@ messaging = "specs/messaging/messaging.spec.md"
         let content = "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\n";
         assert!(parse_registry(content).is_none());
         assert!(!is_inert_legacy_registry_stub(content));
+    }
+
+    #[test]
+    fn specs_mapping_with_non_string_path_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[specs]\nlib = 42\n";
+        let error = parse_registry_toml(content).unwrap_err();
+        assert!(error.contains("[specs].lib"), "{error}");
+        assert!(!is_inert_legacy_registry_stub(content));
+
+        let temp = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(temp.path().join(".specsync")).unwrap();
+        fs::write(temp.path().join(".specsync/registry.toml"), content).unwrap();
+        let load_error = load_local_registry(temp.path()).unwrap_err();
+        assert!(load_error.contains("[specs].lib"), "{load_error}");
+    }
+
+    #[test]
+    fn specs_mapping_with_empty_module_name_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[specs]\n\"\" = \"custom/lib.spec.md\"\n";
+        let error = parse_registry_toml(content).unwrap_err();
+        assert!(
+            error.contains("module mapping name must not be empty"),
+            "{error}"
+        );
+        assert!(!is_inert_legacy_registry_stub(content));
+    }
+
+    #[test]
+    fn nonempty_legacy_modules_table_is_not_inert() {
+        let content = "version = 1\n\n[modules]\nlib = \"custom/lib.spec.md\"\n";
+        assert!(parse_registry_toml(content).is_err());
+        assert!(!is_inert_legacy_registry_stub(content));
+    }
+
+    #[test]
+    fn duplicate_mapping_across_supported_shapes_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[specs]\nlib = \"specs/lib.spec.md\"\n\n[[modules]]\nname = \"lib\"\nspec = \"custom/lib.spec.md\"\n";
+        let error = parse_registry_toml(content).unwrap_err();
+        assert!(error.contains("duplicate module mapping `lib`"), "{error}");
+        assert!(!is_inert_legacy_registry_stub(content));
+    }
+
+    #[test]
+    fn generated_registry_quotes_non_bare_module_keys_without_changing_identity() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("specs/quoted")).unwrap();
+        fs::write(
+            root.join("specs/quoted/quoted.spec.md"),
+            "---\nmodule: api.v2\nversion: 1\nstatus: stable\nfiles: []\n---\n",
+        )
+        .unwrap();
+
+        let content = generate_registry(root, "project", "specs");
+        assert!(content.contains("\"api.v2\" = "), "{content}");
+        let entry = parse_registry(&content).expect("generated registry parses");
+        assert!(entry.specs.iter().any(|(module, _)| module == "api.v2"));
+        assert!(!entry.specs.iter().any(|(module, _)| module == "api"));
     }
 }

--- a/tests/integration/commands.rs
+++ b/tests/integration/commands.rs
@@ -431,10 +431,250 @@ fn init_falls_back_to_src_when_no_source_files() {
         .arg(root)
         .assert()
         .success()
-        .stdout(predicate::str::contains("Detected source directories: src"));
+        .stdout(predicate::str::contains(
+            "No source directories detected — defaulted to source_dirs = [\"src\"]",
+        ))
+        .stdout(predicate::str::contains("Detected source directories").not());
 
     let config = fs::read_to_string(root.join(".specsync/config.toml")).unwrap();
     assert!(config.contains("source_dirs = [\"src\"]"));
+}
+
+#[test]
+fn init_json_reports_fallback_and_complete_outcome_truthfully() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    let assert = specsync()
+        .args(["init", "--format", "json", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout must be one JSON value");
+
+    assert_eq!(value["command"], "init");
+    assert_eq!(value["success"], true);
+    assert_eq!(value["created"], true);
+    assert_eq!(value["repaired"], false);
+    assert_eq!(value["unchanged"], false);
+    assert_eq!(value["source_dirs"], serde_json::json!(["src"]));
+    assert_eq!(value["source_dirs_detected"], false);
+    assert_eq!(value["warnings"], serde_json::json!([]));
+}
+
+#[test]
+fn init_does_not_claim_empty_app_and_lib_directories_were_detected() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::create_dir_all(root.join("lib")).unwrap();
+
+    let assert = specsync()
+        .args(["init", "--json", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout must be JSON");
+    assert_eq!(value["source_dirs"], serde_json::json!(["src"]));
+    assert_eq!(value["detected"], false);
+    assert_eq!(value["source_dirs_detected"], false);
+}
+
+#[test]
+fn init_plain_reinit_is_byte_identical_and_json_reports_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    specsync()
+        .args(["init", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let config_before = fs::read(root.join(".specsync/config.toml")).unwrap();
+    let policy_before = fs::read(root.join(".specsync/sdd.json")).unwrap();
+    let version_before = fs::read(root.join(".specsync/version")).unwrap();
+    let local_ignore_before = fs::read(root.join(".specsync/.gitignore")).unwrap();
+    let root_ignore_before = fs::read(root.join(".gitignore")).unwrap();
+
+    let assert = specsync()
+        .args(["init", "--json", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout must be one JSON value");
+    assert_eq!(value["created"], false);
+    assert_eq!(value["repaired"], false);
+    assert_eq!(value["unchanged"], true);
+    assert_eq!(value["missing"], serde_json::json!([]));
+
+    assert_eq!(
+        fs::read(root.join(".specsync/config.toml")).unwrap(),
+        config_before
+    );
+    assert_eq!(
+        fs::read(root.join(".specsync/sdd.json")).unwrap(),
+        policy_before
+    );
+    assert_eq!(
+        fs::read(root.join(".specsync/version")).unwrap(),
+        version_before
+    );
+    assert_eq!(
+        fs::read(root.join(".specsync/.gitignore")).unwrap(),
+        local_ignore_before
+    );
+    assert_eq!(
+        fs::read(root.join(".gitignore")).unwrap(),
+        root_ignore_before
+    );
+}
+
+#[test]
+fn init_repair_restores_support_files_without_touching_owned_content() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::write(root.join(".gitignore"), "target/\n").unwrap();
+    fs::create_dir_all(root.join("specs/owned")).unwrap();
+    fs::write(root.join("specs/owned/owned.spec.md"), "owned bytes\n").unwrap();
+
+    specsync()
+        .args(["init", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let config_before = fs::read(root.join(".specsync/config.toml")).unwrap();
+    let spec_before = fs::read(root.join("specs/owned/owned.spec.md")).unwrap();
+    fs::remove_file(root.join(".specsync/version")).unwrap();
+    fs::remove_file(root.join(".specsync/.gitignore")).unwrap();
+    fs::remove_file(root.join(".specsync/sdd.json")).unwrap();
+
+    let assert = specsync()
+        .args(["init", "--repair", "--format", "json", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout must be one JSON value");
+    assert_eq!(value["success"], true);
+    assert_eq!(value["created"], false);
+    assert_eq!(value["repaired"], true);
+    assert_eq!(value["unchanged"], false);
+    let restored = value["restored"].as_array().expect("restored array");
+    for expected in [
+        ".specsync/version",
+        ".specsync/.gitignore",
+        ".specsync/sdd.json",
+    ] {
+        assert!(
+            restored.iter().any(|entry| entry == expected),
+            "missing {expected} in {restored:?}"
+        );
+    }
+    assert_eq!(
+        fs::read(root.join(".specsync/config.toml")).unwrap(),
+        config_before
+    );
+    assert_eq!(
+        fs::read(root.join("specs/owned/owned.spec.md")).unwrap(),
+        spec_before
+    );
+    let root_ignore = fs::read_to_string(root.join(".gitignore")).unwrap();
+    assert!(root_ignore.starts_with("target/\n"));
+    assert_eq!(root_ignore.matches(".specsync/hashes.json").count(), 1);
+
+    let second = specsync()
+        .args(["init", "--repair", "--json", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let second_json: serde_json::Value =
+        serde_json::from_slice(&second.get_output().stdout).expect("stdout must be JSON");
+    assert_eq!(second_json["repaired"], true);
+    assert_eq!(second_json["unchanged"], true);
+    assert_eq!(second_json["restored"], serde_json::json!([]));
+}
+
+#[test]
+fn init_repair_rejects_corrupt_config_before_mutating_layout() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = [\"wrong-shape\"]\nunterminated = \"",
+    )
+    .unwrap();
+
+    let assert = specsync()
+        .args(["init", "--repair", "--json", "--root"])
+        .arg(root)
+        .assert()
+        .failure()
+        .code(1);
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout must be one JSON value");
+    assert_eq!(value["command"], "init");
+    assert_eq!(value["success"], false);
+    assert!(value["error"].as_str().unwrap().contains("config.toml"));
+    assert!(!root.join(".specsync/version").exists());
+    assert!(!root.join(".specsync/sdd.json").exists());
+    assert!(!root.join(".specsync/lifecycle").exists());
+}
+
+#[test]
+fn init_nested_project_json_fails_without_creating_nested_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("src/deep")).unwrap();
+    specsync()
+        .args(["init", "--root"])
+        .arg(root)
+        .assert()
+        .success();
+    let nested = root.join("src/deep");
+
+    let assert = specsync()
+        .args(["init", "--format", "json", "--root"])
+        .arg(&nested)
+        .assert()
+        .failure()
+        .code(1);
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("stdout must be one JSON value");
+    assert_eq!(value["command"], "init");
+    assert_eq!(value["success"], false);
+    assert_eq!(
+        value["initialized_ancestor"],
+        root.canonicalize().unwrap().display().to_string()
+    );
+    assert!(!nested.join(".specsync").exists());
+}
+
+#[test]
+fn init_preflights_blocking_layout_without_partial_writes() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(root.join(".specsync/changes"), "blocking file\n").unwrap();
+
+    specsync()
+        .args(["init", "--root"])
+        .arg(root)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(".specsync/changes"));
+
+    assert!(!root.join(".specsync/config.toml").exists());
+    assert!(!root.join(".specsync/version").exists());
+    assert!(!root.join(".specsync/lifecycle").exists());
+    assert_eq!(
+        fs::read_to_string(root.join(".specsync/changes")).unwrap(),
+        "blocking file\n"
+    );
 }
 
 // ─── Score Command Tests ─────────────────────────────────────────────────

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -698,6 +698,165 @@ fn init_registry_is_idempotent_for_v4_registry() {
 }
 
 #[test]
+fn init_registry_json_reports_create_and_existing_noop_truthfully() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(root.join(".specsync/version"), "5.0.0\n").unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+
+    let created = specsync()
+        .args([
+            "init-registry",
+            "--name",
+            "api",
+            "--format",
+            "json",
+            "--root",
+            root.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let created_json: serde_json::Value =
+        serde_json::from_slice(&created.get_output().stdout).expect("create output must be JSON");
+    assert_eq!(created_json["command"], "init-registry");
+    assert_eq!(created_json["success"], true);
+    assert_eq!(created_json["created"], true);
+    assert_eq!(created_json["unchanged"], false);
+    assert_eq!(created_json["name"], "api");
+
+    let before = fs::read(root.join(".specsync/registry.toml")).unwrap();
+    let existing = specsync()
+        .args(["init-registry", "--json", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+    let existing_json: serde_json::Value = serde_json::from_slice(&existing.get_output().stdout)
+        .expect("existing output must be JSON");
+    assert_eq!(existing_json["success"], true);
+    assert_eq!(existing_json["created"], false);
+    assert_eq!(existing_json["unchanged"], true);
+    assert_eq!(
+        fs::read(root.join(".specsync/registry.toml")).unwrap(),
+        before
+    );
+}
+
+#[test]
+fn init_registry_rejects_blank_name_as_structured_failure_without_output_file() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(root.join(".specsync/version"), "5.0.0\n").unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+
+    let assert = specsync()
+        .args([
+            "init-registry",
+            "--name",
+            " \t ",
+            "--format",
+            "json",
+            "--root",
+            root.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .code(1);
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("failure output must be JSON");
+    assert_eq!(value["command"], "init-registry");
+    assert_eq!(value["success"], false);
+    assert!(
+        value["error"]
+            .as_str()
+            .unwrap()
+            .contains("must not be empty")
+    );
+    assert!(!root.join(".specsync/registry.toml").exists());
+}
+
+#[test]
+fn init_registry_rejects_invalid_existing_registry_without_overwrite() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(root.join(".specsync/version"), "5.0.0\n").unwrap();
+    fs::write(
+        root.join(".specsync/registry.toml"),
+        "[registry]\nname = \"unterminated\n",
+    )
+    .unwrap();
+    let before = fs::read(root.join(".specsync/registry.toml")).unwrap();
+
+    let assert = specsync()
+        .args(["init-registry", "--json", "--root", root.to_str().unwrap()])
+        .assert()
+        .failure()
+        .code(1);
+    let value: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("failure output must be JSON");
+    assert_eq!(value["success"], false);
+    assert!(
+        value["error"]
+            .as_str()
+            .unwrap()
+            .contains("failed to parse local registry")
+    );
+    assert_eq!(
+        fs::read(root.join(".specsync/registry.toml")).unwrap(),
+        before
+    );
+}
+
+#[test]
+fn init_registry_serializes_hostile_name_and_module_key_as_valid_toml() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join(".specsync")).unwrap();
+    fs::write(root.join(".specsync/version"), "5.0.0\n").unwrap();
+    fs::write(
+        root.join(".specsync/config.toml"),
+        "specs_dir = \"specs\"\nsource_dirs = [\"src\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("specs/hostile")).unwrap();
+    fs::write(
+        root.join("specs/hostile/hostile.spec.md"),
+        "---\nmodule: api.v2\nversion: 1\nstatus: stable\nfiles: []\n---\n",
+    )
+    .unwrap();
+    let hostile = "evil\"\n[specs]\npwned=\"x";
+
+    specsync()
+        .args([
+            "init-registry",
+            "--name",
+            hostile,
+            "--root",
+            root.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(root.join(".specsync/registry.toml")).unwrap();
+    let parsed: toml::Value = toml::from_str(&content).expect("generated registry must parse");
+    assert_eq!(parsed["registry"]["name"].as_str(), Some(hostile));
+    assert_eq!(
+        parsed["specs"]["api.v2"].as_str(),
+        Some("specs/hostile/hostile.spec.md")
+    );
+    assert!(parsed["specs"].get("pwned").is_none());
+}
+
+#[test]
 fn draft_spec_check_reports_skipped_validation() {
     let tmp = TempDir::new().unwrap();
     let root = setup_minimal_project(&tmp);


### PR DESCRIPTION
## Root cause

`init` / `init-registry` misreported or corrupted project state in five ways:

1. **Dishonest detection** — in an empty directory, `init` printed "Detected source directories: src" when nothing was detected. Added `config::detect_source_dirs_with_confidence` returning `(dirs, actually_detected)`; init now says "No source directories detected — defaulted to source_dirs = [\"src\"]" and `--json` emits a `detected` boolean.
2. **No repair path** — deleting `.specsync/version`, `.specsync/.gitignore`, or `sdd.json` left the project broken; re-running `init` just said "already exists". Added `init --repair`: restores missing support files/dirs without touching the existing config, sanity-checks the config for a `specs_dir` key, and re-init now lists missing support files with a repair hint (text and JSON).
3. **TOML injection via `init-registry --name`** — a name containing `"` or newlines (e.g. `evil"\n[specs]\npwned="x`) produced invalid/injected registry TOML. `generate_registry` now TOML-escapes names and paths.
4. **Empty `--name ""` accepted** — now rejected with exit 1.
5. **Nested `.specsync` in subdirectories** — running `init` inside a subdirectory of an initialized project created a nested `.specsync`; `find_initialized_ancestor` now detects the ancestor project and errors out with guidance. Also `init-registry` now respects `--json`/`--format`.

## Regression tests

- `commands::init::tests::empty_dir_init_reports_fallback_not_detection`
- `commands::init::tests::repair_restores_deleted_support_files`
- `commands::init::tests::find_initialized_ancestor_detects_parent_project`
- `registry::tests::generate_registry_escapes_toml_injection`

## File overlap notes

- `src/registry.rs` is shared with #413 (disjoint regions: #440 owns `toml_escape`/`generate_registry`, #413 owns `parse_registry_toml`); both PRs include the identical full file (blob `04c19b38…`), so either merge order is clean.
- `src/cli.rs` is shared with #442 (identical content in both PRs).

⚠️ **`src/config.rs` is pending**: it exceeded the MCP push size limit during publication and is being pushed to this branch separately (blob sha `a7c58f4a967906d238717757c13e620279d94367`). The branch does not compile until it lands (`detect_source_dirs_with_confidence` is defined there).

Closes #440