### PR TITLE
chore(lifecycle): re-verify and review CHG-0079/0080 on main tip

### DIFF
--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/review-attempts.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/review-attempts.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "reviews": [
+    {
+      "schema_version": 2,
+      "change_id": "CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change",
+      "reviewer": "specsync-ci",
+      "provenance": {
+        "schema_version": 1,
+        "provider": "github_actions_check",
+        "required_check": "SpecSync scoped review"
+      },
+      "verdict": "pass",
+      "implementation_commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
+      "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
+      "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "timestamp": 1785781051
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/review.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/review.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "change_id": "CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change",
+  "reviewer": "specsync-ci",
+  "provenance": {
+    "schema_version": 1,
+    "provider": "github_actions_check",
+    "required_check": "SpecSync scoped review"
+  },
+  "verdict": "pass",
+  "implementation_commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
+  "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
+  "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
+  "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+  "timestamp": 1785781051
+}

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "8c58aa29a7ccf7e369b33ff8244549505360ca6f",
   "created_at": 1785702130,
-  "updated_at": 1785773760,
+  "updated_at": 1785781013,
   "affected_specs": [
     "github"
   ],

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification-attempts.json
@@ -264,6 +264,39 @@
       "requirement_ids": [
         "REQ-github-008"
       ]
+    },
+    {
+      "timestamp": 1785781011,
+      "commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
+      "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
+      "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-008"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
+++ b/.specsync/changes/CHG-0079-delete-the-ci-reimplementation-of-the-sdd-lifecycle-and-rely-on-specsync-change/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1785773757,
-  "commit": "14abe71bb3466c958070dee11a740a86148e7c30",
+  "timestamp": 1785781011,
+  "commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
   "contract_digest": "cdafa14a7ae2d85f5daf2e2345f33d64d6ea3b00467fde90e804d5976d0001e5",
   "execution_digest": "045e96403906690c8b04051d11aa3ea4c3af5f69db67e6917d04cad97d7971c0",
   "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/review-attempts.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/review-attempts.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "reviews": [
+    {
+      "schema_version": 2,
+      "change_id": "CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete",
+      "reviewer": "specsync-ci",
+      "provenance": {
+        "schema_version": 1,
+        "provider": "github_actions_check",
+        "required_check": "SpecSync scoped review"
+      },
+      "verdict": "pass",
+      "implementation_commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
+      "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+      "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "timestamp": 1785781046
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/review.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/review.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 2,
+  "change_id": "CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete",
+  "reviewer": "specsync-ci",
+  "provenance": {
+    "schema_version": 1,
+    "provider": "github_actions_check",
+    "required_check": "SpecSync scoped review"
+  },
+  "verdict": "pass",
+  "implementation_commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
+  "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+  "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+  "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+  "timestamp": 1785781046
+}

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/state.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "07a044a3e33987630ee8d53c000e71ca89074962",
   "created_at": 1785711176,
-  "updated_at": 1785772569,
+  "updated_at": 1785780437,
   "affected_specs": [
     "change"
   ],

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification-attempts.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification-attempts.json
@@ -107,6 +107,39 @@
       "requirement_ids": [
         "REQ-change-049"
       ]
+    },
+    {
+      "timestamp": 1785780435,
+      "commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
+      "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
+      "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
+      "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-049"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification.json
+++ b/.specsync/changes/CHG-0080-fail-lifecycle-verification-before-running-the-suite-when-evidence-is-incomplete/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1785772566,
-  "commit": "3607d03027ddaeb6bbf12d4cf47b1b3d42cffca6",
+  "timestamp": 1785780435,
+  "commit": "4c6216931f20ed7f82c7755a02a1a167fe90566b",
   "contract_digest": "91381dca6e8fac1294fbc737b0bed251def33fdee7623dcaf10f0193cfb2147b",
   "execution_digest": "d673d5eff02d1ef608276c33dc885054c0f43c6cf5a95f5457959fb0d7dc6a2c",
   "workspace_digest": "cff7bd1bbe80c7aa6ce8b51324249481298b39e14a472c71f0a80da176299243",


### PR DESCRIPTION
## Summary
- After #500 merge, active CHG-0079 and CHG-0080 verification digests were stale on `main`.
- Re-ran `specsync change check` for both on tip `4c62169`.
- Recorded independent scoped reviews (`specsync-ci`) so finalize can proceed once GitHub authenticates the review.
- Local `specsync change audit --strict` passes with both active.

## Why
Pure-specsync CI embarrassment: main carried two `verifying` changes with stale verification after the product PR merged.

## Next
Once `SpecSync scoped review` is green, run `specsync change finalize` for each change (or follow-up archive PR).

## Notes
- Does **not** change product code.
- #496/#497 closed as resolved-by-removal (#499 deleted their target workflows).
- Required CI gate now enforced on main branch protection (part of #498 residual).