### PR TITLE
docs: 6.0 findings, decisions, and the archival design

### DIFF
--- a/docs/6-0-findings.md
+++ b/docs/6-0-findings.md
@@ -1,0 +1,525 @@
+# Three findings, 2026-08-03
+
+Written up plainly. No code changes proposed here.
+
+---
+
+## 1. A fresh 6.0 project cannot run its own lifecycle
+
+`specsync init` writes `"verification_commands": []`. Every lifecycle command then fails
+on that empty list.
+
+```
+specsync init
+specsync change new "..."          # works
+specsync change check CHG-0001-... # fails
+```
+
+```
+error: no verification commands are configured for this change;
+       add a component command or a bounded project fallback in .specsync/sdd.json
+```
+
+Source: `src/change.rs:2523-2528`.
+
+Reproduced using only 6.0 commands — no 5.x verbs involved. The user has to hand-edit
+`.specsync/sdd.json` before the tool works at all. `change adopt` detects a test command
+per `MIGRATION.md`, so the intended path likely runs through adopt, but plain `init`
+leaves people stuck with an error that names a file they have never opened.
+
+**Severity:** out-of-box blocker. First thing a new user hits.
+
+---
+
+## 2. Five sandbox drills are out of date, not broken behaviour
+
+These five fail on 6.0 and pass on released 5.2.0:
+
+```
+008-squash-archive-regression   011-registry-stub-tolerance   013-batch-correct-owner
+009-migrate-5-0-backfill        012-registry-parser-realities
+```
+
+They call `change start`, `verify`, `accept`, `archive` — verbs 6.0 removed deliberately
+and replaced with `review`, `finalize`, and a repurposed `check`. The CHANGELOG documents
+this as "One guided change workflow for SpecSync 6.0".
+
+The split is exact: the drills calling removed verbs are precisely these five and no
+others. The `026-*` and `022` drills carry `SKIP:` version guards; these five never got
+one.
+
+**This is not evidence of a 6.0 defect.** It was initially reported as five regressions;
+that reading was wrong. They are un-migrated fixtures.
+
+**Action:** rewrite them onto 6.0 verbs, or add the version guard the `026-*` drills use.
+Until then every sandbox run is red for an uninteresting reason, which hides real signal.
+
+---
+
+## 3. The test suite cannot see the bugs that matter
+
+The Rust suite is green at 2,181 unit + 333 integration. Both tiers use a single process
+and a single `TempDir` repository root.
+
+The lifecycle lock is `flock` on `.specsync/change.lock` — a per-root path. It cannot
+serialize two roots. So:
+
+| Test | Shape | Result |
+|---|---|---|
+| `concurrent_change_creation_assigns_unique_ids` (`src/change.rs:21288`) | 8 threads, **one root** | permanently green |
+| `drills/026-multi-clone-new.sh` | 2 processes, **two roots** | reproduces a real ID collision |
+
+Both are "concurrency tests". Only one can fail. The unit fixture is structurally
+incapable of catching the bug.
+
+The 6.0 integration tier contains zero occurrences of `concurrent`, `squash`, `rebase`,
+`clone`, or `push`.
+
+Related: the effective-contract validation gate has had **no test coverage in either
+direction** since the original 5.0 commit. A change to its severity semantics passed the
+entire suite while opening a path that silently empties a required spec section. Green
+told us nothing.
+
+**Consequence:** green tests are not evidence that 6.0 is ready. Behavioural drills against
+a real binary, across multiple processes and repository roots, are where the remaining
+defects live.
+
+---
+
+## 4. The guided path produces a commit its own gate refuses
+
+Reproduced by following the workflow SpecSync itself prescribes:
+
+```
+change approve → change check → git commit → change review
+```
+
+```
+error: scoped review cannot bind stale verification
+       (verification descendant changed disallowed path
+        `.specsync/changes/CHG-0001-p/approvals.json`)
+```
+
+Also fires for `.specsync/change-sequence.json`, and for the same reason.
+
+### The gate is correct. Do not widen it.
+
+`REQ-change-016` (`specs/change/requirements.md:185`) restricts what a commit between
+verification and review may touch:
+
+> Only `state.json`, `verification.json`, `verification-attempts.json`, `review.json`, and
+> `review-attempts.json` …
+
+Its purpose is stated in the same requirement: reject *"unintegrated, altered, or historically
+tainted evidence"*. `approvals.json` carries the **scope-approval digest** — an authorisation,
+not an output. Allowing it to move inside that window would let a scope be approved that
+differs from the one verified. `change-sequence.json` is excluded by name in the same list.
+
+The test `verification_persistence_allowlist_is_exact_and_canonical` (`src/change.rs` ~:28160)
+asserts both rejections explicitly, citing REQ-change-013 and REQ-change-016.
+
+**An earlier attempt to skip `change-sequence.json` at the call site was reverted.** It would
+have passed the full suite: the test asserts the *function's* behaviour, and the change was in
+the caller, so the assertion stayed green while the effective policy loosened. Any fix here must
+be judged by the requirement, not by the suite.
+
+### So the defect is the workflow, not the rule
+
+`approve` and `change new` write files that the verification anchor then forbids moving. The
+lifecycle instructs the author to make a commit its own gate refuses.
+
+Candidate directions, none evaluated:
+
+- **Set the verification anchor after those writes**, so the files predate the window rather
+  than falling inside it
+- **Have `change check` absorb the commit boundary**, so authors are not told to commit between
+  verification and review
+- **Separate authorisation from evidence on disk**, so `approvals.json` is not in the same
+  directory the anchor policies
+
+This is a design question about *when* things are written, not about what the gate accepts.
+Decide the direction before writing code.
+
+**Severity:** blocks the documented path for any change committed before review — the normal
+order. Workaround today: do not commit between `check` and `review`.
+
+**Reproduction:** `spec-sync-sandbox/drills/030-correct-owner-6.sh` avoids it by not committing
+in that window, and says so in a comment.
+
+## 5. Three recovery commands cannot be reached on 6.0
+
+`change reopen`, `change correct`, and `change correct-owner` all appear in
+`change --help`. None can succeed through the guided path.
+
+`finalize_change` (`src/change.rs:5549-5556`) performs both halves in one command:
+
+```rust
+accept_change_with_gate(...)      // state = Accepted
+archive_change_with_options(...)  // state = Archived
+```
+
+So `Accepted` exists only transiently inside `finalize` and is never a state a user can
+stop at. There is no `accept` verb on 6.0 — the 5.x code path survives but is fenced off:
+
+```
+CHG-… uses the single 6.0 workflow; record scoped review and run `specsync change finalize`
+```
+
+Three functions require `Accepted`:
+
+| Function | Requires | CLI verb |
+|---|---|---|
+| `reopen_change` (`:2568`) | `[Accepted]` | `change reopen` |
+| `correct_interview_metadata` (`:4207`) | `[Accepted]` | `change correct` |
+| `archive_change` (`:5587`) | `[Accepted]` | internal |
+
+`correct-owner` requires `Verifying`, reachable only via `reopen`, so it is blocked one
+step further back. Nothing transitions `Archived` back to `Accepted`.
+
+Reproduced in `spec-sync-sandbox/drills/030-correct-owner-6.sh`:
+
+```
+error: cannot reopen accepted evidence while CHG-0001 is archived; expected accepted
+error: cannot discover missing acceptance input owners while CHG-0001 is archived; expected verifying
+```
+
+**Why it matters:** these are the recovery tools. `reopen` exists to recover when accepted
+evidence goes stale — a spec drops a file, ownership breaks, work needs re-verifying. On
+5.x that was reachable. On 6.0 there appears to be no route.
+
+**DECIDED 2026-08-03 by 0xLeif: reopen from archived.** `reopen` will operate on
+`Archived` changes, restoring them to a working state. The alternative — having `finalize`
+stop at `Accepted` with archiving as a separate step — was not taken; it would have
+reintroduced a second step to the guided path that 6.0 deliberately collapsed.
+
+### Scope — larger than relaxing the state check
+
+Allowing `[Archived]` in `require_state` alone is **wrong** and would corrupt the workspace.
+`reopen_change` writes to `change_dir(root, id)`, the *active* directory:
+
+```rust
+change_dir(root, &record.id).join("approvals.json")   // src/change.rs ~:2670
+change_dir(root, &record.id).join("state.json")
+change_dir(root, &record.id).join("change.md")
+```
+
+An archived change lives under `.specsync/archive/changes/`. Writing there would leave two
+directories claiming the same change ID, in disagreeing states.
+
+The correct shape is **un-archive, then reopen**: move the change directory back from
+`archive/changes/` to `changes/`, set state to `Verifying`, and record the reopen in the
+append-only ledger as today.
+
+Already solved: `find_change_dir` (`src/change.rs:15192`) searches the archive, which is why
+the failure is `is archived; expected accepted` rather than "not found". Loading works; only
+the write path and the state gate need changing.
+
+### Open sub-question
+
+Should un-archiving be recorded as a **distinct audited event**, separate from the reopen
+itself? An archived change that quietly becomes active again is a gap in the audit trail.
+The existing `reopenings[]` ledger may or may not be the right home for it. Decide before
+implementing — it is easier to add an event than to backfill one.
+
+### Before starting
+
+- Entry point: `reopen_change`, `src/change.rs:2568`
+- Reproduction: `spec-sync-sandbox/drills/030-correct-owner-6.sh` asserts today's failure and
+  is written to go **red** when this is fixed; invert those two assertions and extend the
+  drill to cover `correct-owner` properly
+- Watch the `archive_*` and `*_squash_*` test families — this touches archive-integrity, whose
+  whole job is noticing an archived directory that moved
+
+**Confidence:** four independent code sites agree and a drill reproduces it. Not proven
+exhaustively — `adopt` or a hand-edited `state.json` might reach `Accepted`, though
+hand-editing is not a real answer.
+
+---
+
+## 6. `change new` fails on any branch missing an earlier change's directory
+
+The most ordinary git workflow there is:
+
+```
+git checkout -b dev-a
+specsync change new "Feature A"     # creates CHG-0001-feature-a
+git commit -am "change A"
+
+git checkout main && git checkout -b dev-b
+specsync change new "Feature B"
+```
+
+```
+error: failed to read active change state
+       .specsync/changes/CHG-0001-feature-a/state.json: No such file or directory (os error 2)
+```
+
+`.specsync/change-sequence.json` is committed and records `CHG-0001-feature-a` as active. The
+change *directory* exists only on `dev-a`. On any branch without that directory, SpecSync
+reads the ledger, tries to load a change that is not there, and fails hard.
+
+**You cannot start a second change from a branch that does not contain the first one.** The
+error names a missing file rather than saying the ledger and the working tree disagree.
+
+Reproduced with 6.0 verbs only, in a fresh repository, in six commands.
+
+### This is the third symptom of one design problem
+
+| Finding | Symptom |
+|---|---|
+| 2 (coverage) | `audit --strict` reports the ledger as an uncovered path right after `change new` |
+| 4 (review gate) | the review gate rejects a commit containing the ledger |
+| **6** | `change new` fails outright on a branch missing an earlier change's directory |
+
+All three trace to `.specsync/change-sequence.json` being **committed state that is
+branch-sensitive**, while the changes it references live in directories that are also
+branch-sensitive — and nothing keeps the two in step.
+
+Worth treating as one design question rather than three bugs. Candidate directions, none
+evaluated:
+
+- Make ledger entries tolerate a missing directory (treat as not-active-here rather than an error)
+- Keep the ledger out of version control and derive the sequence from directories present
+- Reconcile ledger against directories on load, warning rather than failing
+
+**Severity:** blocks `change new`, the first command in the workflow, in a completely
+ordinary branching pattern. Arguably the most user-visible finding so far.
+
+**Reproduction:** `spec-sync-sandbox/drills/031-specsync-merge-conflict.sh`, which hit this
+during setup while trying to test something else.
+
+---
+
+## 7. `specsync new` scaffolds a spec that `change finalize` refuses
+
+```
+specsync new lib                      # tool generates specs/lib/lib.spec.md
+specsync change new … --spec lib      # complete the guided path
+specsync change finalize CHG-0001-…
+```
+
+```
+error: effective contract `lib`: Section ## Dependencies contains only unfinished draft text
+```
+
+`specsync new` emits a scaffold whose `## Dependencies` and `## Purpose` sections carry
+placeholder prose. Effective-contract validation promotes every validator warning to a hard
+error (`src/change.rs`, `.chain(result.warnings)` in `validate_effective_contracts`), so the
+stub warning becomes fatal at finalize.
+
+**The tool authored the text it then rejects.** The user never wrote it.
+
+**Reproduction:** `spec-sync-sandbox/drills/032-next-action-loop.sh`, which drives the guided
+path using only `next_action` and sticks here.
+
+### Bearing on decision A
+
+Decision A was framed as "6.0 tightened draft-text tolerance and broke migration". That framing
+was **wrong** — an adversarial audit showed migration never calls this gate, and the proposed
+fix (filtering `StubSection` warnings wholesale) would have opened a silent content-loss path:
+a `## MODIFIED` delta with an empty body writes an emptied section into the canonical spec, and
+the stub warning is the only gate catching it. That change was reverted.
+
+This finding is the **genuine narrow case** the audit described: a change blocked on stub text
+in a canonical spec it did not author. The fix the audit recommended still stands:
+
+- scope any exemption to sections **this change did not author** (the applied `SpecSection`
+  delta keys name exactly which ones it did), plus the `canonical_applied && Verifying` case
+  where no delta is replayed at all
+- route it through `IgnoreRules` so `.specsyncignore` and inline directives finally work at
+  this gate, and every suppression is reported rather than silent
+
+### The scaffold-side fix is wrong — do not take it
+
+An earlier draft of this finding suggested having `specsync new` emit scaffolds that pass the
+gate. That would defeat the detector. `SCAFFOLD_BOILERPLATE_PREFIXES` (`src/parser.rs:838`)
+contains the scaffold's exact strings:
+
+```rust
+"document this module's responsibility",               // scaffold's ## Purpose
+"list runtime dependencies and the specific symbols",  // scaffold's ## Dependencies
+```
+
+The generator and the detector are **deliberately coupled** — that coupling is how "you have
+not filled this in yet" is recognised at all. Rewording the scaffold to slip past its own
+detector would silently disable unfilled-section detection for every project.
+
+So the scaffold is *correctly* flagged. The defect is only that a correct warning is promoted
+to a hard error at the finalize gate, for a section the change did not author. The gate-side
+fix above is the whole fix.
+
+**Severity:** blocks finalize for the ordinary first change against a freshly scaffolded module.
+Combined with finding 1, a brand-new project cannot complete a change without editing two files
+the tool generated.
+
+---
+
+## 8. `supersede` requires a digest with no way to obtain it
+
+```
+specsync change supersede --path <PATH> --spec <MODULE> --digest <DIGEST> <ID> <PREDECESSOR>
+```
+
+`--digest` is documented only as *"Full `specsync.acceptance-entry.v1` predecessor digest"*.
+
+The value exists at `.specsync/changes/<predecessor>/verification.json` →
+`acceptance_manifest.entries[].entry_digest`, matched by `path`. Nothing tells the user that:
+
+- No CLI command emits it. `change show --json` exposes `summary.definition_digest` and
+  `effective_definition.view_digest`; neither is an acceptance-entry digest.
+- The help text names the format but not the source.
+- `acceptance-entry` appears nowhere in `docs/` or `README.md`.
+
+So the only route is: know the manifest exists, open an internal evidence file, find the entry
+matching your path, and copy the field by hand.
+
+**Why it matters:** `supersede` exists to adopt a predecessor obligation, which is a recovery
+operation reached when something has already gone wrong. Requiring an undiscoverable argument at
+that moment is the worst place for it. An agent driving from `--help` cannot construct the
+command at all.
+
+**Candidate fixes, none evaluated:**
+
+- Expose entry digests in `change show --json` for accepted changes
+- Add `--path`-based lookup so `supersede` resolves the digest itself, keeping `--digest` as an
+  explicit override
+- At minimum, name the source file and field in the help text
+
+**Severity:** not a correctness defect. Squarely in the "hard to use, wastes time" class — the
+kind of thing that makes a recovery path unusable in practice even though it works.
+
+**Status:** no drill yet. `030` covers `correct-owner`; `supersede` has no coverage on 6.0.
+
+---
+
+## 9. OPEN QUESTION: can a `change depend` dependency ever be satisfied?
+
+Not confirmed — recorded so it is not lost.
+
+`change depend <ID> <ON>` declares ordering. `change check` on the dependent refuses until the
+dependency is **accepted**:
+
+```
+error: dependency `CHG-0001-first` is implementing;
+       it must be accepted before CHG-0002-second can start
+```
+
+But `finalize` performs accept and archive in one command, so a change is never observably
+`Accepted` — that is finding 5. If the dependency check requires exactly `Accepted`, the same
+way `reopen` and owner correction did, then **a declared dependency may never become
+satisfiable through the guided path**.
+
+Two possibilities, untested:
+
+- The check accepts `Archived` as well, in which case this is fine
+- It requires exactly `Accepted`, in which case `depend` is unusable for the same reason three
+  recovery commands were
+
+**How to settle it:** drive a dependency to `finalize`, then run `change check` on the
+dependent. A probe attempt got as far as declaring the dependency and confirming the ordering
+is enforced while the dependency is draft/implementing, but the dependency could not be
+finalized because the fixture tripped finding 7 (scaffold `## Public API` prose) and a missing
+`files:` frontmatter entry.
+
+**Why it is plausible:** finding 5 turned out to be three coupled sites, each requiring
+`Accepted` — `reopen`, `correct`, and owner correction. Dependency satisfaction is a fourth
+place with the same shape. Two were found only by exercising the path.
+
+**Confirmed so far:** `change depend` accepts the ordering, and `change check` correctly
+enforces it while the dependency is draft or implementing. The ordering mechanism works; only
+its terminal condition is in doubt.
+
+---
+
+## 10. DESIGN: archival should fold lessons into the spec's context
+
+Not a defect — a missing lifecycle stage, specified here from the author's intent.
+
+`finalize` moves a directory. In the intended model it is the moment knowledge moves from the
+change into the spec, and it is the only place the system compounds rather than merely records.
+
+### The three stages
+
+| Stage | |
+|---|---|
+| **Proposal** | spec, design, requirements, planning and review agents, cleared context — reviewed and signed off. PR or local sign-off, either works. Approval is its terminal act. |
+| **Implementation** | merged and *live* in `.specsync/changes/`, deliberately visible so other agents and reviews can see what is in flight and what was intended. |
+| **Archival** | archive the change **and** fold lessons into the spec's companion context. |
+
+Active changes on main are therefore intentional, not accumulation to be eliminated. The defect
+was that they went stale and cost a re-verification per PR, which finding 5's fix addressed.
+
+### Where lessons live
+
+In `specs/<module>/context.md` — the **spec's** companion, not the change's. A per-change
+lessons file dies with the change; the point is that a module accumulates what was learned
+about it across every change that touched it.
+
+Written by **the agent**, at archival, drawn from the change's commits, PR, and PR comments —
+synthesised from what actually happened, not recalled.
+
+### How, without spec-sync becoming opinionated
+
+SpecSync must not shell out to a particular agent. It does not need to: the agent driving the
+lifecycle just ran `finalize`. So `finalize` assembles the material and sets `next_action`:
+
+```
+Next: write lessons for `change` into specs/change/context.md
+      from .specsync/changes/CHG-XXXX/lesson-bundle.md
+```
+
+Same mechanism the lifecycle already uses everywhere, and drill `032-next-action-loop.sh`
+confirms agents can follow `next_action` to termination. Neither blocking nor nagging — a step.
+
+### Two pieces of work
+
+1. **Capture** — the change accumulates its commit range, PR number and PR comments as it goes.
+   Some is already reachable (`verification.json` records commits, review evidence records
+   verdicts); PR comments need fetching. Mechanical.
+2. **Synthesise** — `finalize` assembles the bundle, sets `next_action`, and completes archival
+   once the spec's context has been written.
+
+### On unbounded growth
+
+Raised and answered: if a module's lessons grow without bound, that is a signal the module is
+too large or too hot, and compaction would hide exactly what you want to see. Treat volume as a
+health signal. `specsync compact` exists if it is ever needed, but routine compaction is not the
+goal.
+
+There is likely a second tier for lessons that are project-wide rather than module-specific.
+This session's own output splits that way:
+
+- *module-specific* — the effective-contract gate has had no coverage since 5.0; `finalize`
+  collapses accept and archive so `Accepted` is never observable
+- *project-wide* — `touch` before `cargo build` or you test a stale binary; grepping an error
+  message is unreliable because several are assembled with `format!`; the test fixtures are
+  single-process and single-root, so a whole class of defect cannot fail there
+
+Leave the project-level tier undesigned until several modules have accumulated something real.
+
+### Status
+
+`feat(change): prompt the context artifact` was initially written as lesson prompts on the
+change's context artifact. That was the wrong home and has been rescoped: the change's context
+now prompts for its own working record — what led here, what a session picking it up mid-flight
+needs to know. Lessons await this archival stage.
+
+---
+
+## Also observed (drill 030)
+
+- 6.0 refuses approval until every selected artifact carries real content **and** a
+  semantic delta exists per affected spec. 5.x approved without either. This is a real
+  workflow difference agents must be told about; nothing in the docs states it as a
+  precondition of `approve`.
+
+## Also observed (earlier)
+
+- `drills/027-ship-sequence.sh` greps `--help` output and checks two docs exist. It never
+  runs a lifecycle, so the ship/finalize path has no behavioural coverage in the sandbox.
+- `examples/sdd-lifecycle/run.sh`, `examples/sdd-concurrent-changes/run.sh`, and
+  `examples/sdd-five-epics/run.sh` are real-binary harnesses referenced by no CI job or
+  test. `sdd-concurrent-changes` is sequential with one actor despite the name.
+- Squash merges leave a change's recorded verification commit unreachable from main, so
+  squash-merged changes cannot be finalized. Both changes currently on main are
+  unfinalized for this reason.

--- a/docs/6-0-tolerance-decisions.md
+++ b/docs/6-0-tolerance-decisions.md
@@ -1,0 +1,121 @@
+# Three tolerance decisions blocking 6.0
+
+> **DECIDED 2026-08-03 by 0xLeif.** A: scope to authored specs. B: exempt no-op changes.
+> C: exempt metadata-only corrections. Rationale for each is the recommended option below.
+
+Five sandbox drills that pass on released 5.2.0 fail on 6.0. They collapse to three
+places where 6.0 got stricter, each with a legitimate counter-example the stricter rule
+did not anticipate.
+
+None looks like a correctness break. All three are product calls about what the tool
+should tolerate — which is why they are written up rather than fixed.
+
+Reproduce any of these with:
+
+```
+SS=<6.0 binary> SPECSYNC=<6.0 binary> bash drills/<name>.sh    # in spec-sync-sandbox
+```
+
+---
+
+## A — Should an effective contract accept scaffolded sections?
+
+**Breaks:** `008-squash-archive-regression`, `009-migrate-5-0-backfill`,
+`012-registry-parser-realities` — three of the five.
+
+```
+error: effective contract `lib`: Section ## Purpose contains only unfinished draft text;
+       effective contract `lib`: Section ## Dependencies contains only unfinished draft text
+```
+
+5.2.0 accepted these sections. 6.0 rejects them.
+
+**Why it matters:** the paths that break are *migration* and *registry parsing* — the two
+places whose job is to handle content that has not been written yet. `009` backfills a
+5.0-era ledger; a backfilled spec is scaffolding by definition. Requiring finished prose
+before a migration can complete means a 5.x project cannot reach 6.0 without hand-editing
+every generated section first.
+
+**Options**
+
+1. **Scope the rule to authored specs.** — **CHOSEN** Migration and scaffolding paths tolerate draft
+   sections; specs a human is actively delivering do not. Keeps the guarantee where it has
+   value, removes it where it is self-defeating. *Recommended.*
+2. **Warn instead of erroring** in effective-contract evaluation. Simpler, but weakens the
+   guarantee everywhere including where it was working.
+3. **Keep as-is** and change migration to emit finished placeholder prose. Honest, but
+   generates text nobody wrote and everybody must then rewrite.
+
+**Note:** this is the mirror image of #495. There, `# TODO` headings pass scope approval;
+here, draft sections fail contract evaluation. Same subsystem, opposite direction — worth
+deciding together so the two rules agree on what "unfinished" means.
+
+---
+
+## B — Should an inert stub complete a lifecycle?
+
+**Breaks:** `011-registry-stub-tolerance`
+
+```
+inert stub failed at accept: error: CHG-0001-registry-probe uses the single 6.0 workflow;
+record scoped review and run `specsync change finalize CHG-0001-registry-probe`
+```
+
+Not a defect — workflow-v2 asserting itself. But the drill's subject is an *inert registry
+stub*: a probe that changes nothing. Requiring a scoped review and a finalize for it is
+ceremony with no reviewable content.
+
+**Options**
+
+1. **Exempt no-op changes** — **CHOSEN** — from scoped review and finalization when the delta is empty.
+   Needs a precise definition of "inert" — likely: no canonical spec delta and no tracked
+   file change outside `.specsync/`.
+2. **Keep the requirement** and change the drill to complete the lifecycle. Consistent, but
+   concedes that trivial changes cost a full lifecycle.
+3. **Scope by change kind** — `operations`/`documentation` kinds skip review. Blunter, and
+   invites mislabelling to dodge review.
+
+Interacts with the open scoped-review question: if a review binds to implementation content,
+an inert change has no content to review, which argues for option 1.
+
+---
+
+## C — Should metadata correction require verification commands?
+
+**Breaks:** `013-batch-correct-owner`
+
+```
+error: no verification commands are configured for this change;
+add a component command or a bounded project fallback in .specsync/sdd.json
+```
+
+`change correct-owner` rewrites accepted-evidence ownership. It changes no code, so there is
+nothing for a verification command to verify — but 6.0 demands one be configured.
+
+**Options**
+
+1. **Exempt metadata-only corrections** — **CHOSEN** — from the verification-command requirement. The
+   audit trail is append-only regardless, so the evidence guarantee is unaffected.
+   *Recommended.*
+2. **Allow an explicit empty command set** for correction operations, recorded as such.
+   More auditable, more ceremony.
+3. **Keep as-is.** Every project must configure a command purely to satisfy a code path that
+   cannot use it.
+
+---
+
+## Cross-cutting
+
+All three share a shape: **6.0 tightened a rule without the case that needed tolerating.**
+The Rust suite is green at 2,181 + 333 — these paths are exercised from the outside, by a
+person or an agent using the tool, and nothing tested that until the sandbox was unpinned
+from 5.2.0 today.
+
+That is the argument for the scenario matrix (solo dev, multiple devs, async clones, merge
+topologies, conflicts, green and bad paths) rather than fixing three bugs and calling 6.0
+done.
+
+**Also outstanding:** `027-ship-sequence` fails because it asserts `ship-status`/`ship`
+exist. Those were deliberately dropped with #487 and #499 removed the tip dance that
+motivated them. That drill needs updating or deleting — it is a drill bug, not a product
+bug.

--- a/docs/GOAL-6-fixes.md
+++ b/docs/GOAL-6-fixes.md
@@ -1,0 +1,96 @@
+# GOAL: fix the seven findings
+
+**Definition of done:** a fresh project can complete a change end to end, on an ordinary
+branch, without editing a file the tool generated — and the drills that assert today's
+failures have been inverted to assert the fix.
+
+Findings and reproductions: `docs/6-0-findings.md`.
+Every finding has a drill that goes **red when fixed**. That is the signal to invert it.
+
+---
+
+## Order
+
+### 1. The ledger design problem — findings 2, 4, 6
+
+One cause, three symptoms. Highest leverage.
+
+`.specsync/change-sequence.json` is committed, branch-sensitive state that references change
+directories which are also branch-sensitive, with nothing keeping the two in step.
+
+| Finding | Symptom |
+|---|---|
+| 6 | `change new` fails outright on a branch missing an earlier change's directory |
+| 4 | the review gate rejects a commit containing the ledger |
+| 2 | `audit --strict` reports the ledger as uncovered right after `change new` |
+
+Finding 6 is the one to fix first — it blocks the first command in the workflow.
+
+Candidate directions, none yet evaluated:
+
+- Ledger entries tolerate a missing directory: treat as not-active-*here* rather than an error
+- Keep the ledger out of version control, deriving the sequence from directories present
+- Reconcile ledger against directories on load, warning rather than failing
+
+Decide the direction before writing code. The first is narrowest; the second removes the
+whole class but changes what the ledger is for; the third is a half-measure worth rejecting
+explicitly rather than drifting into.
+
+**Drill:** `031-specsync-merge-conflict.sh`
+
+### 2. Scaffold versus contract gate — finding 7
+
+`specsync new` emits placeholder prose; effective-contract validation promotes that stub
+warning to a hard error at finalize. The tool authored the text it then rejects.
+
+Two fixes, not exclusive:
+
+- **At the gate:** scope any stub exemption to sections *this change did not author* — the
+  applied `SpecSection` delta keys name exactly which ones it did — plus the
+  `canonical_applied && Verifying` case where no delta is replayed. Route it through
+  `IgnoreRules` so `.specsyncignore` works here and every suppression is reported.
+- **At the source:** have `specsync new` emit scaffolds that pass the gate they will be
+  judged by.
+
+**Do not** filter `StubSection` warnings wholesale. That was tried and reverted: a
+`## MODIFIED` delta with an empty body writes an emptied section into the canonical spec, and
+the stub warning is the only gate catching it. See finding 7's "Bearing on decision A".
+
+**Drill:** `032-next-action-loop.sh`
+
+### 3. `reopen` from archived — finding 5
+
+Decided. Scope is written into finding 5: un-archive then reopen, because `reopen_change`
+writes to the *active* directory while an archived change lives under `archive/changes/`.
+Relaxing `require_state` alone would create two directories claiming one ID.
+
+Open sub-question to settle first: should un-archiving be a **distinct audited event**?
+
+**Drill:** `030-correct-owner-6.sh`
+
+### 4. Already fixed
+
+Finding 1 — `init` writes usable verification commands, or warns. `leif/finalize-adopt`
+`3c28e29`, suite green, pushed.
+
+---
+
+## Standing rules
+
+- **The drills are the judge.** The Rust suite is green while all seven of these exist; it
+  cannot see this class of defect (finding 3).
+- **Invert the drill in the same change as the fix.** A finding whose drill still asserts the
+  old behaviour is not finished.
+- **Do not swallow errors.** Two false leads today came from `>/dev/null 2>&1` turning a
+  fixture mistake into an apparent product bug.
+- **Assert observed wording, never guessed wording.**
+- Warn before any edit that invalidates an approval or verification digest.
+- `src/change.rs` is a strict-validation path: each fix needs a change workspace and a human
+  approval digest.
+
+## Elevate to human
+
+- The ledger direction (§1) — three candidates, materially different consequences
+- Whether un-archiving is a distinct audited event (§3)
+- Anything touching digest, acceptance, or archive-integrity semantics
+- Any approval digest, scoped review, or admin merge

--- a/docs/GOAL-6-taggable.md
+++ b/docs/GOAL-6-taggable.md
@@ -1,0 +1,168 @@
+# GOAL: a taggable spec-sync 6.0.0
+
+**Definition of done:** a clean `v6.0.0` tag where local `specsync` catches essentially every
+"spec-sync reason" that currently turns CI red, and no agent is forced into a ship dance.
+
+**Not done until:** the failure class below is empty on a real PR, twice in a row, without a human
+knowing a workaround.
+
+---
+
+## The failure class we are eliminating
+
+CI red for *spec-sync reasons*, not ordinary test failures:
+
+| Failure | Status |
+|---|---|
+| Stale verification evidence | **root cause confirmed** — see §1 |
+| Incomplete change artifacts / missing requirement evidence | fixed in #500 (fail-early + named artifact) |
+| Approval digest invalidation after edits | open — no warning before the edit |
+| Ship / finalize tip thrash | removed by #499; finalization now has *no* trigger (§2) |
+| TODO/placeholder artifacts passing approval | open — #495 |
+
+---
+
+## §1 — Stale verification evidence (highest value)
+
+**Confirmed mechanism.** `project_input_digest` derives content from the **Git index**
+(`inspect_git_candidates` → `git ls-files --stage`), but `change check` materializes the delta into
+the **working tree**. Verification runs the suite against the working tree and records a digest of
+index content that was never tested. Staging that same delta then invalidates the evidence it just
+produced. Non-git projects are immune (`capture_non_git_candidates` reads the filesystem), which is
+the tell that the index path is the anomaly.
+
+**Fix, staged:** a fail-early guard in `verify_change_with_strict` comparing working tree vs index
+for the canonical specs a delta materializes, refusing before the suite runs with a message naming
+the file, the action, and the reason. Touches no digest semantics.
+
+**ANSWERED.** The index-based digest is *intended*. Verifying while the materialized spec is
+unstaged is a supported flow — spec-sync's own fixtures depend on it, which is why a fail-early
+"stage it first" guard broke `stale_accepted_change_*` and two others. That guard was wrong and is
+not in the tree.
+
+The real defect is narrower: **verify → stage → stale**, with no warning. Deterministic workaround
+that provably terminates: `change check` → commit the materialized spec → `change check` → commit
+evidence. Confirmed on CHG-0079/CHG-0080 — `audit --strict` passed *after* the evidence commit,
+because `.specsync/changes/` is excluded from the project-input digest.
+
+### §1 fix — analysis complete, NOT implemented
+
+Call sites (`src/change.rs`):
+
+| Caller | `allow_verified_tree_adoption` | `require_scoped_review` |
+|---|---|---|
+| `accept_change` (5315) | `false` | `false` |
+| `finalize_change` (5540) | **`true`** | `true` |
+
+Finalize already adopts a changed **commit** (5343-5345). It never gets there because
+`validate_verification_for_commit_binding` (5131) refuses first, at 5148:
+`verification.workspace_digest != project_input_digest(root)?`.
+
+**Two designs, and they are not equivalent:**
+
+1. *Adopt the digest* alongside the commit. Small. **But it weakens evidence** — it declares "the
+   tree changed since we tested, accept anyway." The digest exists precisely to prove what was
+   tested. Do not do this without deciding that trade deliberately.
+2. *Re-record at finalize* — finalize re-runs verification against the committed tree. Evidence stays
+   honest because it was genuinely tested. Costs a suite run at finalize, but replaces the manual
+   second pass, so it is time-neutral and requires no author knowledge. **Recommended.**
+
+Design 2 is what "re-record at finalize" meant and is the one to build. It also composes with §2:
+if finalize is triggered post-merge, the re-record happens there automatically.
+
+### Implementation hazard — DEADLOCK. Read before writing code.
+
+`accept_change_with_gate` (5318) opens with `let _lock = acquire_project_lock(root)?;`.
+`verify_change` (2351) **also** calls `acquire_project_lock`, which is a `file.lock_exclusive()`
+flock (405-433). Calling `verify_change` from inside acceptance therefore blocks forever — it hangs
+rather than failing, which is worse than any error.
+
+The re-record must be built as:
+
+1. Extract the body of `verify_change_with_strict` below its `acquire_project_lock` into a
+   lock-free `verify_change_locked(root, id, strict)`.
+2. `verify_change_with_strict` becomes: acquire lock, call the inner.
+3. `accept_change_with_gate` calls the **inner** while holding its own lock, when
+   `allow_verified_tree_adoption` is set and `validate_verification_for_commit_binding` failed.
+4. Re-load verification and re-validate. Fail if it still does not bind.
+
+Do not shortcut by dropping and re-taking the lock — that opens a window where another process can
+mutate the workspace between verification and acceptance, which is the exact race the lock exists to
+prevent.
+
+Validate against `stale_accepted_change_*`, `verification_freshness_*`, and any test asserting that
+acceptance does not re-run commands. Expect the finalize path to get materially slower — that is the
+intended trade: one automatic suite run replaces one manual pass the author had to know about.
+
+## §2 — Finalization has no trigger — BLOCKED ON §1, and they are one task
+
+Post-merge finalize **cannot work as a standalone workflow.** Confirmed on main at `4c62169`:
+
+```
+$ specsync change finalize CHG-0079-...
+error: cannot accept stale verification: verification commit is not an ancestor of HEAD
+
+$ git merge-base --is-ancestor 14abe71 origin/main   ->  NOT an ancestor
+$ git log -1 --format="%H %p" origin/main            ->  one parent = squash
+```
+
+**Squash merge destroys the verification commit binding.** Evidence records the branch tip; the
+squash creates a new commit with no branch ancestry, so the recorded commit is not reachable from
+main. Every squash-merged change is permanently unfinalizable by commit binding alone.
+
+This is not the scoped-review requirement (that comes later, and is a separate gate). It fires first.
+
+**Therefore:** a post-merge finalize job is only viable if finalize *re-records* verification against
+the merged tree — §1 design 2. Re-running on main sets `commit = HEAD` and refreshes the digest, so
+ancestry and staleness both resolve by construction.
+
+Options if re-record is rejected: switch main to merge commits instead of squash (preserves
+ancestry, changes history shape), or accept that changes are finalized pre-merge.
+
+Old §2 notes follow.
+
+#499 deleted the `ci-gate` failure that forced `specsync change finalize`. That failure *was* the
+tip dance, so removing it was right — but nothing replaced it. CHG-0079 merged unfinalized; CHG-0080
+will too. Active changes accumulate on main and stale.
+
+**Decision needed:** post-merge finalize job on main (recommended — keeps merges clean, makes
+finalization inevitable) vs documented pre-merge step.
+
+## §3 — Approval digest invalidation
+
+Editing artifacts after approval silently invalidates the approval digest; the author discovers it
+at the next gate. Per working style: **warn at the edit, not at the gate.** Needs a cheap
+`change status` signal, or a hook.
+
+## §4 — #495 TODO/placeholder artifacts
+
+`# TODO` headings pass scope approval while prose containing "TODO" false-positives. Product-side,
+unaffected by #499.
+
+---
+
+## Closed by deletion (verify before planning work on them)
+
+#496, #497, #498 all target files deleted in #499
+(`reuse-check-from-ancestors.py`, `post-merge-archive.yml`, `lifecycle-policy-guard.yml`).
+#487 "buttery ship" premise removed — `ship-status` dropped, tip dance deleted.
+
+---
+
+## Sequence
+
+1. Land #500 (three fixes + §1 guard) — unblocks every subsequent PR
+2. §2 finalization trigger — required before a clean tag or changes pile up on main
+3. §3 approval-digest warning
+4. #495
+5. Sandbox candidate CI: unpin from v5.2.0, build from candidate SHA, `SKIP` must stop counting as
+   `PASS` — until then nothing exercises 6.0 behaviour
+6. Two consecutive clean PRs with zero spec-sync-reason failures → tag
+
+## Elevate to human
+
+- §1 open question, once validation lands
+- §2 decision
+- Any change to digest/acceptance semantics — twice this session a fix there looked right and
+  contradicted a deliberate invariant, caught only by the full suite
+- Anything needing an approval digest, scoped review, or admin merge

--- a/docs/SESSION-SUMMARY-6-0.md
+++ b/docs/SESSION-SUMMARY-6-0.md
@@ -1,0 +1,81 @@
+# spec-sync 6.0 — session summary
+
+## Shipped
+
+| PR | |
+|---|---|
+| **#499** merged | Deleted 7,257 lines of CI that reimplemented the SDD lifecycle against Git commit topology, plus two defects living in it. Closed #496/#497/#498 by deletion. |
+| **#500** merged | Three lifecycle fixes. First PR in this repo to pass CI green with no bypass. |
+| **#503** open | Six findings fixed. 10 commits, rebased on current main, CHG-0081 approved and verified. |
+| **#28** open (sandbox) | 13 passing 6.0 drills, three-outcome runner, two lanes, five legacy drills guarded. |
+
+Also merged by you: **#501**, **#502** — re-verified and archived CHG-0079/0080, which removed the compounding refresh cost.
+
+## Findings: nine found, six fixed
+
+| # | Finding | Status |
+|---|---|---|
+| 1 | `init` writes empty `verification_commands`; a fresh project cannot complete its own lifecycle | **fixed** |
+| 2 | `audit --strict` reports the sequence ledger as uncovered | **fixed** (by 6) |
+| 5 | `reopen`, `correct`, `correct-owner` unreachable — `finalize` never stops at `Accepted` | **fixed** (3 coupled changes) |
+| 6 | `change new` fails on any branch missing an earlier change's directory | **fixed** |
+| — | Owner correction rejected an archive-origin reopen | **fixed** |
+| 8 | `supersede --digest` had no discoverable source | **fixed** |
+| 3 | The Rust suite cannot see this class of defect | structural |
+| 4 | The guided path produces a commit its own gate correctly refuses | **open — needs a decision** |
+| 7 | `specsync new` scaffolds a spec `finalize` rejects | **open — two wrong fixes documented** |
+| 9 | Can a `change depend` dependency ever be satisfied? | **open question** |
+
+## Confirmed working
+
+Worth stating after a day of cataloguing rough edges — these all hold:
+
+- Separation of duties: self-review refused, independent review accepted
+- `depend` ordering enforced while the dependency is draft or implementing
+- `supersede` rejects a wrong predecessor digest
+- A hand-resolved `change-sequence.json` merge conflict is **rejected, not trusted**
+- The spec gate caught an undocumented public export I added, naming file and symbol
+
+The core guarantees are sound. The friction is around them.
+
+## The three lessons that cost the most
+
+**1. The Rust suite cannot judge this work.** It passed 2,181 + 333 through all nine defects. Two of my own changes would have shipped green while quietly loosening a rule — the wholesale stub filter, and a `change-sequence.json` allowlist skip that changed the caller so the test asserting the function stayed green. Fixtures are single-process and single-root, so concurrency and multi-clone defects cannot fail there by construction. The effective-contract gate has had zero coverage since 5.0.
+
+**Use the drills and the requirements as the judge.**
+
+**2. Read the requirement before writing code.** Nine wrong calls. The cheapest catches all came from reading `REQ-change-*` first — `REQ-change-016` stopped a bad allowlist change, `REQ-change-033` settled the owner-correction gate correctly. The expensive ones came from writing first and discovering intent afterwards.
+
+**3. Never swallow command output in a probe.** `>/dev/null 2>&1` turned fixture mistakes into apparent product defects three times. Drills have assertions to catch what you missed; ad-hoc probes do not.
+
+Two mechanical traps specific to this repo:
+
+- **`touch` before `cargo build`.** Script edits do not reliably trip cargo's fingerprint in a worktree; `cargo build` reports `Finished` and you test a stale binary. This produced one entirely false conclusion and looked like edits "vanishing".
+- **Grepping an error message is unreliable.** Several are assembled — e.g. `format!("failed to read {} change state", if archived { .. })` — so the literal string never appears in source.
+
+## The pattern that made this safe
+
+Every fix followed: **drill asserts the bug → fix it → drill goes red to announce the fix → invert it to guard the fix.** That happened four times. It is what let six findings land in a day on a codebase whose test suite is blind to the whole class.
+
+## Open for decision
+
+- **Finding 4** — the gate is correct; the question is *when* `approvals.json` and the sequence ledger are written relative to the verification anchor.
+- **Finding 7** — gate-side only. The scaffold-side option is ruled out: `SCAFFOLD_BOILERPLATE_PREFIXES` contains the scaffold's exact strings *by design*, and that coupling is the unfilled-section detector. Two gate-side attempts also failed; write the negative test first — an authored `## MODIFIED` section with a stub body must fail.
+- **Finding 9** — blocked behind 7, since fixtures trip the scaffold gate.
+- **`SPECSYNC_CANDIDATE_SHA`** — needed as a repo variable for PR #28's candidate lane.
+- **SDD tool comparison** — requested, not done. Needs real research, not an aside.
+
+## Note: lessons and learnings are not a first-class artifact
+
+`ArtifactKind` is `Requirements | Research | Design | Plan | Tasks | Context | Testing | Docs | Custom(String)`.
+There is no lessons, learnings, retrospective or postmortem artifact, and no CLI surface for one.
+
+`Custom(String)` means `specsync change new --artifact lessons` creates `lessons.md` as a selected
+artifact that must be completed before approval — so the mechanism exists, but nothing suggests it,
+scaffolds it, or aggregates across changes.
+
+Worth considering: this session produced nine findings and three durable lessons, none of which the
+lifecycle had anywhere to record. They live in hand-written docs instead. A `lessons` artifact —
+adaptive for `bug_fix` and `migration` kinds, aggregated by `change list` or a `lessons` command —
+would let the tool accumulate what its users learn, which is exactly the material that made today's
+work possible.


### PR DESCRIPTION
Documentation only — no code. `change audit --strict` passes with zero active changes, so this needs no change workspace.

Ten findings from driving the real binary through the lifecycle in `spec-sync-sandbox`. **Six are already fixed** (in #503); four remain, each with a reproduction and a scoped direction.

| Doc | |
|---|---|
| `6-0-findings.md` | The ten findings, with reproductions and code sites |
| `GOAL-6-taggable.md` | What a taggable 6.0.0 requires |
| `GOAL-6-fixes.md` | Fix order and the standing rules |
| `6-0-tolerance-decisions.md` | Three decisions, since superseded — kept for the reasoning |
| `SESSION-SUMMARY-6-0.md` | What shipped, and the three costliest lessons |

## Worth reading first

**Finding 10** — the archival stage. `finalize` currently moves a directory; it should also fold lessons into the spec's companion context, written by the driving agent from the change's commits and PR, delivered via `next_action` so SpecSync never shells out to a particular agent. This is the only place the system compounds rather than records.

**Finding 4** — the guided path produces a commit its own gate correctly refuses. The fix is a real boundary between proposal and implementation: the verification anchor should open at approval, so proposal artifacts fall outside the window. `REQ-change-016` doesn't change.

**Finding 7** — two wrong approaches documented, both from this session. The scaffold-side fix would disable unfilled-section detection for every project; a wholesale stub filter opens a silent content-loss path. Write the negative test first.

## The claim that matters

The Rust suite passed **2,181 + 333** through all ten findings. Fixtures are single-process and single-root, so concurrency and multi-clone defects cannot fail there by construction, and the effective-contract gate has had no coverage since 5.0. Two changes written during this work would have shipped green while loosening a rule.

Green is not evidence for this class. The drills and the requirements are.