### PR TITLE
fix(ci): catch verification evidence a squash merge discarded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,9 +220,17 @@ jobs:
           print(c if isinstance(c, str) and len(c) == 40 else '')
           " 2>/dev/null)
             [ -n "$commit" ] || continue
-            git cat-file -e "${commit}^{commit}" 2>/dev/null || continue
+            # fetch-depth: 0 above means every commit reachable from this ref is
+            # present. Absence is orphaned evidence (squash merge of an
+            # unfinalized change, or a force-push/rebase/amend that dropped the
+            # recorded tip). Either way the active change must be re-checked.
+            if ! git cat-file -e "${commit}^{commit}" 2>/dev/null; then
+              echo "::error::${dir%/} verification commit ${commit:0:8} is not in this repository — re-run 'specsync change check' (evidence was orphaned by a squash merge, rebase, amend, or force-push)" >&2
+              stale=1
+              continue
+            fi
             if ! git merge-base --is-ancestor "$commit" HEAD 2>/dev/null; then
-              echo "::error::${dir%/} verification commit ${commit:0:8} is not an ancestor of HEAD — the change was very likely merged before it was finalized" >&2
+              echo "::error::${dir%/} verification commit ${commit:0:8} is not an ancestor of HEAD — re-run 'specsync change check' then review and finalize before merging" >&2
               stale=1
             fi
           done

--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 87,
-  "id": "CHG-0087-decide-pull-requests-in-seconds-instead-of-minutes",
+  "sequence": 88,
+  "id": "CHG-0088-catch-verification-evidence-a-squash-merge-discarded",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/approvals.json
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/approvals.json
@@ -1,0 +1,70 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "claude",
+      "timestamp": 1786031797,
+      "digest": "d417a40b94216b5509e7030a1db8ae6083c471788639eeadf5e4c9737c6fe98b",
+      "note": null,
+      "approved_scope": {
+        "schema_version": 1,
+        "change_id": "CHG-0088-catch-verification-evidence-a-squash-merge-discarded",
+        "title": "Catch verification evidence a squash merge discarded",
+        "description": "Catch verification evidence a squash merge discarded",
+        "kind": "bug_fix",
+        "affected_specs": [
+          "github"
+        ],
+        "affected_paths": [
+          ".github/workflows/ci.yml",
+          ".specsync/change-sequence.json"
+        ],
+        "no_spec_change": false,
+        "no_spec_change_rationale": null,
+        "acceptance_criteria": [
+          "the preflight fails when an active change's verification commit is absent from the repository, which is what a squash merge leaves behind"
+        ],
+        "dependencies": [],
+        "supersedes": [],
+        "answers": {
+          "architecture_risk": "no",
+          "public_contract": "no"
+        }
+      }
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1786059466,
+      "digest": "37270a10e9a76b45c2ec150ab5ba80fa11289b88bffa4b0134f4d3d2cc8ccd43",
+      "note": null,
+      "approved_scope": {
+        "schema_version": 1,
+        "change_id": "CHG-0088-catch-verification-evidence-a-squash-merge-discarded",
+        "title": "Catch verification evidence a squash merge discarded",
+        "description": "Catch verification evidence a squash merge discarded",
+        "kind": "bug_fix",
+        "affected_specs": [
+          "github"
+        ],
+        "affected_paths": [
+          ".github/workflows/ci.yml",
+          ".specsync/change-sequence.json"
+        ],
+        "no_spec_change": false,
+        "no_spec_change_rationale": null,
+        "acceptance_criteria": [
+          "the error names re-check as the remedy rather than only blaming squash merges",
+          "the preflight fails when an active change's verification commit is absent from the repository or not an ancestor of HEAD (orphaned by squash merge, rebase, amend, or force-push)"
+        ],
+        "dependencies": [],
+        "supersedes": [],
+        "answers": {
+          "architecture_risk": "no",
+          "public_contract": "no"
+        }
+      }
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/change.md
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/change.md
@@ -1,0 +1,25 @@
+---
+id: CHG-0088-catch-verification-evidence-a-squash-merge-discarded
+state: verifying
+type: bug_fix
+base_commit: 176719bb6acde18ca96fa2eadba53fd11faa00ed
+---
+
+# Catch verification evidence a squash merge discarded
+
+## Intent
+
+Catch verification evidence a squash merge discarded
+
+## Affected Canonical Specs
+
+- `github`
+
+## Acceptance Criteria
+
+- the preflight fails when an active change's verification commit is absent from the repository or not an ancestor of HEAD (orphaned by squash merge, rebase, amend, or force-push)
+- the error names re-check as the remedy rather than only blaming squash merges
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/context.md
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/context.md
@@ -1,0 +1,21 @@
+---
+change: CHG-0088-catch-verification-evidence-a-squash-merge-discarded
+artifact: context
+---
+
+# Context
+
+The preflight was written to catch verification evidence orphaned by a squash
+merge, and tested against a commit that was present but not an ancestor of HEAD.
+
+A squash merge does not produce a non-ancestor commit. It produces an absent
+one: nothing reachable points at the original commit any more, so a clone of the
+target branch never fetches it. The script treated an absent commit as
+shallow-clone ambiguity and skipped it, which meant the job passed while missing
+the only case it existed for.
+
+The job checks out with `fetch-depth: 0`, so every reachable commit is present.
+An absent one was discarded by a squash, which is the defect rather than noise.
+
+The original tests missed this because none of them modelled a commit that is
+absent from the clone. Both failing cases had the commit present.

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/deltas/github.md
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/deltas/github.md
@@ -1,0 +1,21 @@
+## MODIFIED
+
+### REQUIREMENT REQ-github-020
+
+Continuous integration SHALL reject a pull request whose active change carries
+verification evidence anchored to a commit that is absent from the repository or
+not an ancestor of the head under test, before running any job that builds or
+tests the project.
+
+Acceptance Criteria
+
+- The rejecting job requires no Rust toolchain and no build step.
+- A recorded commit the repository does not contain fails the check: the job
+  fetches full history (`fetch-depth: 0`), so absence means the recorded tip was
+  orphaned (squash merge of an unfinalized change, rebase, amend, or force-push).
+- A recorded commit present but not an ancestor of the head fails the check.
+- Missing evidence files, unparseable JSON, and absent or malformed commit
+  fields are left to the authoritative audit rather than failing here.
+- Jobs that build or test the project do not run when the check fails.
+- The single required aggregate check still reports a conclusion, so a pull
+  request is never left waiting on a check that cannot run.

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/state.json
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "176719bb6acde18ca96fa2eadba53fd11faa00ed",
   "created_at": 1786031683,
-  "updated_at": 1786060126,
+  "updated_at": 1786060783,
   "affected_specs": [
     "github"
   ],

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/state.json
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/state.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "workflow_version": 2,
+  "workflow_origin_version": 2,
+  "id": "CHG-0088-catch-verification-evidence-a-squash-merge-discarded",
+  "slug": "catch-verification-evidence-a-squash-merge-discarded",
+  "title": "Catch verification evidence a squash merge discarded",
+  "description": "Catch verification evidence a squash merge discarded",
+  "kind": "bug_fix",
+  "state": "verifying",
+  "canonical_applied": true,
+  "base_commit": "176719bb6acde18ca96fa2eadba53fd11faa00ed",
+  "created_at": 1786031683,
+  "updated_at": 1786060126,
+  "affected_specs": [
+    "github"
+  ],
+  "affected_paths": [
+    ".github/workflows/ci.yml",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "the preflight fails when an active change's verification commit is absent from the repository or not an ancestor of HEAD (orphaned by squash merge, rebase, amend, or force-push)",
+    "the error names re-check as the remedy rather than only blaming squash merges"
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/tasks.md
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/tasks.md
@@ -1,0 +1,9 @@
+---
+change: CHG-0088-catch-verification-evidence-a-squash-merge-discarded
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Fail when a recorded verification commit is absent from the repository
+- [x] Name the squash merge as the cause in the error text

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/testing.md
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/testing.md
@@ -1,0 +1,26 @@
+---
+change: CHG-0088-catch-verification-evidence-a-squash-merge-discarded
+artifact: testing
+---
+
+# Testing
+
+## Requirement evidence
+
+| Requirement | Evidence |
+|-------------|----------|
+| `REQ-github-020` | The preflight script was extracted with PyYAML and run under GitHub Actions' literal default invocation, `bash --noprofile --norc -eo pipefail`, across six repository states. It exits 0 for null JSON, malformed JSON, a null commit and an ancestor commit; it exits 1 for a commit absent from the repository and for a present non-ancestor commit. The absent case is the one this change adds. |
+
+## Manual verification
+
+Observed on main at 121168ac, where CHG-0087 had been merged before it was
+finalized:
+
+| job | result | time |
+|---|---|---|
+| Lifecycle preflight | success | 7s |
+| Lifecycle gate | failure | 4m28s |
+
+The preflight passed by skipping the orphaned commit. The gate caught the same
+condition four and a half minutes later. After this change the preflight fails
+in seconds on that state.

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification-attempts.json
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification-attempts.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1786032387,
+      "commit": "0227d289336482fb68174da899562ff4a1d073db",
+      "contract_digest": "d417a40b94216b5509e7030a1db8ae6083c471788639eeadf5e4c9737c6fe98b",
+      "execution_digest": "045d280957e342bd8a64e71e95d1ef9357fab7d42c5b20707665dbaab7b00832",
+      "workspace_digest": "0a077dbfe07a63a0847f1244eeac2fa15c7e4c728b891bf88b1c99b5edd34967",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-020"
+      ]
+    },
+    {
+      "timestamp": 1786032944,
+      "commit": "80c561dd81092e4735cc1a3725cb4c9eeeb894e5",
+      "contract_digest": "d417a40b94216b5509e7030a1db8ae6083c471788639eeadf5e4c9737c6fe98b",
+      "execution_digest": "045d280957e342bd8a64e71e95d1ef9357fab7d42c5b20707665dbaab7b00832",
+      "workspace_digest": "0a077dbfe07a63a0847f1244eeac2fa15c7e4c728b891bf88b1c99b5edd34967",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-020"
+      ]
+    },
+    {
+      "timestamp": 1786060124,
+      "commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
+      "contract_digest": "37270a10e9a76b45c2ec150ab5ba80fa11289b88bffa4b0134f4d3d2cc8ccd43",
+      "execution_digest": "36885e8f4e2b778af18577a43854aa08d333338e964cd11cad65cd47c981c59b",
+      "workspace_digest": "e0e1c428d2631010559d24b8a3bfefb3dcc8b1b41fb22efc35351663099f5515",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-020"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification-attempts.json
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification-attempts.json
@@ -99,6 +99,39 @@
       "requirement_ids": [
         "REQ-github-020"
       ]
+    },
+    {
+      "timestamp": 1786060781,
+      "commit": "1281cfd40c3893075508baa49ba102c48625e6d2",
+      "contract_digest": "37270a10e9a76b45c2ec150ab5ba80fa11289b88bffa4b0134f4d3d2cc8ccd43",
+      "execution_digest": "36885e8f4e2b778af18577a43854aa08d333338e964cd11cad65cd47c981c59b",
+      "workspace_digest": "e0e1c428d2631010559d24b8a3bfefb3dcc8b1b41fb22efc35351663099f5515",
+      "passed": true,
+      "commands": [
+        {
+          "command": "bash .github/scripts/test-classify-ci-paths.sh",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-github-020"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification.json
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1786060124,
-  "commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
+  "timestamp": 1786060781,
+  "commit": "1281cfd40c3893075508baa49ba102c48625e6d2",
   "contract_digest": "37270a10e9a76b45c2ec150ab5ba80fa11289b88bffa4b0134f4d3d2cc8ccd43",
   "execution_digest": "36885e8f4e2b778af18577a43854aa08d333338e964cd11cad65cd47c981c59b",
   "workspace_digest": "e0e1c428d2631010559d24b8a3bfefb3dcc8b1b41fb22efc35351663099f5515",

--- a/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification.json
+++ b/.specsync/changes/CHG-0088-catch-verification-evidence-a-squash-merge-discarded/verification.json
@@ -1,0 +1,33 @@
+{
+  "timestamp": 1786060124,
+  "commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
+  "contract_digest": "37270a10e9a76b45c2ec150ab5ba80fa11289b88bffa4b0134f4d3d2cc8ccd43",
+  "execution_digest": "36885e8f4e2b778af18577a43854aa08d333338e964cd11cad65cd47c981c59b",
+  "workspace_digest": "e0e1c428d2631010559d24b8a3bfefb3dcc8b1b41fb22efc35351663099f5515",
+  "passed": true,
+  "commands": [
+    {
+      "command": "bash .github/scripts/test-classify-ci-paths.sh",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-github-020"
+  ]
+}

--- a/specs/github/requirements.md
+++ b/specs/github/requirements.md
@@ -238,15 +238,19 @@ Acceptance Criteria
 ### REQ-github-020
 
 Continuous integration SHALL reject a pull request whose active change carries
-verification evidence anchored to a commit that is not an ancestor of the head
-under test, before running any job that builds or tests the project.
+verification evidence anchored to a commit that is absent from the repository or
+not an ancestor of the head under test, before running any job that builds or
+tests the project.
 
 Acceptance Criteria
 
 - The rejecting job requires no Rust toolchain and no build step.
-- The check fails only when the recorded commit exists and is provably not an
-  ancestor; missing files, unparseable JSON, absent commits and commits the
-  repository does not contain are left to the authoritative audit.
+- A recorded commit the repository does not contain fails the check: the job
+  fetches full history (`fetch-depth: 0`), so absence means the recorded tip was
+  orphaned (squash merge of an unfinalized change, rebase, amend, or force-push).
+- A recorded commit present but not an ancestor of the head fails the check.
+- Missing evidence files, unparseable JSON, and absent or malformed commit
+  fields are left to the authoritative audit rather than failing here.
 - Jobs that build or test the project do not run when the check fails.
 - The single required aggregate check still reports a conclusion, so a pull
   request is never left waiting on a check that cannot run.


### PR DESCRIPTION
## The bug

The preflight added in #510 was written to catch verification evidence orphaned by a squash merge. It tested whether the recorded commit is an **ancestor** of HEAD.

A squash merge does not leave a non-ancestor commit behind. It leaves an **absent** one — nothing reachable points at the original any more, so a clone of the target branch never fetches it. The script treated absence as shallow-clone ambiguity and skipped it.

## The fix

That job checks out with `fetch-depth: 0`, so every reachable commit is present. An absent one is orphaned evidence — squash merge of an unfinalized change, **or** rebase / amend / force-push that dropped the recorded tip. It now fails and names re-check as the remedy:

```
::error::.specsync/changes/CHG-XXXX verification commit abc12345 is not in this
repository — re-run 'specsync change check' (evidence was orphaned by a squash
merge, rebase, amend, or force-push)
```

## Lifecycle

CHG-0088 stays **active** on purpose (finalize-in-same-PR vs coverage). Follow-up finalize after merge.

## Validation

| state | expected |
|---|---|
| null / malformed JSON / null commit | pass (defer to audit) |
| ancestor commit | pass |
| **absent commit** | **fail** |
| non-ancestor commit | fail |