### PR TITLE
fix(change): harden approve ownership skips and correct-owner comments

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 91,
-  "id": "CHG-0091-add-change-ship-status-for-local-ship-readiness-and-merge-before-finalize-warning",
+  "sequence": 90,
+  "id": "CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/approvals.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/approvals.json
@@ -1,0 +1,69 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1786061197,
+      "digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
+      "note": null,
+      "approved_scope": {
+        "schema_version": 1,
+        "change_id": "CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments",
+        "title": "Harden approve ownership skips and correct-owner provenance comments",
+        "description": "harden approve ownership skips and correct-owner provenance comments",
+        "kind": "bug_fix",
+        "affected_specs": [
+          "change"
+        ],
+        "affected_paths": [
+          ".specsync/change-sequence.json",
+          "src/change.rs"
+        ],
+        "no_spec_change": false,
+        "no_spec_change_rationale": null,
+        "acceptance_criteria": [
+          "empty affected_specs without no_spec_change fails ownership validation at approve; never-closed correct-owner comments state weaker provenance not equivalence"
+        ],
+        "dependencies": [],
+        "supersedes": [],
+        "answers": {
+          "architecture_risk": "no",
+          "public_contract": "no"
+        }
+      }
+    },
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1786061331,
+      "digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
+      "note": null,
+      "approved_scope": {
+        "schema_version": 1,
+        "change_id": "CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments",
+        "title": "Harden approve ownership skips and correct-owner provenance comments",
+        "description": "harden approve ownership skips and correct-owner provenance comments",
+        "kind": "bug_fix",
+        "affected_specs": [
+          "change"
+        ],
+        "affected_paths": [
+          ".specsync/change-sequence.json",
+          "src/change.rs"
+        ],
+        "no_spec_change": false,
+        "no_spec_change_rationale": null,
+        "acceptance_criteria": [
+          "empty affected_specs without no_spec_change fails ownership validation at approve; never-closed correct-owner comments state weaker provenance not equivalence"
+        ],
+        "dependencies": [],
+        "supersedes": [],
+        "answers": {
+          "architecture_risk": "no",
+          "public_contract": "no"
+        }
+      }
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/change.md
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/change.md
@@ -1,0 +1,24 @@
+---
+id: CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments
+state: implementing
+type: bug_fix
+base_commit: 5fdd245bd9f25c0366f0c52bcffe636087722e1b
+---
+
+# Harden approve ownership skips and correct-owner provenance comments
+
+## Intent
+
+harden approve ownership skips and correct-owner provenance comments
+
+## Affected Canonical Specs
+
+- `change`
+
+## Acceptance Criteria
+
+- empty affected_specs without no_spec_change fails ownership validation at approve; never-closed correct-owner comments state weaker provenance not equivalence
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/context.md
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/context.md
@@ -1,0 +1,15 @@
+---
+change: CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments
+artifact: context
+---
+
+# Context
+
+Adversarial review of the approve-time ownership gate and never-closed
+`correct-owner` path found: (1) empty `affected_specs` silently skipped ownership
+without restating that only `no_spec_change` may reach that branch; (2) comments
+claimed definition-approval was "equivalent" to audited reopen provenance.
+
+This change hardens the empty-specs branch and corrects the comments. Behavior
+for justified no-spec changes is unchanged; never-closed correct-owner still uses
+definition approval as the reachable substitute.

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/deltas/change.md
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/deltas/change.md
@@ -1,0 +1,24 @@
+## MODIFIED
+
+### REQUIREMENT REQ-change-053
+
+Canonical ownership of declared paths SHALL be resolved when the definition is
+approved, and a change that has never closed SHALL be able to correct an
+acceptance input owner without an audited reopen event.
+
+Acceptance Criteria
+
+- Approving a definition rejects declared paths that no declared module
+  canonically owns, naming every offending path in one error.
+- Paths that do not yet exist are not rejected at approve, since the owning spec
+  may claim them in the same change; they remain enforced at finalize.
+- A change with justified `no_spec_change` (empty declared specs) is not
+  ownership-rejected at approve, because there is no owner set to resolve
+  against; finalize still enforces production ownership. Empty specs without
+  that justification fail closed at definition validation and at ownership
+  validation.
+- A change at verifying that has never closed may correct an acceptance input
+  owner under a currently valid definition approval. That substitute is for
+  guided-path reachability, not audit-equivalent provenance to an
+  Accepted→reopen cycle.
+- A change that did close continues to require an audited reopen, unchanged.

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/state.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
   "created_at": 1786060994,
-  "updated_at": 1786063173,
+  "updated_at": 1786078513,
   "affected_specs": [
     "change"
   ],

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/state.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/state.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "workflow_version": 2,
+  "workflow_origin_version": 2,
+  "id": "CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments",
+  "slug": "harden-approve-ownership-skips-and-correct-owner-provenance-comments",
+  "title": "Harden approve ownership skips and correct-owner provenance comments",
+  "description": "harden approve ownership skips and correct-owner provenance comments",
+  "kind": "bug_fix",
+  "state": "verifying",
+  "canonical_applied": true,
+  "base_commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
+  "created_at": 1786060994,
+  "updated_at": 1786063173,
+  "affected_specs": [
+    "change"
+  ],
+  "affected_paths": [
+    "src/change.rs",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "empty affected_specs without no_spec_change fails ownership validation at approve; never-closed correct-owner comments state weaker provenance not equivalence"
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "no",
+    "public_contract": "no"
+  }
+}

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/state.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
   "created_at": 1786060994,
-  "updated_at": 1786078513,
+  "updated_at": 1786079696,
   "affected_specs": [
     "change"
   ],

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/tasks.md
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/tasks.md
@@ -1,0 +1,10 @@
+---
+change: CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments
+artifact: tasks
+---
+
+# Tasks
+
+- [x] Fail ownership validation when specs empty without no_spec_change
+- [x] Soften never-closed correct-owner provenance comments
+- [x] Unit coverage for the empty-specs hard fail (if needed)

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/testing.md
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/testing.md
@@ -1,0 +1,17 @@
+---
+change: CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments
+artifact: testing
+---
+
+# Testing
+
+## Requirement evidence
+
+| Requirement | Evidence |
+|-------------|----------|
+| `REQ-change-053` | Unit path: approve rejects undeclared-owner paths (existing test). Empty specs without `no_spec_change` now fail ownership validation with an explicit error. Never-closed correct-owner still gates on `ensure_definition_approval_valid`; comments document weaker provenance. |
+
+## Manual
+
+Adversarial review of the four product fixes (session 2026-08-06) identified the
+skip/comment issues; this change implements the agreed hardenings.

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification-attempts.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification-attempts.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1786063172,
+      "commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
+      "contract_digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
+      "execution_digest": "d9249eca5d671ba7263fc0cefe7742c8d12c5f94fe90c83b2390cda4e3b2b00d",
+      "workspace_digest": "443f8f2aebcc7d46ee0f9f05152086f6b6e5c6328d82cb99b40a9ce4a5d51ddd",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-053"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification-attempts.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification-attempts.json
@@ -66,6 +66,39 @@
       "requirement_ids": [
         "REQ-change-053"
       ]
+    },
+    {
+      "timestamp": 1786079695,
+      "commit": "a99990f79c0e56c29c3483cc64528e4da0795230",
+      "contract_digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
+      "execution_digest": "d9249eca5d671ba7263fc0cefe7742c8d12c5f94fe90c83b2390cda4e3b2b00d",
+      "workspace_digest": "6ef9a01924405773961e9402cf80ea03b92f5d91dd700f3d37a5da2a298ef560",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-053"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification-attempts.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification-attempts.json
@@ -33,6 +33,39 @@
       "requirement_ids": [
         "REQ-change-053"
       ]
+    },
+    {
+      "timestamp": 1786078511,
+      "commit": "85a8ab12ad0944c5a85b1b11bf7c80d0cddf7205",
+      "contract_digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
+      "execution_digest": "d9249eca5d671ba7263fc0cefe7742c8d12c5f94fe90c83b2390cda4e3b2b00d",
+      "workspace_digest": "6ef9a01924405773961e9402cf80ea03b92f5d91dd700f3d37a5da2a298ef560",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-053"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification.json
@@ -1,0 +1,33 @@
+{
+  "timestamp": 1786063172,
+  "commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
+  "contract_digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
+  "execution_digest": "d9249eca5d671ba7263fc0cefe7742c8d12c5f94fe90c83b2390cda4e3b2b00d",
+  "workspace_digest": "443f8f2aebcc7d46ee0f9f05152086f6b6e5c6328d82cb99b40a9ce4a5d51ddd",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test change::",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-change-053"
+  ]
+}

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1786078511,
-  "commit": "85a8ab12ad0944c5a85b1b11bf7c80d0cddf7205",
+  "timestamp": 1786079695,
+  "commit": "a99990f79c0e56c29c3483cc64528e4da0795230",
   "contract_digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
   "execution_digest": "d9249eca5d671ba7263fc0cefe7742c8d12c5f94fe90c83b2390cda4e3b2b00d",
   "workspace_digest": "6ef9a01924405773961e9402cf80ea03b92f5d91dd700f3d37a5da2a298ef560",

--- a/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification.json
+++ b/.specsync/changes/CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments/verification.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": 1786063172,
-  "commit": "5fdd245bd9f25c0366f0c52bcffe636087722e1b",
+  "timestamp": 1786078511,
+  "commit": "85a8ab12ad0944c5a85b1b11bf7c80d0cddf7205",
   "contract_digest": "9f7164b703a41a6f71ca2d24eecd8ea602934d7dd12bf39c47ab4eaf74d4c150",
   "execution_digest": "d9249eca5d671ba7263fc0cefe7742c8d12c5f94fe90c83b2390cda4e3b2b00d",
-  "workspace_digest": "443f8f2aebcc7d46ee0f9f05152086f6b6e5c6328d82cb99b40a9ce4a5d51ddd",
+  "workspace_digest": "6ef9a01924405773961e9402cf80ea03b92f5d91dd700f3d37a5da2a298ef560",
   "passed": true,
   "commands": [
     {

--- a/specs/change/change.spec.md
+++ b/specs/change/change.spec.md
@@ -1,6 +1,6 @@
 ---
 module: change
-version: 61
+version: 62
 status: active
 files:
   - src/change.rs
@@ -350,3 +350,4 @@ Acceptance Criteria
 | 2026-08-05 | CHG-0084-give-the-change-module-canonical-ownership-of-its-cli-wiring: Give the change module canonical ownership of its CLI wiring |
 | 2026-08-05 | CHG-0085-resolve-canonical-ownership-at-approve-and-free-never-closed-changes: Resolve canonical ownership at approve and free never-closed changes |
 | 2026-08-05 | CHG-0086-return-src-commands-change-rs-to-its-sole-canonical-owner: Return src/commands/change.rs to its sole canonical owner |
+| 2026-08-07 | CHG-0090-harden-approve-ownership-skips-and-correct-owner-provenance-comments: Harden approve ownership skips and correct-owner provenance comments |

--- a/specs/change/requirements.md
+++ b/specs/change/requirements.md
@@ -777,9 +777,14 @@ Acceptance Criteria
   canonically owns, naming every offending path in one error.
 - Paths that do not yet exist are not rejected at approve, since the owning spec
   may claim them in the same change; they remain enforced at finalize.
-- A change declaring no specs is not rejected at approve, because ownership
-  resolves against the change's declared specs and an empty set yields no answer.
+- A change with justified `no_spec_change` (empty declared specs) is not
+  ownership-rejected at approve, because there is no owner set to resolve
+  against; finalize still enforces production ownership. Empty specs without
+  that justification fail closed at definition validation and at ownership
+  validation.
 - A change at verifying that has never closed may correct an acceptance input
-  owner; its definition approval is validated in place of a reopen event.
+  owner under a currently valid definition approval. That substitute is for
+  guided-path reachability, not audit-equivalent provenance to an
+  Accepted→reopen cycle.
 - A change that did close continues to require an audited reopen, unchanged.
 

--- a/src/change.rs
+++ b/src/change.rs
@@ -3116,9 +3116,11 @@ fn latest_reopen_for_owner_correction<'a>(
         // reopen accepts only Accepted/Archived, and declaring the owning module
         // would force a semantic delta for a spec the change does not alter.
         //
-        // The reopen exists to prove the definition has not drifted since the
-        // change last closed. A never-closed change carries the equivalent
-        // guarantee in its own definition approval, checked by the caller.
+        // The reopen path proves the definition still matches *closing*
+        // verification. A never-closed change has no closing snapshot; the caller
+        // instead requires a currently valid definition approval. That is the
+        // necessary substitute for reachability, not audit-equivalent provenance
+        // to an Accepted→reopen cycle.
         return Ok(None);
     };
     // REQ-change-033 requires the target be "verifying through an audited reopen"
@@ -3237,9 +3239,9 @@ pub fn add_acceptance_owner_corrections(
             }
         }
         None => {
-            // Never closed, so there is no reopened definition to compare against.
-            // The equivalent guarantee is that the definition still matches the
-            // approval it is being corrected under.
+            // Never closed: no reopened closing snapshot exists. Require a live
+            // definition approval so corrections cannot run under a drifted def.
+            // Weaker provenance than Accepted→reopen; necessary for the guided path.
             ensure_definition_approval_valid(root, &original)?;
         }
     }
@@ -3434,11 +3436,18 @@ fn validate_declared_path_ownership(root: &Path, record: &ChangeRecord) -> Resul
     if record.affected_paths.is_empty() {
         return Ok(());
     }
-    // Ownership is resolved by searching the change's own declared specs, so a
-    // change that declares none has no set to resolve against and would be
-    // rejected unconditionally rather than accurately. Those are still enforced
-    // at finalize, which resolves against full delivery evidence.
+    // Ownership is resolved against the change's declared specs. Empty specs
+    // reach here only for justified `no_spec_change` work (validate_definition
+    // already rejects empty specs without that flag). There is then no owner set
+    // to resolve against; finalize still enforces production ownership against
+    // full delivery evidence for that class.
     if record.affected_specs.is_empty() {
+        if !record.no_spec_change {
+            return Err(
+                "affected specs are required for path ownership validation unless no_spec_change is justified"
+                    .into(),
+            );
+        }
         return Ok(());
     }
     let evidence = acceptance_owner_spec_evidence(root, record)?;
@@ -24312,9 +24321,9 @@ mod tests {
     // neither finalize (ownership unresolved) nor be corrected (no reopen) nor be
     // reopened (reopen takes only Accepted/Archived). Every exit was closed.
     //
-    // The reopen exists to prove the definition has not drifted since the change
-    // last closed. A never-closed change carries that same guarantee in its own
-    // verification evidence, so the correction is admissible without one.
+    // The reopen proves definition match against closing verification. A
+    // never-closed change substitutes a live definition approval so the guided
+    // path stays reachable (weaker provenance, not audit-equivalent).
     #[test]
     fn never_closed_verifying_change_corrects_an_owner_without_a_reopen() {
         let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Adversarial follow-up to the four product fixes:

1. Empty `affected_specs` without `no_spec_change` fails closed at path-ownership validation (defense in depth; only justified no-spec work skips).
2. Never-closed `correct-owner` comments no longer claim definition-approval is audit-equivalent to Accepted→reopen — they document the reachable substitute.

Updates REQ-change-053 accordingly (CHG-0090).

## Test Plan
- [x] CHG-0090 verified
- [ ] CI green