### PR TITLE
fix(6.0): make the first five minutes work — init, scaffold, and directory mappings (#472)

### DIFF
--- a/.specsync/change-sequence.json
+++ b/.specsync/change-sequence.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "sequence": 106,
-  "id": "CHG-0106-make-verification-currency-a-content-question-delete-the-git-ancestry-walk-the",
+  "sequence": 107,
+  "id": "CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc",
   "acknowledged_collisions": [
     {
       "sequence": 16,

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/approvals.json
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/approvals.json
@@ -1,0 +1,46 @@
+{
+  "approvals": [
+    {
+      "gate": "definition",
+      "actor": "0xLeif",
+      "timestamp": 1786580308,
+      "digest": "02dcdcfaedf3f6ff46bee160fc09482c1615b299377265f7c88174cff35ec295",
+      "note": null,
+      "approved_scope": {
+        "schema_version": 1,
+        "change_id": "CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc",
+        "title": "Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green",
+        "description": "Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green",
+        "kind": "bug_fix",
+        "affected_specs": [
+          "change",
+          "cmd_init",
+          "cmd_issues",
+          "generator",
+          "validator"
+        ],
+        "affected_paths": [
+          ".specsync/change-sequence.json",
+          "CHANGELOG.md",
+          "src/change.rs",
+          "src/commands/init.rs",
+          "src/commands/issues.rs",
+          "src/generator.rs",
+          "src/validator.rs"
+        ],
+        "no_spec_change": false,
+        "no_spec_change_rationale": null,
+        "acceptance_criteria": [
+          "A repository initialized with `specsync init` passes `specsync check --strict` with exit 0 before any spec is authored. A module created with `specsync scaffold` passes `specsync check --strict` with exit 0 while its sections still hold generated placeholder prose, and a section a change actually authored then emptied still fails. A directory listed in a spec's `files:` block resolves to the source files beneath it for validation, coverage, and export extraction instead of being silently skipped, and an unresolvable directory reports an error rather than passing green."
+        ],
+        "dependencies": [],
+        "supersedes": [],
+        "answers": {
+          "architecture_risk": "yes",
+          "public_contract": "yes"
+        }
+      }
+    }
+  ],
+  "reopenings": []
+}

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/change.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/change.md
@@ -1,0 +1,28 @@
+---
+id: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+state: implementing
+type: bug_fix
+base_commit: 4ddf810ed39b56482ba96a0d209ee9216ef56fe9
+---
+
+# Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green
+
+## Intent
+
+Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green
+
+## Affected Canonical Specs
+
+- `change`
+- `cmd_init`
+- `cmd_issues`
+- `generator`
+- `validator`
+
+## Acceptance Criteria
+
+- A repository initialized with `specsync init` passes `specsync check --strict` with exit 0 before any spec is authored. A module created with `specsync scaffold` passes `specsync check --strict` with exit 0 while its sections still hold generated placeholder prose, and a section a change actually authored then emptied still fails. A directory listed in a spec's `files:` block resolves to the source files beneath it for validation, coverage, and export extraction instead of being silently skipped, and an unresolvable directory reports an error rather than passing green.
+
+## No-spec Rationale
+
+Not applicable

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/context.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/context.md
@@ -1,0 +1,65 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: context
+---
+
+# Context
+
+## What led here
+
+Preparing `v6.0.0-rc.1` for team adoption, the release promise was scoped to the
+*product surface* — `check`, `coverage`, drift detection, export extraction — while
+the lifecycle verbs finish their reduction. That promise only holds if a cold agent
+or a new engineer can pick up the binary and get a green repository. Three defects
+sit directly on that path, and all three were found by walking it rather than by
+reading code:
+
+1. **`specsync init` leaves a repository that fails `specsync check`.** Every file
+   `init` writes (`.specsync/config.toml`, `.specsync/version`, `.specsync/sdd.json`)
+   is a protected SDD path. `path_is_meaningful_with_specs` returns `true` from
+   `is_protected_sdd_path` *before* the ignore filter runs, so the first commit after
+   initialization lands as uncovered meaningful delivery. The gate is unsatisfiable by
+   construction: it demands a change workspace that covers files written before any
+   workspace could exist.
+
+2. **`specsync scaffold` writes prose that `specsync check` rejects.** Scaffolding a
+   module emits placeholder sections; the effective-contract gate treats an unfinished
+   section as a stub warning, and under `--strict` that is fatal. The tool's own output
+   fails the tool's own gate.
+
+3. **A directory in a spec's `files:` block makes `check` silently green (#472).**
+   Filed as Kotlin-specific; it is not. A directory mapping extracts zero exports, so
+   the Public API comparison has nothing to compare and passes. `check --strict --force`
+   exits 0 with zero warnings while measuring nothing — the worst failure mode a
+   verification tool has, because the signal it emits is indistinguishable from success.
+
+## What a session picking this up needs to know
+
+- **Quill is Rust.** These three are the RC blockers for a Rust consumer. #479 (Ruby
+  visibility leakage), #529, #474, #477, and #473 do not block it and ride to `rc.2`.
+- **Delivery scope freezes at the interview and cannot be widened** (#542). The full
+  suite was run against the finished implementation *before* `change new`, so the
+  declared scope is the measured blast radius, not an estimate.
+- **These three fixes were batched into one change deliberately.** Running them as
+  three parallel changes cost roughly a million tokens and eleven agent-hours, almost
+  all of it in `change check --commit` retry loops contending on the same target
+  directory. Verification is ~18 minutes uncontended and considerably worse under
+  parallelism.
+- **Fix 1 and fix 2 interact.** The bootstrap exemption adds a path to
+  `uncovered_meaningful_paths`, while the scaffold fix changes how
+  `validate_effective_contracts` splits warnings from errors. Both feed `check_project`.
+  A fresh `init` → `scaffold` → `check` sequence exercises both at once, which is
+  exactly the sequence the RC promises works.
+
+## Ruled out
+
+- **Adding the protected SDD paths to the default ignore list.** It would fix the
+  symptom and disarm the guard permanently: later hand-edits to `sdd.json` would stop
+  being meaningful delivery, which is precisely what the guard exists to catch.
+- **Exempting all stub warnings for scaffolded modules.** A section a change actually
+  authored and then emptied must stay fatal. The exemption is keyed to authorship, not
+  to content shape.
+- **Expanding a directory mapping into its files during validation.** Rejected as a
+  silent behavior change: a spec that declares `src/provider` would begin asserting a
+  Public API it never wrote. The directory is reported as an error with the expansion
+  offered as the *fix*, so the author opts in.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/change.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/change.md
@@ -1,0 +1,179 @@
+## ADDED
+
+### REQUIREMENT REQ-change-060
+
+A bootstrap record SHALL exempt a path from lifecycle path coverage only when that exemption cannot
+be used to hide product delivery or later policy edits.
+
+Acceptance Criteria
+
+- A recorded path is honored only when it is a protected SDD path, is absent at the delivery
+  comparison base, its recorded base commit is an ancestor of `HEAD`, and its content still matches
+  the recorded digest.
+- A bootstrap record never exempts a path that is not a protected SDD path.
+- Editing a bootstrapped file revokes its own exemption and the normal change workflow applies from
+  that point on.
+- Bootstrap records written in the earlier single-path shape continue to be honored.
+
+### REQUIREMENT REQ-change-061
+
+The digest recorded for a bootstrapped policy SHALL pin the enforcement surface rather than the
+file's bytes.
+
+Acceptance Criteria
+
+- Every field that determines whether the coverage gate applies is covered by the digest.
+- Verification commands are excluded, so populating them as initialization instructs does not revoke
+  the bootstrap.
+- A policy file that cannot be parsed falls back to a digest of its bytes.
+
+### REQUIREMENT REQ-change-062
+
+Resolution of the delivery comparison base SHALL succeed in a repository containing a single commit.
+
+Acceptance Criteria
+
+- Both a range form and a bare commit reduce to a single commit through its merge base with `HEAD`.
+- No resolution path depends on a parent commit existing.
+
+### REQUIREMENT REQ-change-063
+
+An unfinished spec section SHALL gate on whether a change authored it, not on its content shape.
+
+Acceptance Criteria
+
+- A generated section no active change authored produces no fatal effective-contract finding.
+- A section an active change authored and then emptied remains fatal, through both the pending and
+  the applied delta paths.
+- Unknown authorship fails closed and exempts nothing.
+- Ignore configuration is applied through the project's ignore rules rather than re-derived.
+- Suppressions are reported as warnings rather than dropped silently.
+## MODIFIED
+
+### SPEC SECTION Public API
+
+**Exported Constants**
+
+| Name | Description |
+|------|-------------|
+| `SDD_VERSION` | Current SDD project-layout version written by initialization |
+
+**Exported Types**
+
+| Type | Description |
+|------|-------------|
+| `ChangeState` | Six-state delivery lifecycle: draft, approved, implementing, verifying, accepted, archived |
+| `ChangeKind` | Deterministic policy classification for feature, bug fix, refactor, migration, documentation, and operations work |
+| `ArtifactKind` | Built-in or custom adaptive companion artifact selection |
+| `SddPolicy` | Versioned enforcement, path, verification-command, template, and principles configuration |
+| `SuccessionObligation` | Definition-bound predecessor path, canonical owner module, and full predecessor entry digest |
+| `SupersedesEdge` | Durable predecessor ID and its sorted semantic succession obligations |
+| `AcceptanceOwnerCorrection` | Sequenced human-authored exact path/module ownership correction for acceptance evidence |
+| `ChangeRecord` | Durable machine state for one change workspace, including an explicit legacy-or-single-workflow version and omitted-when-empty supersedes/correction evidence |
+| `LegacyArchiveBaselineV1` | Definition- and closing-bound authority, cutoff, and sorted legacy archive subtree entries |
+| `LegacyArchiveBaselineEntryV1` | Archive ID, canonical dated path, unique introduction commit, and exact subtree digest |
+| `CreateChangeRequest` | Validated creation inputs grouped for CLI, imports, and agent clients |
+| `ApprovalRecord` | Actor, timestamp, gate, digest, optional note, and optional backward-readable portable-pair metadata for one approval |
+| `ApprovedScopeV1` | Canonical stable intent, acceptance contract, risk declarations, and affected scope bound by one human approval |
+| `NonMaterialScopeChangeCategory` | Closed implementation, test/evidence, canonical-materialization, and lifecycle-metadata classification set |
+| `NonMaterialScopeChangeV1` | Path and concise evidence-backed classification for one approval-preserving migration change |
+| `ScopeApprovalMigrationV1` | Historical embedded migration shape retained only to authenticate the allowlisted CHG-0068 anchor blob; it is not accepted as a general live projection bridge |
+| `ScopeAdoptionSourcePreimageStatus` | Explicit declaration that the one allowlisted legacy approval preimage is unavailable |
+| `ScopeAdoptionEquivalenceClaim` | Explicit declaration that the allowlisted adoption makes no cryptographic equivalence claim |
+| `ScopeAdoptionAnchorV1` | Exact historical commit, approval index, and approval-ledger blob digest |
+| `ScopeAdoptionAuthorizationV1` | Actor, recording time, and truthful reason for the one allowlisted adoption exception |
+| `ScopeAdoptionV1` | Frozen adopted stable scope, anchor, authorization, and non-material classification evidence |
+| `DefinitionApprovalPairRole` | Current/full or legacy/projected role for one marked portable definition member |
+| `DefinitionApprovalPairV1` | Versioned pair identity, projection, role, change/correction coordinates, event index, and both digests |
+| `ReopenRecord` | Immutable audit event preserving superseded closing approval, prior verification, actor, reason, transition, and stale/current input digests |
+| `ReopenResult` | Deterministic change-plus-audit result returned by the reopen transition |
+| `ReopenBackfillReport` | Per-change repair, skip, and failure detail for a `migrate 5.0` ledger backfill |
+| `CorrectionField` | Closed supported accepted-metadata field set: public contract and architecture risk |
+| `CorrectionRecord` | Immutable sequenced metadata correction with original/effective values, actor, reason, artifacts, prior evidence, and portable digest chain |
+| `EffectiveChangeDefinition` | Validated projection of original answers/artifacts plus ordered corrections |
+| `CorrectionResult` | Deterministic corrected change, event, effective definition, history, and gate-summary projection |
+| `DefinitionMutationResult` | Crate-private successful definition mutation plus the effective definition, correction history, and normal/strict summaries validated inside its persistence transaction |
+| `ApprovalLedger` | Ordered portable approval, allowlisted scope-adoption, and reopen history |
+| `CommandEvidence` | Exit evidence for one configured verification command |
+| `AcceptanceInputKind` | Canonical file, symlink, gitlink, missing, or non-file topology kind |
+| `AcceptanceInputEntryV1` | Bounded path, kind, mode, payload digest, full-entry digest, and sorted owners for one accepted input |
+| `AcceptanceManifestV1` | Versioned sorted per-input acceptance manifest |
+| `SemanticSuccessionTupleV1` | Exact predecessor, path, module, old-entry digest, and new-entry digest transition |
+| `SemanticSuccessionEvidenceV1` | Versioned sorted one-to-one closing evidence for approved supersedes obligations |
+| `VerificationRecord` | Commit-bound verification result with separate stable-scope and volatile-execution digests, commands, requirement coverage, and optional acceptance manifest/succession evidence |
+| `ScopedReviewVerdict` | Explicit passing or blocking conclusion for one independent scoped review |
+| `ScopedReviewProvenanceProvider` | External provider class that authenticates the required scoped-review result |
+| `ScopedReviewProvenanceV1` | Versioned required GitHub Actions check binding carried by review evidence |
+| `ScopedReviewRecord` | Stable reviewer claim, required-check provenance, explicit verdict, implementation commit, scope/execution/workspace digests, and review timestamp bound before finalization |
+| `FinalizationRecord` | Automated non-approval evidence binding implementation commit/tree, contract/workspace/closing/review digests, archive identity, and a domain-separated finalization digest |
+| `ChangeReadScope` | Crate-private invocation guard that owns one bounded read-only lifecycle snapshot |
+| `InterviewQuestion` | Stable deterministic question with choices and recommendation |
+| `TerminalEvidenceValidity` | State-aware exact, successor-covered, stale, authenticated-history, or corrupt-history evidence conclusion |
+| `TerminalEvidenceSummary` | Shared terminal validity plus optional fail-closed reason |
+| `TerminalEvidenceResult` | Change ID paired with its shared terminal-evidence summary |
+| `ChangeSummary` | Human/agent status projection with approval health/current scope digest, plain-language material expansion, validator plan, scoped-review freshness, exactly one next action, and optional terminal evidence |
+| `SddCheckReport` | Unified lifecycle errors, warnings, checked-change count, and terminal-evidence results |
+
+**Exported Functions**
+
+| Function | Parameters | Returns | Description |
+|----------|------------|---------|-------------|
+| `load_policy` | `root: &Path` | `Option<SddPolicy>` | Load `.specsync/sdd.json`; absence leaves existing projects unenforced |
+| `record_bootstrap_paths` | `root: &Path` | `Result<(), String>` | Record the protected SDD paths this bootstrap created in `.specsync/bootstrap.json`, so initialization's own output is not reported as uncovered meaningful delivery; editing a recorded file revokes its exemption |
+| `write_default_policy` | `root: &Path, verification_commands: Vec<String>` | `Result<(), String>` | Write new-project/adoption policy without overwriting existing policy |
+| `create_change` | `root: &Path, request: CreateChangeRequest` | `Result<ChangeRecord, String>` | Create a sequential draft workspace and adaptive artifacts |
+| `load_change` | `root: &Path, id: &str` | `Result<ChangeRecord, String>` | Load active or archived change state |
+| `acceptance_entries` | `root: &Path, record: &ChangeRecord` | `Vec<AcceptanceInputEntryV1>` | Accepted acceptance-input entries, so `change show --json` can surface the `specsync.acceptance-entry.v1` digests `change supersede --digest` requires; empty when evidence is absent |
+| `list_changes` | `root: &Path` | `Vec<ChangeRecord>` | List active changes in stable ID order |
+| `next_questions` | `record: &ChangeRecord` | `Vec<InterviewQuestion>` | Return deterministic unanswered interview questions |
+| `answer_question` | `root, id, question, answer` | `Result<ChangeRecord, String>` | Production domain API that validates ledger health under lock, then persists an interview answer and updates adaptive artifacts |
+| `answer_question_with_snapshot` | `root, id, question, answer` | `Result<DefinitionMutationResult, String>` | Crate-private command path that returns the answer mutation with its full in-transaction machine snapshot |
+| `add_dependency` | `root, id, dependency` | `Result<ChangeRecord, String>` | Production domain API that validates ledger health under lock, declares ordering between active changes, and invalidates stale approval digests |
+| `add_dependency_with_snapshot` | `root, id, dependency` | `Result<DefinitionMutationResult, String>` | Crate-private command path that returns the dependency mutation with its full in-transaction machine snapshot |
+| `add_supersedes_obligation` | `root, id, predecessor, path, module, predecessor_entry_digest` | `Result<ChangeRecord, String>` | Production domain API that validates ledger health under lock, then adds one definition-bound semantic succession obligation to a draft |
+| `add_supersedes_obligation_with_snapshot` | `root, id, predecessor, path, module, predecessor_entry_digest` | `Result<DefinitionMutationResult, String>` | Crate-private command path that returns the supersession mutation with its full in-transaction machine snapshot |
+| `add_acceptance_owner_correction` | `root, id, path, module, actor, reason` | `Result<ChangeRecord, String>` | Append one audited exact canonical owner correction to a reopened already-applied change |
+| `add_acceptance_owner_corrections` | `root, id, entries, actor, reason` | `Result<ChangeRecord, String>` | Validate every exact path/module owner correction, then append all as sequenced audit entries in one transactional write |
+| `add_missing_acceptance_owner_corrections` | `root, id, module, actor, reason` | `Result<ChangeRecord, String>` | Discover production-source affected paths lacking canonical ownership for a module and append them as one transactional batch |
+| `approve_definition` | `root, id, actor, note` | `Result<ChangeRecord, String>` | Validate and record an ordinary mandatory definition approval |
+| `approve_definition_portable_v501` | `root, id, actor, note` | `Result<ChangeRecord, String>` | Atomically record the marked current/5.0.1 portable definition pair |
+| `start_implementation` | `root, id` | `Result<ChangeRecord, String>` | Enter implementation after approval and conflict validation |
+| `verify_change` | `root, id` | `Result<VerificationRecord, String>` | Run configured tests and record commit/contract evidence |
+| `verify_change_with_strict` | `root, id, strict` | `Result<VerificationRecord, String>` | Run targeted validators plus additive strict policy/classification validators on the same evidence path |
+| `check_change` | `root, optional id` | `Result<Option<VerificationRecord>, String>` | Select one approved/implementing change, materialize its canonical deltas, and verify it |
+| `check_change_with_strict` | `root, optional id, strict` | `Result<Option<VerificationRecord>, String>` | Run `check_change` with additive strict validators |
+| `record_scoped_review` | `root, id, reviewer` | `Result<ScopedReviewRecord, String>` | Record one independent implementation-scoped review bound to current governed inputs |
+| `record_scoped_review_with_verdict` | `root, id, reviewer, verdict` | `Result<ScopedReviewRecord, String>` | Record an explicit passing or blocking independent review; only a current passing verdict permits finalization |
+| `finalize_change` | `root, id` | `Result<PathBuf, String>` | Validate current verification/review evidence and transactionally produce the dated same-PR archive |
+| `reopen_change` | `root, id, actor, reason` | `Result<ReopenResult, String>` | Move stale accepted evidence to verifying and append an immutable supersession audit event |
+| `correct_interview_metadata` | `root, id, field, value, actor, reason` | `Result<CorrectionResult, String>` | Append a supported accepted-metadata correction and return the effective audited view |
+| `effective_change_definition` | `root, record` | `Result<EffectiveChangeDefinition, String>` | Validate and project original metadata through its ordered correction history |
+| `correction_history` | `root, record` | `Result<Vec<CorrectionRecord>, String>` | Load validated append-only correction records for inspection clients |
+| `accept_change` | `root, id, actor, note` | `Result<ChangeRecord, String>` | Record closing approval and atomically apply semantic deltas only when not already canonical |
+| `archive_change` | `root, id` | `Result<PathBuf, String>` | Move an accepted workspace into the dated archive |
+| `backfill_reopen_digests` | `root: &Path, dry_run: bool` | `Result<ReopenBackfillReport, String>` | Backfill 5.1 reopening digest fields on 5.0.1-era ledgers with verified, idempotent, dry-run-aware writes |
+| `begin_change_read_scope` | `root: &Path` | `ChangeReadScope` | Install one invocation-scoped read snapshot for list/show/status and project reports |
+| `summarize_change` | `root, record` | `ChangeSummary` | Project gate health, correction health, and next action using the shared verification-freshness predicate |
+| `summarize_change_with_strict` | `root, record, explicit_strict` | `ChangeSummary` | Project the same status plus exact targeted/additive-strict validator commands |
+| `artifacts_complete_for_guidance` | `root, record` | `bool` | Lightweight selected-artifact completeness for human next-action guidance without digest loaders |
+| `check_project` | `root: &Path` | `SddCheckReport` | Full lifecycle integrity including archive terminal evidence (tests and rare callers; not the default CLI path) |
+| `audit_project` | `root: &Path` | `SddCheckReport` | Active workspaces + living policy/spec coherence only — does not rewalk archived terminal evidence |
+| `adopt` | `root, dry_run, source` | `Result<Vec<String>, String>` | Preview or atomically enable SDD, activate workflow v2 without stranding cutoff-ineligible legacy records or rewriting legacy policy, and import OpenSpec or Spec Kit artifacts |
+| `detect_verification_commands` | `root: &Path` | `Vec<String>` | Detect explicit fledge, Cargo, Bun, or Swift test commands |
+
+**Exported Methods**
+
+| Method | Description |
+|--------|-------------|
+| `as_str` | Return the stable serialized name for a change state, kind, or correction field |
+| `parse` | Parse user-facing change-kind, artifact, or supported correction-field names into typed values |
+| `file_name` | Resolve an adaptive artifact to its safe Markdown filename |
+| `is_clean` | Return true when a ledger backfill recorded no per-change failures |
+
+Acceptance Criteria
+
+- Nested lifecycle commands still fail once with the established deterministic contextual error.
+- The process marker and diagnostic helper remain private binary implementation details.
+- Correction inspection exposes typed portable records without exposing mutable ledger internals.
+- Acceptance-owner corrections expose only immutable audit fields and never mutable internal ledgers.
+

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/cmd_init.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/cmd_init.md
@@ -1,0 +1,11 @@
+## ADDED
+
+### REQUIREMENT REQ-cmd-init-005
+
+Initialization SHALL leave a repository that passes the very next lifecycle check.
+
+Acceptance Criteria
+- The protected SDD paths initialization creates are recorded in `.specsync/bootstrap.json`.
+- The first check after initialization reports no uncovered meaningful delivery for files
+  initialization itself wrote.
+- Failure to write the record is reported as a warning and does not fail initialization.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/cmd_issues.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/cmd_issues.md
@@ -1,0 +1,12 @@
+## ADDED
+
+### REQUIREMENT REQ-cmd-issues-002
+
+Snapshot source validation SHALL distinguish a confined directory from a rejected path.
+
+Acceptance Criteria
+
+- A `files:` entry that resolves to a directory inside the project root is represented distinctly
+  and reported as a mapping-shape error, not as an out-of-root security escape.
+- Symbolic links and reparse points remain rejected, and that rejection is evaluated before the
+  directory case.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/generator.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/generator.md
@@ -1,0 +1,27 @@
+## MODIFIED
+
+### SPEC SECTION Public API
+
+**Exported Functions**
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `generate_specs_for_unspecced_modules_retained` | `project, root, report, config, progress` | `Result<GenerationOutcome, String>` | Generate CLI scaffolds through one retained project-root capability |
+| `generate_specs_for_unspecced_modules` | `root, report, config` | `GenerationOutcome` | Generate local template specs for all unspecced modules with progress output |
+| `generate_specs_for_unspecced_modules_paths` | `root, report, config` | `GenerationOutcome` | Generate local template specs without progress output for JSON/MCP callers |
+| `generate_companion_files_for_spec` | `spec_dir, module_name, design_enabled` | `()` | Generate companion files (tasks.md, context.md, requirements.md, testing.md, and design.md if enabled) alongside a spec |
+| `find_files_for_module` | `root, module_name, config` | `Vec<String>` | Find source files for a module by checking config definitions, subdirectories, then flat files |
+| `find_module_source_files` | `dir: &Path, config: &SpecSyncConfig, root: &Path` | `Vec<String>` | Source files beneath a module directory, honoring configured extensions and exclusions; shared with spec validation so a directory in `files:` is corrected with exactly what generation would have written |
+| `find_single_source_fallback` | `root, config` | `Option<String>` | Root-relative path of the project's only non-test source file (e.g. `src/lib.rs`), or `None` when there are zero or multiple candidates — fallback for `new`/`scaffold` when no name match exists |
+| `generate_spec` | `module_name, source_files, root, specs_dir` | `String` | Generate a spec from a template (custom or language-aware default) |
+| `generate_spec_from_custom_template` | `template_dir, module_name, source_files, root` | `String` | Generate a spec using files from a custom template directory |
+| `generate_companion_files_from_template` | `spec_dir, module_name, template_dir, design_enabled` | `()` | Generate companion files from a custom template directory with fallback to defaults; creates design.md only when `design_enabled` is true |
+| `collect_exports_for_files` | `root, source_files` | `Vec<String>` | Collect exported symbols across the given source files |
+| `populate_public_api_table` | `spec, exports` | `String` | Insert or refresh a Public API table from discovered export names |
+
+**Exported Types**
+
+| Type | Description |
+|------|-------------|
+| `GenerationOutcome` | Deterministic generation result: generated count and relative generated paths |
+

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/validator.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/deltas/validator.md
@@ -1,0 +1,17 @@
+## ADDED
+
+### REQUIREMENT REQ-validator-010
+
+A `files:` entry that resolves to a directory inside the project root SHALL be a reported error and
+SHALL NOT pass validation.
+
+Acceptance Criteria
+
+- A confined directory mapping produces a validation error rather than extracting zero exports and
+  passing the Public API comparison vacuously.
+- The finding is not reported as resolving outside the project root; escape diagnostics keep
+  precedence over the directory branch.
+- The accompanying fix names the source files beneath the directory using the same expansion module
+  generation applies, excludes configured exclude directories, and is truncated with a remainder
+  count beyond a fixed limit.
+- Snapshot-based validation reports the same error without enumerating the ambient filesystem.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/design.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/design.md
@@ -1,0 +1,93 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: design
+---
+
+# Design
+
+Three independent mechanisms, one shared property: none of them weakens a guard for
+the general case. Each narrows an over-broad gate to the exact situation that made it
+unsatisfiable, and each is revocable by the user's own subsequent edits.
+
+## 1. Bootstrap record — `.specsync/bootstrap.json`
+
+`specsync init` calls the new `change::record_bootstrap_paths(root)`, which writes a
+record naming the protected SDD files this bootstrap created, the commit it was
+created against, and a digest of each.
+
+`bootstrap_exempt_paths` honors a recorded path only when **all four** hold:
+
+1. it is a protected SDD path — a record can never exempt product source;
+2. it is absent at the delivery comparison base, so a *modification* of an
+   already-tracked policy file is never exempt, only its creation;
+3. the recorded base commit is a real ancestor of `HEAD`; and
+4. the file still hashes to the digest recorded when spec-sync wrote it.
+
+Editing a bootstrapped file revokes its own exemption, and the normal change workflow
+applies from that point on. Forging the record requires writing a digest that matches
+a file that is simultaneously absent at the base and descended from a real commit.
+
+**The digest pins the enforcement surface, not the bytes.** `bootstrap_digest` clears
+`verification_commands` before hashing. `init` writes that list empty whenever it
+cannot detect a test command and then instructs the author to populate it; pinning the
+field would revoke the bootstrap for following the tool's own instructions. Every field
+that decides whether the gate bites stays pinned. A policy that does not parse falls
+back to a byte digest, so a malformed file cannot slip through the projection.
+
+**Backward compatibility:** `bootstrap_records` also reads the original single-path
+`bootstrap_policy` shape written by `change adopt`, so records from earlier versions
+keep covering the policy they created.
+
+**Companion fix:** `comparison_base_commit` reduces both forms `pull_request_diff_base`
+can yield — a `<ref>...HEAD` range and a bare commit — to the merge base with `HEAD`,
+replacing the `HEAD~1...HEAD` fallback that does not resolve in a one-commit repository.
+
+Failure to write the record is a **warning, not an error**. A project without Git
+evidence has no coverage gate to satisfy in the first place, so failing initialization
+over it would trade a spurious gate for a spurious hard failure.
+
+## 2. Authorship-keyed stub exemption
+
+`validate_effective_contracts` exempts a stub-section warning only when **no active
+change authored that section**. The section name is parsed from the validator's warning
+text via `STUB_SECTION_WARNING_PREFIX`; classification cannot be reused because
+`WarningCategory::classify` matches `requirements` first and never reaches the stub
+case. That coupling is deliberate and documented at the constant, mirroring how
+`SCAFFOLD_BOILERPLATE_PREFIXES` is coupled to the scaffold text it detects.
+
+The exemption is routed through `IgnoreRules` rather than re-deriving ignore semantics,
+so a project's ignore configuration is honored identically here and everywhere else.
+
+The negative case is the load-bearing one: a section an active change authored and then
+emptied stays fatal. `effective_contract_keeps_authored_emptied_section_fatal` pins it.
+
+## 3. Directory mappings become a reported error with an actionable fix
+
+A new `SourceSnapshot::Directory` variant is kept distinct from `Rejected` so the
+snapshot path stops reporting a confined directory as an out-of-root security escape.
+
+Ambient validation gains a `directory_mapping` branch, guarded by
+`safe_project_relative && full_path.is_dir() && source_within_root(root, file)` so it
+fires only for a confined directory and never shadows the escape diagnostics that must
+take precedence.
+
+The error carries a fix built by `directory_mapping_fix`, which expands the directory
+using `generator::find_module_source_files` — the same expansion `generate` and
+`scaffold` apply to a `[modules."x"] files` directory. The remedy therefore names
+exactly what generation would have written. `expand_directory_mapping` filters
+`config.exclude_dirs`, sorts, and dedupes; the list is truncated at
+`DIRECTORY_MAPPING_FIX_LIMIT` (5) with an "and N more" tail.
+
+Snapshot callers validate retained bytes only and must not enumerate the ambient
+filesystem, so they receive the shape guidance without the file list.
+
+**Deliberately not done:** silently expanding the directory during validation. That
+would make a spec assert a Public API it never declared. The author opts in by applying
+the fix.
+
+## Public API added
+
+| Symbol | Module | Why public |
+|---|---|---|
+| `change::record_bootstrap_paths` | `change` | Called by `commands::init` |
+| `generator::find_module_source_files` | `generator` | Called by `validator` to build the fix |

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/docs.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/docs.md
@@ -1,0 +1,51 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: docs
+---
+
+# Docs
+
+## CHANGELOG
+
+`CHANGELOG.md` gains three `Fixed` entries under the unreleased 6.0.0 heading:
+
+- `specsync init` now records the protected SDD files it creates, so the first
+  `specsync check` after initialization no longer reports initialization's own output as
+  uncovered meaningful delivery.
+- Generated spec sections no longer fail the effective-contract gate. A section an
+  active change authored and then emptied still fails.
+- A directory listed in a spec's `files:` block is now a reported error naming the source
+  files to list instead of passing validation with zero exports extracted (#472). The
+  snapshot validation path reports it as a directory rather than as an out-of-root
+  security escape.
+
+## New public API
+
+Both symbols are documented in their canonical specs as part of this change, because
+adding a public function without documenting it is precisely the drift this tool exists
+to catch — `specsync check --strict` flagged both before this change was authored.
+
+| Symbol | Spec |
+|---|---|
+| `change::record_bootstrap_paths` | `specs/change/change.spec.md` |
+| `generator::find_module_source_files` | `specs/generator/generator.spec.md` |
+
+## `.specsync/bootstrap.json`
+
+A new on-disk artifact written by `specsync init`. It records the protected SDD paths
+that initialization created, the commit it was created against, and a digest of each.
+It is not user-authored and should be committed alongside the files it describes.
+
+Editing any file it names revokes that file's exemption, so the record cannot be used to
+keep policy changes out of the change workflow.
+
+## No migration owed
+
+6.0 is untagged. A repository initialized by an earlier 6.0 build has no bootstrap
+record and is unaffected: the exemption only ever removes a finding.
+
+## Release-note scope
+
+`v6.0.0-rc.1` promises the **product surface** — `check`, `coverage`, drift detection,
+export extraction. The `change *` lifecycle verbs are mid-reduction and are explicitly
+not part of the RC promise. These three fixes are all on the product surface.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/plan.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/plan.md
@@ -1,0 +1,49 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: plan
+---
+
+# Plan
+
+The implementation was completed and the full suite run **before** `change new`, per
+#542: delivery scope freezes at the interview and cannot be widened, while blast radius
+only becomes visible at compile, test, and verification time. The declared scope is
+therefore measured, not estimated.
+
+## Sequence
+
+1. **Bootstrap record.** Add `BOOTSTRAP_RECORD_PATH` and `BOOTSTRAP_RECORD_CANDIDATES`
+   to `change`; implement `record_bootstrap_paths`, `bootstrap_exempt_paths`,
+   `bootstrap_records`, `bootstrap_record_entry`, `bootstrap_digest`,
+   `policy_enforcement_projection`, `content_digest`, and the four predicate helpers
+   (`comparison_base_commit`, `commit_is_ancestor_of_head`, `project_path_is_absent_at`,
+   `project_path_matches_digest`). Call it from `execute_init`, collecting failure as a
+   warning.
+2. **Comparison base.** Replace the `HEAD~1...HEAD` fallback with
+   `comparison_base_commit`, reducing both diff-base forms to a merge base with `HEAD`.
+3. **Stub exemption.** Add `STUB_SECTION_WARNING_PREFIX`; teach
+   `validate_effective_contracts` to exempt stub warnings for sections no active change
+   authored, routing through `IgnoreRules`.
+4. **Directory mappings.** Add `SourceSnapshot::Directory`; branch on it in
+   `snapshot_source_file`; add the `directory_mapping` branch to
+   `validate_spec_content_internal`; implement `directory_mapping_fix` and
+   `expand_directory_mapping`; make `generator::find_module_source_files` public.
+5. **Verify.** `cargo fmt --check`, `cargo clippy -- -D warnings`, full `cargo test`.
+6. **Author the change workspace** with the measured scope; update the five affected
+   canonical specs to document the two new public functions and the new requirements.
+7. **`change check --commit`**, then ship and open the PR.
+
+## Ordering constraints
+
+- Step 4 must precede any run of `check` against this repository: making
+  `find_module_source_files` public without documenting it in `generator.spec.md`
+  produces the very undocumented-export drift this tool exists to catch. The same
+  applies to `record_bootstrap_paths` in `change.spec.md`.
+- Steps 1 and 3 both feed `check_project`. They must be verified together, not
+  separately — a fresh `init` → `scaffold` → `check` sequence exercises both at once.
+
+## Rollout
+
+Lands before the `v6.0.0` tag, so no migration is owed. Repositories initialized by
+earlier 6.0 builds have no bootstrap record; they are unaffected, because the exemption
+only ever removes a finding and never adds one.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/requirements.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/requirements.md
@@ -1,0 +1,74 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: requirements
+---
+
+# Requirements
+
+## REQ-cmd-init-005 — initialization leaves a checkable repository
+
+`specsync init` MUST record the protected SDD paths it creates in
+`.specsync/bootstrap.json`, so that `specsync check` immediately afterwards reports no
+uncovered meaningful delivery for files initialization itself wrote.
+
+Failure to write the record MUST be reported as a warning and MUST NOT fail
+initialization.
+
+## REQ-change-060 — bootstrap exemption is narrow and revocable
+
+A path recorded in a bootstrap record MUST be exempt from lifecycle path coverage only
+when all of the following hold:
+
+1. the path is a protected SDD path;
+2. the path is absent at the delivery comparison base;
+3. the recorded base commit is an ancestor of `HEAD`; and
+4. the file's current content matches the recorded digest.
+
+Editing a bootstrapped file MUST revoke its exemption. A bootstrap record MUST NOT
+exempt any path that is not a protected SDD path.
+
+Bootstrap records written in the earlier single-path `bootstrap_policy` shape MUST
+continue to be honored.
+
+## REQ-change-061 — the bootstrap digest pins the enforcement surface
+
+The digest recorded for `.specsync/sdd.json` MUST cover every field that determines
+whether the coverage gate applies, and MUST NOT cover `verification_commands`.
+
+A policy file that cannot be parsed MUST fall back to a digest of its bytes.
+
+## REQ-change-062 — delivery comparison base resolves in a one-commit repository
+
+Resolution of the delivery comparison base MUST succeed in a repository containing a
+single commit. It MUST reduce both a `<ref>...HEAD` range and a bare commit to a single
+commit via its merge base with `HEAD`.
+
+## REQ-change-063 — generated sections gate on authorship, not on shape
+
+An unfinished spec section MUST NOT produce a fatal effective-contract finding when no
+active change authored that section.
+
+An unfinished spec section that an active change authored MUST remain fatal.
+
+Ignore configuration MUST be applied through the project's `IgnoreRules`.
+
+## REQ-validator-010 — a directory in `files:` is an error, never silent success
+
+A `files:` entry that resolves to a directory inside the project root MUST produce a
+validation error. It MUST NOT be reported as resolving outside the project root, and it
+MUST NOT pass validation.
+
+The error MUST carry a fix naming the source files beneath the directory, expanded by
+the same rule module generation applies, excluding configured exclude directories, and
+truncated with a remainder count beyond five entries.
+
+Snapshot-based validation MUST report the same error without enumerating the ambient
+filesystem.
+
+## REQ-cmd-issues-002 — snapshot validation distinguishes directories from escapes
+
+`SourceSnapshot` MUST represent a confined directory distinctly from a rejected path,
+so a directory mapping is reported as a mapping-shape error rather than a security
+escape.
+
+Symbolic links and reparse points MUST continue to be rejected.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/research.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/research.md
@@ -1,0 +1,73 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: research
+---
+
+# Research
+
+Root-cause findings for each defect, and the second-order bugs each investigation
+surfaced.
+
+## 1. `init` leaves an unsatisfiable coverage gate
+
+`path_is_meaningful_with_specs` consults `is_protected_sdd_path` and returns `true`
+before the ignore filter is applied. That protection is correct in general — a hand
+edit to `.specsync/sdd.json` is exactly the delivery a change workspace should have
+to declare — but the protected list is *precisely* the set of files `init` writes.
+
+The failure is therefore not a misconfiguration a user can escape. Every possible
+first commit after `specsync init` is uncovered meaningful delivery, and no change
+workspace can cover it, because the files predate the existence of any workspace.
+
+**Second bug found in the same code path:** `recorded_diff_base` falls back to
+`HEAD~1...HEAD`. In a repository with one commit — the overwhelmingly common state
+immediately after `git init` — `HEAD~1` does not resolve, so the gate errors out on
+a repository shape the quick-start guide produces.
+
+**Design constraint discovered:** the exemption cannot be pinned to the *bytes* of
+`sdd.json`. `init` writes an empty `verification_commands` list whenever it cannot
+detect a test command, and prints instructions telling the author to fill it in.
+Pinning bytes would revoke the bootstrap for doing exactly what the tool just asked
+for. The digest therefore pins the **enforcement surface** — `enabled`,
+`require_change_for_meaningful_files`, `meaningful_paths`, `ignored_paths`, custom
+artifacts, principles — and clears `verification_commands` before hashing. This is a
+judgment call and is called out as such in the design.
+
+## 2. `scaffold` output fails the effective-contract gate
+
+The stub-section warning is emitted by `validator::validate_spec` with fixed wording.
+`WarningCategory::classify` matches `requirements` before it would reach the stub
+case, so classification cannot be reused to recognize these; the section name has to
+be parsed from the warning text. That coupling is real and is documented at the
+constant, in the same manner `SCAFFOLD_BOILERPLATE_PREFIXES` is coupled to the
+scaffold text it detects.
+
+The correct exemption key is **authorship, not content**. A generated section that no
+active change has touched is not evidence of anything and should not gate. A section
+an active change authored and then emptied is a regression and must stay fatal. The
+implementation routes the exemption through `IgnoreRules` so ignore configuration is
+honored consistently rather than re-derived.
+
+## 3. Directory in `files:` — #472, worse than filed
+
+Filed as Kotlin-specific. It is language-independent.
+
+Two independent code paths reach a `files:` entry, and both mishandled a directory:
+
+| Path | Before | After |
+|---|---|---|
+| Ambient filesystem validation | `full_path.exists()` is true and `source_within_root` is true, so no branch fires; zero exports extracted, Public API comparison vacuously passes | `Source file … is a directory` error with an expansion fix |
+| Snapshot validation (`issues.rs`) | `!metadata.is_file()` returned `SourceSnapshot::Rejected`, reported to the user as an out-of-root **security escape** | New `SourceSnapshot::Directory` variant reports the real cause |
+
+The snapshot path was therefore not silent, but it was actively misleading: it told
+the author their path escaped the project root when the path was confined and merely
+the wrong shape. Both paths now agree on the diagnosis.
+
+**Reuse discovered:** `generate` and `scaffold` already expand a directory listed
+under `[modules."x"] files` into the source files beneath it. Making the validator's
+suggested fix reuse that same expansion — `generator::find_module_source_files` —
+means the remedy the error prints is byte-identical to what generation would have
+written, instead of a second, subtly different notion of "the files under here".
+
+**Constraint:** snapshot callers validate retained bytes only and must not enumerate
+the ambient filesystem. They receive the shape guidance without the file list.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/state.json
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/state.json
@@ -11,7 +11,7 @@
   "canonical_applied": true,
   "base_commit": "4ddf810ed39b56482ba96a0d209ee9216ef56fe9",
   "created_at": 1786579705,
-  "updated_at": 1786581887,
+  "updated_at": 1786583115,
   "affected_specs": [
     "change",
     "cmd_init",

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/state.json
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/state.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "workflow_version": 2,
+  "workflow_origin_version": 2,
+  "id": "CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc",
+  "slug": "fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc",
+  "title": "Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green",
+  "description": "Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green",
+  "kind": "bug_fix",
+  "state": "verifying",
+  "canonical_applied": true,
+  "base_commit": "4ddf810ed39b56482ba96a0d209ee9216ef56fe9",
+  "created_at": 1786579705,
+  "updated_at": 1786581887,
+  "affected_specs": [
+    "change",
+    "cmd_init",
+    "cmd_issues",
+    "generator",
+    "validator"
+  ],
+  "affected_paths": [
+    "src/change.rs",
+    "src/commands/init.rs",
+    "src/commands/issues.rs",
+    "src/generator.rs",
+    "src/validator.rs",
+    "CHANGELOG.md",
+    ".specsync/change-sequence.json"
+  ],
+  "no_spec_change": false,
+  "no_spec_change_rationale": null,
+  "acceptance_criteria": [
+    "A repository initialized with `specsync init` passes `specsync check --strict` with exit 0 before any spec is authored. A module created with `specsync scaffold` passes `specsync check --strict` with exit 0 while its sections still hold generated placeholder prose, and a section a change actually authored then emptied still fails. A directory listed in a spec's `files:` block resolves to the source files beneath it for validation, coverage, and export extraction instead of being silently skipped, and an unresolvable directory reports an error rather than passing green."
+  ],
+  "selected_artifacts": [
+    "context",
+    "testing",
+    "tasks",
+    "design",
+    "requirements",
+    "docs",
+    "research",
+    "plan"
+  ],
+  "dependencies": [],
+  "answers": {
+    "architecture_risk": "yes",
+    "public_contract": "yes"
+  }
+}

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/tasks.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/tasks.md
@@ -1,0 +1,51 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: tasks
+---
+
+# Tasks
+
+## Bootstrap record (REQ-cmd-init-005, REQ-change-060, -061, -062)
+
+- [x] Add `BOOTSTRAP_RECORD_PATH` and `BOOTSTRAP_RECORD_CANDIDATES` to `change`
+- [x] Implement `record_bootstrap_paths` and export it
+- [x] Implement `bootstrap_exempt_paths` with the four-condition guard
+- [x] Implement `bootstrap_records` including the legacy `bootstrap_policy` shape
+- [x] Implement `bootstrap_digest` / `policy_enforcement_projection` / `content_digest`
+- [x] Implement `comparison_base_commit`, `commit_is_ancestor_of_head`,
+      `project_path_is_absent_at`, `project_path_matches_digest`
+- [x] Call `record_bootstrap_paths` from `execute_init`, collecting failure as a warning
+- [x] Replace the `HEAD~1...HEAD` comparison-base fallback
+
+## Stub exemption (REQ-change-063)
+
+- [x] Add `STUB_SECTION_WARNING_PREFIX` with its coupling documented
+- [x] Exempt stub warnings for sections no active change authored
+- [x] Route the exemption through `IgnoreRules`
+
+## Directory mappings (REQ-validator-010, REQ-cmd-issues-002)
+
+- [x] Add `SourceSnapshot::Directory`
+- [x] Return it from `snapshot_source_file` for a confined directory
+- [x] Keep symlink and reparse-point rejection ahead of the directory branch
+- [x] Add the `directory_mapping` branch to `validate_spec_content_internal`
+- [x] Implement `directory_mapping_fix` with `DIRECTORY_MAPPING_FIX_LIMIT`
+- [x] Implement `expand_directory_mapping` with `exclude_dirs` filtering, sort, dedupe
+- [x] Make `generator::find_module_source_files` public
+
+## Specs
+
+- [x] Document `record_bootstrap_paths` in `specs/change`
+- [x] Document `find_module_source_files` in `specs/generator`
+- [x] Add the new requirements to `specs/cmd_init`, `specs/change`, `specs/validator`,
+      `specs/cmd_issues`
+
+## Verification
+
+- [x] `cargo fmt --check` clean
+- [x] `cargo clippy -- -D warnings` clean
+- [x] Full `cargo test` green — 2203 unit, 331 integration, 0 failures
+- [x] `specsync check --strict` green on this repository — 62 specs, 0 warnings, 0 failed
+
+Sandbox drills run against a binary built from this branch after it lands; that pass
+belongs to the RC loop, not to this change.

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/testing.md
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/testing.md
@@ -1,0 +1,81 @@
+---
+change: CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc
+artifact: testing
+---
+
+# Testing
+
+## Strategy
+
+Each fix removes a finding that should never have fired. The risk is therefore not that
+the fix fails to work but that it removes findings that *should* fire. Every mechanism
+consequently gets a **negative test that is the load-bearing one** — the assertion that
+the guard still bites where it must.
+
+The Rust suite is single-process and single-root, so it cannot observe squash merges,
+multi-clone races, or branch topology. The sandbox drills judge those. Drill 038 (the
+drift invariant) must stay 10/10 and drill 039 (export extraction, seven languages)
+43/43; if either moves, the fix broke the product.
+
+## Tests added
+
+### Bootstrap record
+
+| Test | Asserts |
+|---|---|
+| `fresh_init_leaves_the_next_lifecycle_check_clean` | `git init` → `specsync init` → check is clean, both **before** the bootstrap commit (the one-commit `HEAD~1` case) and after; filling in `verification_commands` does not revoke the bootstrap; **widening `meaningful_paths` does revoke it** |
+| `bootstrap_records_exempt_only_newly_created_protected_paths` | A record cannot exempt a path that is not protected, nor one already present at the comparison base |
+| `uncovered_paths_error_names_the_escape_hatch_and_ignore_precedence` | The remaining uncovered-paths error stays actionable |
+
+The revocation assertion is the important one: it proves the exemption is a pin on the
+enforcement surface rather than a blanket amnesty for anything under `.specsync/`.
+
+### Stub exemption
+
+| Test | Asserts |
+|---|---|
+| `effective_contract_exempts_stub_sections_no_active_change_authored` | The positive case — scaffold output passes |
+| `effective_contract_keeps_authored_emptied_section_fatal` | **The negative case** — a section an active change authored and then emptied stays fatal |
+| `effective_contract_keeps_applied_authored_emptied_section_fatal` | Same, through the applied-delta path |
+| `effective_contract_exempts_nothing_when_authorship_is_unknown` | Fails closed when authorship cannot be determined |
+| `effective_contract_reports_ignore_rule_suppressions` | Ignore-rule suppressions are surfaced, not silent |
+| `effective_contract_reports_suppressions_alongside_errors` | Suppressions do not mask concurrent errors |
+| `project_check_reports_effective_contract_suppressions_as_warnings` | Suppressions reach `check` output as warnings |
+
+Failing closed on unknown authorship matters: the exemption's key is "no active change
+authored this", and an inability to answer that question must not be read as "no".
+
+### Directory mappings
+
+| Test | Asserts |
+|---|---|
+| `directory_source_mapping_fails_loud_and_names_the_files_to_list` | The error fires and the fix names the expanded files |
+| `directory_source_mapping_does_not_disturb_sibling_file_mappings` | Valid file entries in the same `files:` block are unaffected |
+| `snapshot_validation_reports_a_directory_mapping_as_a_directory` | The snapshot path reports a directory, **not** an out-of-root escape |
+| `draft_directory_source_mapping_is_not_a_planned_mapping_notice` | A directory is not misreported as a planned-but-absent mapping |
+
+## Results
+
+- `cargo fmt --check` — clean
+- `cargo clippy -- -D warnings` — exit 0
+- `cargo test` — **2203 unit, 331 integration, 0 failures**
+- Sandbox board at the base commit — **28 pass, 0 fail, 0 skip**; drill 039 43/43
+
+## Not covered here
+
+Behavior of a repository initialized by an earlier 6.0 build that has no bootstrap
+record. Reasoned rather than tested: the exemption only ever removes a finding, so its
+absence reproduces today's behavior exactly. 6.0 is untagged, so no released version is
+affected.
+
+## Requirement evidence
+
+| Requirement | Evidence |
+|-------------|----------|
+| REQ-cmd-init-005 | `cargo test`; `fresh_init_leaves_the_next_lifecycle_check_clean` asserts `.specsync/bootstrap.json` exists after `cmd_init` and that the next check is clean both before and after the bootstrap commit. Confirmed by hand: `git init` → `specsync init` → `specsync check` exits 0 on a repository with one commit and an uncommitted `.specsync/` tree |
+| REQ-change-060 | `cargo test`; `bootstrap_records_exempt_only_newly_created_protected_paths` proves a record cannot exempt a non-protected path nor one already present at the comparison base, and `fresh_init_leaves_the_next_lifecycle_check_clean` proves that widening `meaningful_paths` revokes the exemption the edited file was granted |
+| REQ-change-061 | `cargo test`; `fresh_init_leaves_the_next_lifecycle_check_clean` populates `verification_commands` and asserts the exemption survives, then edits `meaningful_paths` and asserts it is revoked — the two halves of the enforcement-surface projection |
+| REQ-change-062 | `cargo test`; the same test checks a one-commit repository before the bootstrap commit exists, the case where `HEAD~1` does not resolve |
+| REQ-change-063 | `cargo test`; `effective_contract_exempts_stub_sections_no_active_change_authored` covers the positive case, `effective_contract_keeps_authored_emptied_section_fatal` and `effective_contract_keeps_applied_authored_emptied_section_fatal` the negative case through both delta paths, `effective_contract_exempts_nothing_when_authorship_is_unknown` the fail-closed case, and `effective_contract_reports_ignore_rule_suppressions`, `effective_contract_reports_suppressions_alongside_errors`, and `project_check_reports_effective_contract_suppressions_as_warnings` the reporting of suppressions. Confirmed by hand: `specsync scaffold auth` → `specsync check` exits 0 |
+| REQ-validator-010 | `cargo test`; `directory_source_mapping_fails_loud_and_names_the_files_to_list` asserts the error and the expanded fix, `directory_source_mapping_does_not_disturb_sibling_file_mappings` that valid entries in the same block are unaffected, and `draft_directory_source_mapping_is_not_a_planned_mapping_notice` that a directory is not misreported as a planned mapping |
+| REQ-cmd-issues-002 | `cargo test`; `snapshot_validation_reports_a_directory_mapping_as_a_directory` asserts the snapshot path reports a directory rather than an out-of-root escape, with symlink rejection still evaluated first |

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification-attempts.json
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification-attempts.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1786581886,
+      "commit": "4ddf810ed39b56482ba96a0d209ee9216ef56fe9",
+      "contract_digest": "02dcdcfaedf3f6ff46bee160fc09482c1615b299377265f7c88174cff35ec295",
+      "execution_digest": "76db06b6beb19736ba38b93c0f12008ea940270134fa862acf9ede94c9a0e9df",
+      "workspace_digest": "a0222ec992170bb2f16e17a81ec4bcd727ae3cf17cfd31bacc80427301ae1946",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test validator::tests::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-060",
+        "REQ-change-061",
+        "REQ-change-062",
+        "REQ-change-063",
+        "REQ-cmd-init-005",
+        "REQ-cmd-issues-002",
+        "REQ-validator-010"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification-attempts.json
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification-attempts.json
@@ -44,6 +44,50 @@
         "REQ-cmd-issues-002",
         "REQ-validator-010"
       ]
+    },
+    {
+      "timestamp": 1786583113,
+      "commit": "b6240364bece010d01cb4c9a40927d7012a272dd",
+      "contract_digest": "02dcdcfaedf3f6ff46bee160fc09482c1615b299377265f7c88174cff35ec295",
+      "execution_digest": "76db06b6beb19736ba38b93c0f12008ea940270134fa862acf9ede94c9a0e9df",
+      "workspace_digest": "a0222ec992170bb2f16e17a81ec4bcd727ae3cf17cfd31bacc80427301ae1946",
+      "passed": true,
+      "commands": [
+        {
+          "command": "cargo test change::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test validator::tests::",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "cargo test",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-release-version.py",
+          "success": true,
+          "exit_code": 0
+        },
+        {
+          "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-change-060",
+        "REQ-change-061",
+        "REQ-change-062",
+        "REQ-change-063",
+        "REQ-cmd-init-005",
+        "REQ-cmd-issues-002",
+        "REQ-validator-010"
+      ]
     }
   ]
 }

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification.json
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": 1786581886,
-  "commit": "4ddf810ed39b56482ba96a0d209ee9216ef56fe9",
+  "timestamp": 1786583113,
+  "commit": "b6240364bece010d01cb4c9a40927d7012a272dd",
   "contract_digest": "02dcdcfaedf3f6ff46bee160fc09482c1615b299377265f7c88174cff35ec295",
   "execution_digest": "76db06b6beb19736ba38b93c0f12008ea940270134fa862acf9ede94c9a0e9df",
   "workspace_digest": "a0222ec992170bb2f16e17a81ec4bcd727ae3cf17cfd31bacc80427301ae1946",

--- a/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification.json
+++ b/.specsync/changes/CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc/verification.json
@@ -1,0 +1,44 @@
+{
+  "timestamp": 1786581886,
+  "commit": "4ddf810ed39b56482ba96a0d209ee9216ef56fe9",
+  "contract_digest": "02dcdcfaedf3f6ff46bee160fc09482c1615b299377265f7c88174cff35ec295",
+  "execution_digest": "76db06b6beb19736ba38b93c0f12008ea940270134fa862acf9ede94c9a0e9df",
+  "workspace_digest": "a0222ec992170bb2f16e17a81ec4bcd727ae3cf17cfd31bacc80427301ae1946",
+  "passed": true,
+  "commands": [
+    {
+      "command": "cargo test change::",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test validator::tests::",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "cargo test",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-release-version.py",
+      "success": true,
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -S .github/scripts/validate-workflow-runtime-pins.py",
+      "success": true,
+      "exit_code": 0
+    }
+  ],
+  "requirement_ids": [
+    "REQ-change-060",
+    "REQ-change-061",
+    "REQ-change-062",
+    "REQ-change-063",
+    "REQ-cmd-init-005",
+    "REQ-cmd-issues-002",
+    "REQ-validator-010"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`specsync init` no longer leaves a project failing its own coverage gate.** Initialization
+  writes `.specsync/config.toml`, `.specsync/version`, and `.specsync/sdd.json` — all three are
+  protected SDD paths, so the first commit after `specsync init` was reported as uncovered
+  meaningful delivery (`meaningful changed paths are not covered by an active change`) on a gate
+  no change workspace could satisfy, because none existed when the files were written. `init` now
+  records what it created in a committed `.specsync/bootstrap.json`, and the coverage gate honours
+  that record.
+
+  The exemption is pinned, not blanket: a recorded path counts only while it is a protected SDD
+  path, is absent at the delivery comparison base (so only *creation* is ever exempt, never a
+  modification of an already-tracked policy file), has a recorded base commit that is an ancestor
+  of `HEAD`, and still matches its recorded digest. The policy digest covers the enforcement
+  surface rather than the file bytes — filling in `verification_commands`, which `init` asks you
+  to do, keeps the exemption, while changing `enabled`, `require_change_for_meaningful_files`,
+  `meaningful_paths`, or `ignored_paths` revokes it. `change adopt`'s existing single-path
+  bootstrap record is honoured through the same, now stricter, validator.
+
+- **The coverage gate no longer breaks in a one-commit repository.** With no active change to
+  supply a base commit, the gate fell back to `HEAD~1...HEAD`; in a repository whose first commit
+  is also its only one that does not resolve, and a dirty tree — exactly the state `specsync init`
+  leaves behind — produced `error: unable to inspect changed paths for SDD coverage`. The fallback
+  now resolves to `HEAD`: there is no earlier commit to review, so the committed delivery is empty
+  and the working tree is what needs coverage.
+
+- **The coverage-gate failure names the way out.** `meaningful changed paths are not covered by an
+  active change` now prints a runnable `specsync change new … --path …` line carrying every
+  reported path, names the `--no-spec-change --rationale` variant, and — when a reported path
+  matches a configured `ignored_paths` entry — states why the entry did not apply: protected SDD
+  policy files and the configured specs tree are always meaningful and cannot be ignored away.
+
+- **`specsync scaffold` output no longer fails `specsync check`.** Scaffolding a module emits
+  placeholder sections, and the effective-contract gate treated every unfinished section as a stub
+  warning — fatal under `--strict`. The tool's own output failed the tool's own gate, on the second
+  command of the quick start. The exemption is keyed to **authorship, not content shape**: a
+  generated section no active change has authored no longer gates, while a section an active change
+  authored and then emptied stays fatal, through both the pending and the applied delta paths.
+  Unknown authorship fails closed and exempts nothing, and suppressions are reported as warnings
+  rather than dropped silently.
+
+- **A directory in a spec's `files:` block is now an error instead of silent success**
+  (CorvidLabs/spec-sync#472). A directory mapping extracts zero exports, so the Public API
+  comparison had nothing to compare and passed: `specsync check --strict --force` exited 0 with
+  zero warnings while measuring nothing — a green result indistinguishable from a real one. Filed as
+  Kotlin-specific; it was language-independent. Validation now reports
+  `Source file <path> is a directory — files: must list source files, not directories`, with a fix
+  naming the source files beneath it, expanded by the same rule `generate` and `scaffold` apply to a
+  `[modules."x"] files` directory, so the remedy matches what generation would have written.
+
+  The snapshot validation path had the same defect in a more misleading form: it refused the
+  directory but reported it as an out-of-root **security escape**, telling authors their confined
+  path had left the project root. Both paths now name the real cause. Symlink and reparse-point
+  rejection is unchanged and still evaluated first.
+
 - SpecSync 6.0 reopen/finalize paths address stranded accepted-record deadlocks reported via CorvidLabs/spec-sync#481 (fledge PR CorvidLabs/fledge#506 worked around the 5.x strand by manual archive).
 
 - **Draft `next_action` no longer recommends approve while artifacts are incomplete** — when the interview is done but selected artifacts still contain `<!-- TODO -->` stubs (or are empty), status/show guidance prefers completing those artifacts first (sandbox #16).

--- a/specs/change/change.spec.md
+++ b/specs/change/change.spec.md
@@ -1,6 +1,6 @@
 ---
 module: change
-version: 72
+version: 73
 status: active
 files:
   - src/change.rs
@@ -109,6 +109,7 @@ Provides the SpecSync verified spec-driven development lifecycle: one scope appr
 | Function | Parameters | Returns | Description |
 |----------|------------|---------|-------------|
 | `load_policy` | `root: &Path` | `Option<SddPolicy>` | Load `.specsync/sdd.json`; absence leaves existing projects unenforced |
+| `record_bootstrap_paths` | `root: &Path` | `Result<(), String>` | Record the protected SDD paths this bootstrap created in `.specsync/bootstrap.json`, so initialization's own output is not reported as uncovered meaningful delivery; editing a recorded file revokes its exemption |
 | `write_default_policy` | `root: &Path, verification_commands: Vec<String>` | `Result<(), String>` | Write new-project/adoption policy without overwriting existing policy |
 | `create_change` | `root: &Path, request: CreateChangeRequest` | `Result<ChangeRecord, String>` | Create a sequential draft workspace and adaptive artifacts |
 | `load_change` | `root: &Path, id: &str` | `Result<ChangeRecord, String>` | Load active or archived change state |
@@ -375,3 +376,4 @@ Acceptance Criteria
 | 2026-08-10 | CHG-0103: Keep documented mutation wrappers in production and capture normal/strict machine summaries inside the locked transaction |
 | 2026-08-12 | CHG-0104-sever-specsync-check-and-comment-from-the-trust-layer-lifecycle-state-becomes-i: Sever specsync check and comment from the trust layer: lifecycle state becomes informational and never affects exit status |
 | 2026-08-12 | CHG-0106-make-verification-currency-a-content-question-delete-the-git-ancestry-walk-the: Make verification currency a content question: delete the git-ancestry walk, the REQ-change-016 persistence allowlist, and the verification-commit ancestry binding |
+| 2026-08-13 | CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc: Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green |

--- a/specs/change/requirements.md
+++ b/specs/change/requirements.md
@@ -859,3 +859,52 @@ Acceptance Criteria
 - Verification command execution, failure reporting, and recursion refusal are otherwise
   unchanged.
 
+
+### REQ-change-060
+
+A bootstrap record SHALL exempt a path from lifecycle path coverage only when that exemption cannot
+be used to hide product delivery or later policy edits.
+
+Acceptance Criteria
+
+- A recorded path is honored only when it is a protected SDD path, is absent at the delivery
+  comparison base, its recorded base commit is an ancestor of `HEAD`, and its content still matches
+  the recorded digest.
+- A bootstrap record never exempts a path that is not a protected SDD path.
+- Editing a bootstrapped file revokes its own exemption and the normal change workflow applies from
+  that point on.
+- Bootstrap records written in the earlier single-path shape continue to be honored.
+
+### REQ-change-061
+
+The digest recorded for a bootstrapped policy SHALL pin the enforcement surface rather than the
+file's bytes.
+
+Acceptance Criteria
+
+- Every field that determines whether the coverage gate applies is covered by the digest.
+- Verification commands are excluded, so populating them as initialization instructs does not revoke
+  the bootstrap.
+- A policy file that cannot be parsed falls back to a digest of its bytes.
+
+### REQ-change-062
+
+Resolution of the delivery comparison base SHALL succeed in a repository containing a single commit.
+
+Acceptance Criteria
+
+- Both a range form and a bare commit reduce to a single commit through its merge base with `HEAD`.
+- No resolution path depends on a parent commit existing.
+
+### REQ-change-063
+
+An unfinished spec section SHALL gate on whether a change authored it, not on its content shape.
+
+Acceptance Criteria
+
+- A generated section no active change authored produces no fatal effective-contract finding.
+- A section an active change authored and then emptied remains fatal, through both the pending and
+  the applied delta paths.
+- Unknown authorship fails closed and exempts nothing.
+- Ignore configuration is applied through the project's ignore rules rather than re-derived.
+- Suppressions are reported as warnings rather than dropped silently.

--- a/specs/cmd_init/cmd_init.spec.md
+++ b/specs/cmd_init/cmd_init.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_init
-version: 9
+version: 10
 status: stable
 files:
   - src/commands/init.rs
@@ -86,3 +86,4 @@ Implementation SHALL add these canonical dependency specs to `depends_on`: `spec
 | 2026-07-11 | CHG-0006-close-final-specsync-5-0-evidence-monorepo-bootstrap-reporting-and-import-re: Close final SpecSync 5.0 evidence, monorepo, bootstrap, reporting, and import review gaps |
 | 2026-07-11 | CHG-0010-canonicalize-every-specsync-5-0-contract-and-requirement: Canonicalize every SpecSync 5.0 contract and requirement |
 | 2026-08-01 | CHG-0071-land-pre-6-0-product-fixes-for-hooks-init-coverage-naming-and-exit-codes-scoped: Land pre-6.0 product fixes for hooks init coverage naming and exit codes (scoped paths) |
+| 2026-08-13 | CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc: Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green |

--- a/specs/cmd_init/requirements.md
+++ b/specs/cmd_init/requirements.md
@@ -60,3 +60,13 @@ Initialization SHALL enable Git-dependent SDD coverage only when the project can
 Acceptance Criteria
 - Git repositories receive normal strict SDD defaults.
 - Non-Git directories initialize successfully without an immediately impossible changed-path gate.
+
+### REQ-cmd-init-005
+
+Initialization SHALL leave a repository that passes the very next lifecycle check.
+
+Acceptance Criteria
+- The protected SDD paths initialization creates are recorded in `.specsync/bootstrap.json`.
+- The first check after initialization reports no uncovered meaningful delivery for files
+  initialization itself wrote.
+- Failure to write the record is reported as a warning and does not fail initialization.

--- a/specs/cmd_issues/cmd_issues.spec.md
+++ b/specs/cmd_issues/cmd_issues.spec.md
@@ -1,6 +1,6 @@
 ---
 module: cmd_issues
-version: 11
+version: 12
 status: stable
 files:
   - src/commands/issues.rs
@@ -149,3 +149,4 @@ path replacement cannot redirect issue inspection or `--create` validation.
 | 2026-07-22 | CHG-0063 final agent-review follow-up: align retained ignored-directory behavior and reject special-file manifests as inconclusive |
 | 2026-07-23 | CHG-0063 retained-handle follow-up: use no-follow, non-blocking config/manifest acquisition and reject regular-file replacement or FIFO substitution between discovery and read |
 | 2026-07-27 | CHG-0063-close-independent-mcp-security-review-gaps-for-issue-414: Close independent MCP security review gaps for issue 414 |
+| 2026-08-13 | CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc: Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green |

--- a/specs/cmd_issues/requirements.md
+++ b/specs/cmd_issues/requirements.md
@@ -134,3 +134,14 @@ Acceptance Criteria
   supplied-content TypeScript wildcard imports through ambient paths, then preserves normal
   drift-issue creation for validation errors.
 
+
+### REQ-cmd-issues-002
+
+Snapshot source validation SHALL distinguish a confined directory from a rejected path.
+
+Acceptance Criteria
+
+- A `files:` entry that resolves to a directory inside the project root is represented distinctly
+  and reported as a mapping-shape error, not as an out-of-root security escape.
+- Symbolic links and reparse points remain rejected, and that rejection is evaluated before the
+  directory case.

--- a/specs/generator/generator.spec.md
+++ b/specs/generator/generator.spec.md
@@ -1,6 +1,6 @@
 ---
 module: generator
-version: 9
+version: 10
 status: stable
 files:
   - src/generator.rs
@@ -19,7 +19,7 @@ Deterministically scaffolds spec files and companion files for unspecced modules
 
 ## Public API
 
-### Exported Functions
+**Exported Functions**
 
 | Function | Parameters | Returns | Description |
 |----------|-----------|---------|-------------|
@@ -28,6 +28,7 @@ Deterministically scaffolds spec files and companion files for unspecced modules
 | `generate_specs_for_unspecced_modules_paths` | `root, report, config` | `GenerationOutcome` | Generate local template specs without progress output for JSON/MCP callers |
 | `generate_companion_files_for_spec` | `spec_dir, module_name, design_enabled` | `()` | Generate companion files (tasks.md, context.md, requirements.md, testing.md, and design.md if enabled) alongside a spec |
 | `find_files_for_module` | `root, module_name, config` | `Vec<String>` | Find source files for a module by checking config definitions, subdirectories, then flat files |
+| `find_module_source_files` | `dir: &Path, config: &SpecSyncConfig, root: &Path` | `Vec<String>` | Source files beneath a module directory, honoring configured extensions and exclusions; shared with spec validation so a directory in `files:` is corrected with exactly what generation would have written |
 | `find_single_source_fallback` | `root, config` | `Option<String>` | Root-relative path of the project's only non-test source file (e.g. `src/lib.rs`), or `None` when there are zero or multiple candidates — fallback for `new`/`scaffold` when no name match exists |
 | `generate_spec` | `module_name, source_files, root, specs_dir` | `String` | Generate a spec from a template (custom or language-aware default) |
 | `generate_spec_from_custom_template` | `template_dir, module_name, source_files, root` | `String` | Generate a spec using files from a custom template directory |
@@ -35,7 +36,7 @@ Deterministically scaffolds spec files and companion files for unspecced modules
 | `collect_exports_for_files` | `root, source_files` | `Vec<String>` | Collect exported symbols across the given source files |
 | `populate_public_api_table` | `spec, exports` | `String` | Insert or refresh a Public API table from discovered export names |
 
-### Exported Types
+**Exported Types**
 
 | Type | Description |
 |------|-------------|
@@ -113,3 +114,4 @@ Deterministically scaffolds spec files and companion files for unspecced modules
 | 2026-07-11 | CHG-0007-harden-specsync-5-0-as-an-agent-native-secret-free-sdd-core-and-close-release-r: Harden SpecSync 5.0 as an agent-native, secret-free SDD core and close release regressions |
 | 2026-07-27 | CHG-0063-close-independent-mcp-security-review-gaps-for-issue-414: Close independent MCP security review gaps for issue 414 |
 | 2026-08-01 | CHG-0071-land-pre-6-0-product-fixes-for-hooks-init-coverage-naming-and-exit-codes-scoped: Land pre-6.0 product fixes for hooks init coverage naming and exit codes (scoped paths) |
+| 2026-08-13 | CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc: Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green |

--- a/specs/validator/requirements.md
+++ b/specs/validator/requirements.md
@@ -182,3 +182,19 @@ Acceptance Criteria
 - Declared `db_tables` without a configured readable schema produce a finding instead of a vacuous
   pass.
 
+
+### REQ-validator-010
+
+A `files:` entry that resolves to a directory inside the project root SHALL be a reported error and
+SHALL NOT pass validation.
+
+Acceptance Criteria
+
+- A confined directory mapping produces a validation error rather than extracting zero exports and
+  passing the Public API comparison vacuously.
+- The finding is not reported as resolving outside the project root; escape diagnostics keep
+  precedence over the directory branch.
+- The accompanying fix names the source files beneath the directory using the same expansion module
+  generation applies, excludes configured exclude directories, and is truncated with a remainder
+  count beyond a fixed limit.
+- Snapshot-based validation reports the same error without enumerating the ambient filesystem.

--- a/specs/validator/validator.spec.md
+++ b/specs/validator/validator.spec.md
@@ -1,6 +1,6 @@
 ---
 module: validator
-version: 26
+version: 27
 status: stable
 files:
   - src/validator.rs
@@ -267,3 +267,4 @@ Implementation SHALL add these canonical dependency specs to `depends_on`: `spec
 | 2026-07-30 | CHG-0068-stabilize-specsync-6-0-with-a-low-churn-normal-workflow-preserved-audited-guara: Stabilize SpecSync 6.0 with one scope approval, same-PR finalization, lightweight archive CI, scoped review, and selected UX fixes |
 | 2026-07-31 | CHG-0070-land-pre-6-0-product-fixes-for-hooks-init-coverage-naming-and-exit-codes: Land pre-6.0 product fixes for hooks init coverage naming and exit codes |
 | 2026-08-01 | CHG-0071-land-pre-6-0-product-fixes-for-hooks-init-coverage-naming-and-exit-codes-scoped: Land pre-6.0 product fixes for hooks init coverage naming and exit codes (scoped paths) |
+| 2026-08-13 | CHG-0107-fix-the-first-five-minutes-of-spec-sync-init-leaves-a-repo-that-fails-check-sc: Fix the first five minutes of spec-sync: init leaves a repo that fails check, scaffold writes prose that check rejects, and a directory in files: makes check silently green |

--- a/src/change.rs
+++ b/src/change.rs
@@ -22,6 +22,14 @@ const LEGACY_BASELINE_PATH: &str = ".specsync/archive/legacy-baseline.json";
 const WORKFLOW_V2_BASELINE_PATH: &str = ".specsync/workflow-v2-baseline.json";
 const LOCK_PATH: &str = ".specsync/change.lock";
 const SEQUENCE_PATH: &str = ".specsync/change-sequence.json";
+const BOOTSTRAP_RECORD_PATH: &str = ".specsync/bootstrap.json";
+/// Protected SDD paths `specsync init` creates for a fresh project.
+const BOOTSTRAP_RECORD_CANDIDATES: [&str; 4] = [
+    ".specsync/config.toml",
+    ".specsync/config.json",
+    ".specsync/version",
+    POLICY_PATH,
+];
 const TRANSACTION_PATH: &str = ".specsync/change-transaction.json";
 const CORRECTIONS_FILE: &str = "corrections.json";
 const SCOPED_REVIEW_FILE: &str = "review.json";
@@ -2526,7 +2534,11 @@ fn verify_change_locked(root: &Path, id: &str, strict: bool) -> Result<Verificat
     ensure_dependencies_satisfied(root, &record)?;
     ensure_no_delta_conflicts(root, &record)?;
     let records = list_changes_checked(root)?;
-    validate_effective_contracts(root, &records).map_err(|errors| errors.join("; "))?;
+    // Verification has no non-error output channel; `specsync check` and
+    // `specsync change audit` run this same gate and report the suppressions.
+    if let Some(errors) = validate_effective_contracts(root, &records).error_text() {
+        return Err(errors);
+    }
     ensure_tasks_complete(root, &record)?;
     let policy = load_policy_checked(root)?.unwrap_or_default();
     let verification_commands = verification_commands_for_change(root, &policy, &record, strict)?;
@@ -5586,7 +5598,11 @@ fn accept_change_with_gate(
     ensure_no_delta_conflicts(root, &record)?;
     validate_delta_files(root, &record)?;
     let records = list_changes_checked(root)?;
-    validate_effective_contracts(root, &records).map_err(|errors| errors.join("; "))?;
+    // Same as verification: acceptance reports only failures, and the project
+    // surfaces report every suppression this gate applied.
+    if let Some(errors) = validate_effective_contracts(root, &records).error_text() {
+        return Err(errors);
+    }
     ensure_reopened_definition_unchanged(root, &record)?;
     let mut prepared = if record.canonical_applied {
         Vec::new()
@@ -6492,9 +6508,9 @@ fn check_project_with_command_output(
             }
         }
     }
-    if let Err(errors) = validate_effective_contracts(root, &records) {
-        report.errors.extend(errors);
-    }
+    let effective = validate_effective_contracts(root, &records);
+    report.warnings.extend(effective.suppressions);
+    report.errors.extend(effective.errors);
     let verifying_project_digest = if records
         .iter()
         .any(|record| record.state == ChangeState::Verifying)
@@ -6599,10 +6615,7 @@ fn check_project_with_command_output(
         match uncovered_meaningful_paths(root, &policy, &records) {
             Ok(paths) => {
                 if !paths.is_empty() {
-                    report.errors.push(format!(
-                        "meaningful changed paths are not covered by an active change: {}",
-                        paths.join(", ")
-                    ));
+                    report.errors.push(uncovered_paths_error(&policy, &paths));
                 }
             }
             Err(error) => report.errors.push(error),
@@ -6702,59 +6715,223 @@ fn adoption_bootstrap_record_for_content(
     let Some(base_commit) = git_output(root, &["rev-parse", "--verify", "HEAD"]) else {
         return Ok(None);
     };
-    let mut hasher = Sha256::new();
-    hasher.update(content);
     Ok(Some(serde_json::json!({
         "path": POLICY_PATH,
-        "digest": format!("{:x}", hasher.finalize()),
+        "digest": bootstrap_digest(POLICY_PATH, content),
         "base_commit": base_commit,
     })))
 }
 
-fn adoption_bootstrap_covers_policy(root: &Path) -> bool {
-    let Ok(content) = fs::read_to_string(root.join(".specsync/adoption-report.json")) else {
-        return false;
+/// Record the protected SDD files this bootstrap just created.
+///
+/// `specsync init` writes `.specsync/config.toml`, `.specsync/version`, and
+/// `.specsync/sdd.json`. All three are protected SDD paths, so the first commit
+/// after initialization used to land as uncovered meaningful delivery — a gate
+/// no change workspace could have satisfied, because none existed when the
+/// files were written. Recording them here lets the coverage gate recognize
+/// spec-sync's own output without weakening the guard on later edits.
+pub fn record_bootstrap_paths(root: &Path) -> Result<(), String> {
+    let Some(base_commit) = git_output(root, &["rev-parse", "--verify", "HEAD"]) else {
+        // Without Git evidence the coverage gate is disabled anyway
+        // (see `default_policy`), so there is nothing to exempt.
+        return Ok(());
     };
-    let Ok(report) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return false;
+    let mut paths = Vec::new();
+    for candidate in BOOTSTRAP_RECORD_CANDIDATES {
+        let Ok(content) = fs::read(root.join(candidate)) else {
+            continue;
+        };
+        paths.push(serde_json::json!({
+            "path": candidate,
+            "digest": bootstrap_digest(candidate, &content),
+        }));
+    }
+    if paths.is_empty() {
+        return Ok(());
+    }
+    write_json(
+        &root.join(BOOTSTRAP_RECORD_PATH),
+        &serde_json::json!({
+            "version": 1,
+            "created_at": now(),
+            "base_commit": base_commit,
+            "paths": paths,
+        }),
+    )
+}
+
+/// Protected SDD paths a bootstrap record exempts from lifecycle path coverage.
+///
+/// The exemption is deliberately hard to forge. A recorded path is honored only
+/// when all four hold:
+///
+/// 1. it is a protected SDD path — a record can never exempt product source;
+/// 2. it is absent at the delivery comparison base, so a *modification* of an
+///    already-tracked policy file is never exempt, only its creation;
+/// 3. the recorded base commit is a real ancestor of `HEAD`; and
+/// 4. the file still hashes to the digest recorded when spec-sync wrote it
+///    (see [`bootstrap_digest`] for what the policy digest covers).
+///
+/// Editing a bootstrapped file therefore revokes its own exemption and the
+/// normal change workflow applies from that point on.
+fn bootstrap_exempt_paths(root: &Path, comparison_base: &str) -> BTreeSet<String> {
+    let mut exempt = BTreeSet::new();
+    let records = bootstrap_records(root);
+    if records.is_empty() {
+        return exempt;
+    }
+    let Some(base_commit) = comparison_base_commit(root, comparison_base) else {
+        return exempt;
     };
-    let Some(bootstrap) = report.get("bootstrap_policy") else {
-        return false;
-    };
-    if bootstrap.get("path").and_then(serde_json::Value::as_str) != Some(POLICY_PATH) {
+    for record in records {
+        if !is_protected_sdd_path(&record.path) {
+            continue;
+        }
+        if !commit_is_ancestor_of_head(root, &record.base_commit) {
+            continue;
+        }
+        if !project_path_is_absent_at(root, &base_commit, &record.path) {
+            continue;
+        }
+        if !project_path_matches_digest(root, &record.path, &record.digest) {
+            continue;
+        }
+        exempt.insert(record.path);
+    }
+    exempt
+}
+
+struct BootstrapRecord {
+    path: String,
+    digest: String,
+    base_commit: String,
+}
+
+/// Bootstrap records written by `specsync init` and by `change adopt`.
+///
+/// Adoption keeps its original single-path `bootstrap_policy` shape so reports
+/// written by earlier versions keep covering the policy they created.
+fn bootstrap_records(root: &Path) -> Vec<BootstrapRecord> {
+    let mut records = Vec::new();
+    if let Some(report) = read_json_value(root, ".specsync/adoption-report.json")
+        && let Some(bootstrap) = report.get("bootstrap_policy")
+        && let Some(record) = bootstrap_record_entry(bootstrap, bootstrap)
+    {
+        records.push(record);
+    }
+    if let Some(report) = read_json_value(root, BOOTSTRAP_RECORD_PATH)
+        && let Some(entries) = report.get("paths").and_then(serde_json::Value::as_array)
+    {
+        records.extend(
+            entries
+                .iter()
+                .filter_map(|entry| bootstrap_record_entry(entry, &report)),
+        );
+    }
+    records
+}
+
+fn bootstrap_record_entry(
+    entry: &serde_json::Value,
+    base_source: &serde_json::Value,
+) -> Option<BootstrapRecord> {
+    Some(BootstrapRecord {
+        path: entry.get("path")?.as_str()?.to_string(),
+        digest: entry.get("digest")?.as_str()?.to_string(),
+        base_commit: base_source.get("base_commit")?.as_str()?.to_string(),
+    })
+}
+
+fn read_json_value(root: &Path, relative: &str) -> Option<serde_json::Value> {
+    let content = fs::read_to_string(root.join(relative)).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Resolve the single commit a delivery is compared against.
+///
+/// [`pull_request_diff_base`] yields either a `<ref>...HEAD` range or a bare
+/// commit; both reduce to the merge base with `HEAD`.
+fn comparison_base_commit(root: &Path, comparison_base: &str) -> Option<String> {
+    let left = comparison_base
+        .split("...")
+        .next()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(comparison_base);
+    git_output(root, &["merge-base", left, "HEAD"]).or_else(|| {
+        git_output(
+            root,
+            &["rev-parse", "--verify", &format!("{left}^{{commit}}")],
+        )
+    })
+}
+
+fn commit_is_ancestor_of_head(root: &Path, commit: &str) -> bool {
+    if git_output(root, &["rev-parse", "--verify", commit]).is_none() {
         return false;
     }
-    let Some(base_commit) = bootstrap
-        .get("base_commit")
-        .and_then(serde_json::Value::as_str)
-    else {
-        return false;
-    };
-    if git_output(root, &["rev-parse", "--verify", base_commit]).is_none() {
-        return false;
-    }
-    let ancestor_status = Command::new("git")
-        .args(["merge-base", "--is-ancestor", base_commit, "HEAD"])
+    Command::new("git")
+        .args(["merge-base", "--is-ancestor", commit, "HEAD"])
         .current_dir(root)
         .stderr(Stdio::null())
-        .status();
-    if !ancestor_status.is_ok_and(|status| status.success()) {
-        return false;
-    }
-    let Ok(tree_path) = git_repo_relative_path(root, POLICY_PATH) else {
-        return false;
-    };
-    let object = format!("{base_commit}:{tree_path}");
-    if git_output_allow_empty(root, &["show", &object]).is_some() {
-        return false;
-    }
-    let Ok(policy) = fs::read(root.join(POLICY_PATH)) else {
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn project_path_is_absent_at(root: &Path, commit: &str, path: &str) -> bool {
+    let Ok(tree_path) = git_repo_relative_path(root, path) else {
         return false;
     };
+    git_output_allow_empty(root, &["show", &format!("{commit}:{tree_path}")]).is_none()
+}
+
+fn project_path_matches_digest(root: &Path, path: &str, digest: &str) -> bool {
+    let Ok(content) = fs::read(root.join(path)) else {
+        return false;
+    };
+    if bootstrap_digest(path, &content) == digest || content_digest(&content) == digest {
+        return true;
+    }
+    // `.specsync/config.toml` and `.specsync/version` are not covered by the
+    // JSON `eol=lf` attribute, so a Windows autocrlf checkout can rewrite the
+    // bytes without changing the content. Accept that rewrite rather than
+    // revoking the bootstrap on a platform that never edited the file.
+    let lf_only: Vec<u8> = content
+        .iter()
+        .copied()
+        .filter(|byte| *byte != b'\r')
+        .collect();
+    lf_only != content && content_digest(&lf_only) == digest
+}
+
+/// Digest recorded for one bootstrapped path.
+///
+/// The policy is pinned by its *enforcement surface*, not its bytes:
+/// `verification_commands` is cleared before hashing. `init` writes an empty
+/// list whenever it cannot detect a test command and tells the author to fill
+/// it in — pinning that field would revoke the bootstrap for doing exactly what
+/// the tool just asked for. Everything that decides whether the gate bites —
+/// `enabled`, `require_change_for_meaningful_files`, `meaningful_paths`,
+/// `ignored_paths`, custom artifacts, principles — stays pinned, and a policy
+/// that does not parse falls back to a byte digest.
+fn bootstrap_digest(path: &str, content: &[u8]) -> String {
+    if path == POLICY_PATH
+        && let Some(projection) = policy_enforcement_projection(content)
+    {
+        return content_digest(&projection);
+    }
+    content_digest(content)
+}
+
+fn policy_enforcement_projection(content: &[u8]) -> Option<Vec<u8>> {
+    let mut policy: SddPolicy = serde_json::from_slice(content).ok()?;
+    policy.verification_commands.clear();
+    serde_json::to_vec(&policy).ok()
+}
+
+fn content_digest(content: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(policy);
-    let current_digest = format!("{:x}", hasher.finalize());
-    bootstrap.get("digest").and_then(serde_json::Value::as_str) == Some(current_digest.as_str())
+    hasher.update(content);
+    format!("{:x}", hasher.finalize())
 }
 
 fn requirement_id_proposals(root: &Path) -> Vec<serde_json::Value> {
@@ -7301,7 +7478,64 @@ fn requirement_evidence_missing(root: &Path, record: &ChangeRecord, ids: &[Strin
         .collect()
 }
 
-fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result<(), Vec<String>> {
+/// The section name carried by a stub-section validator warning.
+///
+/// Deliberately coupled to the exact text `validator::validate_spec` emits for
+/// an unfinished section, the same way `SCAFFOLD_BOILERPLATE_PREFIXES` is
+/// coupled to the scaffold it detects. Classification is not reused here:
+/// `WarningCategory::classify` matches `requirements` first, so the stub warning
+/// for `## Requirements` never reaches its stub-section arm.
+fn stub_section_warning(warning: &str) -> Option<&str> {
+    warning
+        .strip_prefix("Section ## ")?
+        .strip_suffix(" contains only unfinished draft text")
+}
+
+/// Hard errors plus every suppression one effective-contract validation applied.
+///
+/// Suppressions are carried alongside errors rather than instead of them, so a
+/// module that both fails and suppresses still reports what it let through.
+#[derive(Debug, Default)]
+struct EffectiveContractOutcome {
+    errors: Vec<String>,
+    suppressions: Vec<String>,
+}
+
+impl EffectiveContractOutcome {
+    fn failed(error: String) -> Self {
+        Self {
+            errors: vec![error],
+            suppressions: Vec::new(),
+        }
+    }
+
+    /// Join the errors for gates whose only output channel is a failure string.
+    fn error_text(&self) -> Option<String> {
+        (!self.errors.is_empty()).then(|| self.errors.join("; "))
+    }
+}
+
+/// Validate every canonical contract with the active semantic deltas replayed.
+///
+/// Reports the suppressions applied, so no exemption is silent; `check_project`
+/// and `audit_project` surface them as warnings.
+///
+/// Every validator warning is promoted to a hard error here, which is what makes
+/// an emptied `## MODIFIED` block fatal — the stub warning is the only gate that
+/// sees a section a delta blanked out. Two suppressions are scoped narrowly
+/// around that:
+///
+/// - `.specsyncignore` and inline `<!-- specsync-ignore: … -->` directives, which
+///   apply at every other validation surface and now apply here as well.
+/// - Stub sections **no active change authored**. `specsync new` writes scaffold
+///   placeholders into `## Purpose` and `## Dependencies`, and the first change
+///   against a fresh module was blocked by text the tool itself generated. The
+///   applied `SpecSection` delta keys name exactly the sections a change is
+///   responsible for; anything else is pre-existing canonical text. Authorship
+///   is read from the delta file even when the delta is already applied to the
+///   canonical spec (`canonical_applied` while verifying, where nothing is
+///   replayed), and authorship that cannot be established suppresses nothing.
+fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> EffectiveContractOutcome {
     let active: Vec<&ChangeRecord> = records
         .iter()
         .filter(|record| {
@@ -7314,19 +7548,30 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
         })
         .collect();
     if active.is_empty() {
-        return Ok(());
+        return EffectiveContractOutcome::default();
     }
-    let active = dependency_ordered_changes(active)
-        .map_err(|error| vec![format!("effective contract ordering: {error}")])?;
+    let active = match dependency_ordered_changes(active) {
+        Ok(active) => active,
+        Err(error) => {
+            return EffectiveContractOutcome::failed(format!(
+                "effective contract ordering: {error}"
+            ));
+        }
+    };
     let mut modules = BTreeSet::new();
     for record in &active {
         modules.extend(record.affected_specs.iter().cloned());
     }
-    let temp = create_effective_contract_workspace().map_err(|error| vec![error])?;
+    let temp = match create_effective_contract_workspace() {
+        Ok(temp) => temp,
+        Err(error) => return EffectiveContractOutcome::failed(error),
+    };
     let config = crate::config::load_config(root);
     let schema_tables = crate::validator::get_schema_table_names(root, &config);
     let schema_columns = crate::commands::build_schema_columns(root, &config);
+    let ignore_rules = crate::ignore::IgnoreRules::load(root);
     let mut errors = Vec::new();
+    let mut suppressions = Vec::new();
     for module in modules {
         let canonical = match canonical_module_paths(root, &config.specs_dir, &module) {
             Ok((spec_path, _)) => spec_path,
@@ -7346,15 +7591,33 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
                 continue;
             }
         };
+        // Sections written by an active change, lowercased. A change owns every
+        // section its delta names, whether or not that delta is replayed here.
+        let mut authored_sections: BTreeSet<String> = BTreeSet::new();
+        // An unreadable delta leaves authorship unknown, which suppresses nothing.
+        let mut authorship_known = true;
         for record in &active {
-            if record.canonical_applied || !record.affected_specs.contains(&module) {
+            if !record.affected_specs.contains(&module) {
                 continue;
             }
-            let delta_path =
-                delta_path_checked(root, record, &module).map_err(|error| vec![error])?;
+            // An applied delta is already part of the canonical spec, so it is read
+            // for authorship only. Its absence is not a new hard error at this gate.
+            let applied = record.canonical_applied;
+            let delta_path = match delta_path_checked(root, record, &module) {
+                Ok(path) => path,
+                Err(_) if applied => {
+                    authorship_known = false;
+                    continue;
+                }
+                Err(error) => return EffectiveContractOutcome::failed(error),
+            };
             let delta = match read_bounded_change_text(&delta_path, "semantic delta") {
                 Ok(delta) => delta,
                 Err(error) => {
+                    if applied {
+                        authorship_known = false;
+                        continue;
+                    }
                     errors.push(format!(
                         "{} effective delta for `{module}`: {error}",
                         record.id
@@ -7368,6 +7631,10 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
                         .into_iter()
                         .filter(|item| item.target == DeltaTarget::SpecSection)
                     {
+                        authored_sections.insert(item.key.to_ascii_lowercase());
+                        if applied {
+                            continue;
+                        }
                         match apply_markdown_block(
                             &spec,
                             "## ",
@@ -7382,7 +7649,13 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
                         }
                     }
                 }
-                Err(error) => errors.push(format!("{} effective `{module}`: {error}", record.id)),
+                Err(error) => {
+                    if applied {
+                        authorship_known = false;
+                        continue;
+                    }
+                    errors.push(format!("{} effective `{module}`: {error}", record.id));
+                }
             }
         }
         let effective_dir = temp.join(&module);
@@ -7391,10 +7664,14 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
             continue;
         }
         let effective = effective_dir.join(format!("{module}.spec.md"));
+        let inline_ignores = crate::ignore::IgnoreRules::parse_inline(&spec);
         if let Err(error) = fs::write(&effective, spec) {
             errors.push(format!("failed to write effective contract: {error}"));
             continue;
         }
+        // Ignore rules are written against the canonical spec path, not the
+        // temporary effective copy this gate validates.
+        let spec_rel_path = portable_project_path(root, &canonical);
         let result = crate::validator::validate_spec(
             &effective,
             root,
@@ -7406,15 +7683,36 @@ fn validate_effective_contracts(root: &Path, records: &[ChangeRecord]) -> Result
             result
                 .errors
                 .into_iter()
-                .chain(result.warnings)
                 .map(|error| format!("effective contract `{module}`: {error}")),
         );
+        for warning in result.warnings {
+            if let Some((category, source)) =
+                ignore_rules.suppression_source(&warning, &spec_rel_path, &inline_ignores)
+            {
+                suppressions.push(format!(
+                    "effective contract `{module}`: suppressed `{}` warning by {source} ignore rule: {warning}",
+                    category.as_str()
+                ));
+                continue;
+            }
+            if authorship_known
+                && let Some(section) = stub_section_warning(&warning)
+                && !authored_sections.contains(&section.to_ascii_lowercase())
+            {
+                suppressions.push(format!(
+                    "effective contract `{module}`: {warning}; no active change authored ## {section}, \
+                     so it is not blocking — complete it in {spec_rel_path} or suppress it with \
+                     `stub-section:{spec_rel_path}` in .specsyncignore"
+                ));
+                continue;
+            }
+            errors.push(format!("effective contract `{module}`: {warning}"));
+        }
     }
     let _ = fs::remove_dir_all(temp);
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors)
+    EffectiveContractOutcome {
+        errors,
+        suppressions,
     }
 }
 
@@ -14504,6 +14802,46 @@ fn record_verification_attempt(
     )
 }
 
+/// The coverage gate is the first hard failure most projects meet, and the way
+/// out of it — opening a change workspace, optionally without a spec change —
+/// is not discoverable from the bare list of paths. Name the command, and say
+/// why an `ignored_paths` entry did not apply when one appears to cover a
+/// reported path: protected SDD policy files and the configured specs tree are
+/// structurally meaningful and cannot be ignored away.
+fn uncovered_paths_error(policy: &SddPolicy, paths: &[String]) -> String {
+    let mut message = format!(
+        "meaningful changed paths are not covered by an active change: {}",
+        paths.join(", ")
+    );
+    let mut path_flags = String::new();
+    for path in paths {
+        path_flags.push_str(&format!(" --path {path}"));
+    }
+    message.push_str(&format!(
+        "\n  cover them: specsync change new \"<summary>\" --kind fix --spec <module>{path_flags}"
+    ));
+    message.push_str(
+        "\n  no spec text changes: add --no-spec-change --rationale \"<why>\" to that command",
+    );
+    let shadowed: Vec<&str> = paths
+        .iter()
+        .filter(|path| {
+            policy
+                .ignored_paths
+                .iter()
+                .any(|scope| path_matches_scope(path, scope))
+        })
+        .map(String::as_str)
+        .collect();
+    if !shadowed.is_empty() {
+        message.push_str(&format!(
+            "\n  note: an ignored_paths entry covers {}, but SDD policy files and the configured specs tree are always meaningful",
+            shadowed.join(", ")
+        ));
+    }
+    message
+}
+
 fn uncovered_meaningful_paths(
     root: &Path,
     policy: &SddPolicy,
@@ -14536,8 +14874,8 @@ fn uncovered_meaningful_paths(
             changed.extend(output.lines().map(str::to_string));
         }
     }
-    if adoption_bootstrap_covers_policy(root) {
-        changed.remove(POLICY_PATH);
+    for path in bootstrap_exempt_paths(root, &base) {
+        changed.remove(&path);
     }
     // Same-PR finalize archives the covering change before merge. Product paths
     // remain in the delivery vs base, but the archive package is on the tip.
@@ -14688,7 +15026,7 @@ fn pull_request_diff_base(root: &Path, records: &[ChangeRecord]) -> String {
     if let Some(remote_default) = remote_default_ref(root) {
         return format!("{remote_default}...HEAD");
     }
-    recorded_diff_base(records)
+    recorded_diff_base(root, records)
 }
 
 fn remote_default_ref(root: &Path) -> Option<String> {
@@ -14704,12 +15042,23 @@ fn remote_default_ref(root: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
-fn recorded_diff_base(records: &[ChangeRecord]) -> String {
+fn recorded_diff_base(root: &Path, records: &[ChangeRecord]) -> String {
     records
         .iter()
         .filter_map(|record| record.base_commit.clone())
         .next()
-        .unwrap_or_else(|| "HEAD~1...HEAD".into())
+        .unwrap_or_else(|| {
+            // `HEAD~1` does not resolve in a repository whose first commit is
+            // also its only one, and the resulting `git diff` failure reported
+            // the entire gate as broken ("unable to inspect changed paths").
+            // There is no earlier commit to review, so the committed delivery
+            // is empty and only the working tree is up for coverage.
+            if git_output(root, &["rev-parse", "--verify", "HEAD~1"]).is_some() {
+                "HEAD~1...HEAD".into()
+            } else {
+                "HEAD".into()
+            }
+        })
 }
 
 #[cfg(test)]
@@ -26234,7 +26583,11 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
-        assert!(validate_effective_contracts(temp.path(), &[record]).is_ok());
+        assert!(
+            validate_effective_contracts(temp.path(), &[record])
+                .errors
+                .is_empty()
+        );
     }
 
     #[test]
@@ -26254,7 +26607,11 @@ mod tests {
                 .is_err(),
             "the fixture must fail if an already-applied delta is replayed"
         );
-        assert!(validate_effective_contracts(root, &[record.clone()]).is_ok());
+        assert!(
+            validate_effective_contracts(root, &[record.clone()])
+                .errors
+                .is_empty()
+        );
 
         fs::write(
             root.join("specs/auth/auth.spec.md"),
@@ -26262,12 +26619,210 @@ mod tests {
         )
         .unwrap();
 
-        let errors = validate_effective_contracts(root, &[record]).unwrap_err();
+        let errors = validate_effective_contracts(root, &[record]).errors;
         assert!(
             errors
                 .iter()
                 .any(|error| error.contains("effective contract `auth`")),
             "{errors:?}"
+        );
+    }
+
+    /// The canonical spec a fresh `specsync new` leaves behind: real structure,
+    /// scaffold placeholder prose in `## Purpose` and `## Dependencies`.
+    fn write_scaffolded_auth_spec(root: &Path) {
+        fs::write(
+            root.join("specs/auth/auth.spec.md"),
+            "---\nmodule: auth\nversion: 1.0.0\nstatus: stable\nfiles:\n  - src/auth.rs\n---\n\n# Auth\n\n## Purpose\n\nDocument this module's responsibility, inputs, outputs, and ownership boundaries.\n\n## Public API\n\nNone.\n\n## Invariants\n\nStable.\n\n## Behavioral Examples\n\nWorks.\n\n## Error Cases\n\nNone.\n\n## Dependencies\n\nList runtime dependencies and the specific symbols, services, or data they provide.\n\n## Legacy Notes\n\nRetained for compatibility.\n\n## Change Log\n\n| Date | Change |\n|------|--------|\n| 2026-01-01 | Initial |\n",
+        )
+        .unwrap();
+    }
+
+    // Verifies REQ-change-059. The content-loss path stays closed: a `## MODIFIED`
+    // block with an empty body blanks the section in the canonical spec, and the
+    // stub warning is the only gate that sees it.
+    #[test]
+    fn effective_contract_keeps_authored_emptied_section_fatal() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let delta = "## MODIFIED\n\n### SPEC SECTION Dependencies\n";
+        let mut record = completed_section_only_record(root, delta);
+        record.state = ChangeState::Approved;
+
+        let errors = validate_effective_contracts(root, &[record]).errors;
+
+        assert!(
+            errors.iter().any(|error| error
+                == "effective contract `auth`: Section ## Dependencies contains only unfinished draft text"),
+            "{errors:?}"
+        );
+    }
+
+    // Verifies REQ-change-059. Same content loss through the `canonical_applied`
+    // path, where the delta is never replayed: authorship comes from the delta
+    // file, so the emptied section stays fatal.
+    #[test]
+    fn effective_contract_keeps_applied_authored_emptied_section_fatal() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let delta = "## MODIFIED\n\n### SPEC SECTION Dependencies\n";
+        let mut record = completed_section_only_record(root, delta);
+        record.state = ChangeState::Verifying;
+        record.canonical_applied = true;
+        save_change(root, &record).unwrap();
+        let canonical = fs::read_to_string(root.join("specs/auth/auth.spec.md")).unwrap();
+        let item = parse_delta(delta).unwrap().remove(0);
+        fs::write(
+            root.join("specs/auth/auth.spec.md"),
+            apply_markdown_block(&canonical, "## ", &item.key, &item.content, item.operation)
+                .unwrap(),
+        )
+        .unwrap();
+
+        let errors = validate_effective_contracts(root, &[record]).errors;
+
+        assert!(
+            errors.iter().any(|error| error
+                == "effective contract `auth`: Section ## Dependencies contains only unfinished draft text"),
+            "{errors:?}"
+        );
+    }
+
+    // Verifies REQ-change-059.
+    #[test]
+    fn effective_contract_exempts_stub_sections_no_active_change_authored() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let delta = "## MODIFIED\n\n### SPEC SECTION Invariants\n\nPasskey material never leaves the enclave.\n";
+        let mut record = completed_section_only_record(root, delta);
+        record.state = ChangeState::Approved;
+        write_scaffolded_auth_spec(root);
+
+        let outcome = validate_effective_contracts(root, &[record]);
+
+        assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
+        let suppressions = outcome.suppressions;
+        for section in ["Purpose", "Dependencies"] {
+            assert!(
+                suppressions.iter().any(|note| note.contains(&format!(
+                    "Section ## {section} contains only unfinished draft text"
+                )) && note
+                    .contains(&format!("no active change authored ## {section}"))),
+                "{suppressions:?}"
+            );
+        }
+        assert!(
+            !suppressions
+                .iter()
+                .any(|note| note.contains("## Invariants")),
+            "{suppressions:?}"
+        );
+    }
+
+    // Verifies REQ-change-059. Authorship that cannot be read exempts nothing.
+    #[test]
+    fn effective_contract_exempts_nothing_when_authorship_is_unknown() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let delta = "## MODIFIED\n\n### SPEC SECTION Invariants\n\nStable.\n";
+        let mut record = completed_section_only_record(root, delta);
+        record.state = ChangeState::Verifying;
+        record.canonical_applied = true;
+        save_change(root, &record).unwrap();
+        write_scaffolded_auth_spec(root);
+        fs::remove_file(delta_path(root, &record, "auth")).unwrap();
+
+        let errors = validate_effective_contracts(root, &[record]).errors;
+
+        assert!(
+            errors.iter().any(|error| error
+                == "effective contract `auth`: Section ## Purpose contains only unfinished draft text"),
+            "{errors:?}"
+        );
+    }
+
+    // Verifies REQ-change-059. `.specsyncignore` reaches this gate, and the
+    // suppression it grants is reported rather than silent.
+    #[test]
+    fn effective_contract_reports_ignore_rule_suppressions() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let delta = "## MODIFIED\n\n### SPEC SECTION Dependencies\n";
+        let mut record = completed_section_only_record(root, delta);
+        record.state = ChangeState::Approved;
+        fs::write(root.join(".specsyncignore"), "stub-section:specs/auth/\n").unwrap();
+
+        let outcome = validate_effective_contracts(root, &[record]);
+
+        assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
+        assert!(
+            outcome.suppressions.iter().any(|note| note.contains(
+                "suppressed `stub-section` warning by path ignore rule: Section ## Dependencies"
+            )),
+            "{:?}",
+            outcome.suppressions
+        );
+    }
+
+    // Verifies REQ-change-059. A module that fails still reports what it let
+    // through, so a suppression is never lost behind an unrelated error.
+    #[test]
+    fn effective_contract_reports_suppressions_alongside_errors() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        // Authors `## Dependencies` (emptied — fatal) and leaves the scaffolded
+        // `## Purpose` alone (suppressed).
+        let delta = "## MODIFIED\n\n### SPEC SECTION Dependencies\n";
+        let mut record = completed_section_only_record(root, delta);
+        record.state = ChangeState::Approved;
+        write_scaffolded_auth_spec(root);
+
+        let outcome = validate_effective_contracts(root, &[record]);
+
+        assert!(
+            outcome.errors.iter().any(|error| error
+                == "effective contract `auth`: Section ## Dependencies contains only unfinished draft text"),
+            "{:?}",
+            outcome.errors
+        );
+        assert!(
+            outcome
+                .suppressions
+                .iter()
+                .any(|note| note.contains("no active change authored ## Purpose")),
+            "{:?}",
+            outcome.suppressions
+        );
+    }
+
+    // Verifies REQ-change-059. Suppressions reach the surfaces that report them.
+    #[test]
+    fn project_check_reports_effective_contract_suppressions_as_warnings() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let delta = "## MODIFIED\n\n### SPEC SECTION Invariants\n\nPasskey material never leaves the enclave.\n";
+        let record = completed_section_only_record(root, delta);
+        approve_definition(root, &record.id, Some("Reviewer".into()), None).unwrap();
+        write_scaffolded_auth_spec(root);
+
+        let report = check_project(root);
+
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("effective contract `auth`")
+                    && warning.contains("Section ## Purpose contains only unfinished draft text")),
+            "{:?}",
+            report.warnings
+        );
+        assert!(
+            !report
+                .errors
+                .iter()
+                .any(|error| error.contains("unfinished draft text")),
+            "{:?}",
+            report.errors
         );
     }
 
@@ -28076,7 +28631,11 @@ mod tests {
         let mut second = first.clone();
         second.id = "CHG-0002-second".into();
         second.base_commit = Some("00000000".into());
-        assert_eq!(recorded_diff_base(&[first, second]), "ffffffff");
+        let temp = TempDir::new().unwrap();
+        assert_eq!(
+            recorded_diff_base(temp.path(), &[first, second]),
+            "ffffffff"
+        );
     }
 
     #[test]
@@ -28320,7 +28879,11 @@ mod tests {
 
         let mut effective_record = record;
         effective_record.state = ChangeState::Approved;
-        assert!(validate_effective_contracts(root, &[effective_record]).is_ok());
+        assert!(
+            validate_effective_contracts(root, &[effective_record])
+                .errors
+                .is_empty()
+        );
     }
 
     // Verifies REQ-change-041.
@@ -28437,7 +29000,7 @@ mod tests {
 
         let mut effective_record = record;
         effective_record.state = ChangeState::Approved;
-        let errors = validate_effective_contracts(root, &[effective_record]).unwrap_err();
+        let errors = validate_effective_contracts(root, &[effective_record]).errors;
         assert!(
             errors
                 .iter()
@@ -29124,6 +29687,93 @@ mod tests {
             uncovered_meaningful_paths(root, &changed, &[])
                 .unwrap()
                 .contains(&POLICY_PATH.to_string())
+        );
+    }
+
+    #[test]
+    fn bootstrap_records_exempt_only_newly_created_protected_paths() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let git = |args: &[&str]| {
+            assert!(
+                Command::new("git")
+                    .args(args)
+                    .current_dir(root)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), "base\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "base"]);
+        git(&["update-ref", "refs/remotes/origin/main", "HEAD"]);
+
+        write_json(&root.join(POLICY_PATH), &SddPolicy::default()).unwrap();
+        fs::create_dir_all(root.join(".specsync")).unwrap();
+        fs::write(root.join(".specsync/version"), "5.0.0\n").unwrap();
+        record_bootstrap_paths(root).unwrap();
+        let policy = SddPolicy::default();
+        assert!(
+            uncovered_meaningful_paths(root, &policy, &[])
+                .unwrap()
+                .is_empty(),
+            "a fresh bootstrap covers the protected files it created"
+        );
+
+        // A forged record cannot lend coverage to product source.
+        let digest = content_digest(b"forged\n");
+        fs::write(root.join("src/lib.rs"), "forged\n").unwrap();
+        let head = git_output(root, &["rev-parse", "--verify", "HEAD"]).unwrap();
+        write_json(
+            &root.join(BOOTSTRAP_RECORD_PATH),
+            &serde_json::json!({
+                "version": 1,
+                "base_commit": head,
+                "paths": [{"path": "src/lib.rs", "digest": digest}],
+            }),
+        )
+        .unwrap();
+        assert!(
+            uncovered_meaningful_paths(root, &policy, &[])
+                .unwrap()
+                .contains(&"src/lib.rs".to_string()),
+            "a bootstrap record must never exempt product source"
+        );
+
+        // Nor can it exempt a policy file that already exists at the base.
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "bootstrap"]);
+        git(&["update-ref", "refs/remotes/origin/main", "HEAD"]);
+        fs::write(root.join(".specsync/version"), "5.0.1\n").unwrap();
+        record_bootstrap_paths(root).unwrap();
+        assert!(
+            uncovered_meaningful_paths(root, &policy, &[])
+                .unwrap()
+                .contains(&".specsync/version".to_string()),
+            "re-recording must not exempt an edit to an already-tracked policy file"
+        );
+    }
+
+    #[test]
+    fn uncovered_paths_error_names_the_escape_hatch_and_ignore_precedence() {
+        let policy = SddPolicy::default();
+        let message = uncovered_paths_error(
+            &policy,
+            &["src/lib.rs".to_string(), "specs/zzz/note.md".to_string()],
+        );
+        assert!(message.contains("specsync change new"));
+        assert!(message.contains("--path src/lib.rs"));
+        assert!(message.contains("--no-spec-change"));
+        assert!(
+            message.contains("an ignored_paths entry covers specs/zzz/note.md")
+                && message.contains("always meaningful")
+                && !message.contains("covers src/lib.rs"),
+            "only paths shadowed by an ignored_paths entry get the precedence note: {message}"
         );
     }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -192,6 +192,14 @@ fn execute_init(root: &Path, repair: bool) -> Result<InitReport, Box<InitReport>
 
     let mut restored = Vec::new();
     let mut warnings = Vec::new();
+    // Every file init just wrote is a protected SDD path, so without this record
+    // the very next `specsync check` reports init's own output as uncovered
+    // meaningful delivery — a gate no change workspace could have satisfied,
+    // because none existed when the files were written. Non-fatal: a project
+    // without Git evidence has no coverage gate to satisfy in the first place.
+    if let Err(error) = crate::change::record_bootstrap_paths(root) {
+        warnings.push(error);
+    }
     // An empty verification command list is written silently and only surfaces
     // later, when a lifecycle command fails naming a file the user has never
     // opened. Say it here, while they are still looking at init output.
@@ -883,6 +891,81 @@ mod tests {
         assert!(root.join(".specsync/.gitignore").is_file());
         assert!(root.join(".specsync/sdd.json").is_file());
         assert!(missing_support_files(root).is_empty());
+    }
+
+    #[test]
+    fn fresh_init_leaves_the_next_lifecycle_check_clean() {
+        // #542 first-five-minutes: `git init` → `specsync init` → commit →
+        // `specsync check` reported init's own protected output as uncovered
+        // meaningful delivery, a gate no change workspace could satisfy.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let git = |args: &[&str]| {
+            assert!(
+                std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(root)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "init"]);
+
+        cmd_init(root, false, crate::types::OutputFormat::Text);
+        assert!(
+            root.join(".specsync/bootstrap.json").is_file(),
+            "init must record the protected files it created"
+        );
+        // The gate must also survive being run before that output is committed:
+        // `HEAD~1` does not resolve in a one-commit repository.
+        let uncommitted = crate::change::check_project(root);
+        assert!(
+            uncommitted.errors.is_empty(),
+            "checking before the bootstrap commit must not fail: {:?}",
+            uncommitted.errors
+        );
+        // Init tells the author to fill in verification commands when it cannot
+        // detect any. Doing so must not revoke the bootstrap it just recorded.
+        let policy_path = root.join(".specsync/sdd.json");
+        let write_policy = |policy: &crate::change::SddPolicy| {
+            fs::write(
+                &policy_path,
+                format!("{}\n", serde_json::to_string_pretty(policy).unwrap()),
+            )
+            .unwrap();
+        };
+        let mut policy = crate::change::load_policy(root).unwrap();
+        policy.verification_commands = vec!["true".to_string()];
+        write_policy(&policy);
+
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "Add: initialize spec-sync"]);
+
+        let report = crate::change::check_project(root);
+        assert!(
+            report.errors.is_empty(),
+            "the first check after init must pass: {:?}",
+            report.errors
+        );
+
+        // The pin still covers the enforcement surface: widening the policy's
+        // meaningful paths revokes the exemption it was granted.
+        policy.meaningful_paths.push("private/".into());
+        write_policy(&policy);
+        assert!(
+            crate::change::check_project(root)
+                .errors
+                .iter()
+                .any(|error| error.contains(".specsync/sdd.json")),
+            "editing a bootstrapped policy must revoke its own exemption"
+        );
     }
 
     #[test]

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -1091,7 +1091,15 @@ fn snapshot_source_file(project: &Dir, mapping: &str, max_bytes: u64) -> SourceS
         Err(error) if error.kind() == io::ErrorKind::NotFound => return SourceSnapshot::Missing,
         Err(_) => return SourceSnapshot::Unreadable,
     };
-    if is_link_or_reparse_point(&metadata) || !metadata.is_file() {
+    if is_link_or_reparse_point(&metadata) {
+        return SourceSnapshot::Rejected;
+    }
+    // A confined directory is a mapping-shape error, not a security escape: report
+    // it as one instead of hiding the real cause behind the escape message.
+    if metadata.is_dir() {
+        return SourceSnapshot::Directory;
+    }
+    if !metadata.is_file() {
         return SourceSnapshot::Rejected;
     }
     let identity = match discovered_file_identity(&directory, name, &metadata) {
@@ -2335,6 +2343,63 @@ mod tests {
         assert!(!combined.contains("OUTSIDE_SOURCE_SECRET"));
         assert!(!combined.contains(&outside.to_string_lossy().to_string()));
         assert_eq!(fs::read(&outside).unwrap(), outside_bytes);
+    }
+
+    #[test]
+    fn snapshot_validation_reports_a_directory_mapping_as_a_directory() {
+        // Regression (#472): the snapshot path already refused to read a directory
+        // mapping, but reported it as an out-of-root escape. Name the real cause so
+        // both validation paths agree on why the mapping is invalid.
+        let temporary = tempfile::TempDir::new().unwrap();
+        let root = temporary.path().join("project");
+        fs::create_dir_all(root.join("src/provider")).unwrap();
+        fs::create_dir_all(root.join("specs/provider")).unwrap();
+        fs::write(
+            root.join("src/provider/provider.rs"),
+            "pub fn provide() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("specs/provider/provider.spec.md"),
+            concat!(
+                "---\nmodule: provider\nversion: 1\nstatus: active\nfiles:\n",
+                "  - src/provider\n---\n\n",
+                "## Purpose\nProvide.\n\n## Requirements\nProvide.\n\n",
+                "## Public API\n| Name | Description |\n|---|---|\n\n",
+                "## Invariants\nSafe.\n\n## Behavioral Examples\nWorks.\n\n",
+                "## Error Cases\nNone.\n\n## Dependencies\nNone.\n\n",
+                "## Change Log\n- Initial.\n",
+            ),
+        )
+        .unwrap();
+
+        let opened = open_specs_directory(&root, "specs")
+            .expect("configuration must be confined")
+            .expect("specs directory must exist");
+        let (snapshots, findings) = find_spec_snapshots_checked_with_hook(&opened, |_| {});
+        assert!(findings.is_empty());
+
+        let config = crate::config::load_config(&root);
+        let (errors, _, _) = collect_snapshot_validation_with_hook(
+            &opened.project,
+            &root,
+            &snapshots,
+            &config,
+            || {},
+        );
+        let errors = errors.to_vec();
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("`src/provider` is a directory")),
+            "expected a directory mapping error, got: {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .all(|error| !error.contains("resolves outside the project root")),
+            "a confined directory is not an escape: {errors:?}"
+        );
     }
 
     #[test]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -522,7 +522,15 @@ Document this module's responsibility, inputs, outputs, and ownership boundaries
 }
 
 /// Find source files in a module directory.
-fn find_module_source_files(dir: &Path, config: &SpecSyncConfig, root: &Path) -> Vec<String> {
+///
+/// Shared with spec validation: a `files:` entry that resolves to a directory is
+/// rejected with a fix naming these same files, so the remedy a spec author is
+/// told to paste matches what generation would have written.
+pub(crate) fn find_module_source_files(
+    dir: &Path,
+    config: &SpecSyncConfig,
+    root: &Path,
+) -> Vec<String> {
     let mut results = Vec::new();
     if !dir.exists() {
         return results;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1839,6 +1839,9 @@ pub(crate) enum SourceSnapshot {
     Missing,
     Rejected,
     Unreadable,
+    /// The mapping resolved to a directory inside the project. Kept distinct from
+    /// `Rejected` so validation reports the real cause instead of a security escape.
+    Directory,
 }
 
 /// Validate a single spec file against source code.
@@ -2072,6 +2075,14 @@ fn validate_spec_content_internal(
             source_snapshots.is_none() && full_path.exists() && !source_within_root(root, file);
         let confined_rejection = matches!(snapshot, Some(SourceSnapshot::Rejected))
             || (source_snapshots.is_none() && !source_within_root(root, file));
+        // A `files:` entry that resolves to a directory extracts zero exports, so
+        // leaving it unreported lets a spec document nothing and still pass the
+        // Public API comparison — the gate goes green while measuring nothing.
+        let directory_mapping = matches!(snapshot, Some(SourceSnapshot::Directory))
+            || (source_snapshots.is_none()
+                && safe_project_relative
+                && full_path.is_dir()
+                && source_within_root(root, file));
         if ambient_existing_escape || (safe_project_relative && confined_rejection) {
             result.errors.push(format!(
                 "Source file `{file}` resolves outside the project root and is ignored for security"
@@ -2086,6 +2097,13 @@ fn validate_spec_content_internal(
             result.fixes.push(format!(
                 "Use a safe project-relative path for `{file}` (no absolute paths, `..`, drive prefixes, or backslashes)"
             ));
+        } else if directory_mapping {
+            result.errors.push(format!(
+                "Source file `{file}` is a directory — `files:` must list source files, not directories"
+            ));
+            result
+                .fixes
+                .push(directory_mapping_fix(root, file, config, source_snapshots));
         } else if matches!(snapshot, Some(SourceSnapshot::Unreadable)) {
             result.errors.push(format!(
                 "Source file `{file}` could not be read for validation"
@@ -2817,6 +2835,77 @@ fn suggest_similar_file(root: &Path, missing_file: &str) -> Option<String> {
     }
 
     best.map(|(s, _)| s)
+}
+
+/// How many expanded source files a directory-mapping fix names before summarizing.
+const DIRECTORY_MAPPING_FIX_LIMIT: usize = 5;
+
+/// Build the actionable fix for a `files:` entry that resolved to a directory.
+///
+/// Names the source files the entry should have listed, reusing the same
+/// directory expansion `generate`/`scaffold` apply to a `[modules."x"] files`
+/// directory (`generator::find_module_source_files`), so the remedy matches what
+/// generation would have written. Snapshot callers validate retained bytes only
+/// and must not enumerate the ambient filesystem, so they get the shape guidance
+/// without the file list.
+fn directory_mapping_fix(
+    root: &Path,
+    file: &str,
+    config: &SpecSyncConfig,
+    source_snapshots: Option<&HashMap<String, SourceSnapshot>>,
+) -> String {
+    let expanded = if source_snapshots.is_none() {
+        expand_directory_mapping(root, file, config)
+    } else {
+        Vec::new()
+    };
+    if expanded.is_empty() {
+        return format!(
+            "Replace `{file}` in the files list with the source files beneath it (one entry per file)"
+        );
+    }
+    let shown: Vec<String> = expanded
+        .iter()
+        .take(DIRECTORY_MAPPING_FIX_LIMIT)
+        .cloned()
+        .collect();
+    let remaining = expanded.len().saturating_sub(shown.len());
+    let listed = shown.join(", ");
+    if remaining > 0 {
+        format!(
+            "Replace `{file}` in the files list with the {} source files beneath it: {listed}, and {remaining} more",
+            expanded.len()
+        )
+    } else {
+        format!("Replace `{file}` in the files list with: {listed}")
+    }
+}
+
+/// Expand a project-relative directory into the root-relative source files beneath
+/// it, excluding configured exclude directories. Ambient filesystem read: callers
+/// must confine the entry first (`source_within_root`).
+fn expand_directory_mapping(root: &Path, file: &str, config: &SpecSyncConfig) -> Vec<String> {
+    let full_path = root.join(file);
+    let mut expanded: Vec<String> =
+        crate::generator::find_module_source_files(&full_path, config, root)
+            .into_iter()
+            .filter_map(|path| {
+                let relative = Path::new(&path)
+                    .strip_prefix(root)
+                    .ok()
+                    .map(|relative| relative.to_string_lossy().replace('\\', "/"))?;
+                let excluded = Path::new(&relative).components().any(|component| {
+                    component
+                        .as_os_str()
+                        .to_str()
+                        .is_some_and(|name| config.exclude_dirs.iter().any(|dir| dir == name))
+                });
+                (!excluded).then_some(relative)
+            })
+            .collect();
+    expanded.sort();
+    expanded.dedup();
+    expanded
 }
 
 /// Whether a spec `files:` entry resolves to a real path INSIDE the project root.
@@ -4208,6 +4297,124 @@ mod tests {
                 .errors
                 .iter()
                 .any(|e| e.contains("Source file not found"))
+        );
+    }
+
+    #[test]
+    fn directory_source_mapping_fails_loud_and_names_the_files_to_list() {
+        // Regression (#472): a `files:` entry that resolves to a directory yields
+        // zero exports, so the whole Public API comparison used to be skipped while
+        // the entry still counted as an existing source file — a spec documenting
+        // nothing passed `check --strict`. The directory must fail loud instead.
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src/provider");
+        fs::create_dir_all(src_dir.join("nested")).unwrap();
+        fs::write(src_dir.join("provider.ts"), "export class Provider {}\n").unwrap();
+        fs::write(
+            src_dir.join("nested/deep.ts"),
+            "export function deep() {}\n",
+        )
+        .unwrap();
+
+        let spec = tmp.path().join("provider.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: provider\nversion: 1\nstatus: stable\nfiles:\n  - src/provider\n---\n\n## Purpose\nTest\n## Public API\n## Invariants\n## Behavioral Examples\n## Error Cases\n## Dependencies\n## Change Log\n",
+        )
+        .unwrap();
+
+        let tables = HashSet::new();
+        let schema_cols = HashMap::new();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(&spec, tmp.path(), &tables, &schema_cols, &config);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.contains("`src/provider` is a directory")),
+            "expected a directory mapping error, got: {:?}",
+            result.errors
+        );
+        assert!(
+            result.fixes.iter().any(|fix| {
+                fix.contains("src/provider/provider.ts")
+                    && fix.contains("src/provider/nested/deep.ts")
+            }),
+            "expected the fix to name the source files beneath the directory, got: {:?}",
+            result.fixes
+        );
+    }
+
+    #[test]
+    fn directory_source_mapping_does_not_disturb_sibling_file_mappings() {
+        // A mixed list keeps validating its file entries: the directory entry is the
+        // only failure, and the real file's undocumented export is still reported.
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src/provider");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::write(src_dir.join("provider.ts"), "export class Provider {}\n").unwrap();
+
+        let spec = tmp.path().join("provider.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: provider\nversion: 1\nstatus: stable\nfiles:\n  - src/provider\n  - src/provider/provider.ts\n---\n\n## Purpose\nTest\n## Public API\n## Invariants\n## Behavioral Examples\n## Error Cases\n## Dependencies\n## Change Log\n",
+        )
+        .unwrap();
+
+        let tables = HashSet::new();
+        let schema_cols = HashMap::new();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(&spec, tmp.path(), &tables, &schema_cols, &config);
+        assert_eq!(
+            result
+                .errors
+                .iter()
+                .filter(|error| error.contains("is a directory"))
+                .count(),
+            1,
+            "only the directory entry may fail: {:?}",
+            result.errors
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("Provider")),
+            "the file entry must still be scanned for exports: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn draft_directory_source_mapping_is_not_a_planned_mapping_notice() {
+        // A draft may map a file that does not exist yet; an existing directory is a
+        // wrong-shaped mapping in any status and must not pass as a planned mapping.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("src/provider")).unwrap();
+
+        let spec = tmp.path().join("provider.spec.md");
+        fs::write(
+            &spec,
+            "---\nmodule: provider\nversion: 1\nstatus: draft\nfiles:\n  - src/provider\n---\n\n## Purpose\nTest\n",
+        )
+        .unwrap();
+
+        let tables = HashSet::new();
+        let schema_cols = HashMap::new();
+        let config = SpecSyncConfig::default();
+        let result = validate_spec(&spec, tmp.path(), &tables, &schema_cols, &config);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.contains("is a directory")),
+            "expected a directory mapping error for a draft, got: {:?}",
+            result.errors
+        );
+        assert!(
+            result.notices.is_empty(),
+            "a directory must not be recorded as a planned mapping: {:?}",
+            result.notices
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the first five minutes of spec-sync. Three defects sit directly on the path a new
adopter walks, and all three were found by walking it rather than by reading code. They
are the remaining RC blockers on the **product surface** for `v6.0.0-rc.1`.

| | before | after |
|---|---|---|
| `git init` → `specsync init` → `specsync check` | **exit 1**, uncovered meaningful delivery | **exit 0** |
| `specsync scaffold auth` → `specsync check` | **exit 1** on the tool's own generated prose | **exit 0** |
| a directory in a spec's `files:` block | **exit 0, zero warnings, nothing measured** | **exit 1**, named, with the files to list |

### 1. `init` left a repository failing its own coverage gate

Every file `init` writes — `.specsync/config.toml`, `.specsync/version`,
`.specsync/sdd.json` — is a protected SDD path, and `path_is_meaningful_with_specs`
returns `true` from `is_protected_sdd_path` *before* the ignore filter. The first commit
after initialization therefore landed as uncovered meaningful delivery, on a gate no
change workspace could satisfy, because none existed when the files were written.

`init` now records what it created in `.specsync/bootstrap.json`. The exemption is
pinned, not blanket — a recorded path counts only while it is a protected SDD path, is
absent at the delivery comparison base (so only *creation* is exempt, never a later
modification), has a recorded base commit that is an ancestor of `HEAD`, and still
matches its recorded digest. Editing a bootstrapped file revokes its own exemption.

The policy digest covers the **enforcement surface**, not the bytes: filling in
`verification_commands` — which `init` explicitly asks you to do — keeps the exemption,
while changing `enabled`, `require_change_for_meaningful_files`, `meaningful_paths`, or
`ignored_paths` revokes it. This is a judgment call and is documented as one in
`design.md`.

**Second bug fixed in the same path:** the comparison base fell back to `HEAD~1...HEAD`,
which does not resolve in a one-commit repository — exactly the state `git init` +
`specsync init` produces.

### 2. `scaffold` wrote prose that `check` rejected

The effective-contract gate treated every unfinished section as a stub warning, so the
tool's own output failed the tool's own gate on the second command of the quick start.

The exemption is keyed to **authorship, not content shape**. A generated section no
active change has authored no longer gates; a section an active change authored and then
emptied stays fatal, through both the pending and the applied delta paths. Unknown
authorship fails closed and exempts nothing.

### 3. A directory in `files:` made `check` silently green — #472

Filed as Kotlin-specific; it is language-independent, and worse than filed. A directory
mapping extracts zero exports, so the Public API comparison had nothing to compare and
passed. `specsync check --strict --force` exited 0 with **zero warnings** while measuring
nothing — a green result indistinguishable from a real one, which is the worst failure
mode a verification tool has.

Validation now reports the directory and offers a fix naming the source files beneath it,
expanded by the same rule `generate` and `scaffold` apply to a `[modules."x"] files`
directory, so the remedy matches what generation would have written.

The snapshot validation path had the same defect in a more misleading form: it refused
the directory but reported it as an out-of-root **security escape**, telling authors their
confined path had left the project root. A new `SourceSnapshot::Directory` variant makes
both paths name the real cause. Symlink and reparse-point rejection is unchanged and
still evaluated first.

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` exit 0
- [x] `cargo test` — **2203 unit, 331 integration, 0 failures**
- [x] `specsync check --strict` on this repository — 62 specs, 0 warnings, 0 failed
- [x] Cold-agent walk by hand: `git init` → `init` → `check` → `scaffold` → `check` →
      `coverage` → `score` → `deps`, all green
- [x] Sandbox drill board at the base commit — **28 pass, 0 fail, 0 skip**; drill 039
      (export extraction, seven languages) 43/43

Fourteen tests added. The load-bearing ones are the negatives, since each fix *removes* a
finding: `effective_contract_keeps_authored_emptied_section_fatal` proves an authored-then-
emptied section still fails, `effective_contract_exempts_nothing_when_authorship_is_unknown`
proves the gate fails closed, and `fresh_init_leaves_the_next_lifecycle_check_clean` proves
that widening `meaningful_paths` revokes the exemption the edited file was granted.

## Notes

Lands before the `v6.0.0` tag, so no migration is owed. A repository initialized by an
earlier 6.0 build has no bootstrap record and is unaffected — the exemption only ever
removes a finding.

Closes #472.
