### PR TITLE
Docs: refresh workflow and agent pack for SpecSync 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ brew install CorvidLabs/tap/spec-sync
     require-coverage: '100'
 ```
 
-After each immutable release passes its platform smoke tests, `@v5` follows compatible 5.x Action
-updates. Until that promotion completes, use the immutable Action and binary pins shown above.
+Prefer the immutable `@v6.0.0` Action and binary pins shown above for release gates. A floating
+`@v6` tag may follow compatible 6.x Action updates after each immutable release passes its platform
+smoke tests.
 
 Minimal immutable configuration:
 

--- a/examples/sdd-concurrent-changes/README.md
+++ b/examples/sdd-concurrent-changes/README.md
@@ -1,7 +1,9 @@
 # Executable ordered changes
 
-This example proves that a dependent change cannot start until its prerequisite
-is accepted, then completes both changes in dependency order.
+This example proves that a dependent change cannot complete scoped verification
+until its prerequisite is accepted or archived, then finalizes both changes in
+dependency order using the SpecSync 6.0 workflow (`check` → independent
+`review` → `finalize`).
 
 ```bash
 SPECSYNC_BIN="$PWD/target/release/specsync" ./examples/sdd-concurrent-changes/run.sh
@@ -9,4 +11,3 @@ SPECSYNC_BIN="$PWD/target/release/specsync" ./examples/sdd-concurrent-changes/ru
 
 The same ordering is used when SpecSync builds the effective contract from
 multiple active semantic deltas.
-

--- a/examples/sdd-concurrent-changes/run.sh
+++ b/examples/sdd-concurrent-changes/run.sh
@@ -11,6 +11,17 @@ git config user.email example@specsync.dev
 git config user.name "SpecSync Example"
 printf '# Ordered changes\n' > README.md
 "$bin" init >/dev/null
+# Operations-only projects need a bounded fallback so scoped check can record evidence.
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path(".specsync/sdd.json")
+policy = json.loads(path.read_text())
+if not policy.get("verification_commands"):
+    policy["verification_commands"] = ["true"]
+    path.write_text(json.dumps(policy, indent=2) + "\n")
+PY
 git add .
 git commit -m "Initialize example" >/dev/null
 
@@ -34,22 +45,22 @@ second="CHG-0002-provision-prerequisite"
 create_change "Deploy dependent service" "ops/service/" "$first"
 create_change "Provision prerequisite" "ops/platform/" "$second"
 "$bin" change depend "$first" "$second" >/dev/null
-"$bin" change approve "$first" --actor "Example Reviewer" >/dev/null
-"$bin" change approve "$second" --actor "Example Reviewer" >/dev/null
+"$bin" change approve "$first" --actor "Example Scope Owner" >/dev/null
+"$bin" change approve "$second" --actor "Example Scope Owner" >/dev/null
 
-if "$bin" change start "$first" >/dev/null 2>&1; then
-  echo "dependent change started before prerequisite" >&2
+if "$bin" change check "$first" >/dev/null 2>&1; then
+  echo "dependent change verified before prerequisite" >&2
   exit 1
 fi
 
-"$bin" change start "$second" >/dev/null
-"$bin" change verify "$second" >/dev/null
-"$bin" change accept "$second" --actor "Example Reviewer" >/dev/null
-"$bin" change start "$first" >/dev/null
-"$bin" change verify "$first" >/dev/null
-"$bin" change accept "$first" --actor "Example Reviewer" >/dev/null
+"$bin" change check "$second" >/dev/null
+"$bin" change review "$second" --reviewer "Example Independent Reviewer" >/dev/null
+"$bin" change finalize "$second" >/dev/null
+"$bin" change check "$first" >/dev/null
+"$bin" change review "$first" --reviewer "Example Independent Reviewer" >/dev/null
+"$bin" change finalize "$first" >/dev/null
 git add .
 git commit -m "Complete ordered changes" >/dev/null
-"$bin" change check
+"$bin" change audit
 
 printf '\nConcurrent-change example passed in %s\n' "$root"

--- a/examples/sdd-five-epics/README.md
+++ b/examples/sdd-five-epics/README.md
@@ -1,4 +1,4 @@
-# Five-epic SpecSync 5.0 proof
+# Five-epic SpecSync 6.0 proof
 
 This executable example builds a disposable Rust product and evolves it through five independently reviewed epics:
 
@@ -8,7 +8,7 @@ This executable example builds a disposable Rust product and evolves it through 
 4. audit events, and
 5. health reporting.
 
-Every epic uses the real SpecSync 5.0 lifecycle: deterministic interview, complete adaptive artifacts, semantic requirement/spec delta, definition approval, ordered dependency, implementation, Cargo tests, verification evidence, closing approval, simulated merge, and immutable archive. The project is preserved after the run so its Git history and evidence can be inspected.
+Every epic uses the real SpecSync 6.0 lifecycle: deterministic interview, complete adaptive artifacts, semantic requirement/spec delta, one human scope approval, ordered dependency, implementation, Cargo tests, scoped `change check` evidence, independent scoped review, and same-PR `change finalize` into the immutable dated archive. The project is preserved after the run so its Git history and evidence can be inspected.
 
 ```bash
 SPECSYNC_BIN=/absolute/path/to/specsync ./run.sh
@@ -22,13 +22,14 @@ The final `review-report.md` contains the strict validation, coverage, quality s
 
 A successful run ends with:
 
-- SpecSync `5.0.0`,
-- five accepted and archived epics with zero active changes,
-- ten approval gates and five verification records,
+- SpecSync `6.0.0`,
+- five finalized and archived epics with zero active changes,
+- five definition approvals and five scoped-review records,
+- five verification records,
 - a six-version canonical spec with six permanent requirements,
 - six passing product tests,
 - 100% file and LOC coverage,
 - an A/100 spec quality score, and
-- a clean 16-commit implementation, acceptance, and archive timeline.
+- a clean implementation-plus-finalize Git timeline.
 
 The installed Claude, Cursor, Codex, and Gemini files prove the local integration layout. Invoking remote agent models to prove live skill discovery is a separate, explicitly authorized network check because it can transmit project metadata to those services.

--- a/examples/sdd-five-epics/run.sh
+++ b/examples/sdd-five-epics/run.sh
@@ -60,12 +60,12 @@ printf '%s\n' \
     '' \
     '1. Every public behavior is backed by a permanent requirement ID.' \
     '2. Every accepted epic passes the configured Cargo test command.' \
-    '3. Canonical truth changes only through closing approval.' \
+    '3. Canonical truth changes only through approved check and finalize.' \
     '' \
     '## Behavioral Examples' \
     '' \
     '- Product clients can read a stable product name.' \
-    '- New behaviors appear only after their epic is accepted.' \
+    '- New behaviors appear only after their epic is finalized.' \
     '' \
     '## Error Cases' \
     '' \
@@ -107,7 +107,7 @@ printf '%s\n' '---' 'spec: product.spec.md' '---' '' '# Tasks' '' '- [x] Establi
 "$bin" agents install >/dev/null
 printf '\n# Generated demonstration evidence\nreview-report.md\n' >> .gitignore
 git add .
-git commit -m "Initialize SpecSync 5.0 product" >/dev/null
+git commit -m "Initialize SpecSync 6.0 product" >/dev/null
 git update-ref refs/remotes/origin/main HEAD
 
 titles=(
@@ -210,27 +210,21 @@ for index in 0 1 2 3 4; do
         > "$change_dir/deltas/product.md"
 
     "$bin" change approve "$id" --actor "Epic Product Reviewer" >/dev/null
-    "$bin" change start "$id" >/dev/null
     implement_epic "$number"
+    # Materialize approved deltas and run targeted verification before binding evidence.
+    "$bin" change check "$id"
     git add .
     git commit -m "Implement epic $number: $title" >/dev/null
-    "$bin" change verify "$id"
-    "$bin" change accept "$id" --actor "Epic Closing Reviewer" >/dev/null
+    "$bin" change check "$id"
+    "$bin" change review "$id" --reviewer "Epic Independent Reviewer" >/dev/null
+    "$bin" change finalize "$id" >/dev/null
     git add .
-    git commit -m "Accept epic $number contract" >/dev/null
-
-    # Updating origin/main models the reviewed feature being merged. Archival is
-    # intentionally post-merge because its active scope covers the delivery diff.
-    git update-ref refs/remotes/origin/main HEAD
-    "$bin" change archive "$id" >/dev/null
-    git add .
-    git commit -m "Archive epic $number evidence" >/dev/null
-    git update-ref refs/remotes/origin/main HEAD
+    git commit -m "Finalize epic $number archive" >/dev/null
     previous_id="$id"
 done
 
 {
-    printf '# SpecSync 5.0 five-epic review\n\n'
+    printf '# SpecSync 6.0 five-epic review\n\n'
     printf '## Release identity\n\n'
     "$bin" --version
     printf '\n## Strict validation\n\n```text\n'
@@ -238,9 +232,10 @@ done
     printf '```\n\n## Quality score\n\n```text\n'
     "$bin" score --all --explain
     printf '```\n\n## Lifecycle inventory\n\n'
-    printf -- '- Accepted and archived epics: %s/5\n' "$(find .specsync/archive/changes -name state.json | wc -l | tr -d ' ')"
+    printf -- '- Finalized and archived epics: %s/5\n' "$(find .specsync/archive/changes -name state.json | wc -l | tr -d ' ')"
     printf -- '- Active changes: %s\n' "$(find .specsync/changes -name state.json | wc -l | tr -d ' ')"
-    printf -- '- Approval gates recorded: %s/10\n' "$(grep -h '\"gate\"' .specsync/archive/changes/*/approvals.json | wc -l | tr -d ' ')"
+    printf -- '- Definition approvals recorded: %s/5\n' "$(grep -h '\"gate\"' .specsync/archive/changes/*/approvals.json | wc -l | tr -d ' ')"
+    printf -- '- Scoped review records: %s/5\n' "$(find .specsync/archive/changes -name review.json 2>/dev/null | wc -l | tr -d ' ')"
     printf -- '- Verification records: %s/5\n' "$(find .specsync/archive/changes -name verification.json | wc -l | tr -d ' ')"
     printf -- '- Canonical product spec version: %s\n' "$(awk '/^version:/ { print $2; exit }' specs/product/product.spec.md)"
     printf -- '- Permanent product requirements: %s\n' "$(grep -c '^### REQ-product-' specs/product/requirements.md)"
@@ -259,4 +254,4 @@ done
 } > review-report.md
 
 "$bin" check --strict --require-coverage 100 --force
-printf '\nFive-epic SpecSync 5.0 proof passed.\nProject: %s\nReport: %s/review-report.md\n' "$root" "$root"
+printf '\nFive-epic SpecSync 6.0 proof passed.\nProject: %s\nReport: %s/review-report.md\n' "$root" "$root"

--- a/examples/sdd-lifecycle/README.md
+++ b/examples/sdd-lifecycle/README.md
@@ -1,10 +1,10 @@
 # Executable SDD lifecycle
 
 This example creates an isolated Git repository and drives the packaged
-`specsync` binary through:
+`specsync` binary through the SpecSync 6.0 single workflow:
 
 ```text
-draft → approved → implementing → verifying → accepted
+draft → approved → implement → check → scoped review → finalize → archived
 ```
 
 Run it from the SpecSync repository:
@@ -13,7 +13,7 @@ Run it from the SpecSync repository:
 SPECSYNC_BIN="$PWD/target/release/specsync" ./examples/sdd-lifecycle/run.sh
 ```
 
-The example deliberately leaves the accepted workspace active. Archival belongs
-after the delivery diff is merged and no longer relies on the workspace for path
-coverage.
-
+`change check` verifies **this change only**. `change audit` reports project
+health over active workspaces and living specs. `change finalize` creates the
+dated archive on the same branch (same-PR finalization); GitHub still owns the
+merge when you use this workflow in a real repository.

--- a/examples/sdd-lifecycle/run.sh
+++ b/examples/sdd-lifecycle/run.sh
@@ -11,6 +11,17 @@ git config user.email example@specsync.dev
 git config user.name "SpecSync Example"
 printf '# Example project\n' > README.md
 "$bin" init >/dev/null
+# Documentation-only projects need a bounded fallback so scoped check can record evidence.
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path(".specsync/sdd.json")
+policy = json.loads(path.read_text())
+if not policy.get("verification_commands"):
+    policy["verification_commands"] = ["true"]
+    path.write_text(json.dumps(policy, indent=2) + "\n")
+PY
 git add .
 git commit -m "Initialize example" >/dev/null
 
@@ -30,14 +41,16 @@ dir=".specsync/changes/$id"
 printf '# Context\n\nClarify the contributor workflow.\n' > "$dir/context.md"
 printf '# Docs\n\nThe reviewed workflow is executable.\n' > "$dir/docs.md"
 
-"$bin" change approve "$id" --actor "Example Reviewer" >/dev/null
-"$bin" change start "$id" >/dev/null
+"$bin" change approve "$id" --actor "Example Scope Owner" >/dev/null
 printf '\nFollow the verified SDD lifecycle.\n' >> README.md
+"$bin" change check "$id"
 git add .
 git commit -m "Clarify contributor workflow" >/dev/null
-"$bin" change verify "$id"
-"$bin" change accept "$id" --actor "Example Reviewer" >/dev/null
-"$bin" change check
+"$bin" change check "$id"
+"$bin" change review "$id" --reviewer "Example Independent Reviewer" >/dev/null
+"$bin" change finalize "$id" >/dev/null
+git add .
+git commit -m "Finalize contributor workflow archive" >/dev/null
+"$bin" change audit
 
 printf '\nLifecycle example passed in %s\n' "$root"
-

--- a/site/src/content/docs/cli.md
+++ b/site/src/content/docs/cli.md
@@ -150,7 +150,7 @@ specsync agents status                     # show installation status
 specsync agents uninstall                  # remove generated integrations
 ```
 
-Supports Claude Code, Cursor, Codex, and Gemini CLI. The installed skills use the deterministic SpecSync lifecycle and never grant human approvals on an agent's behalf.
+Supports Claude Code, Cursor, Codex, and Gemini CLI. Claude, Cursor, and Gemini also receive slash commands for `create-spec`, `create-change`, **`check`**, and **`audit`** (`/specsync:check`, `/specsync:audit`). Codex is skill-only. The installed skills use the deterministic SpecSync 6.0 lifecycle (`change check` for one change; `change audit` for active workspaces and living specs) and never grant human approvals on an agent's behalf.
 
 ### `compact`
 

--- a/site/src/content/docs/comparisons/adversarial-proof.md
+++ b/site/src/content/docs/comparisons/adversarial-proof.md
@@ -11,7 +11,7 @@ An SDD tool can preserve excellent knowledge without deterministically proving t
 
 ## Knowledge preservation
 
-| Adversarial question | SpecSync 5.1 | Spec Kit core | OpenSpec core |
+| Adversarial question | SpecSync 6.0 | Spec Kit core | OpenSpec core |
 |---|---|---|---|
 | Why was the behavior requested? | **Record** — requirements/change artifacts | **Record** — `spec.md` | **Record** — proposal and delta requirements |
 | What architecture was chosen and why? | **Record** — context/design | **Record** — plan/research/data model | **Record** — design/proposal |
@@ -22,7 +22,7 @@ An SDD tool can preserve excellent knowledge without deterministically proving t
 
 ## Implementation drift
 
-| Mutation introduced after the spec is written | SpecSync 5.1 | Spec Kit core | OpenSpec core |
+| Mutation introduced after the spec is written | SpecSync 6.0 | Spec Kit core | OpenSpec core |
 |---|---|---|---|
 | Add an undocumented public export | **Block** in strict mode | **Agent** / extension | **Agent** |
 | Delete or rename a documented export | **Block** | **Agent** / extension | **Agent** |
@@ -30,7 +30,7 @@ An SDD tool can preserve excellent knowledge without deterministically proving t
 | Remove a documented database table or column | **Block** | **Agent** / extension | **Agent** |
 | Change a database column type without updating the spec | **Block** in strict mode | **Agent** / extension | **Agent** |
 | Break a declared cross-module spec dependency | **Block** | **Agent** / extension | **Agent** |
-| Leave a requirement without required test/API evidence | **Block** at acceptance | Analyze/checklist/workflow dependent | Validate/verify workflow dependent |
+| Leave a requirement without required test/API evidence | **Block** at check / finalize | Analyze/checklist/workflow dependent | Validate/verify workflow dependent |
 | Make tests fail | **Block** when configured for verification/CI | Configurable workflow command | Agent/tool execution |
 | Corrupt or stale approval/verification evidence | **Block** | Workflow implementation dependent | Workflow implementation dependent |
 

--- a/site/src/content/docs/comparisons/bmad.md
+++ b/site/src/content/docs/comparisons/bmad.md
@@ -12,14 +12,14 @@ and evidence engine that checks durable module truth against the repository.
 
 ## Practical boundary
 
-| Question | SpecSync 5.1 | BMAD 6.10 core |
+| Question | SpecSync 6.0 | BMAD 6.10 core |
 |---|---|---|
 | Fast path for a small change | Adaptive change interview and lifecycle | Quick Dev clarifies, plans, implements, reviews, and presents |
 | Full product planning | Focused change artifacts and module requirements | Analysis, PRD, UX, architecture, epics, and stories |
 | Specialized agent roles | Uses the developer's existing agent | Analyst, PM, architect, developer, UX, and technical-writer agents |
 | Contextual next-step guidance | Deterministic status and next action | `bmad-help` inspects available artifacts and recommends workflows |
-| Human review | Two mandatory digest-bound approvals | Workflow checkpoints and review decisions |
-| Requirements and test governance | Stable IDs plus required acceptance evidence | Process traceability; stronger optional TEA workflows |
+| Human review | One digest-bound scope approval plus independent scoped PR review | Workflow checkpoints and review decisions |
+| Requirements and test governance | Stable IDs plus required verification evidence | Process traceability; stronger optional TEA workflows |
 | Real export/schema parsing | Built into the deterministic core | Not a core BMAD responsibility |
 | Stale tested-input invalidation | Deterministic blocking gate | Agent/workflow dependent |
 

--- a/site/src/content/docs/comparisons/openspec.md
+++ b/site/src/content/docs/comparisons/openspec.md
@@ -20,18 +20,18 @@ Both tools provide:
 
 ## Enforcement boundary
 
-| Question | SpecSync 5.1 | OpenSpec core |
+| Question | SpecSync 6.0 | OpenSpec core |
 |---|---|---|
 | Canonical current behavior | Module `requirements.md` + `*.spec.md` | `openspec/specs/<domain>/spec.md` |
 | Proposed intent | `change.md`, interview answers, companions | `proposal.md` |
 | Semantic changes | Module-scoped deltas | Change-local delta specs |
 | Technical design | Optional `design.md`, durable `context.md` | `design.md` |
 | Work tracking | `tasks.md` | `tasks.md` |
-| Definition approval | Mandatory digest-bound human gate | Review/agent workflow convention |
-| Verification | Configured commands plus requirement evidence | Validation and agent-led verification |
+| Definition approval | One digest-bound human scope approval | Review/agent workflow convention |
+| Verification | Scoped `change check` plus requirement evidence | Validation and agent-led verification |
 | Real export/schema parsing | Built into the deterministic core | Not built into the core artifact workflow |
-| Canonical merge | Atomic during acceptance | Applied during sync/archive workflow |
-| Post-change history | Accepted workspace, then immutable archive | Archived change folder |
+| Canonical merge | Atomic during `change check` / same-PR `finalize` | Applied during sync/archive workflow |
+| Post-change history | Same-PR finalize into immutable dated archive | Archived change folder |
 
 OpenSpec is lighter when the team wants a proposal-oriented agent workflow and semantic requirements without language-specific enforcement. Its default core profile keeps a small propose/apply/sync/archive surface, while verification, onboarding, bulk archival, and stepwise artifact control are available through expanded workflows. SpecSync carries more machinery because it also acts as a CI contract checker: a documented export that disappeared, an undocumented public export, a missing source file, or database-schema drift becomes a deterministic finding.
 

--- a/site/src/content/docs/comparisons/spec-kit.md
+++ b/site/src/content/docs/comparisons/spec-kit.md
@@ -11,16 +11,16 @@ Spec Kit is an extensible, agent-led development toolkit. Its core path is **Spe
 
 ## The practical difference
 
-| Question | SpecSync 5.1 | Spec Kit core |
+| Question | SpecSync 6.0 | Spec Kit core |
 |---|---|---|
 | What is the durable truth? | Canonical module requirements and `*.spec.md` contracts | Team-selected persistence model for feature artifacts |
 | How is work shaped? | Deterministic interview selects risk-appropriate artifacts | Templates, commands, presets, extensions, and workflows |
 | What implements the plan? | Any human or coding agent; SpecSync stays deterministic | The selected coding-agent integration |
-| Are human gates available? | Two mandatory digest-bound approvals | Configurable workflow gate steps |
+| Are human gates available? | One digest-bound scope approval plus independent scoped PR review | Configurable workflow gate steps |
 | Are public exports parsed from code? | Yes, for 33 languages | Not by the core workflow |
 | Does CI fail on a phantom or undocumented export? | Yes, deterministically | Only through an added extension or custom check |
 | Are database tables/columns/types compared with specs? | Yes | Not by the core workflow |
-| How do requirements evolve? | Semantic deltas merge atomically into canonical truth | Flow-back, flow-forward, or living-spec conventions chosen by the team |
+| How do requirements evolve? | Semantic deltas merge atomically into canonical truth at check/finalize | Flow-back, flow-forward, or living-spec conventions chosen by the team |
 
 ## Where Spec Kit is stronger
 

--- a/site/src/content/docs/comparisons/using-together.md
+++ b/site/src/content/docs/comparisons/using-together.md
@@ -17,9 +17,9 @@ Different filenames do not mean missing capability. The tools package related kn
 | Architecture | Context/design | Plan/research/contracts | Design/proposal | Architecture workflow |
 | Work breakdown | Tasks | Tasks | Tasks | Epics and stories |
 | Quality/evidence | Testing plus verification record | Checklists/analyze/workflow logs | Validate/verify results | Readiness, review, optional TEA |
-| Definition review | Mandatory digest-bound gate | Optional workflow gate | Review convention | Workflow checkpoint |
-| Closing review | Mandatory evidence-bound gate | Optional workflow/team review | Archive workflow | Code/release review workflows |
-| History | Accepted then immutable archive | Chosen persistence model | Change archive | Planning and implementation artifacts |
+| Definition review | Mandatory digest-bound scope approval | Optional workflow gate | Review convention | Workflow checkpoint |
+| Closing review | Independent scoped PR review plus same-PR finalize | Optional workflow/team review | Archive workflow | Code/release review workflows |
+| History | Same-PR finalize into immutable dated archive | Chosen persistence model | Change archive | Planning and implementation artifacts |
 
 The rows are equivalent by **purpose**, not identical guarantees. For example, Spec Kit's `analyze` and OpenSpec's verification can reason across artifacts through an agent, while SpecSync's `verification.json` and source validators are deterministic records consumed by CI.
 
@@ -29,7 +29,7 @@ The rows are equivalent by **purpose**, not identical guarantees. For example, S
 2. Translate stable product requirements into module-scoped SpecSync requirement IDs.
 3. Put enforceable exports, dependencies, invariants, and schema expectations in `*.spec.md`.
 4. Implement with the same coding agent.
-5. Require `specsync check --strict` and the SpecSync acceptance gate in CI.
+5. Require `specsync check --strict` plus the SpecSync scoped-review / finalize CI gates.
 
 This keeps Spec Kit's rich planning ecosystem without making generated feature artifacts the only long-term source of truth.
 

--- a/site/src/content/docs/configuration.md
+++ b/site/src/content/docs/configuration.md
@@ -4,7 +4,7 @@ section: "Reference"
 order: 1
 ---
 
-SpecSync 5.0 separates canonical validation settings from the verified SDD policy:
+SpecSync 6.0 separates canonical validation settings from the verified SDD policy:
 
 - `.specsync/config.toml` configures specs, source discovery, rules, maturity guards, and integrations.
 - `.specsync/sdd.json` enables and protects the change lifecycle, meaningful paths, verification commands, and custom artifacts.

--- a/site/src/content/docs/integrations/ai-agents.md
+++ b/site/src/content/docs/integrations/ai-agents.md
@@ -4,7 +4,7 @@ section: "Integrations"
 order: 2
 ---
 
-SpecSync 5.0 is agent-native without embedding an inference client. The core is deterministic: it scaffolds markdown, validates contracts, records approvals and evidence, and never stores model credentials or sends source to a provider.
+SpecSync 6.0 is agent-native without embedding an inference client. The core is deterministic: it scaffolds markdown, validates contracts, records approvals and evidence, and never stores model credentials or sends source to a provider.
 
 ## Trust Boundary
 

--- a/site/src/content/docs/why-specsync.md
+++ b/site/src/content/docs/why-specsync.md
@@ -45,16 +45,16 @@ SpecSync occupies a third space: **validated hand-written specs**. You write the
 
 [Spec Kit](https://github.github.com/spec-kit/) provides guided SDD plus configurable, resumable workflows and human gates. [OpenSpec](https://github.com/Fission-AI/OpenSpec) provides a lightweight action graph, semantic deltas, synchronization, and archival. [BMAD Method](https://docs.bmad-method.org/) provides a broader agent-led product workflow spanning discovery through implementation and review. The comparison below was verified against Spec Kit 0.12.15 and OpenSpec 1.6.0 on 2026-07-14 and distinguishes deterministic blocking enforcement from configurable or agentic workflows:
 
-| SDD capability | SpecSync 5.1 | Spec Kit core | OpenSpec core |
+| SDD capability | SpecSync 6.0 | Spec Kit core | OpenSpec core |
 |:---------------|:-------------:|:-------------:|:-------------:|
 | Deterministic adaptive interview | **Yes** | Template/workflow driven | Schema/instruction driven |
 | Optional artifacts selected by risk | **Yes** | Presets/workflows | Configurable schemas |
 | Semantic deltas and canonical merge | **Yes** | No | **Yes** |
 | Bidirectional spec ↔ real code exports | **Yes** | Extension/agent analysis | No |
 | Stable requirement → test evidence | **Required** | Artifact-level by default | Artifact-level by default |
-| Digest-bound human approvals | **Two required gates** | Workflow gates | Confirmation at archive |
+| Digest-bound human approvals | **One scope approval** plus independent scoped PR review | Workflow gates | Confirmation at archive |
 | Active code checked against future contract | **Deterministic blocking gate** | Agent/workflow analysis | Agentic `/opsx:verify`; non-blocking by default |
-| Concurrent semantic conflict detection | **Deterministic pre-implementation/acceptance gate** | Workflow/extension dependent | Sync/archive-time agentic handling |
+| Concurrent semantic conflict detection | **Deterministic pre-check / finalize gate** | Workflow/extension dependent | Sync/archive-time agentic handling |
 | Configured tests executed by CI gate | **Yes** | Configurable workflow shell steps | Agentic verification |
 | Verification command shell isolation | **No shell** | Workflow shell supported | Agent/tool dependent |
 | Import existing Spec Kit/OpenSpec work | **Yes** | N/A | N/A |


### PR DESCRIPTION
## Summary
- Refresh executable SDD examples to the SpecSync **6.0** path: `approve` → implement → `change check` → independent `change review` → `change finalize` (same-PR archive), with `change audit` for project health.
- Update comparison/why/config/agent docs off **5.x** branding and “two mandatory SpecSync approvals” language toward one scope approval + independent scoped PR review.
- Clarify `specsync agents install` ships create-spec, create-change, **check**, and **audit** slash commands (Codex skill-only); pin README Action guidance to immutable `@v6.0.0`.

## Test plan
- [x] `SPECSYNC_BIN=$PWD/target/release/specsync ./examples/sdd-lifecycle/run.sh`
- [x] `SPECSYNC_BIN=$PWD/target/release/specsync ./examples/sdd-concurrent-changes/run.sh`
- [x] `SPECSYNC_BIN=$PWD/target/release/specsync ./examples/sdd-five-epics/run.sh`
- [x] `cd site && bun install && bun run build`
- [ ] Spot-check rendered workflow / AI agents / comparisons pages after deploy preview (if available)

## Intentional skips
- Left `workflow.md` reopen / correct / correct-owner sections on compatibility `accept` / `verify` verbs (historical two-approval repair path already labeled as non-default).
- Did not rewrite the whole docs site or touch `src/**` Rust.
- Root `Agents.md` already matched the two-verb + finalize model on main; no edit needed.
- Sandbox repo not in this monorepo.