### PR TITLE
fix: parse local registries with real TOML (closes #413)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1157,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "toml",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-commonlisp",
@@ -1290,6 +1300,45 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tree-sitter"
@@ -1817,6 +1866,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tree-sitter-commonlisp = "0.4.1"
 tree-sitter-scheme = "0.24.7"
 tree-sitter-elisp = "1.6.1"
 tree-sitter-perl = "1.1.2"
+toml = "1.1.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/site/src/content/docs/cross-project-refs.md
+++ b/site/src/content/docs/cross-project-refs.md
@@ -47,10 +47,22 @@ git push
 
 The registry lists all modules from your specs directory:
 
+`specsync init-registry` emits the compact `[specs]` table:
+
 ```toml
 [registry]
 name = "spec-sync"
-generated = "2026-03-28T00:00:00Z"
+
+[specs]
+cli = "specs/cli/cli.spec.md"
+parser = "specs/parser/parser.spec.md"
+```
+
+The documented array-of-tables shape is also accepted when authoring a registry by hand:
+
+```toml
+[registry]
+name = "spec-sync"
 
 [[modules]]
 name = "cli"
@@ -60,6 +72,8 @@ spec = "specs/cli/cli.spec.md"
 name = "parser"
 spec = "specs/parser/parser.spec.md"
 ```
+
+Known registry fields are checked. Malformed TOML, wrong field types or shapes, empty mapping names or paths, and duplicate module names fail closed instead of silently dropping a mapping.
 
 > **Inert stubs are tolerated.** A 5.0.1-era `registry.toml` with no registry `name` and no
 > `[specs]`/`[[modules]]` mappings loads as absent: canonical module resolution falls back to the

--- a/specs/registry/context.md
+++ b/specs/registry/context.md
@@ -4,9 +4,9 @@ spec: registry.spec.md
 
 ## Key Decisions
 
-- **TOML registry format**: The registry uses a simple TOML file (`specsync-registry.toml`) with a `[registry]` section for metadata and a `[specs]` section mapping module names to spec file paths. This is human-readable and easy to parse.
+- **TOML registry format**: Generated registries use `[registry]` metadata plus a `[specs]` module-to-path table. The documented `[[modules]]` array-of-tables shape is accepted for compatibility.
 - **GitHub raw URL fetching**: Remote registries are fetched from GitHub's raw content URL (`raw.githubusercontent.com`) with a 10-second HTTP timeout. No authentication required for public repos.
-- **Zero-dependency TOML parsing**: Like other modules, registry parsing is line-by-line string operations rather than a TOML library.
+- **Checked TOML parsing**: Registry syntax is parsed with the `toml` crate. Known fields are validated for type and shape, and duplicate mappings fail closed rather than silently selecting a path.
 - **Template files excluded**: Specs starting with `_` (like `_template.spec.md`) are skipped during registry generation to keep the registry clean.
 - **Module name from frontmatter**: The registry extracts the `module` field from each spec's frontmatter rather than inferring from file paths, ensuring consistency with the spec's own identity.
 - **Alphabetical sorting**: Generated registry entries are sorted by module name for deterministic output.
@@ -17,7 +17,7 @@ spec: registry.spec.md
 
 ## Current Status
 
-Fully implemented. Local registry generation and remote fetching both work. The `resolve` CLI command uses this module for cross-project dependency validation. Inert 5.0.1-era stubs (no registry `name`, no `[specs]` mappings) load as absent through `load_local_registry` so module resolution can fall back to conventional paths.
+Fully implemented. Local registry generation and remote fetching both work. The `resolve` CLI command uses this module for cross-project dependency validation. Both `[specs]` and `[[modules]]` mappings are retained. Inert 5.0.1-era stubs load as absent, while malformed and non-inert invalid registries fail closed.
 
 ## Notes
 

--- a/specs/registry/registry.spec.md
+++ b/specs/registry/registry.spec.md
@@ -1,10 +1,11 @@
 ---
 module: registry
-version: 5
+version: 6
 status: stable
 files:
   - src/registry.rs
 db_tables: []
+implements: [413]
 tracks: [52]
 depends_on:
   - specs/types/types.spec.md
@@ -14,7 +15,7 @@ depends_on:
 
 ## Purpose
 
-Manages cross-project spec registries for dependency resolution. Generates `specsync-registry.toml` from local spec files, fetches remote registries from GitHub repos via HTTPS, and parses the TOML registry format using zero-dependency parsing.
+Manages cross-project spec registries for dependency resolution. Generates registry TOML from local spec files, fetches remote registries from GitHub repos via HTTPS, and parses supported registry shapes with checked TOML syntax and field validation.
 
 ## Public API
 
@@ -49,14 +50,14 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 ## Invariants
 
 1. Remote registry fetch uses a 10-second HTTP timeout
-2. Registry TOML format: `[registry]` section with `name`, `[specs]` section with `module = "path"` entries
+2. Registry TOML accepts both the emitted `[specs]` table (`module = "path"`) and the documented `[[modules]]` array-of-tables (`name` plus `spec`)
 3. `generate_registry` skips template files (names starting with `_`)
 4. Module names are extracted from spec frontmatter, not file paths
 5. Generated registry entries are sorted alphabetically by module name
 6. `RemoteRegistry::has_spec` performs exact module name matching
-7. TOML parsing is zero-dependency — uses line-by-line string parsing
+7. Registry parsing uses a real TOML parser and rejects malformed syntax, wrong known-field types or shapes, empty mapping identities or paths, and duplicate module mappings
 8. Local registry resolution prefers the v4 `.specsync/registry.toml` location; the legacy root-level `specsync-registry.toml` is only used for un-migrated 3.x layouts
-9. Inert 5.0.1-era stubs (no registry name and no `[specs]` mappings) are treated as absent; non-inert unparsable registries fail closed through `load_local_registry`
+9. Inert 5.0.1-era stubs (no registry name and no `[specs]` or `[[modules]]` mappings) are treated as absent; non-inert invalid registries fail closed through `load_local_registry`
 
 ## Behavioral Examples
 
@@ -78,6 +79,12 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 - **When** `has_spec("auth")` is called
 - **Then** returns `true`
 
+**Scenario: Resolve the documented modules shape**
+
+- **Given** a named registry with `[[modules]]`, `name = "lib"`, and `spec = "custom/lib.spec.md"`
+- **When** the local registry is loaded
+- **Then** the `lib` mapping resolves to `custom/lib.spec.md` without falling back to a conventional path
+
 **Scenario: Tolerate inert 5.0.1 registry stub**
 
 - **Given** a local `.specsync/registry.toml` containing only `version = 1` and an empty `[modules]` table
@@ -90,9 +97,11 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 |-----------|----------|
 | HTTP request fails | Error: "HTTP request failed: {details}" |
 | Repo has no registry file | Error: "HTTP 404 — {repo} may not have a specsync-registry.toml" |
-| Malformed TOML (no name) | `parse_registry` returns `None` |
+| Malformed TOML | `load_local_registry` returns `Err` with the registry path and parser diagnostic |
+| Wrong known-field type or shape | `load_local_registry` returns `Err` identifying the invalid field |
+| Duplicate module mapping across supported shapes | Registry parsing fails with `duplicate module mapping` |
 | Local registry file unreadable | `load_registry` returns `None`; `load_local_registry` returns `Err` |
-| Inert legacy stub (no name, no `[specs]` mappings) | `load_local_registry` returns `Ok(None)`; `load_registry` returns `None` |
+| Inert legacy stub (no name, no `[specs]` or `[[modules]]` mappings) | `load_local_registry` returns `Ok(None)`; `load_registry` returns `None` |
 | Non-inert unparsable local registry | `load_local_registry` returns `Err`; `load_registry` returns `None` |
 
 ## Dependencies
@@ -103,6 +112,7 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 |--------|-------------|
 | types | `RegistryEntry` |
 | ureq | HTTP client for fetching remote registries |
+| toml | TOML syntax and value parsing |
 
 ### Consumed By
 
@@ -120,3 +130,4 @@ Manages cross-project spec registries for dependency resolution. Generates `spec
 | 2026-06-11 | v3: Added `local_registry_path`; `load_registry`/`register_module` now resolve the v4 `.specsync/registry.toml` location with legacy fallback |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-07-19 | CHG-0059-tolerate-inert-5-0-1-registry-toml-stubs-so-module-resolution-falls-back-to-defa: Tolerate inert 5.0.1 registry.toml stubs so module resolution falls back to default specs layout without failing closed on empty legacy stubs |
+| 2026-07-26 | v6: Parse registries as checked TOML, support `[specs]` and `[[modules]]`, and fail closed on malformed or ambiguous mappings (#413) |

--- a/specs/registry/requirements.md
+++ b/specs/registry/requirements.md
@@ -17,7 +17,9 @@ spec: registry.spec.md
 - Registry entries are sorted alphabetically by module name
 - `fetch_remote_registry` uses HTTPS with a 10-second timeout
 - `RemoteRegistry::has_spec` performs exact module name matching
-- TOML parsing is zero-dependency (line-by-line string parsing)
+- Registry parsing uses a real TOML parser and validates supported field types and shapes
+- Both emitted `[specs]` mappings and documented `[[modules]]` entries are accepted
+- Invalid or ambiguous non-inert registries fail closed with a diagnostic
 - HTTP errors and timeouts produce clear error messages
 
 ## Constraints
@@ -44,7 +46,9 @@ Acceptance Criteria
 - Registry entries are sorted alphabetically by module name
 - `fetch_remote_registry` uses HTTPS with a 10-second timeout
 - `RemoteRegistry::has_spec` performs exact module name matching
-- TOML parsing is zero-dependency (line-by-line string parsing)
+- Registry parsing uses a real TOML parser and validates supported field types and shapes
+- Both emitted `[specs]` mappings and documented `[[modules]]` entries are accepted
+- Invalid or ambiguous non-inert registries fail closed with a diagnostic
 - HTTP errors and timeouts produce clear error messages
 
 ### REQ-registry-002
@@ -59,3 +63,15 @@ Acceptance Criteria
 - A file that is not inert but cannot parse as a named registry fails closed through the Result-based local loader.
 - Best-effort `load_registry` continues to return `None` for missing, inert, and unparsable content.
 
+### REQ-registry-003
+
+The registry module SHALL preserve every valid mapping in either supported TOML shape and reject invalid or ambiguous non-inert registry content.
+
+Acceptance Criteria
+
+- A named `[specs]` table maps each string-valued module key to its declared spec path.
+- A named `[[modules]]` array maps each non-empty `name` to its non-empty `spec` path.
+- Malformed TOML fails closed instead of being classified as an inert registry.
+- Wrong known-field types or shapes fail closed with a field-specific diagnostic.
+- Duplicate module names across supported shapes fail closed instead of selecting one mapping silently.
+- The nameless, mapping-free 5.0.1 `[modules]` table placeholder remains inert for compatibility.

--- a/specs/registry/tasks.md
+++ b/specs/registry/tasks.md
@@ -15,7 +15,7 @@ spec: registry.spec.md
 
 - [x] Local registry generation from specs directory
 - [x] Remote registry fetching from GitHub raw URLs
-- [x] Zero-dependency TOML parsing
+- [x] Checked TOML parsing for `[specs]` and `[[modules]]`
 - [x] Template file exclusion
 - [x] Module name extraction from frontmatter
 - [x] Alphabetically sorted output
@@ -23,12 +23,13 @@ spec: registry.spec.md
 - [x] `register_module` — idempotent append of a module entry to an existing registry
 - [x] Cross-repo content verification: `fetch_remote_spec`, `parse_remote_spec`, `RemoteSpec`
 - [x] Tolerate inert 5.0.1 registry.toml stubs via `load_local_registry`
+- [x] Fail closed on malformed TOML, invalid supported shapes, and duplicate mappings
 
 ## Gaps
 
 - No caching — every `resolve --remote` re-fetches all remote registries
 - Private repos are inaccessible (no auth token support)
-- No validation of registry TOML structure (malformed files fail silently)
+- No version negotiation between registry producers and consumers
 
 ## Review Status
 

--- a/specs/registry/testing.md
+++ b/specs/registry/testing.md
@@ -6,7 +6,7 @@ spec: registry.spec.md
 
 | Area | Command | Assertions To Watch |
 |------|---------|---------------------|
-| `src/registry.rs` | cargo test registry:: | `test_parse_registry`, `test_parse_registry_empty`, `inert_legacy_registry_stub_is_detected`, `load_local_registry_treats_inert_stub_as_absent`, `load_local_registry_fails_closed_on_non_inert_unparsable`, `test_extract_module_name`, `test_remote_registry_has_spec` |
+| `src/registry.rs` | `fledge run test -- registry::tests::` | `[specs]` and `[[modules]]` parsing, malformed TOML, wrong known-field types/shapes, duplicate mappings, inert-stub compatibility, generation, and lookup |
 
 ## Coverage Gaps
 
@@ -19,6 +19,7 @@ spec: registry.spec.md
 | Fetch remote registry | a GitHub repo "corvid-labs/algochat" with a `specsync-registry.toml` at root | `fetch_remote_registry("corvid-labs/algochat")` is called | returns `Ok(RemoteRegistry)` with parsed module-to-path mappings |
 | Generate registry from local specs | specs at `specs/auth/auth.spec.md` and `specs/messaging/messaging.spec.md` | `generate_registry(root, "myproject", "specs")` is called | returns TOML string with `[registry]\nname = "myproject"\n\n[specs]\nauth = "specs/auth/auth.spec.md"\nmessaging = "specs/messaging/messaging.spec.md"\n` |
 | Check module existence | a `RemoteRegistry` with specs for "auth" and "messaging" | `has_spec("auth")` is called | returns `true` |
+| Resolve documented mapping | a named registry with `[[modules]]` mapping `lib` to `custom/lib.spec.md` | load the local registry and look up `lib` | returns the declared custom path |
 
 ## Regression Matrix
 
@@ -26,7 +27,10 @@ spec: registry.spec.md
 |------|-------------------|-----------------|
 | HTTP request fails | Error: "HTTP request failed: {details}" | Keep or add a focused assertion before changing this behavior |
 | Repo has no registry file | Error: "HTTP 404 — {repo} may not have a specsync-registry.toml" | Keep or add a focused assertion before changing this behavior |
-| Malformed TOML (no name) | `parse_registry` returns `None` | Keep or add a focused assertion before changing this behavior |
+| Malformed TOML with a surviving `name` line | `load_local_registry` returns `Err` | `load_local_registry_fails_closed_on_malformed_toml_with_name_line` |
+| Non-string `[specs]` path | field-specific parse and load error | `specs_mapping_with_non_string_path_is_an_error` |
+| Non-empty legacy `[modules]` table | not inert; parse error | `nonempty_legacy_modules_table_is_not_inert` |
+| Duplicate mapping across `[specs]` and `[[modules]]` | parse error rather than silent selection | `duplicate_mapping_across_supported_shapes_is_an_error` |
 | Local registry file unreadable | `load_registry` returns `None` | Keep or add a focused assertion before changing this behavior |
 
 ## Reviewer Checklist

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -156,8 +156,12 @@ pub fn fetch_remote_registry(repo: &str) -> Result<RemoteRegistry, String> {
 /// Matches inert 5.0.1-era placeholders such as `version = 1` plus an empty
 /// `[modules]` table that never carried module authority under 5.1.x parsing.
 pub fn is_inert_legacy_registry_stub(content: &str) -> bool {
-    let (name, specs) = scan_registry_fields(content);
-    name.is_empty() && specs.is_empty()
+    match parse_registry_toml(content) {
+        Ok((name, specs)) => name.is_empty() && specs.is_empty(),
+        // Malformed TOML is not inert — it must fail closed in
+        // load_local_registry, not silently vanish.
+        Err(_) => false,
+    }
 }
 
 /// Load the local registry with explicit missing/inert/invalid discrimination.
@@ -189,49 +193,75 @@ pub fn load_registry(root: &Path) -> Option<RegistryEntry> {
     load_local_registry(root).ok().flatten()
 }
 
-/// Scan registry TOML for a `name` value and `[specs]` mappings.
-fn scan_registry_fields(content: &str) -> (String, Vec<(String, String)>) {
+/// Parse registry TOML into `(name, spec mappings)` with a real TOML parser.
+///
+/// Two mapping shapes are supported:
+/// - the generated `[specs]` table (`module = "path"`), emitted by
+///   `init-registry` / `generate_registry`
+/// - the documented `[[modules]]` array-of-tables (`name` + `spec` keys) from
+///   `cross-project-refs.md`
+///
+/// The registry `name` is read from `[registry] name` first, then a top-level
+/// `name`. Returns `Err` on malformed TOML or malformed `[[modules]]` entries
+/// so callers fail closed instead of silently dropping mappings.
+fn parse_registry_toml(content: &str) -> Result<(String, Vec<(String, String)>), String> {
+    let value: toml::Value =
+        toml::from_str(content).map_err(|e| format!("invalid TOML: {e}"))?;
+
     let mut name = String::new();
-    let mut specs = Vec::new();
-    let mut in_specs = false;
+    if let Some(n) = value.get("name").and_then(|v| v.as_str()) {
+        name = n.to_string();
+    }
+    if let Some(n) = value
+        .get("registry")
+        .and_then(|r| r.get("name"))
+        .and_then(|v| v.as_str())
+    {
+        name = n.to_string();
+    }
 
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
+    let mut specs: Vec<(String, String)> = Vec::new();
 
-        if line.starts_with('[') && line.ends_with(']') {
-            in_specs = line == "[specs]";
-            continue;
-        }
-
-        if let Some(eq_pos) = line.find('=') {
-            let key = line[..eq_pos].trim();
-            let value = line[eq_pos + 1..].trim();
-            let value = value.trim_matches('"');
-
-            if in_specs {
-                specs.push((key.to_string(), value.to_string()));
-            } else if key == "name" && !value.is_empty() {
-                name = value.to_string();
+    // Generated shape: [specs] table of module = "path".
+    if let Some(table) = value.get("specs").and_then(|v| v.as_table()) {
+        for (module, path) in table {
+            if let Some(path) = path.as_str() {
+                specs.push((module.clone(), path.to_string()));
             }
         }
     }
 
-    (name, specs)
+    // Documented shape: [[modules]] array of { name, spec }.
+    if let Some(modules) = value.get("modules").and_then(|v| v.as_array()) {
+        for module in modules {
+            let module_name = module.get("name").and_then(|v| v.as_str());
+            let spec_path = module.get("spec").and_then(|v| v.as_str());
+            match (module_name, spec_path) {
+                (Some(m), Some(p)) => specs.push((m.to_string(), p.to_string())),
+                _ => {
+                    return Err(
+                        "every [[modules]] entry needs both `name` and `spec` keys".to_string()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok((name, specs))
 }
 
 /// Parse registry TOML content.
+///
+/// Returns `None` when the content is malformed TOML or carries no registry
+/// `name` — callers treat that as "failed to parse" and fail closed.
 fn parse_registry(content: &str) -> Option<RegistryEntry> {
-    let (name, specs) = scan_registry_fields(content);
+    let (name, specs) = parse_registry_toml(content).ok()?;
     if name.is_empty() {
         return None;
     }
 
     Some(RegistryEntry { name, specs })
 }
-
 /// Generate a registry file by scanning for spec files.
 pub fn generate_registry(root: &Path, project_name: &str, specs_dir: &str) -> String {
     let specs_path = root.join(specs_dir);
@@ -272,13 +302,33 @@ pub fn generate_registry(root: &Path, project_name: &str, specs_dir: &str) -> St
 
     let mut output = String::new();
     output.push_str("[registry]\n");
-    output.push_str(&format!("name = \"{project_name}\"\n"));
+    output.push_str(&format!("name = \"{}\"\n", toml_escape(project_name)));
     output.push_str("\n[specs]\n");
     for (module, path) in &specs {
-        output.push_str(&format!("{module} = \"{path}\"\n"));
+        output.push_str(&format!("{module} = \"{}\"\n", toml_escape(path)));
     }
 
     output
+}
+
+/// Escape a string for embedding inside a TOML basic string (`"..."`).
+/// Without this, a project name containing `"`, `\`, or control characters
+/// (e.g. newlines) produces a registry that fails TOML parsing — or worse,
+/// injects extra keys into it.
+fn toml_escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Add a module entry to an existing local registry file
@@ -448,5 +498,51 @@ messaging = "specs/messaging/messaging.spec.md"
         assert!(reg.has_spec("auth"));
         assert!(reg.has_spec("messaging"));
         assert!(!reg.has_spec("nonexistent"));
+    }
+
+    #[test]
+    fn generate_registry_escapes_toml_injection() {
+        // #440: a --name with quotes/newlines must produce valid TOML.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let content = generate_registry(tmp.path(), "evil\"\n[specs]\npwned=\"x", "specs");
+        let parsed: Result<toml::Value, toml::de::Error> = toml::from_str(&content);
+        assert!(parsed.is_ok(), "generated registry must be valid TOML: {content}");
+        // No injected [specs] key survived.
+        let value = parsed.unwrap();
+        assert!(value.get("specs").is_none() || value["specs"].get("pwned").is_none());
+    }
+
+    #[test]
+    fn parse_registry_supports_documented_modules_shape() {
+        // #413 facet 1: [[modules]] array-of-tables must not drop mappings.
+        let content = "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\nspec = \"custom/lib.spec.md\"\n";
+        let entry = parse_registry(content).expect("documented shape parses");
+        assert_eq!(entry.name, "probe");
+        assert_eq!(
+            entry.specs,
+            vec![("lib".to_string(), "custom/lib.spec.md".to_string())]
+        );
+    }
+
+    #[test]
+    fn load_local_registry_fails_closed_on_malformed_toml_with_name_line() {
+        // #413 facet 2: `name = {{{` is not valid TOML and must not parse.
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(root.join(".specsync/registry.toml"), "version = 1\nname = {{{\n").unwrap();
+
+        assert!(!is_inert_legacy_registry_stub(
+            "version = 1\nname = {{{\n"
+        ));
+        let error = load_local_registry(root).unwrap_err();
+        assert!(error.contains("failed to parse local registry"), "{error}");
+    }
+
+    #[test]
+    fn modules_entry_missing_spec_key_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\n";
+        assert!(parse_registry(content).is_none());
+        assert!(!is_inert_legacy_registry_stub(content));
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -179,9 +179,15 @@ pub fn load_local_registry(root: &Path) -> Result<Option<RegistryEntry>, String>
     if is_inert_legacy_registry_stub(&content) {
         return Ok(None);
     }
-    parse_registry(&content)
-        .map(Some)
-        .ok_or_else(|| format!("failed to parse local registry {}", path.display()))
+    let (name, specs) = parse_registry_toml(&content)
+        .map_err(|error| format!("failed to parse local registry {}: {error}", path.display()))?;
+    if name.is_empty() {
+        return Err(format!(
+            "failed to parse local registry {}: registry name is required",
+            path.display()
+        ));
+    }
+    Ok(Some(RegistryEntry { name, specs }))
 }
 
 /// Load a registry from the local registry file
@@ -205,49 +211,106 @@ pub fn load_registry(root: &Path) -> Option<RegistryEntry> {
 /// `name`. Returns `Err` on malformed TOML or malformed `[[modules]]` entries
 /// so callers fail closed instead of silently dropping mappings.
 fn parse_registry_toml(content: &str) -> Result<(String, Vec<(String, String)>), String> {
-    let value: toml::Value =
-        toml::from_str(content).map_err(|e| format!("invalid TOML: {e}"))?;
+    let value: toml::Value = toml::from_str(content).map_err(|e| format!("invalid TOML: {e}"))?;
+    let root = value
+        .as_table()
+        .ok_or_else(|| "registry root must be a TOML table".to_string())?;
 
-    let mut name = String::new();
-    if let Some(n) = value.get("name").and_then(|v| v.as_str()) {
-        name = n.to_string();
-    }
-    if let Some(n) = value
-        .get("registry")
-        .and_then(|r| r.get("name"))
-        .and_then(|v| v.as_str())
-    {
-        name = n.to_string();
+    let mut name = match root.get("name") {
+        Some(value) => Some(required_registry_string(value, "`name`")?.to_string()),
+        None => None,
+    };
+    if let Some(registry_value) = root.get("registry") {
+        let registry = registry_value
+            .as_table()
+            .ok_or_else(|| "`registry` must be a table".to_string())?;
+        if let Some(registry_name_value) = registry.get("name") {
+            let registry_name = required_registry_string(registry_name_value, "`registry.name`")?;
+            if let Some(top_level_name) = &name
+                && top_level_name != registry_name
+            {
+                return Err("top-level `name` conflicts with `[registry].name`".to_string());
+            }
+            name = Some(registry_name.to_string());
+        }
     }
 
-    let mut specs: Vec<(String, String)> = Vec::new();
+    let mut specs = Vec::new();
+    let mut seen_modules = std::collections::HashSet::new();
 
     // Generated shape: [specs] table of module = "path".
-    if let Some(table) = value.get("specs").and_then(|v| v.as_table()) {
-        for (module, path) in table {
-            if let Some(path) = path.as_str() {
-                specs.push((module.clone(), path.to_string()));
-            }
+    if let Some(specs_value) = root.get("specs") {
+        let table = specs_value
+            .as_table()
+            .ok_or_else(|| "`specs` must be a table".to_string())?;
+        for (module, path_value) in table {
+            let field = format!("`[specs].{module}`");
+            let path = required_registry_string(path_value, &field)?;
+            insert_registry_mapping(&mut specs, &mut seen_modules, module, path)?;
         }
     }
 
     // Documented shape: [[modules]] array of { name, spec }.
-    if let Some(modules) = value.get("modules").and_then(|v| v.as_array()) {
-        for module in modules {
-            let module_name = module.get("name").and_then(|v| v.as_str());
-            let spec_path = module.get("spec").and_then(|v| v.as_str());
-            match (module_name, spec_path) {
-                (Some(m), Some(p)) => specs.push((m.to_string(), p.to_string())),
-                _ => {
-                    return Err(
-                        "every [[modules]] entry needs both `name` and `spec` keys".to_string()
-                    );
-                }
+    if let Some(modules_value) = root.get("modules") {
+        if let Some(modules) = modules_value.as_array() {
+            for (index, module_value) in modules.iter().enumerate() {
+                let module = module_value
+                    .as_table()
+                    .ok_or_else(|| format!("`modules[{index}]` must be a table"))?;
+                let module_name = module
+                    .get("name")
+                    .ok_or_else(|| format!("`modules[{index}].name` is required"))
+                    .and_then(|value| {
+                        required_registry_string(value, &format!("`modules[{index}].name`"))
+                    })?;
+                let spec_path = module
+                    .get("spec")
+                    .ok_or_else(|| format!("`modules[{index}].spec` is required"))
+                    .and_then(|value| {
+                        required_registry_string(value, &format!("`modules[{index}].spec`"))
+                    })?;
+                insert_registry_mapping(&mut specs, &mut seen_modules, module_name, spec_path)?;
             }
+        } else if modules_value
+            .as_table()
+            .is_some_and(|table| table.is_empty())
+            && name.is_none()
+            && specs.is_empty()
+        {
+            // A 5.0.1 migration placeholder used an empty `[modules]` table.
+            // Preserve that exact nameless, mapping-free shape as inert.
+        } else {
+            return Err("`modules` must be an array of tables".to_string());
         }
     }
 
-    Ok((name, specs))
+    Ok((name.unwrap_or_default(), specs))
+}
+
+fn required_registry_string<'a>(value: &'a toml::Value, field: &str) -> Result<&'a str, String> {
+    let string = value
+        .as_str()
+        .ok_or_else(|| format!("{field} must be a string"))?;
+    if string.is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    Ok(string)
+}
+
+fn insert_registry_mapping(
+    specs: &mut Vec<(String, String)>,
+    seen_modules: &mut std::collections::HashSet<String>,
+    module: &str,
+    path: &str,
+) -> Result<(), String> {
+    if module.is_empty() {
+        return Err("module mapping name must not be empty".to_string());
+    }
+    if !seen_modules.insert(module.to_string()) {
+        return Err(format!("duplicate module mapping `{module}`"));
+    }
+    specs.push((module.to_string(), path.to_string()));
+    Ok(())
 }
 
 /// Parse registry TOML content.
@@ -506,7 +569,10 @@ messaging = "specs/messaging/messaging.spec.md"
         let tmp = tempfile::TempDir::new().unwrap();
         let content = generate_registry(tmp.path(), "evil\"\n[specs]\npwned=\"x", "specs");
         let parsed: Result<toml::Value, toml::de::Error> = toml::from_str(&content);
-        assert!(parsed.is_ok(), "generated registry must be valid TOML: {content}");
+        assert!(
+            parsed.is_ok(),
+            "generated registry must be valid TOML: {content}"
+        );
         // No injected [specs] key survived.
         let value = parsed.unwrap();
         assert!(value.get("specs").is_none() || value["specs"].get("pwned").is_none());
@@ -525,16 +591,37 @@ messaging = "specs/messaging/messaging.spec.md"
     }
 
     #[test]
+    fn load_local_registry_retains_documented_modules_mapping() {
+        let temp = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(temp.path().join(".specsync")).unwrap();
+        fs::write(
+            temp.path().join(".specsync/registry.toml"),
+            "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\nspec = \"custom/lib.spec.md\"\n",
+        )
+        .unwrap();
+
+        let entry = load_local_registry(temp.path())
+            .expect("documented shape must be valid")
+            .expect("named registry must load");
+        assert_eq!(
+            entry.specs,
+            vec![("lib".to_string(), "custom/lib.spec.md".to_string())]
+        );
+    }
+
+    #[test]
     fn load_local_registry_fails_closed_on_malformed_toml_with_name_line() {
         // #413 facet 2: `name = {{{` is not valid TOML and must not parse.
         let temp = tempfile::TempDir::new().unwrap();
         let root = temp.path();
         fs::create_dir_all(root.join(".specsync")).unwrap();
-        fs::write(root.join(".specsync/registry.toml"), "version = 1\nname = {{{\n").unwrap();
+        fs::write(
+            root.join(".specsync/registry.toml"),
+            "version = 1\nname = {{{\n",
+        )
+        .unwrap();
 
-        assert!(!is_inert_legacy_registry_stub(
-            "version = 1\nname = {{{\n"
-        ));
+        assert!(!is_inert_legacy_registry_stub("version = 1\nname = {{{\n"));
         let error = load_local_registry(root).unwrap_err();
         assert!(error.contains("failed to parse local registry"), "{error}");
     }
@@ -543,6 +630,46 @@ messaging = "specs/messaging/messaging.spec.md"
     fn modules_entry_missing_spec_key_is_an_error() {
         let content = "[registry]\nname = \"probe\"\n\n[[modules]]\nname = \"lib\"\n";
         assert!(parse_registry(content).is_none());
+        assert!(!is_inert_legacy_registry_stub(content));
+    }
+
+    #[test]
+    fn specs_mapping_with_non_string_path_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[specs]\nlib = 42\n";
+        let error = parse_registry_toml(content).unwrap_err();
+        assert!(error.contains("[specs].lib"), "{error}");
+        assert!(!is_inert_legacy_registry_stub(content));
+
+        let temp = tempfile::TempDir::new().unwrap();
+        fs::create_dir_all(temp.path().join(".specsync")).unwrap();
+        fs::write(temp.path().join(".specsync/registry.toml"), content).unwrap();
+        let load_error = load_local_registry(temp.path()).unwrap_err();
+        assert!(load_error.contains("[specs].lib"), "{load_error}");
+    }
+
+    #[test]
+    fn specs_mapping_with_empty_module_name_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[specs]\n\"\" = \"custom/lib.spec.md\"\n";
+        let error = parse_registry_toml(content).unwrap_err();
+        assert!(
+            error.contains("module mapping name must not be empty"),
+            "{error}"
+        );
+        assert!(!is_inert_legacy_registry_stub(content));
+    }
+
+    #[test]
+    fn nonempty_legacy_modules_table_is_not_inert() {
+        let content = "version = 1\n\n[modules]\nlib = \"custom/lib.spec.md\"\n";
+        assert!(parse_registry_toml(content).is_err());
+        assert!(!is_inert_legacy_registry_stub(content));
+    }
+
+    #[test]
+    fn duplicate_mapping_across_supported_shapes_is_an_error() {
+        let content = "[registry]\nname = \"probe\"\n\n[specs]\nlib = \"specs/lib.spec.md\"\n\n[[modules]]\nname = \"lib\"\nspec = \"custom/lib.spec.md\"\n";
+        let error = parse_registry_toml(content).unwrap_err();
+        assert!(error.contains("duplicate module mapping `lib`"), "{error}");
         assert!(!is_inert_legacy_registry_stub(content));
     }
 }


### PR DESCRIPTION
## Problem
Local registry handling (`src/registry.rs`) used a line scanner instead of a real TOML parser:
1. The documented array-of-tables modules format was silently misparsed — only mappings under the specs table were collected, so a registry written in the documented shape parsed as name = last module's name with zero mappings; every mapping was silently dropped.
2. Malformed TOML with a surviving `name=` line (e.g. `name = {{{`) was silently accepted, violating the fail-closed contract.

## Fix
- Replaced the line scanner with real TOML parsing (added `toml` crate dependency).
- Both the specs-table shape and the documented array-of-tables modules shape are supported; malformed module entries are rejected.
- Malformed TOML now hits the established `failed to parse local registry …` error; `is_inert_legacy_registry_stub` no longer treats garbage as inert.

## Regression tests
- `parse_registry_supports_documented_modules_shape`
- `load_local_registry_fails_closed_on_malformed_toml_with_name_line`
- `modules_entry_missing_spec_key_is_an_error`
- Previously failing `canonical_resolution_tolerates_inert_legacy_registry_stub` and both `semantic_application_*registry*` tests now pass.
- Drill reference: CorvidLabs/spec-sync-sandbox `drills/012-registry-parser-realities.sh`

## Validation
cargo test + `cargo clippy -- -D warnings` green (only pre-existing root-only failure `change::tests::non_git_walk_skips_volatile_trees_but_fails_on_relevant_walk_errors`).

Closes #413