### PR TITLE
fix(change): stop the lifecycle from wasting a verification cycle

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 79,
-  "id": "CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change",
+  "sequence": 80,
+  "id": "CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "8c58aa29a7ccf7e369b33ff8244549505360ca6f",
   "created_at": 1785702130,
-  "updated_at": 1785710515,
+  "updated_at": 1785717724,
   "affected_specs": [
     "github"
   ],

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "8c58aa29a7ccf7e369b33ff8244549505360ca6f",
   "created_at": 1785702130,
-  "updated_at": 1785773167,
+  "updated_at": 1785773760,
   "affected_specs": [
     "github"
   ],

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "8c58aa29a7ccf7e369b33ff8244549505360ca6f",
   "created_at": 1785702130,
-  "updated_at": 1785717724,
+  "updated_at": 1785773167,
   "affected_specs": [
     "github"
   ],

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
@@ -231,6 +231,39 @@
       "requirement_ids": [
         "REQ-github-008"
       ]
+    },
+    {
+      "timestamp": 1785773757,
+      "commit": "14abe71bb3466c958070dee11a740a86148e7c30",
+      "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
+      "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-008"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
@@ -165,6 +165,39 @@
       "requirement_ids": [
         "REQ-github-008"
       ]
+    },
+    {
+      "timestamp": 1785717721,
+      "commit": "07a044a3e33987630ee8d53c000e71ca89074962",
+      "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
+      "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-008"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
@@ -198,6 +198,39 @@
       "requirement_ids": [
         "REQ-github-008"
       ]
+    },
+    {
+      "timestamp": 1785773164,
+      "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
+      "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
+      "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-008"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1785710513,
-  "commit": "ebebc82ceccf73417757a12e08c21fa0a24c0d61",
+  "timestamp": 1785717721,
+  "commit": "07a044a3e33987630ee8d53c000e71ca89074962",
   "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
   "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
-  "workspace_digest": "f939a228381085b904ee942a217354835e4b0d160bf1653bd07d4d88bf963e66",
+  "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1785717721,
-  "commit": "07a044a3e33987630ee8d53c000e71ca89074962",
+  "timestamp": 1785773164,
+  "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
   "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
   "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
   "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1785773164,
-  "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
+  "timestamp": 1785773757,
+  "commit": "14abe71bb3466c958070dee11a740a86148e7c30",
   "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
   "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
   "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/approvals.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/approvals.json
@@ -1,0 +1,38 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1785715817,
+      "digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+      "note": null,
+      "approved_scope": {
+        "schema_version": 1,
+        "change_id": "CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete",
+        "title": "Fail lifecycle verification before running the suite when evidence is incomplete, make already-applied ADDED deltas converge, and reject duplicate change ordinals from one base",
+        "description": "Fail lifecycle verification before running the suite when evidence is incomplete, make already-applied ADDED deltas converge, and reject duplicate change ordinals from one base",
+        "kind": "bug_fix",
+        "affected_specs": [
+          "change"
+        ],
+        "affected_paths": [
+          ".specsync",
+          "specs/change",
+          "src/change.rs"
+        ],
+        "no_spec_change": false,
+        "no_spec_change_rationale": null,
+        "acceptance_criteria": [
+          "Verification refuses to start when acceptance or requirement evidence is incomplete, naming the change testing.md and its Requirement evidence table rather than verification.json; command failures name the failing command and exit code; an ADDED delta whose block is already present with byte-identical content converges instead of erroring, while present-but-different still errors and directs the author to MODIFIED; two distinct changes claiming the same CHG-NNNN ordinal from the same base commit are rejected at approve and in change audit, while differing or unknown base commits never raise a collision"
+        ],
+        "dependencies": [],
+        "supersedes": [],
+        "answers": {
+          "architecture_risk": "no",
+          "public_contract": "yes"
+        }
+      }
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/change.md
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete
+state: implementing
+type: bug_fix
+base_commit: 07a044a3e33987630ee8d53c000e71ca89074962
+---
+
+# Fail lifecycle verification before running the suite when evidence is incomplete, make already-applied ADDED deltas converge, and reject duplicate change ordinals from one base
+
+## Intent
+
+Fail lifecycle verification before running the suite when evidence is incomplete, make already-applied ADDED deltas converge, and reject duplicate change ordinals from one base
+
+## Affected Canonical Specs
+
+- `change`
+
+## Acceptance Criteria
+
+- Verification refuses to start when acceptance or requirement evidence is incomplete, naming the change testing.md and its Requirement evidence table rather than verification.json; command failures name the failing command and exit code; an ADDED delta whose block is already present with byte-identical content converges instead of erroring, while present-but-different still errors and directs the author to MODIFIED; two distinct changes claiming the same CHG-NNNN ordinal from the same base commit are rejected at approve and in change audit, while differing or unknown base commits never raise a collision
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/context.md
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/context.md
@@ -1,0 +1,21 @@
+---
+change: CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete
+artifact: context
+---
+
+# Context
+
+Three defects surfaced by driving CHG-0079 (PR #499) through the lifecycle. Each cost a full
+re-verification — roughly ten minutes — to discover something the workspace already described.
+
+Evidence completeness was resolved after the verification commands ran, so a missing
+`## Requirement evidence` row was reported only once the whole suite had executed. The message
+then pointed at `verification.json`, which records the outcome but cannot contain the fix.
+
+`change check` could not run twice. The first run applied an `## ADDED` block to the canonical
+spec; the second rejected it as `cannot add existing block`, leaving the change unverifiable
+without hand-editing the tree.
+
+Independent worktrees allocate from their own sequence ledger, so two handed out CHG-0078 for
+different work. Nothing detected it, because the ordinal only stops identifying a single change
+once both land.

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/deltas/change.md
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/deltas/change.md
@@ -1,0 +1,22 @@
+## ADDED
+
+### REQUIREMENT REQ-change-049
+
+Lifecycle verification SHALL resolve evidence completeness before running any
+verification command, SHALL name the artifact and section an author must edit to close an
+evidence gap, and SHALL name the failing command when a command fails. Delta application
+SHALL converge when an `## ADDED` block is already present with byte-identical content, and
+SHALL reject a duplicate `CHG-NNNN` ordinal claimed by two distinct changes from the same
+base commit.
+
+Acceptance Criteria
+
+- Incomplete acceptance or requirement evidence fails before any verification command runs.
+- The evidence-gap message names the change `testing.md` and its `## Requirement evidence`
+  table; the command-failure message names the failing command and its exit code.
+- An `## ADDED` block already present with byte-identical content applies as a no-op, so
+  re-deriving the canonical tree converges.
+- An `## ADDED` block present with different content fails and directs the author to
+  `## MODIFIED`.
+- Two distinct changes claiming one ordinal from the same base commit are rejected at
+  definition approval and by `change audit`; differing or unknown base commits are accepted.

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/docs.md
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/docs.md
@@ -1,0 +1,17 @@
+---
+change: CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete
+artifact: docs
+---
+
+# Docs
+
+User-visible message changes only; no CLI surface, flag, or file format changes.
+
+- Evidence gaps now fail with `verification cannot start: …` and name
+  `.specsync/changes/<ID>/testing.md` plus its `## Requirement evidence` table.
+- Command failures name the failing command and exit code instead of reporting that
+  "a configured verification command failed".
+- Duplicate ordinals fail with the two claiming change IDs, the shared base commit, and the
+  instruction to recreate one with `specsync change new`.
+
+No README, MIGRATION, or site page describes the previous messages, so no doc edits are required.

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/requirements.md
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/requirements.md
@@ -1,0 +1,13 @@
+---
+change: CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete
+artifact: requirements
+---
+
+# Requirements
+
+## REQ-change-049: Verification fails fast, explains itself, and converges
+
+Evidence completeness is derived from committed artifacts alone, so it is resolved before any
+verification command runs. Messages name the artifact to edit and the command that failed.
+Applying a delta whose effect is already present converges instead of erroring, and duplicate
+change ordinals from one base commit are rejected.

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/state.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/state.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "workflow_version": 2,
+  "workflow_origin_version": 2,
+  "id": "CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete",
+  "slug": "fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete",
+  "title": "Fail lifecycle verification before running the suite when evidence is incomplete, make already-applied ADDED deltas converge, and reject duplicate change ordinals from one base",
+  "description": "Fail lifecycle verification before running the suite when evidence is incomplete, make already-applied ADDED deltas converge, and reject duplicate change ordinals from one base",
+  "kind": "bug_fix",
+  "state": "verifying",
+  "canonical_applied": true,
+  "base_commit": "07a044a3e33987630ee8d53c000e71ca89074962",
+  "created_at": 1785711176,
+  "updated_at": 1785717071,
+  "affected_specs": [
+    "change"
+  ],
+  "affected_paths": [
+    "src/change.rs",
+    "specs/change",
+    ".specsync"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "Verification refuses to start when acceptance or requirement evidence is incomplete, naming the change testing.md and its Requirement evidence table rather than verification.json; command failures name the failing command and exit code; an ADDED delta whose block is already present with byte-identical content converges instead of erroring, while present-but-different still errors and directs the author to MODIFIED; two distinct changes claiming the same CHG-NNNN ordinal from the same base commit are rejected at approve and in change audit, while differing or unknown base commits never raise a collision"
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "requirements",
+    "docs"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/state.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "07a044a3e33987630ee8d53c000e71ca89074962",
   "created_at": 1785711176,
-  "updated_at": 1785717071,
+  "updated_at": 1785772569,
   "affected_specs": [
     "change"
   ],

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/tasks.md
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/tasks.md
@@ -1,0 +1,15 @@
+---
+change: CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Resolve evidence completeness before running verification commands
+- [x] Name the artifact and section in the evidence-gap message
+- [x] Name the failing command and exit code in the command-failure message
+- [x] Converge on an `## ADDED` block already present with identical content
+- [x] Keep present-but-different an error that directs the author to `## MODIFIED`
+- [x] Reject duplicate ordinals at definition approval and in `change audit`
+- [x] Add focused regression tests for delta convergence and ordinal identity
+- [x] Run the full Rust suite

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/testing.md
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/testing.md
@@ -1,0 +1,24 @@
+---
+change: CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete
+artifact: testing
+---
+
+# Testing
+
+## Requirement evidence
+
+| Requirement | Evidence |
+|-------------|----------|
+| `REQ-change-049` | `added_block_reapplies_when_content_is_identical` covers convergence and the different-content error; `change_ordinals_identify_independently_allocated_workspaces` covers ordinal identity; `failed_native_verification_is_retryable_with_append_only_history` covers the named command failure and append-only attempt history. |
+
+## Focused regressions
+
+- Re-deriving an already-applied `## ADDED` block returns the source unchanged.
+- The same block with different content errors and names `## MODIFIED`.
+- `CHG-0078-…` and a second `CHG-0078-…` share an ordinal; `CHG-0079-…` does not.
+- Non-ordinal identifiers never raise a collision.
+- A failed verification command names itself and its exit code, and still records an attempt.
+
+## Full suite
+
+`cargo test` — 2,181 unit and 333 integration tests passed.

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification-attempts.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification-attempts.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1785717068,
+      "commit": "07a044a3e33987630ee8d53c000e71ca89074962",
+      "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+      "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-049"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification-attempts.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification-attempts.json
@@ -33,6 +33,80 @@
       "requirement_ids": [
         "REQ-change-049"
       ]
+    },
+    {
+      "timestamp": 1785771233,
+      "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
+      "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+      "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+      "workspace_digest": "2134158f3a255093eca1ddec599b5635b976362d8ace6d0093e4a1d5f41fb88f",
+      "passed": false,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": false,
+          "exit_code": 101
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-049"
+      ]
+    },
+    {
+      "timestamp": 1785771439,
+      "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
+      "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+      "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": false,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": false,
+          "exit_code": 101
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-049"
+      ]
+    },
+    {
+      "timestamp": 1785772566,
+      "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
+      "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+      "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-049"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification.json
@@ -1,0 +1,33 @@
+{
+  "timestamp": 1785717068,
+  "commit": "07a044a3e33987630ee8d53c000e71ca89074962",
+  "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+  "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+  "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test change::",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-change-049"
+  ]
+}

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1785717068,
-  "commit": "07a044a3e33987630ee8d53c000e71ca89074962",
+  "timestamp": 1785772566,
+  "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
   "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
   "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
   "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",

--- a/specs/change/change.spec.md
+++ b/specs/change/change.spec.md
@@ -1,6 +1,6 @@
 ---
 module: change
-version: 55
+version: 56
 status: active
 files:
   - src/change.rs
@@ -343,3 +343,4 @@ Acceptance Criteria
 | 2026-07-31 | CHG-0069-scoped-change-check-change-audit-and-agent-pack-for-the-two-verb-lifecycle: Scoped change check, change audit, and agent pack for the two-verb lifecycle |
 | 2026-08-01 | CHG-0072-heal-reopen-closing-approval-recovery-for-stale-accepted-evidence: Heal reopen closing-approval recovery for stale accepted evidence |
 | 2026-08-01 | CHG-0073-approve-rejects-living-added-reqs-and-draft-next-action-waits-on-complete-artifa: Approve rejects living ADDED REQs and draft next_action waits on complete artifacts |
+| 2026-08-03 | CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete: Fail lifecycle verification before running the suite when evidence is incomplete, make already-applied ADDED deltas converge, and reject duplicate change ordinals from one base |

--- a/specs/change/requirements.md
+++ b/specs/change/requirements.md
@@ -693,3 +693,24 @@ Acceptance Criteria
 - The error text mentions MODIFIED.
 - MODIFIED of an existing living requirement ID validates successfully.
 
+### REQ-change-049
+
+Lifecycle verification SHALL resolve evidence completeness before running any
+verification command, SHALL name the artifact and section an author must edit to close an
+evidence gap, and SHALL name the failing command when a command fails. Delta application
+SHALL converge when an `## ADDED` block is already present with byte-identical content, and
+SHALL reject a duplicate `CHG-NNNN` ordinal claimed by two distinct changes from the same
+base commit.
+
+Acceptance Criteria
+
+- Incomplete acceptance or requirement evidence fails before any verification command runs.
+- The evidence-gap message names the change `testing.md` and its `## Requirement evidence`
+  table; the command-failure message names the failing command and its exit code.
+- An `## ADDED` block already present with byte-identical content applies as a no-op, so
+  re-deriving the canonical tree converges.
+- An `## ADDED` block present with different content fails and directs the author to
+  `## MODIFIED`.
+- Two distinct changes claiming one ordinal from the same base commit are rejected at
+  definition approval and by `change audit`; differing or unknown base commits are accepted.
+

--- a/src/change.rs
+++ b/src/change.rs
@@ -2131,6 +2131,7 @@ fn approve_definition_with_projection(
 ) -> Result<ChangeRecord, String> {
     let _lock = acquire_project_lock(root)?;
     let mut record = load_change(root, id)?;
+    ensure_no_sequence_collision(root, &record)?;
     // Accepted records may re-approve the definition when the artifact digest drifted
     // (reopen recovery). Refuse no-op re-approvals that would only rewrite an already-valid
     // definition approval while the change is accepted.
@@ -2380,6 +2381,21 @@ pub fn verify_change_with_strict(
     for configured in &verification_commands {
         reject_direct_lifecycle_verification(root, configured)?;
     }
+    // Evidence completeness is derived from committed artifacts alone, so it is
+    // resolved before the verification commands run. Discovering a missing
+    // requirement-evidence row only after a full suite costs an entire
+    // re-verification cycle for a defect the workspace already described.
+    let requirement_ids = collect_requirement_ids(root, &record)?;
+    let has_semantic_acceptance_item = semantic_acceptance_item_exists(root, &record)?;
+    let missing_evidence = requirement_evidence_missing(root, &record, &requirement_ids);
+    let acceptance_evidence_present =
+        acceptance_criteria_have_evidence(&record, has_semantic_acceptance_item);
+    if !acceptance_evidence_present || !missing_evidence.is_empty() {
+        return Err(format!(
+            "verification cannot start: {}",
+            evidence_gap_detail(&record, acceptance_evidence_present, &missing_evidence)
+        ));
+    }
     let mut commands = Vec::new();
     for configured in verification_commands {
         let status = run_configured_command(root, &configured, ConfiguredCommandOutput::Inherit)?;
@@ -2392,13 +2408,8 @@ pub fn verify_change_with_strict(
             break;
         }
     }
-    let requirement_ids = collect_requirement_ids(root, &record)?;
-    let has_semantic_acceptance_item = semantic_acceptance_item_exists(root, &record)?;
-    let missing_evidence = requirement_evidence_missing(root, &record, &requirement_ids);
     let commands_passed = commands.iter().all(|command| command.success);
-    let acceptance_evidence_present =
-        acceptance_criteria_have_evidence(&record, has_semantic_acceptance_item);
-    let passed = commands_passed && acceptance_evidence_present && missing_evidence.is_empty();
+    let passed = commands_passed;
     let verification = VerificationRecord {
         timestamp: now(),
         commit: git_output(root, &["rev-parse", "HEAD"]),
@@ -2419,21 +2430,55 @@ pub fn verify_change_with_strict(
     record.updated_at = now();
     save_change(root, &record)?;
     if !verification.passed {
-        let detail = if !commands_passed {
-            "configured verification command failed".to_string()
-        } else if !acceptance_evidence_present {
-            "semantic acceptance evidence is missing".to_string()
-        } else {
-            format!(
-                "requirement evidence missing for {}",
-                missing_evidence.join(", ")
-            )
-        };
+        let failed = verification
+            .commands
+            .iter()
+            .find(|command| !command.success)
+            .map(|command| {
+                format!(
+                    "`{}` exited with {}",
+                    command.command,
+                    command
+                        .exit_code
+                        .map_or_else(|| "a signal".to_string(), |code| code.to_string())
+                )
+            })
+            .unwrap_or_else(|| "a configured verification command failed".to_string());
         return Err(format!(
-            "verification failed: {detail}; inspect verification.json"
+            "verification failed: {failed}; see commands[] in {}",
+            portable_project_path(root, &change_dir(root, &record.id).join("verification.json"))
         ));
     }
     Ok(verification)
+}
+
+/// Names the artifact and section an author must edit to close an evidence gap.
+///
+/// The gap is always described by the change workspace rather than by
+/// `verification.json`, so pointing at the record itself sends authors to a file
+/// that cannot contain the answer.
+fn evidence_gap_detail(
+    record: &ChangeRecord,
+    acceptance_evidence_present: bool,
+    missing_evidence: &[String],
+) -> String {
+    let testing = format!(".specsync/changes/{}/testing.md", record.id);
+    if !acceptance_evidence_present {
+        return format!(
+            "semantic acceptance evidence is missing; record how each acceptance criterion is \
+             proven in {testing}"
+        );
+    }
+    format!(
+        "no requirement evidence for {}; add a row for {} to the `## Requirement evidence` table in \
+         {testing}",
+        missing_evidence.join(", "),
+        if missing_evidence.len() == 1 {
+            "it"
+        } else {
+            "each"
+        }
+    )
 }
 
 fn verification_commands_for_change(
@@ -6186,6 +6231,9 @@ fn check_project_with_command_output(
         {
             report.errors.push(format!("{}: {error}", record.id));
         }
+        if let Err(error) = ensure_no_sequence_collision(root, record) {
+            report.errors.push(error);
+        }
         for dependency in &record.dependencies {
             if dependency_reaches(root, dependency, &record.id, &mut BTreeSet::new()) {
                 report.errors.push(format!(
@@ -7221,12 +7269,15 @@ fn validate_delta_files(root: &Path, record: &ChangeRecord) -> Result<(), String
                     item.key
                 ));
             }
+            // A block already present with exactly the declared content means this
+            // delta is applied, not conflicting. Rejecting it here would make an
+            // applied change permanently unverifiable.
             if item.target == DeltaTarget::Requirement
                 && item.operation == DeltaOperation::Added
-                && living_requirement_heading_exists(root, module, &item.key)?
+                && living_requirement_conflicts(root, module, &item.key, &item.content)?
             {
                 return Err(format!(
-                    "cannot add existing block `{}`; use ## MODIFIED for requirements already present in the living tree",
+                    "cannot add existing block `{}` with different content; use ## MODIFIED for requirements already present in the living tree",
                     item.key
                 ));
             }
@@ -7236,14 +7287,32 @@ fn validate_delta_files(root: &Path, record: &ChangeRecord) -> Result<(), String
 }
 
 /// True when living `requirements.md` already has a `### {key}` requirement heading.
-fn living_requirement_heading_exists(root: &Path, module: &str, key: &str) -> Result<bool, String> {
+/// True when living `requirements.md` already has a `### {key}` requirement whose
+/// content differs from what an `## ADDED` delta declares.
+///
+/// A byte-equivalent block is an already-applied delta and is not a conflict, so
+/// re-deriving the canonical tree converges instead of failing.
+fn living_requirement_conflicts(
+    root: &Path,
+    module: &str,
+    key: &str,
+    declared: &str,
+) -> Result<bool, String> {
     let specs_dir = crate::config::load_config(root).specs_dir;
     let (_, requirements_path) = canonical_module_paths(root, &specs_dir, module)?;
-    let Ok(content) = fs::read_to_string(&requirements_path) else {
+    let Ok(source) = fs::read_to_string(&requirements_path) else {
         return Ok(false);
     };
     let heading = format!("### {key}");
-    Ok(content.lines().any(|line| line.trim_end() == heading))
+    let Some(start) = source.find(&heading) else {
+        return Ok(false);
+    };
+    let body = &source[start..];
+    let end = body
+        .match_indices("\n### ")
+        .next()
+        .map_or(body.len(), |(index, _)| index);
+    Ok(!markdown_block_matches(&body[..end], &heading, declared))
 }
 
 fn removed_requirement_ids(root: &Path) -> Result<BTreeSet<String>, String> {
@@ -7527,6 +7596,26 @@ fn canonical_module_paths(
     Ok((spec_path, requirements_path))
 }
 
+/// True when an existing markdown block already carries exactly the declared
+/// heading and body, ignoring line-ending style and surrounding blank lines.
+///
+/// Used to decide whether an `## ADDED` delta has already been applied. Only an
+/// exact content match counts: a block that exists with different text is a real
+/// conflict and must be declared `## MODIFIED`.
+fn markdown_block_matches(existing: &str, heading: &str, content: &str) -> bool {
+    fn normalize(value: &str) -> String {
+        value
+            .replace("\r\n", "\n")
+            .trim_matches(['\n', ' ', '\t'])
+            .to_string()
+    }
+    let existing = normalize(existing);
+    let Some(body) = existing.strip_prefix(&normalize(heading)) else {
+        return false;
+    };
+    normalize(body) == normalize(content)
+}
+
 fn apply_markdown_block(
     source: &str,
     prefix: &str,
@@ -7573,8 +7662,21 @@ fn apply_markdown_block(
             .unwrap_or(source.len())
     });
     match operation {
+        // An ADDED block that is already present with exactly the declared content
+        // is an applied delta, not a conflict. Re-deriving the canonical tree must
+        // converge, otherwise the delta can never be reconciled against the tree
+        // and a partially-applied run leaves the change permanently unverifiable.
         DeltaOperation::Added if start.is_some() => {
-            return Err(format!("cannot add existing block `{key}`"));
+            if let (Some(start_index), Some(end_offset)) = (start, end) {
+                let existing = &source[lines[start_index].0..end_offset];
+                if markdown_block_matches(existing, &heading, content) {
+                    return Ok(source.to_string());
+                }
+            }
+            return Err(format!(
+                "cannot add existing block `{key}` with different content; use ## MODIFIED to \
+                 change a block already present in the living tree"
+            ));
         }
         DeltaOperation::Modified | DeltaOperation::Removed if start.is_none() => {
             return Err(format!("cannot modify/remove missing block `{key}`"));
@@ -13701,6 +13803,53 @@ fn terminal_delivery_projection(record: &ChangeRecord) -> ChangeRecord {
         projection.state = ChangeState::Accepted;
     }
     projection
+}
+
+/// The `CHG-NNNN` ordinal of a change ID, when it has one.
+fn change_sequence_number(id: &str) -> Option<u32> {
+    id.strip_prefix("CHG-")?
+        .split('-')
+        .next()?
+        .parse::<u32>()
+        .ok()
+}
+
+/// Rejects two distinct changes that claimed the same `CHG-NNNN` ordinal from the
+/// same base commit.
+///
+/// Independent worktrees and clones allocate from their own sequence ledger, so
+/// two can hand out the same ordinal to different work. They only become visible
+/// to each other once both land, and by then the ordinal no longer identifies a
+/// single change. Differing base commits are legitimate — a branch re-cut from a
+/// later tip may reuse an ordinal — so only a shared base is a genuine collision.
+fn ensure_no_sequence_collision(root: &Path, record: &ChangeRecord) -> Result<(), String> {
+    let Some(ordinal) = change_sequence_number(&record.id) else {
+        return Ok(());
+    };
+    // An unknown base cannot establish that two changes were cut from the same
+    // point, so it never raises a collision rather than guessing.
+    let Some(base) = record.base_commit.as_deref() else {
+        return Ok(());
+    };
+    let conflicting: Vec<String> = list_all_changes_checked(root)?
+        .values()
+        .filter(|other| {
+            other.id != record.id
+                && other.base_commit.as_deref() == Some(base)
+                && change_sequence_number(&other.id) == Some(ordinal)
+        })
+        .map(|other| other.id.clone())
+        .collect();
+    if conflicting.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "change ordinal CHG-{ordinal:04} is claimed by {} and {} from the same base commit {base}. \
+         Two workspaces allocated it independently. Recreate one of them with `specsync change new` \
+         so each change owns a distinct ordinal.",
+        record.id,
+        conflicting.join(", ")
+    ))
 }
 
 fn list_all_changes_checked(root: &Path) -> Result<BTreeMap<String, ChangeRecord>, String> {
@@ -26092,7 +26241,10 @@ mod tests {
         record = start_implementation(root, &record.id).unwrap();
 
         let first_error = verify_change(root, &record.id).unwrap_err();
-        assert!(first_error.contains("configured verification command failed"));
+        // The failure names the exact command and where its evidence lives, so an
+        // author does not have to open verification.json to learn which step failed.
+        assert!(first_error.contains("cargo metadata --manifest-path definitely-missing/Cargo.toml"));
+        assert!(first_error.contains("verification.json"));
         assert_eq!(
             load_change(root, &record.id).unwrap().state,
             ChangeState::Verifying
@@ -26111,6 +26263,55 @@ mod tests {
         assert!(!history.attempts[0].passed);
         assert!(history.attempts[1].passed);
         assert!(load_verification(root, &record).unwrap().passed);
+    }
+
+    #[test]
+    fn added_block_reapplies_when_content_is_identical() {
+        let source = "# Requirements\n\n### REQ-auth-001\n\nUsers sign in.\n";
+        // Re-deriving an already-applied ADDED block converges instead of failing,
+        // so a partially-applied run can still be reconciled.
+        let unchanged = apply_markdown_block(
+            source,
+            "### ",
+            "REQ-auth-001",
+            "Users sign in.",
+            DeltaOperation::Added,
+        )
+        .unwrap();
+        assert_eq!(unchanged, source);
+
+        // A block present with different text is a real conflict and must be declared.
+        let error = apply_markdown_block(
+            source,
+            "### ",
+            "REQ-auth-001",
+            "Users sign in with passkeys.",
+            DeltaOperation::Added,
+        )
+        .unwrap_err();
+        assert!(error.contains("different content"), "{error}");
+        assert!(error.contains("## MODIFIED"), "{error}");
+    }
+
+    #[test]
+    fn change_ordinals_identify_independently_allocated_workspaces() {
+        // Two workspaces that allocated CHG-0078 for different work share an ordinal,
+        // which is what makes them a collision once both land on the same base.
+        assert_eq!(
+            change_sequence_number("CHG-0078-delete-the-ci-reimplementation"),
+            Some(78)
+        );
+        assert_eq!(
+            change_sequence_number("CHG-0078-todo-artifact-markers"),
+            Some(78)
+        );
+        assert_ne!(
+            change_sequence_number("CHG-0079-something-else"),
+            change_sequence_number("CHG-0078-todo-artifact-markers")
+        );
+        // Non-ordinal identifiers never raise a collision.
+        assert!(change_sequence_number("CHG-not-a-number").is_none());
+        assert!(change_sequence_number("legacy-change").is_none());
     }
 
     #[test]

--- a/src/change.rs
+++ b/src/change.rs
@@ -2446,7 +2446,10 @@ pub fn verify_change_with_strict(
             .unwrap_or_else(|| "a configured verification command failed".to_string());
         return Err(format!(
             "verification failed: {failed}; see commands[] in {}",
-            portable_project_path(root, &change_dir(root, &record.id).join("verification.json"))
+            portable_project_path(
+                root,
+                &change_dir(root, &record.id).join("verification.json")
+            )
         ));
     }
     Ok(verification)
@@ -26243,7 +26246,9 @@ mod tests {
         let first_error = verify_change(root, &record.id).unwrap_err();
         // The failure names the exact command and where its evidence lives, so an
         // author does not have to open verification.json to learn which step failed.
-        assert!(first_error.contains("cargo metadata --manifest-path definitely-missing/Cargo.toml"));
+        assert!(
+            first_error.contains("cargo metadata --manifest-path definitely-missing/Cargo.toml")
+        );
         assert!(first_error.contains("verification.json"));
         assert_eq!(
             load_change(root, &record.id).unwrap().state,


### PR DESCRIPTION
Three defects found by driving a real change (CHG-0079, PR #499) through the lifecycle. Each cost a full ~10-minute re-verification to discover something the workspace already knew.

## Fail before the suite, not after

Evidence completeness is derived from committed artifacts alone, so it now resolves **before** the verification commands run. The message names the file and section to edit rather than pointing at `verification.json`, which structurally cannot contain the fix:

```
verification cannot start: no requirement evidence for REQ-github-009; add a row for it
to the `## Requirement evidence` table in .specsync/changes/CHG-XXXX/testing.md
```

Command failures now name the failing command and exit code instead of "a configured verification command failed".

## `change check` can run twice

An `## ADDED` block already present with byte-identical content is an applied delta, not a conflict, so re-deriving converges. Previously the first run applied the block and the second rejected it, leaving the change permanently unverifiable. Present-with-different-content is still an error and still directs the author to `## MODIFIED`.

## Ordinal collisions are detected

Two workspaces allocating the same `CHG-NNNN` from the same base commit are rejected at `approve` and in `change audit`, with instructions to recreate one. Differing or unknown base commits are legitimate and never raise a collision.

## Two things deliberately NOT changed

While investigating I proposed two more fixes and the test suite proved both wrong. Recording them so they are not re-attempted the same way:

- **`canonical_applied` divergence.** `canonical_applied: True` can coexist with an unmodified canonical spec while `audit --strict` passes. But the latch is deliberate — `corrected_acceptance_requires_fresh_gates_and_never_replays_canonical_deltas` exists precisely to stop deltas replaying onto a tree that acceptance corrections already modified. A correct fix must be **digest-based** (record canonical digests at application time, verify those later), never re-derivation.
- **Sequence-ledger coverage.** `check --strict` on a fresh draft reports `.specsync/change-sequence.json` as uncovered. This is by design: `approved_change_does_not_cover_delivery_paths_until_started` asserts coverage begins at `start_implementation`. The real problem is messaging — the error gives no hint that starting implementation resolves it.

## Verification

- `cargo test` — **2,181 unit + 333 integration passed, 0 failed** (2,179 baseline + 2 new tests)

## Draft status

This touches `src/change.rs`, a strict-validation path, so it needs its own approved change workspace before `spec-check` can pass. Opened as a draft for that reason.